### PR TITLE
Community Standards 문서와 GitHub 템플릿 main 반영

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,165 @@
+name: Bug report / 버그 리포트
+description: Report a reproducible EasyUse Anima bug.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide enough information to reproduce the issue.
+
+        한국어가 더 편하다면 한국어로 작성해도 됩니다.
+
+        Please run environment and dependency checks in the same Python environment used by ComfyUI.
+        ComfyUI portable, ComfyUI Manager, Comfy CLI, venv, Docker, and manual source installs can behave differently.
+
+        If this is a security vulnerability, do not include public exploit details. Follow the Security Policy instead:
+        https://github.com/n0va39/ComfyUI-EasyUseAnima/security/policy
+
+  - type: input
+    id: easyuse-anima-version
+    attributes:
+      label: EasyUse Anima version / EasyUse Anima 버전
+      description: Version, tag, branch, commit hash, or installation source.
+      placeholder: "0.2.6 / latest main / commit hash / ComfyUI Manager"
+    validations:
+      required: true
+
+  - type: input
+    id: comfyui-version
+    attributes:
+      label: ComfyUI version / ComfyUI 버전
+      description: Version, commit hash, or release date if available.
+      placeholder: "ComfyUI v0.xx.x / commit hash"
+    validations:
+      required: true
+
+  - type: textarea
+    id: comfyui-environment
+    attributes:
+      label: ComfyUI environment / ComfyUI 구축 환경
+      description: Describe how ComfyUI is installed and launched.
+      placeholder: |
+        - Install type: portable / manual git clone / Comfy CLI / Docker / other
+        - Manager install mode: release / nightly / git clone / not used
+        - Python executable: path to python used by ComfyUI, if known
+        - Launch command or batch file: if relevant
+        - GPU, CUDA, and torch versions: if relevant
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version / Python 버전
+      placeholder: "Python 3.12.x"
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceleration-dependencies
+    attributes:
+      label: SageAttention / Triton / torch dependency checks
+      description: Run these checks in the same Python environment used by ComfyUI. If not relevant, write "Not used".
+      placeholder: |
+        python -c "import sys; print(sys.executable); print(sys.version)"
+        python -c "import torch; print(torch.__version__); print(torch.version.cuda); print(torch.cuda.is_available())"
+        python -c "import triton; print(triton.__version__)"
+        python -c "import sageattention; print(getattr(sageattention, '__version__', 'installed'))"
+
+        Paste the output here. If Triton or SageAttention is not installed, paste the import error.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system / 운영체제
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area / 영향 영역
+      options:
+        - Prompt tools / 프롬프트 도구
+        - NAIA integration / NAIA 연동
+        - LoRA tools / LoRA 도구
+        - AiO workflow / AiO 워크플로우
+        - Detailer or SAM3 helpers / Detailer 또는 SAM3 헬퍼
+        - UI / frontend
+        - Documentation / 문서
+        - Other / 기타
+    validations:
+      required: true
+
+  - type: textarea
+    id: required-custom-nodes
+    attributes:
+      label: Related custom nodes / 관련 커스텀 노드
+      description: List other custom nodes used by the failing workflow, if any.
+      placeholder: "ComfyUI-Spectrum-KSampler, ComfyUI-Impact-Pack, ComfyUI-Image-Saver, etc."
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce / 재현 단계
+      description: Describe the exact steps needed to reproduce the issue.
+      placeholder: |
+        1. Load this workflow...
+        2. Add or configure this node...
+        3. Queue the prompt...
+        4. Error occurs...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior / 기대 동작
+      placeholder: "What did you expect to happen?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior / 실제 동작
+      placeholder: "What actually happened?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error log / 오류 로그
+      description: Paste the relevant traceback, ComfyUI console log, or browser console error. Remove secrets and private paths.
+      placeholder: "Paste logs here, or write 'No error log' if none is available."
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow or screenshot / 워크플로우 또는 스크린샷
+      description: Attach a minimal workflow JSON, image with embedded workflow, or screenshots if possible.
+      placeholder: "Drag and drop files here, or explain why you cannot share them."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context / 추가 정보
+      placeholder: "Any other information that may help."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation / 문서
+    url: https://github.com/n0va39/ComfyUI-EasyUseAnima
+    about: Check the README and documentation before opening an issue.
+  - name: Security vulnerability / 보안 취약점
+    url: https://github.com/n0va39/ComfyUI-EasyUseAnima/security/policy
+    about: Do not post public exploit details. Follow the Security Policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,79 @@
+name: Feature request / 기능 요청
+description: Suggest an improvement or new feature for EasyUse Anima.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please explain the use case clearly.
+
+        한국어가 더 편하다면 한국어로 작성해도 됩니다.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case / 문제 또는 사용 사례
+      description: What workflow problem does this feature solve?
+      placeholder: "I want to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution / 제안하는 해결 방식
+      description: Describe the feature or behavior you want.
+      placeholder: "Add an option to..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Related area / 관련 영역
+      options:
+        - Prompt tools / 프롬프트 도구
+        - NAIA integration / NAIA 연동
+        - LoRA tools / LoRA 도구
+        - AiO workflow / AiO 워크플로우
+        - Detailer or SAM3 helpers / Detailer 또는 SAM3 헬퍼
+        - UI / frontend
+        - Documentation / 문서
+        - Other / 기타
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility notes / 호환성 메모
+      description: Could this affect existing workflows, saved image metadata, node inputs, outputs, or settings?
+      placeholder: "This should not affect existing workflows / This may change..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered / 고려한 대안
+      description: Is there an existing workaround?
+      placeholder: "Currently I use..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples or references / 예시 또는 참고 자료
+      description: Add screenshots, workflow examples, links, or references if helpful.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context / 추가 정보
+      placeholder: "Any other information that may help."
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,70 @@
+## Summary / 요약
+
+<!-- Briefly describe what this PR changes. 한국어로 작성해도 됩니다. -->
+
+
+
+## Type of change / 변경 유형
+
+- [ ] Bug fix / 버그 수정
+- [ ] New feature / 새 기능
+- [ ] Documentation update / 문서 수정
+- [ ] Refactor / 리팩터링
+- [ ] UI change / UI 변경
+- [ ] Other / 기타
+
+## Affected area / 영향 영역
+
+- [ ] Prompt tools / 프롬프트 도구
+- [ ] NAIA integration / NAIA 연동
+- [ ] LoRA tools / LoRA 도구
+- [ ] AiO workflow / AiO 워크플로우
+- [ ] Detailer or SAM3 helpers / Detailer 또는 SAM3 헬퍼
+- [ ] UI / frontend
+- [ ] Documentation / 문서
+- [ ] Other / 기타
+
+## Compatibility / 호환성
+
+- [ ] Existing workflows should continue to load.
+- [ ] Existing saved image workflows should continue to work.
+- [ ] This PR changes workflow behavior or saved data format.
+- [ ] This PR changes node inputs, outputs, settings, or metadata.
+- [ ] Not applicable.
+
+## Testing / 검증
+
+<!-- List the commands and manual checks you ran. If not tested, explain why. -->
+
+- [ ] `python -m unittest discover -s tests`
+- [ ] `python -m compileall -q .`
+- [ ] `git diff --check`
+- [ ] `node --check web/js/<changed-file>.js`
+- [ ] ComfyUI starts without import errors.
+- [ ] The affected node appears in the node menu.
+- [ ] I tested the changed behavior manually.
+- [ ] I tested an existing workflow.
+- [ ] I could not test this locally.
+
+## Documentation / 문서
+
+- [ ] README or user documentation updated.
+- [ ] Node documentation updated.
+- [ ] Example workflow updated.
+- [ ] Not applicable.
+
+## Screenshots or examples / 스크린샷 또는 예시
+
+<!-- Add screenshots, workflow examples, or before/after results for UI and workflow changes. -->
+
+
+
+## Related issue / 관련 이슈
+
+<!-- Example: Closes #123 -->
+
+
+
+## Notes for maintainers / 유지보수자 참고 사항
+
+<!-- Include risks, migration notes, known limitations, or anything that needs careful review. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+# Code of Conduct
+
+This project is a small open source ComfyUI node pack. Keep discussions
+practical, respectful, and focused on improving the project.
+
+## Expected Behavior
+
+- Be respectful of other users and contributors.
+- Give feedback on code, behavior, documentation, or project scope, not on
+  people.
+- Assume good intent, but be clear when something is unsafe, broken, or out of
+  scope.
+- Keep issues and pull requests relevant to this project.
+
+## Unacceptable Behavior
+
+- Harassment, insults, discrimination, threats, or sexualized attention.
+- Posting private information, tokens, logs with secrets, or personal data.
+- Repeated spam, off-topic comments, or abusive behavior.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments and may block users who repeatedly
+ignore this Code of Conduct. Report concerns through GitHub issues. If public
+reporting is not appropriate, contact a maintainer through their GitHub profile
+when a private channel is available.

