### PR TITLE
Prepare 0.2.6 version docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+## 0.2.6
+
+### Added
+
+- Added hover tooltips for trained Prompt Studio highlight tags, using
+  autocomplete metadata when it is available.
+- Added the `prompt_studio.trained_tag_tooltip` setting and matching Comfy
+  setting key so tag hover tooltips can be enabled or disabled from Prompt
+  Studio settings.
+- Added a dedicated tabbed Prompt Studio highlight color editor so the growing
+  highlight color controls are managed outside the main Prompt Studio settings
+  list.
+
+### Changed
+
+- Reused autocomplete tooltip formatting for Prompt Studio tag highlights so
+  hover text stays consistent between autocomplete suggestions and highlighted
+  prompt tokens.
+- Registered the tag tooltip and highlight color settings in backend defaults,
+  frontend settings UI, and settings key mapping.
+- Shared Prompt Studio highlight color handling across the main Prompt Studio
+  editor and the common highlighter path.
+
+### Validation Notes
+
+- Added regression coverage for Prompt Studio tag tooltip settings.
+- Validated the changed Prompt Studio, common highlighter, autocomplete, and
+  settings JavaScript with syntax checks during 0.2.6 preparation.
+
 ## 0.2.5
 
 ### Added

--- a/docs/development/0.2.6.md
+++ b/docs/development/0.2.6.md
@@ -1,0 +1,50 @@
+# 0.2.6 Development Notes
+
+## Scope
+
+0.2.6 is the next planned patch version after the tagged 0.2.5 release.
+The release scope currently covers trained-tag hover tooltips for Prompt Studio
+highlight spans, a user setting for those tooltips, and a separate tabbed
+editor for Prompt Studio highlight color settings.
+
+## Current Changes
+
+- Package metadata is set to `0.2.6` as the next-version marker because
+  `0.2.5` has already been released.
+- Prompt Studio and the common highlighter path can attach hover tooltip data to
+  trained tag highlight spans by using autocomplete metadata when it is
+  available.
+- Prompt Studio reuses autocomplete tooltip formatting so tag hover text stays
+  consistent with autocomplete suggestion metadata.
+- The tag hover tooltip behavior is controlled by:
+  - `prompt_studio.trained_tag_tooltip`
+  - `EasyUseAnima.Prompt.TrainedTagTooltip`
+- Prompt Studio highlight color settings remain stored in
+  `prompt_studio.colors`, but the settings UI now opens them in a dedicated
+  tabbed editor instead of expanding all color controls in the main settings
+  list.
+- Prompt Studio highlight color handling is shared by the main Prompt Studio
+  editor and the common highlighter path.
+
+## Release Follow-Up
+
+- Confirm the tag tooltip behavior visually in a live ComfyUI 0.25.x instance
+  before tagging 0.2.6.
+- Confirm the dedicated highlight color editor remains usable after any
+  additional Prompt Studio settings are added.
+
+## Validation Checklist
+
+- `node --check web\js\easyuse_anima_prompt_studio.js`
+- `node --check web\js\easyuse_anima_prompt_studio_common.js`
+- `node --check web\js\easyuse_anima_autocomplete.js`
+- `node --check web\js\easyuse_anima_settings.js`
+- `.venv\Scripts\python.exe -m unittest tests.test_prompt_corrector.SettingsTests`
+- `.venv\Scripts\python.exe -m unittest discover -s tests`
+- `.venv\Scripts\python.exe -m compileall -q .`
+- `git diff --check`
+- pyproject TOML metadata sanity check
+
+## Release Notes
+
+- Added to `RELEASE.md` for 0.2.6 release preparation.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,8 +6,8 @@ conversation.
 ## Read Order
 
 1. `docs/development/current-policies.md`
-2. Active version plan, currently `docs/development/0.2.5.md`
-3. Latest released baseline, currently `docs/development/0.2.4.md`
+2. Active version plan, currently `docs/development/0.2.6.md`
+3. Latest released baseline, currently `docs/development/0.2.5.md`
 4. Relevant topic guide:
    - workflow docs or release templates: `docs/Anima AiO/Workflow_Management.md`
    - user-facing AiO docs: `docs/Anima AiO/README.md`
@@ -19,8 +19,8 @@ conversation.
 ## Source Map
 
 - Current policy baseline: `docs/development/current-policies.md`
-- Active next-version plan: `docs/development/0.2.5.md`
-- Latest released baseline: `docs/development/0.2.4.md`
+- Active next-version plan: `docs/development/0.2.6.md`
+- Latest released baseline: `docs/development/0.2.5.md`
 - Older implementation history: `docs/version-plans/`
 - Public workflow JSON templates and preview/source images: `docs/example_workflows/`
 - User-facing workflow documentation: `docs/Anima AiO/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and detailer helpers for ComfyUI."
-version = "0.2.5"
+version = "0.2.6"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## 변경 요약

- `pyproject.toml` 패키지 버전을 `0.2.6` next-version marker로 변경했습니다.
- `RELEASE.md`에 0.2.6 준비 항목을 추가했습니다.
- `docs/development/0.2.6.md`를 추가하고 개발 문서 진입점의 active/latest 포인터를 0.2.6/0.2.5 기준으로 갱신했습니다.

## 수정한 주요 파일

- `pyproject.toml`
- `RELEASE.md`
- `docs/development/README.md`
- `docs/development/0.2.6.md`

## 검증

- `D:\ComfyUI\ComfyUI_main\instances\ComfyUI_v0.24.0\.venv\Scripts\python.exe -c "..."` TOML/문서 포인터 sanity check 통과
- `git diff --check` 통과
- `node --check web\js\easyuse_anima_prompt_studio.js` 통과
- `node --check web\js\easyuse_anima_prompt_studio_common.js` 통과
- `node --check web\js\easyuse_anima_autocomplete.js` 통과
- `node --check web\js\easyuse_anima_settings.js` 통과

## live ComfyUI 인스턴스 반영 여부

- 런타임 코드 변경이 아니라 문서와 패키지 메타데이터 변경이므로 live 인스턴스 파일 동기화는 하지 않았습니다.

## 남은 위험 또는 미확인 항목

- 0.2.6 태그/릴리즈 발행은 진행하지 않았습니다.
- 0.2.6 실제 릴리즈 전에는 live ComfyUI 0.25.x에서 tooltip UX와 highlight color editor를 한 번 더 확인해야 합니다.

## 라벨 후보

- `type: docs`
- `type: chore`
- `area: docs`
- `status: ready`