### PR TITLE
Fix: Global autocomplete in Nodes 2.0

### DIFF
--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -125,6 +125,54 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
         self.assertIn('return context.kind === "wildcard" ? results : [];', strict_body)
 
+    def test_autocomplete_supports_nodes_v2_specs_and_dom_widgets(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+
+        start = source.index("function inputTypeName")
+        end = source.index("\nfunction isExcludedInput", start)
+        spec_body = source[start:end]
+
+        self.assertIn("inputSpec.widgetType || inputSpec.type", spec_body)
+        self.assertIn("nodeData?.inputs", spec_body)
+        self.assertIn("inputSpec.options || {}", spec_body)
+        self.assertIn("typeNames.some((item) => item === \"STRING\" || item === \"TEXTAREA\")", source)
+        self.assertIn("typeNames.includes(\"TEXTAREA\")", source)
+
+        start = source.index("function findInputEl")
+        end = source.index("\nfunction isEscaped", start)
+        input_body = source[start:end]
+
+        self.assertIn("widget?.inputEl || widget?.element", input_body)
+        self.assertIn('querySelector?.("textarea, input")', input_body)
+
+    def test_autocomplete_avoids_double_callback_for_nodes_v2_dom_widgets(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        start = source.index("function widgetValueSetterCallsCallback")
+        end = source.index("\nfunction renderResults", start)
+        sync_body = source[start:end]
+
+        self.assertIn("return !!widget?.element;", sync_body)
+        self.assertIn("state.widget.value = state.input.value;", sync_body)
+        self.assertIn("if (!widgetValueSetterCallsCallback(state.widget))", sync_body)
+        self.assertIn("syncWidgetValue(state);", source)
+        self.assertNotIn("state.widget.callback?.(state.input.value);", source[:source.index("function widgetValueSetterCallsCallback")])
+
+    def test_autocomplete_hooks_focused_nodes_v2_dom_inputs(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        start = source.index("function hookFocusedDomInput")
+        end = source.index("\nfunction installExternalInputHook", start)
+        focus_body = source[start:end]
+
+        self.assertIn("isAutocompleteDomInput(input)", focus_body)
+        self.assertIn("const node = nodeFromDomElement(input);", focus_body)
+        self.assertIn("if (!node)", focus_body)
+        self.assertIn("const targets = nodeData ? targetWidgets(nodeData) : null;", focus_body)
+        self.assertIn("const widget = widgetForDomInput(node, input);", focus_body)
+        self.assertIn("hookInput(input", focus_body)
+        self.assertIn('document.addEventListener("focusin"', source)
+        self.assertIn("hookFocusedDomInput(document.activeElement);", source)
+        self.assertNotIn("easyuseAnimaDebugAutocomplete", source)
+
     def test_prompt_highlight_wildcards_accept_unicode_keys(self):
         source = PROMPT_STUDIO_COMMON_JS.read_text(encoding="utf-8")
 

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -66,7 +66,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("composing || document.activeElement", update_body)
         self.assertIn('input.addEventListener("compositionupdate", update);', source)
 
-        autocomplete_done = source.index("  input.__easyuseAnimaAutocomplete = true;")
+        autocomplete_done = source.index("  input.__easyuseAnimaAutocompleteHooked = true;")
         keydown_start = source.rindex('  input.addEventListener("keydown", (event) => {', 0, autocomplete_done)
         keydown_end = source.index("  });", keydown_start)
         keydown_body = source[keydown_start:keydown_end]
@@ -77,6 +77,35 @@ class AIOFrontendSourceTests(unittest.TestCase):
             keydown_body.index("event.isComposing"),
             keydown_body.index("!activeState"),
         )
+
+    def test_autocomplete_public_flag_tracks_enabled_state(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+
+        self.assertIn("const hookedAutocompleteInputs = new Set();", source)
+        self.assertIn("input.__easyuseAnimaAutocompleteHooked", source)
+        self.assertNotIn("if (input.__easyuseAnimaAutocomplete) {", source)
+
+        start = source.index("function syncAutocompleteInputFlag")
+        end = source.index("\nasync function refreshAutocompleteSettings", start)
+        sync_body = source[start:end]
+
+        self.assertIn("input.__easyuseAnimaAutocomplete = autocompleteEnabledForState(state);", sync_body)
+        self.assertIn("hookedAutocompleteInputs.delete(input);", sync_body)
+
+        start = source.index("function setAutocompleteMode")
+        end = source.index("\nfunction isEasyUseAnimaNode", start)
+        mode_body = source[start:end]
+
+        self.assertIn("syncAutocompleteInputFlags();", mode_body)
+
+        start = source.index("function hookInput")
+        end = source.index("\nfunction hookWidget", start)
+        hook_body = source[start:end]
+
+        self.assertIn("if (input.__easyuseAnimaAutocompleteHooked) {", hook_body)
+        self.assertIn("syncAutocompleteInputFlag(input, existing);", hook_body)
+        self.assertIn("hookedAutocompleteInputs.add(input);", hook_body)
+        self.assertIn("syncAutocompleteInputFlag(input, state);", hook_body)
 
     def test_autocomplete_arrow_navigation_keeps_adjacent_items_visible(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -431,6 +431,9 @@ function inputTypeName(inputSpec) {
   if (Array.isArray(inputSpec)) {
     return String(inputSpec[0] || "");
   }
+  if (typeof inputSpec === "object" && inputSpec !== null) {
+    return String(inputSpec.widgetType || inputSpec.type || "");
+  }
   return String(inputSpec || "");
 }
 
@@ -438,15 +441,28 @@ function inputOptions(inputSpec) {
   if (Array.isArray(inputSpec) && typeof inputSpec[1] === "object" && inputSpec[1] !== null) {
     return inputSpec[1];
   }
+  if (typeof inputSpec === "object" && inputSpec !== null) {
+    return {
+      ...inputSpec,
+      ...(inputSpec.options || {}),
+    };
+  }
   return {};
 }
 
 function allInputSpecs(nodeData) {
-  const inputs = nodeData?.input || {};
   const specs = [];
+  const v2Inputs = nodeData?.inputs || {};
+  for (const [name, spec] of Object.entries(v2Inputs)) {
+    specs.push([name, spec]);
+  }
+  const inputs = nodeData?.input || {};
   for (const group of ["required", "optional"]) {
     const values = inputs[group] || {};
     for (const [name, spec] of Object.entries(values)) {
+      if (v2Inputs[name]) {
+        continue;
+      }
       specs.push([name, spec]);
     }
   }
@@ -479,13 +495,14 @@ function isPromptLikeWidgetName(name) {
 function isTargetStringInput(nodeData, name, inputSpec) {
   const type = inputTypeName(inputSpec);
   const options = inputOptions(inputSpec);
-  if (!type.split(",").map((item) => item.trim()).includes("STRING")) {
+  const typeNames = type.split(",").map((item) => item.trim().toUpperCase());
+  if (!typeNames.some((item) => item === "STRING" || item === "TEXTAREA")) {
     return false;
   }
   if (isExcludedInput(inputSpec)) {
     return false;
   }
-  if (options.multiline === true) {
+  if (typeNames.includes("TEXTAREA") || options.multiline === true) {
     return isGenericStringNode(nodeData) || isPromptLikeWidgetName(name);
   }
   return isGenericStringNode(nodeData) && isPromptLikeWidgetName(name);
@@ -523,9 +540,13 @@ function shouldSkipNode(node, nodeData) {
 }
 
 function findInputEl(widget) {
-  const input = widget?.inputEl;
+  const input = widget?.inputEl || widget?.element;
   if (input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement) {
     return input;
+  }
+  const nested = input?.querySelector?.("textarea, input");
+  if (nested instanceof HTMLTextAreaElement || nested instanceof HTMLInputElement) {
+    return nested;
   }
   return null;
 }
@@ -1213,10 +1234,7 @@ function commitSuggestion(state, entry, options = {}) {
   if (wildcardToken) {
     const replacement = `__${String(entry.tag || "").replace(/^__|__$/g, "")}__`;
     replaceInputRange(state.input, wildcardToken.start, wildcardToken.end, replacement, replacement.length);
-    if (state.widget) {
-      state.widget.value = state.input.value;
-      state.widget.callback?.(state.input.value);
-    }
+    syncWidgetValue(state);
     state.onCommit?.(state.input.value);
     if (options.suppressPopup) {
       suppressAutocompleteUntilInputChanges(state.input);
@@ -1235,10 +1253,7 @@ function commitSuggestion(state, entry, options = {}) {
     + insert.length
     + suffixPlan.caretExtra;
   replaceInputRange(state.input, token.start, token.end + suffixPlan.consumeAfter, replacement, caretOffset);
-  if (state.widget) {
-    state.widget.value = state.input.value;
-    state.widget.callback?.(state.input.value);
-  }
+  syncWidgetValue(state);
   state.onCommit?.(state.input.value);
   if (options.suppressPopup) {
     suppressAutocompleteUntilInputChanges(state.input);
@@ -1430,13 +1445,6 @@ function updateAutocompletePreview() {
   refreshAutocompleteHighlightPreview(input);
 }
 
-function syncWidgetValue(state) {
-  if (state?.widget) {
-    state.widget.value = state.input.value;
-    state.widget.callback?.(state.input.value);
-  }
-}
-
 function insertBracketPair(state, event, open, close, replacement = null, caretOffset = null) {
   if (!autocompletePreviewClosingBrackets || event.defaultPrevented || event.ctrlKey || event.metaKey || event.altKey) {
     return false;
@@ -1478,6 +1486,19 @@ function handleBracketPreviewKeydown(state, event) {
     return true;
   }
   return false;
+}
+
+function widgetValueSetterCallsCallback(widget) {
+  return !!widget?.element;
+}
+
+function syncWidgetValue(state) {
+  if (state?.widget) {
+    state.widget.value = state.input.value;
+    if (!widgetValueSetterCallsCallback(state.widget)) {
+      state.widget.callback?.(state.input.value);
+    }
+  }
 }
 
 function renderResults(state, results, signature = "") {
@@ -1757,6 +1778,81 @@ function hookWidget(node, widget, scope = "compatible") {
   });
 }
 
+function autocompleteGraphNodes() {
+  const graph = app?.canvas?.graph || app?.graph || app?.rootGraph;
+  return Array.isArray(graph?.nodes) ? graph.nodes.filter(Boolean) : [];
+}
+
+function findGraphNodeById(id) {
+  if (id == null || id === "") {
+    return null;
+  }
+  const graph = app?.canvas?.graph || app?.graph || app?.rootGraph;
+  const normalized = String(id);
+  return graph?.getNodeById?.(id)
+    || graph?.getNodeById?.(Number(id))
+    || autocompleteGraphNodes().find((node) => String(node?.id) === normalized)
+    || null;
+}
+
+function nodeFromDomElement(element) {
+  if (!(element instanceof Element)) {
+    return null;
+  }
+  const root = element.closest?.("[data-node-id], .lg-node");
+  const id = root?.getAttribute?.("data-node-id")
+    || root?.dataset?.nodeId
+    || root?.id?.match?.(/\d+/)?.[0];
+  return findGraphNodeById(id);
+}
+
+function isAutocompleteDomInput(input) {
+  if (input instanceof HTMLTextAreaElement) {
+    return !input.disabled && !input.readOnly;
+  }
+  if (!(input instanceof HTMLInputElement) || input.disabled || input.readOnly) {
+    return false;
+  }
+  const type = String(input.type || "text").toLocaleLowerCase();
+  return ["", "text", "search"].includes(type);
+}
+
+function widgetForDomInput(node, input) {
+  for (const widget of node?.widgets || []) {
+    const widgetInput = findInputEl(widget);
+    if (widgetInput === input || widget?.element?.contains?.(input)) {
+      return widget;
+    }
+  }
+  return null;
+}
+
+function hookFocusedDomInput(input) {
+  if (!isAutocompleteDomInput(input) || popup?.contains(input)) {
+    return;
+  }
+  const node = nodeFromDomElement(input);
+  if (!node) {
+    return;
+  }
+  const nodeData = node?.constructor?.nodeData || null;
+  const targets = nodeData ? targetWidgets(nodeData) : null;
+  if (nodeData && (!targets || (!hasExplicitTargets(nodeData) && shouldSkipNode(node, nodeData)))) {
+    return;
+  }
+  const widget = widgetForDomInput(node, input);
+  if (targets && widget?.name && !targets.has(widget.name)) {
+    return;
+  }
+  const scope = nodeData && hasExplicitTargets(nodeData) ? "easyuse" : autocompleteScope({ node });
+  hookInput(input, {
+    node,
+    widget,
+    scope,
+    forceArtistOnly: !!(widget?.name && node?.__easyuseAnimaArtistOnlyWidgets?.has(widget.name)),
+  });
+}
+
 function installExternalInputHook() {
   window.easyuseAnimaHookAutocompleteInput = (input, options = {}) => {
     hookInput(input, options);
@@ -1767,6 +1863,10 @@ function installExternalInputHook() {
   for (const item of pending) {
     hookInput(item?.input, item?.options || {});
   }
+  document.addEventListener("focusin", (event) => {
+    hookFocusedDomInput(event.target);
+  }, true);
+  hookFocusedDomInput(document.activeElement);
 }
 
 function hookNode(node, nodeData, attempt = 0) {

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -166,6 +166,7 @@ let popup = null;
 let activeState = null;
 let activeRefreshFrame = null;
 let middlePanForwardActive = false;
+const hookedAutocompleteInputs = new Set();
 window.__easyuseAnimaPendingAutocompleteInputs ||= [];
 
 function clamp(value, min, max) {
@@ -262,6 +263,7 @@ function setAutocompleteMode(value) {
     return;
   }
   autocompleteMode = nextMode;
+  syncAutocompleteInputFlags();
   if (!autocompleteEnabledForState(activeState)) {
     hidePopup();
   }
@@ -301,6 +303,24 @@ function autocompleteEnabledForScope(scope) {
 
 function autocompleteEnabledForState(state) {
   return !!state && autocompleteEnabledForScope(state.scope || "compatible");
+}
+
+function syncAutocompleteInputFlag(input, state = input?.__easyuseAnimaAutocompleteState) {
+  if (!input) {
+    return;
+  }
+  input.__easyuseAnimaAutocomplete = autocompleteEnabledForState(state);
+}
+
+function syncAutocompleteInputFlags() {
+  for (const input of [...hookedAutocompleteInputs]) {
+    const state = input?.__easyuseAnimaAutocompleteState;
+    if (!state) {
+      hookedAutocompleteInputs.delete(input);
+      continue;
+    }
+    syncAutocompleteInputFlag(input, state);
+  }
 }
 
 async function refreshAutocompleteSettings() {
@@ -1593,7 +1613,7 @@ function hookInput(input, options = {}) {
   if (!input) {
     return;
   }
-  if (input.__easyuseAnimaAutocomplete) {
+  if (input.__easyuseAnimaAutocompleteHooked) {
     const existing = input.__easyuseAnimaAutocompleteState;
     if (existing) {
       existing.node = options.node || existing.node || null;
@@ -1601,6 +1621,7 @@ function hookInput(input, options = {}) {
       existing.scope = autocompleteScope(options);
       existing.forceArtistOnly = !!options.forceArtistOnly;
       existing.onCommit = typeof options.onCommit === "function" ? options.onCommit : existing.onCommit;
+      syncAutocompleteInputFlag(input, existing);
     }
     return;
   }
@@ -1764,8 +1785,10 @@ function hookInput(input, options = {}) {
     }
   });
 
-  input.__easyuseAnimaAutocomplete = true;
+  input.__easyuseAnimaAutocompleteHooked = true;
   input.__easyuseAnimaAutocompleteState = state;
+  hookedAutocompleteInputs.add(input);
+  syncAutocompleteInputFlag(input, state);
 }
 
 function hookWidget(node, widget, scope = "compatible") {


### PR DESCRIPTION
## Summary / 요약
Nodes 2.0이 켜진 상태에서 자동 완성을 뜨게 하는 PR입니다.
실험적인 방식으로 구현되어 dev브랜치로 PR 요청 드립니다.


## Type of change / 변경 유형

- [x] Bug fix / 버그 수정
- [ ] New feature / 새 기능
- [ ] Documentation update / 문서 수정
- [ ] Refactor / 리팩터링
- [ ] UI change / UI 변경
- [ ] Other / 기타

## Affected area / 영향 영역

- [x] Prompt tools / 프롬프트 도구
- [ ] NAIA integration / NAIA 연동
- [ ] LoRA tools / LoRA 도구
- [ ] AiO workflow / AiO 워크플로우
- [ ] Detailer or SAM3 helpers / Detailer 또는 SAM3 헬퍼
- [ ] UI / frontend
- [ ] Documentation / 문서
- [ ] Other / 기타

## Compatibility / 호환성

- [x] Existing workflows should continue to load.
- [x] Existing saved image workflows should continue to work.
------
- [ ] This PR changes workflow behavior or saved data format.
- [ ] This PR changes node inputs, outputs, settings, or metadata.
- [x] Not applicable.

## Testing / 검증

<!-- List the commands and manual checks you ran. If not tested, explain why. -->

- [ ] `python -m unittest discover -s tests`
- [ ] `python -m compileall -q .`
- [ ] `git diff --check`
- [x] `node --check web/js/<changed-file>.js`
- [x] ComfyUI starts without import errors.
- [x] The affected node appears in the node menu.
- [x] I tested the changed behavior manually.
- [x] I tested an existing workflow.
- [ ] I could not test this locally.

Python 가상 환경이 제대로 세팅 되어있지 않아 python 부분은 장담할 수 없습니다. (제가 잘 못하기도 하구요)

## Documentation / 문서

- [ ] README or user documentation updated.
- [ ] Node documentation updated.
- [ ] Example workflow updated.
- [x] Not applicable.

## Screenshots or examples / 스크린샷 또는 예시

<!-- Add screenshots, workflow examples, or before/after results for UI and workflow changes. -->

<img width="943" height="577" alt="스크린샷 2026-07-04 141839" src="https://github.com/user-attachments/assets/3c7631c3-de46-4558-acaa-2735fe7d8d7f" />

## Related issue / 관련 이슈

없음

## Notes for maintainers / 유지보수자 참고 사항

1. input에 `__easyuseAnimaAutocomplete`를 자동 완성이 실제로 Input에 켜져 있는지 확인하는 변수로 바꾸고 `__easyuseAnimaAutocompleteHooked`로 기존 역할을 수행하게 했습니다.
2. python 부분의 unit test 코드가 유효한지 모르겠습니다. 이 부분은 직접 수정하시는 게 편하실 거예요.
3. focusin에 후킹해 등록하는 코드가 추가되었는데 이게 기존 방식과 달라 dev 브랜치로 PR 요청을 보내봅니다.

<!-- Include risks, migration notes, known limitations, or anything that needs careful review. -->