--- a/CONTRIBUTING.ko.md
+++ b/CONTRIBUTING.ko.md
@@ -1,0 +1,183 @@
+# 기여 가이드
+
+언어: [English](CONTRIBUTING.md) | [한국어](CONTRIBUTING.ko.md)
+
+ComfyUI EasyUse Anima 개선에 관심을 가져 주셔서 감사합니다. 이 프로젝트는
+ComfyUI 커스텀 노드 팩이므로, 가능한 한 기존 워크플로우, 저장된 설정, 사용자
+데이터와의 호환성을 유지해야 합니다.
+
+참여하기 전에 [Code of Conduct](CODE_OF_CONDUCT.md)를 읽어 주세요.
+
+## 언어
+
+이슈, 토론, PR 설명은 영어 또는 한국어로 작성할 수 있습니다. 버그, 기능 요청,
+기여 내용을 한국어로 설명하는 것이 더 편하다면 한국어로 작성해도 됩니다. 한국어
+사용은 선택 사항이며, 영어 기여도 환영합니다.
+
+## 프로젝트 범위
+
+이 저장소는 다음 영역에 집중합니다.
+
+- ANIMA/Spectrum 워크플로우용 프롬프트 편집과 보정.
+- NAIA 프롬프트 가져오기와 재사용 가능한 프롬프트 메타데이터.
+- 와일드카드 확장과 자동완성 동작.
+- LoRA 프리셋 관리.
+- AiO 생성 헬퍼와 Detailer 편의 노드.
+- 공개 예제 워크플로우와 노드 문서.
+
+관련 없는 대규모 프레임워크 변경, 노드 실행 중 런타임 패키지 설치, 난독화된
+코드, 비공개 사용자 데이터를 저장해야 하는 기능은 범위 밖입니다.
+
+## 이슈 작성
+
+이슈를 열기 전에 README, 기존 이슈, 최근 릴리즈 노트를 확인해 주세요. 좋은
+버그 리포트에는 다음 정보가 포함됩니다.
+
+- EasyUse Anima 버전, 커밋, 또는 설치 출처.
+- ComfyUI 버전 또는 Manager 설치 방식.
+- 관련이 있다면 운영체제와 Python 버전.
+- 워크플로우에 필요한 다른 커스텀 노드.
+- 문제를 재현하는 명확한 단계.
+- 기대한 동작과 실제 동작.
+- 관련 줄만 정리한 ComfyUI 콘솔 로그 또는 브라우저 오류.
+- 재현에 도움이 되는 최소 워크플로우 JSON 또는 스크린샷.
+
+API 키, 토큰, 비공개 경로, 비공개 모델 출처, 개인정보는 게시하지 마세요.
+로그에 비밀 정보가 포함되어 있다면 게시 전에 제거해 주세요.
+
+보안 취약점은 public exploit 세부 내용을 올리지 말고
+[Security Policy](SECURITY.md)를 따라 신고해 주세요.
+
+## 기능 요청
+
+기능 요청은 다음 내용을 포함하면 검토하기 쉽습니다.
+
+- 해결하려는 워크플로우 문제.
+- 영향을 받는 노드 또는 UI 영역.
+- 저장 후 다시 불러온 워크플로우에서 기대하는 동작.
+- 기존 노드 입력, 출력, 메타데이터, 설정이 바뀌는지 여부.
+- 관련 커스텀 노드 또는 상위 ComfyUI 동작.
+
+기존 워크플로우에 영향을 주는 기능이라면 호환성 기대치를 설명해 주세요.
+하위 호환되는 변경을 강하게 선호합니다.
+
+## Pull Request
+
+일반 개발 PR은 `dev` 브랜치를 base로 사용해 주세요. `main`은 안정적인
+사용자/설치 브랜치입니다.
+
+PR 작성 시:
+
+- 변경 범위를 작고 명확하게 유지합니다.
+- 의도적으로 breaking change를 논의한 경우가 아니라면 기존 노드 class id,
+  input 이름, output type, workflow serialization을 보존합니다.
+- 동작 변경에는 테스트를 추가하거나 갱신합니다.
+- UI, 노드 동작, 워크플로우 템플릿, 설정이 바뀌면 사용자 문서도 갱신합니다.
+- PR 설명에 변경 전/후 동작을 적습니다.
+- 실행한 검증 명령을 적습니다.
+- 테스트하지 못한 항목을 명확히 적습니다.
+
+관련 없는 리팩터링, 포맷만 바꾸는 수정, 동작 변경을 한 PR에 섞지 마세요.
+
+## 로컬 설정
+
+수동 테스트를 위해 저장소를 ComfyUI custom node 디렉터리에 clone합니다.
+
+```bash
+cd ComfyUI/custom_nodes
+git clone https://github.com/n0va39/ComfyUI-EasyUseAnima
+cd ComfyUI-EasyUseAnima
+```
+
+ComfyUI가 사용하는 같은 Python 환경에 의존성을 설치합니다.
+
+```bash
+pip install -r requirements.txt
+```
+
+설치, 업데이트, Python 파일 변경 후에는 ComfyUI를 재시작해야 합니다.
+프론트엔드 JavaScript를 변경했다면 브라우저 hard refresh가 필요할 수 있습니다.
+
+## 검증
+
+변경한 파일에 맞는 검증을 실행해 주세요. 저장소 루트에서:
+
+```bash
+python -m unittest discover -s tests
+python -m compileall -q .
+git diff --check
+```
+
+프론트엔드 JavaScript 파일을 변경했다면:
+
+```bash
+node --check web/js/<changed-file>.js
+```
+
+워크플로우 템플릿을 변경했다면:
+
+```bash
+python -m unittest tests.test_workflows
+```
+
+변경이 실제 ComfyUI 동작에 의존한다면 실제 ComfyUI 인스턴스에서도 테스트하고,
+PR에 테스트한 ComfyUI 버전을 적어 주세요.
+
+## 코드 작성 기준
+
+- 수정 범위는 대상 노드, 설정, route, UI 동작에 맞게 제한합니다.
+- 이 저장소의 기존 helper와 패턴을 우선 사용합니다.
+- Python 노드 정의는 명확하게 유지합니다: `INPUT_TYPES`, `RETURN_TYPES`,
+  `RETURN_NAMES`, `FUNCTION`, `CATEGORY`.
+- persistent cache key나 저장된 워크플로우 데이터에 Python `hash()`를 사용하지
+  않습니다.
+- 노드 실행 중 shell command를 실행하지 않습니다.
+- 필요한 경우가 아니라면 의존성을 추가하지 않습니다. 추가해야 한다면
+  `pyproject.toml`과 `requirements.txt`에 모두 기록합니다.
+- 사용자 데이터는 저장소 밖에 유지합니다. 설정, LoRA 프로필, 와일드카드는
+  ComfyUI user data 경로에 있어야 합니다.
+
+## 프론트엔드 기준
+
+- ComfyUI frontend extension은 `web/js/` 아래에 둡니다.
+- Python input 값으로 필요한 hidden widget은 serialized 상태로 유지합니다.
+- workflow serialization은 명시적으로 갱신합니다. DOM 상태만으로는 충분하지
+  않습니다.
+- input, mousemove, render, layout loop에서 반복 API polling을 만들지 않습니다.
+- 가능하면 ComfyUI frontend API를 사용합니다.
+- custom DOM widget을 변경했다면 저장된 워크플로우를 다시 불러오는 동작을
+  확인합니다.
+
+## 문서와 워크플로우
+
+- 사용자용 노드 문서는 `docs/nodes/` 아래에 둡니다.
+- 공개 예제 워크플로우 파일과 preview/source 이미지는
+  `docs/example_workflows/` 아래에 둡니다.
+- 릴리즈 워크플로우 파일명은 `*_release_en.json`, `*_release_ko.json`,
+  `*_release_ja.json`, `*_release_zh.json`처럼 언어별 release suffix를
+  유지합니다.
+- 개인 테스트 워크플로우, local LoRA 경로, 임시 preview URL, clipspace 이미지,
+  비공개 모델 경로를 커밋하지 마세요.
+- 릴리즈 워크플로우 템플릿을 수정할 때는 `extra.easyuse_anima_workflow`
+  메타데이터를 최신 상태로 유지합니다.
+
+## 다국어 지원
+
+표준 노드 다국어 지원은 ComfyUI locale 파일인
+`locales/<lang>/nodeDefs.json`을 사용합니다. Python 노드 정의에는 영어 fallback
+텍스트를 유지합니다. Frontend text map은 ComfyUI locale 파일로 처리할 수 없는
+custom DOM widget, 메뉴, alert, prompt, settings panel에만 사용합니다.
+
+locale 파일을 변경했다면 JSON을 검증해 주세요.
+
+```bash
+python -m json.tool locales/ko/nodeDefs.json
+```
+
+수정한 언어에 맞게 경로를 바꿔 실행하면 됩니다.
+
+## 유지보수자 전용 작업
+
+릴리즈 publish, Comfy Registry publish, version tag 생성, 이미 공개된 release
+history 변경은 유지보수자 작업입니다. API key, publisher token, release secret을
+이슈, PR, 문서, workflow 파일, 테스트 데이터에 포함하지 마세요.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,188 @@
+# Contributing
+
+Language: [English](CONTRIBUTING.md) | [한국어](CONTRIBUTING.ko.md)
+
+Thanks for helping improve ComfyUI EasyUse Anima. This project is a ComfyUI
+custom node pack, so contributions should preserve existing workflows, saved
+settings, and user data whenever possible.
+
+Before participating, read the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Language / 언어
+
+Issues, discussions, and pull request descriptions may be written in English or
+Korean. If Korean is more comfortable for explaining a bug, feature request, or
+contribution, please use Korean. This is optional; English contributions are
+also welcome.
+
+한국어가 더 편하다면 이슈, 토론, PR 설명을 한국어로 작성해도 됩니다.
+한국어 사용은 선택 사항이며, 영어 기여도 환영합니다.
+
+## Project Scope
+
+This repository focuses on:
+
+- Prompt editing and correction for ANIMA/Spectrum workflows.
+- NAIA prompt import and reusable prompt metadata.
+- Wildcard expansion and autocomplete behavior.
+- LoRA preset management.
+- AiO generation helpers and detailer convenience nodes.
+- Public example workflows and node documentation.
+
+Large unrelated framework changes, runtime package installation from node
+execution, obfuscated code, or features that require storing private user data
+are out of scope.
+
+## Reporting Issues
+
+Before opening an issue, check the README, existing issues, and recent release
+notes. A good bug report should include:
+
+- The EasyUse Anima version, commit, or installation source.
+- The ComfyUI version or Manager install mode.
+- Operating system and Python version when relevant.
+- Required custom nodes involved in the workflow.
+- Clear steps to reproduce the problem.
+- Expected behavior and actual behavior.
+- ComfyUI console logs or browser errors, trimmed to the relevant lines.
+- A minimal workflow JSON or screenshot when it helps reproduce the issue.
+
+Do not post API keys, tokens, private paths, private model sources, or personal
+data. If logs contain secrets, remove them before posting.
+
+For security vulnerabilities, follow the [Security Policy](SECURITY.md) instead
+of posting public exploit details.
+
+## Requesting Features
+
+Feature requests are easier to evaluate when they describe:
+
+- The workflow problem being solved.
+- The node or UI surface affected.
+- How the feature should behave in a saved and reloaded workflow.
+- Whether it changes existing node inputs, outputs, metadata, or settings.
+- Any related custom nodes or upstream ComfyUI behavior.
+
+If a feature affects existing workflows, explain the compatibility expectation.
+Backward-compatible changes are strongly preferred.
+
+## Pull Requests
+
+Use `dev` as the base branch for normal development pull requests. `main` is the
+stable user/install branch.
+
+For PRs:
+
+- Keep the change focused.
+- Preserve existing node class ids, input names, output types, and workflow
+  serialization unless a breaking change is intentional and discussed first.
+- Add or update tests for behavior changes.
+- Update user-facing docs when UI, node behavior, workflow templates, or settings
+  change.
+- Include before/after behavior in the PR description.
+- List the validation commands you ran.
+- Call out anything not tested.
+
+Avoid mixing unrelated refactors, formatting-only edits, and behavior changes in
+one PR.
+
+## Local Setup
+
+Clone the repository into a ComfyUI custom node directory for manual testing:
+
+```bash
+cd ComfyUI/custom_nodes
+git clone https://github.com/n0va39/ComfyUI-EasyUseAnima
+cd ComfyUI-EasyUseAnima
+```
+
+Install dependencies in the same Python environment used by ComfyUI:
+
+```bash
+pip install -r requirements.txt
+```
+
+Restart ComfyUI after installing, updating, or changing Python files. For
+frontend JavaScript changes, a browser hard refresh may also be required.
+
+## Validation
+
+Run focused checks for the files you changed. From the repository root:
+
+```bash
+python -m unittest discover -s tests
+python -m compileall -q .
+git diff --check
+```
+
+For changed frontend JavaScript files:
+
+```bash
+node --check web/js/<changed-file>.js
+```
+
+For changed workflow templates:
+
+```bash
+python -m unittest tests.test_workflows
+```
+
+If a change depends on live ComfyUI behavior, also test it in a real ComfyUI
+instance and mention the tested ComfyUI version in the PR.
+
+## Coding Guidelines
+
+- Keep changes scoped to the node, setting, route, or UI behavior being fixed.
+- Prefer existing helpers and patterns in this repository.
+- Keep Python node definitions stable and explicit: `INPUT_TYPES`,
+  `RETURN_TYPES`, `RETURN_NAMES`, `FUNCTION`, and `CATEGORY`.
+- Do not use Python `hash()` for persistent cache keys or saved workflow data.
+- Do not run shell commands from node execution.
+- Do not add dependencies unless they are necessary and documented in both
+  `pyproject.toml` and `requirements.txt`.
+- Keep user data outside the repository. Settings, LoRA profiles, and wildcards
+  should remain in ComfyUI user data paths.
+
+## Frontend Guidelines
+
+- Put ComfyUI frontend extensions under `web/js/`.
+- Keep hidden widgets serialized when Python inputs still require their values.
+- Update workflow serialization explicitly. DOM state alone is not enough.
+- Avoid repeated API polling from input, mousemove, render, or layout loops.
+- Use ComfyUI frontend APIs where practical.
+- Verify saved workflow reload behavior when changing custom DOM widgets.
+
+## Documentation and Workflows
+
+- User-facing node docs live under `docs/nodes/`.
+- Public example workflow files and preview/source images live under
+  `docs/example_workflows/`.
+- Release workflow filenames should stay language release-suffixed, such as
+  `*_release_en.json`, `*_release_ko.json`, `*_release_ja.json`, or
+  `*_release_zh.json`.
+- Do not commit personal test workflows, local LoRA paths, temporary preview
+  URLs, clipspace images, or private model paths.
+- Keep workflow metadata under `extra.easyuse_anima_workflow` current when
+  updating release workflow templates.
+
+## Localization
+
+Standard node localization should use ComfyUI locale files under
+`locales/<lang>/nodeDefs.json`. Keep English fallback text in Python node
+definitions. Use frontend text maps only for custom DOM widgets, menus, alerts,
+prompts, and settings panels that ComfyUI locale files cannot cover.
+
+When changing locale files, validate the JSON:
+
+```bash
+python -m json.tool locales/ko/nodeDefs.json
+```
+
+Adjust the path for the language you changed.
+
+## Maintainer-Only Work
+
+Release publishing, Comfy Registry publishing, version tagging, and changes to
+published release history are maintainer tasks. Do not include API keys,
+publisher tokens, or release secrets in issues, PRs, docs, workflow files, or
+test data.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,115 @@
+# Security Policy
+
+Language: [English](#english) | [한국어](#한국어)
+
+## English
+
+### Supported Versions
+
+Security fixes are handled for the latest `main` branch and the latest tagged
+release. Older releases and development branches are handled on a best-effort
+basis.
+
+### Reporting a Vulnerability
+
+Please do not open a public issue with exploit details, secret values, private
+paths, or private workflow data.
+
+Use GitHub's private vulnerability reporting from the repository Security tab if
+it is available. If private vulnerability reporting is not available, email the
+maintainer at `fulgensnova39@gmail.com`.
+
+If neither private channel is available, open a public issue with only a
+high-level request for a security contact and do not include exploit details
+until a private channel is established.
+
+Helpful report details:
+
+- Affected EasyUse Anima version, tag, or commit.
+- ComfyUI version and installation method.
+- Operating system and Python version when relevant.
+- Minimal steps to reproduce the issue.
+- Expected impact and affected feature or file.
+- Sanitized logs or proof-of-concept data without secrets or private paths.
+
+### Security Scope
+
+Please report issues such as:
+
+- Arbitrary command execution.
+- Arbitrary file read or write outside the expected ComfyUI user data paths.
+- Path traversal through workflow, wildcard, LoRA preset, or metadata handling.
+- Injection or unsafe parsing that can execute code or alter files unexpectedly.
+- Accidental exposure of tokens, API keys, private paths, or personal data.
+- Vulnerable dependencies that affect this node pack at runtime.
+
+Issues that require a fully trusted local user to intentionally run unsafe code
+may be treated as lower priority, but they can still be reported if the impact
+is unclear.
+
+### Handling
+
+This is a small project, so response time is best effort. Maintainers may ask
+for reproduction details, prepare a fix on `dev`, and release the fix through
+the normal release process. Public credit can be given if the reporter wants it.
+
+### Responsible Disclosure
+
+Do not publicly disclose exploit details before a fix is available or before the
+maintainer agrees that disclosure is appropriate. Do not test against systems,
+data, or accounts that you do not own or have permission to inspect.
+
+## 한국어
+
+### 지원 버전
+
+보안 수정은 최신 `main` 브랜치와 최신 tag release를 기준으로 처리합니다. 오래된
+release와 개발 브랜치는 가능한 범위에서만 지원합니다.
+
+### 취약점 신고
+
+취약점 세부 내용, secret 값, 비공개 경로, 비공개 workflow 데이터는 public issue에
+올리지 마세요.
+
+저장소 Security 탭에서 GitHub private vulnerability reporting을 사용할 수 있다면
+그 기능으로 신고해 주세요. 사용할 수 없다면 maintainer에게
+`fulgensnova39@gmail.com`으로 이메일을 보내 주세요.
+
+두 private 채널을 모두 사용할 수 없다면 public issue에는 보안 연락 채널 요청만
+높은 수준으로 남기고, exploit 세부 내용은 private 채널이 생긴 뒤 공유해 주세요.
+
+신고에 도움이 되는 정보:
+
+- 영향을 받는 EasyUse Anima 버전, tag, 또는 commit.
+- ComfyUI 버전과 설치 방식.
+- 관련이 있다면 운영체제와 Python 버전.
+- 문제를 재현하는 최소 단계.
+- 예상 영향과 영향을 받는 기능 또는 파일.
+- secret이나 비공개 경로를 제거한 로그 또는 proof-of-concept 데이터.
+
+### 보안 범위
+
+다음과 같은 문제를 신고해 주세요.
+
+- 임의 명령 실행.
+- 예상된 ComfyUI user data 경로 밖의 임의 파일 읽기 또는 쓰기.
+- workflow, wildcard, LoRA preset, metadata 처리에서 발생하는 path traversal.
+- 코드 실행 또는 예상치 못한 파일 변경으로 이어질 수 있는 injection 또는 안전하지
+  않은 parsing.
+- token, API key, 비공개 경로, 개인정보의 accidental exposure.
+- 이 node pack 런타임에 영향을 주는 dependency 취약점.
+
+신뢰할 수 있는 로컬 사용자가 의도적으로 unsafe code를 실행해야만 발생하는 문제는
+우선순위가 낮을 수 있습니다. 영향이 불명확하다면 신고해도 됩니다.
+
+### 처리 방식
+
+이 프로젝트는 작은 프로젝트이므로 응답 시간은 best effort입니다. Maintainer는
+재현 정보를 요청하고, `dev`에서 수정한 뒤 일반 release 절차로 배포할 수 있습니다.
+신고자가 원하면 public credit을 제공할 수 있습니다.
+
+### 책임 있는 공개
+
+수정이 준비되었거나 maintainer가 공개에 동의하기 전에는 exploit 세부 내용을
+공개하지 마세요. 본인이 소유하지 않았거나 점검 권한이 없는 시스템, 데이터, 계정을
+대상으로 테스트하지 마세요.


### PR DESCRIPTION
## 릴리즈 범위

GitHub Community Standards와 기여/이슈/PR 운영용 템플릿을 `main`에 반영합니다.

## 포함된 PR/커밋

- 포함 PR: #10 `codex/community-standards -> dev`
- 포함 커밋: `260d76d Add community standards docs and templates`

## 변경 요약

- `CODE_OF_CONDUCT.md` 추가
- `CONTRIBUTING.md`, `CONTRIBUTING.ko.md` 추가
- `SECURITY.md` 추가, 보안 신고 이메일 `fulgensnova39@gmail.com` 명시
- Bug report / Feature request Issue Form 추가
- Issue template chooser 설정 추가, blank issue 비활성화
- Pull request template 추가

## 검증 결과

- Issue template YAML 3개 PyYAML 파싱 확인: `yaml ok`
- trailing whitespace 검사 완료
- `git diff --check origin/main..origin/dev` 통과
- `git diff --name-status origin/main..origin/dev`로 변경 범위 확인

## live 인스턴스 반영 여부

- 반영하지 않았습니다. GitHub 문서/템플릿 변경만 포함하므로 ComfyUI runtime sync 대상이 아닙니다.

## 롤백 방법

- main 병합 커밋을 revert하면 됩니다.
- 변경은 문서와 `.github` 템플릿 파일 추가만 포함하므로 런타임 동작에는 영향이 없습니다.

## 남은 위험 또는 미확인 항목

- GitHub 웹 UI에서 Community Standards 체크와 Issue Form 렌더링은 main 반영 후 최종 확인해야 합니다.