### PR TITLE
Fix autocomplete search and popup scroll reset

### DIFF
--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -55,6 +55,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
         self.assertIn("descriptionKey.includes(query)", body)
         self.assertIn("candidateKey.startsWith(query)", body)
+        self.assertIn("candidateKey.includes(query)", body)
 
     def test_autocomplete_refreshes_during_ime_composition_without_committing(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
@@ -124,6 +125,60 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("const menu = ensurePopup();", set_active_body)
         self.assertIn("scrollActiveAutocompleteItemIntoView(menu, activeState.index);", set_active_body)
 
+    def test_autocomplete_resets_scroll_for_new_result_sets(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        start = source.index("function hidePopup")
+        end = source.index("\nfunction hideTrainedTagTooltips", start)
+        hide_body = source[start:end]
+
+        self.assertIn("markAutocompleteInputInactive(input);", hide_body)
+        self.assertIn("popup.scrollTop = 0;", hide_body)
+
+        start = source.index("function markAutocompleteInputInactive")
+        end = source.index("\nfunction hideTrainedTagTooltips", start)
+        inactive_body = source[start:end]
+
+        self.assertIn('state.lastAutocompleteSignature = "";', inactive_body)
+
+        start = source.index("function resetActiveAutocompleteMenu")
+        end = source.index("\nfunction endsWithSentencePeriod", start)
+        reset_body = source[start:end]
+
+        self.assertIn("activeState.index = 0;", reset_body)
+        self.assertIn("menu.scrollTop = 0;", reset_body)
+
+        start = source.index("function renderResults")
+        end = source.index("\nfunction isCaretInComment", start)
+        body = source[start:end]
+
+        self.assertIn("menu.scrollTop = 0;", body)
+        self.assertIn("index: 0,", body)
+        self.assertIn("resetActiveAutocompleteMenu(menu);", body)
+        self.assertLess(body.index("menu.scrollTop = 0;"), body.index("menu.replaceChildren();"))
+        self.assertLess(body.index("menu.replaceChildren();"), body.index("resetActiveAutocompleteMenu(menu);"))
+        self.assertLess(body.index("resetActiveAutocompleteMenu(menu);"), body.index("positionPopup(state.input);"))
+
+        start = source.index("  const updateNow = async () => {")
+        end = source.index("    const seq = ++updateSeq;", start)
+        update_body = source[start:end]
+
+        self.assertIn("lastAutocompleteSignature: undefined", source)
+        self.assertIn("const previousSignature = state.lastAutocompleteSignature;", update_body)
+        self.assertIn("state.lastAutocompleteSignature = signature;", update_body)
+        self.assertIn("previousSignature !== undefined && previousSignature !== signature", update_body)
+        self.assertIn("resetActiveAutocompleteMenu(ensurePopup());", update_body)
+
+        start = source.index("function handleOutsideAutocompletePointer")
+        end = source.index("\ndocument.addEventListener(\"pointerdown\"", start)
+        pointer_body = source[start:end]
+
+        self.assertIn("popup?.contains(event.target)", pointer_body)
+        self.assertIn("event.target === input", pointer_body)
+        self.assertIn("markAutocompleteInputInactive(input);", pointer_body)
+        self.assertIn("hidePopup();", pointer_body)
+        self.assertIn('document.addEventListener("pointerdown", handleOutsideAutocompletePointer, true);', source)
+        self.assertIn('document.addEventListener("mousedown", handleOutsideAutocompletePointer, true);', source)
+
     def test_autocomplete_wildcards_accept_empty_and_unicode_queries(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
         start = source.index("function currentWildcardToken")
@@ -153,6 +208,35 @@ class AIOFrontendSourceTests(unittest.TestCase):
         strict_body = source[start:end]
 
         self.assertIn('return context.kind === "wildcard" ? results : [];', strict_body)
+
+    def test_autocomplete_strips_prompt_syntax_from_search_query(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+
+        start = source.index("function autocompleteQuery")
+        end = source.index("\nfunction wildcardAutocompleteQuery", start)
+        query_body = source[start:end]
+
+        self.assertIn("const query = parsed.query;", query_body)
+        self.assertNotIn("artistOnly ? parsed.query : raw.trim()", query_body)
+
+        start = source.index("function parseAutocompleteText")
+        end = source.index("\nfunction normalizeWildcardSearchText", start)
+        parse_body = source[start:end]
+
+        self.assertIn('query = query.replace(/^\\[\\[\\s*/g, "");', parse_body)
+        self.assertIn('query = query.replace(/^\\(\\s*/g, "");', parse_body)
+        self.assertIn("query = stripPromptSyntaxClosingParens(query);", parse_body)
+        self.assertIn(
+            'query = query.replace(/:\\s*[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*$/, "");',
+            parse_body,
+        )
+        self.assertNotIn('query = query.replace(/\\)+\\s*$/, "");', parse_body)
+
+        start = source.index("function trimPromptSyntaxSuffix")
+        end = source.index("\nfunction currentToken", start)
+        trim_body = source[start:end]
+
+        self.assertIn('value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)', trim_body)
 
     def test_autocomplete_supports_nodes_v2_specs_and_dom_widgets(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -132,7 +132,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         hide_body = source[start:end]
 
         self.assertIn("markAutocompleteInputInactive(input);", hide_body)
-        self.assertIn("popup.scrollTop = 0;", hide_body)
+        self.assertIn("resetAutocompleteMenuToTop(popup);", hide_body)
+        self.assertLess(hide_body.index("popup.replaceChildren();"), hide_body.index("resetAutocompleteMenuToTop(popup);"))
+        self.assertLess(hide_body.index("resetAutocompleteMenuToTop(popup);"), hide_body.index('popup.classList.add("hidden");'))
 
         start = source.index("function markAutocompleteInputInactive")
         end = source.index("\nfunction hideTrainedTagTooltips", start)
@@ -140,23 +142,46 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
         self.assertIn('state.lastAutocompleteSignature = "";', inactive_body)
 
+        self.assertIn("overflow-anchor: none;", source)
+
+        start = source.index("function resetAutocompleteMenuToTop")
+        end = source.index("\nfunction resetActiveAutocompleteMenu", start)
+        reset_top_body = source[start:end]
+
+        self.assertIn("menu.scrollTop = 0;", reset_top_body)
+        self.assertIn("menu.scrollLeft = 0;", reset_top_body)
+
         start = source.index("function resetActiveAutocompleteMenu")
-        end = source.index("\nfunction endsWithSentencePeriod", start)
+        end = source.index("\nfunction resetVisibleAutocompleteMenuSoon", start)
         reset_body = source[start:end]
 
         self.assertIn("activeState.index = 0;", reset_body)
-        self.assertIn("menu.scrollTop = 0;", reset_body)
+        self.assertIn("resetAutocompleteMenuToTop(menu);", reset_body)
+
+        start = source.index("function resetVisibleAutocompleteMenuSoon")
+        end = source.index("\nfunction endsWithSentencePeriod", start)
+        visible_reset_body = source[start:end]
+
+        self.assertIn("resetAutocompleteMenuToTop(menu);", visible_reset_body)
+        self.assertIn("requestAnimationFrame(() => {", visible_reset_body)
+        self.assertIn('!menu.classList.contains("hidden")', visible_reset_body)
+        self.assertNotIn("resetActiveAutocompleteMenu(menu);", visible_reset_body)
 
         start = source.index("function renderResults")
         end = source.index("\nfunction isCaretInComment", start)
         body = source[start:end]
 
-        self.assertIn("menu.scrollTop = 0;", body)
+        self.assertIn("resetAutocompleteMenuToTop(menu);", body)
         self.assertIn("index: 0,", body)
+        self.assertIn('menu.classList.remove("hidden");', body)
         self.assertIn("resetActiveAutocompleteMenu(menu);", body)
-        self.assertLess(body.index("menu.scrollTop = 0;"), body.index("menu.replaceChildren();"))
+        self.assertIn("resetVisibleAutocompleteMenuSoon(menu, state.input);", body)
+        self.assertLess(body.index("resetAutocompleteMenuToTop(menu);"), body.index("menu.replaceChildren();"))
         self.assertLess(body.index("menu.replaceChildren();"), body.index("resetActiveAutocompleteMenu(menu);"))
         self.assertLess(body.index("resetActiveAutocompleteMenu(menu);"), body.index("positionPopup(state.input);"))
+        self.assertLess(body.index('menu.classList.remove("hidden");'), body.rindex("resetActiveAutocompleteMenu(menu);"))
+        self.assertLess(body.index('menu.classList.remove("hidden");'), body.index("resetVisibleAutocompleteMenuSoon(menu, state.input);"))
+        self.assertLess(body.index("resetVisibleAutocompleteMenuSoon(menu, state.input);"), body.index("updateAutocompletePreview();"))
 
         start = source.index("  const updateNow = async () => {")
         end = source.index("    const seq = ++updateSeq;", start)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -3009,6 +3009,18 @@ class AutocompleteDatasetTests(unittest.TestCase):
         self.assertEqual(korean["results"][0]["category"], "character")
         self.assertEqual(status["count"], 2)
 
+    def test_searches_escaped_literal_parentheses(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tags.csv"
+            path.write_text(
+                'asuna (blue archive),4,100,"[캐릭터] asuna blue archive"\n',
+                encoding="utf-8",
+            )
+
+            result = search_autocomplete(r"\(blue archive\)", path=path)
+
+        self.assertEqual(result["results"][0]["tag"], "asuna (blue archive)")
+
     def test_autocomplete_cache_reloads_when_csv_mtime_changes(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tags.csv"

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -414,12 +414,21 @@ function ensurePopup() {
 
 function hidePopup() {
   const input = activeState?.input;
+  markAutocompleteInputInactive(input);
   if (popup) {
     popup.classList.add("hidden");
     popup.replaceChildren();
+    popup.scrollTop = 0;
   }
   clearAutocompletePreview(input);
   activeState = null;
+}
+
+function markAutocompleteInputInactive(input) {
+  const state = input?.__easyuseAnimaAutocompleteState;
+  if (state) {
+    state.lastAutocompleteSignature = "";
+  }
 }
 
 function hideTrainedTagTooltips() {
@@ -643,7 +652,7 @@ function trimPromptSyntaxSuffix(value, start, end) {
       cursor -= 1;
     }
   }
-  if (value[cursor - 1] === ")") {
+  if (value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
     cursor -= 1;
     while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
       cursor -= 1;
@@ -768,7 +777,7 @@ function autocompleteQuery(token, forceArtistOnly = false) {
   const raw = String(token.query || "");
   const parsed = parseAutocompleteText(raw);
   const artistOnly = forceArtistOnly || parsed.artistOnly;
-  const query = artistOnly ? parsed.query : raw.trim();
+  const query = parsed.query;
   const category = artistOnly ? "artist" : "";
   return { query, artistOnly, category };
 }
@@ -800,6 +809,20 @@ function autocompleteStateSignature(token, context, state) {
   });
 }
 
+function stripPromptSyntaxClosingParens(value) {
+  let cursor = String(value || "").length;
+  while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
+    cursor -= 1;
+  }
+  while (cursor > 0 && value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
+    cursor -= 1;
+    while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
+      cursor -= 1;
+    }
+  }
+  return value.slice(0, cursor);
+}
+
 function parseAutocompleteText(value) {
   let query = String(value || "").trim();
   query = query.replace(/^\[\[\s*/g, "");
@@ -807,9 +830,10 @@ function parseAutocompleteText(value) {
   const artistOnly = query.startsWith("@");
   if (artistOnly) {
     query = query.slice(1).trimStart();
-    query = query.replace(/:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\)?\s*$/, "");
-    query = query.replace(/\)+\s*$/, "");
   }
+  query = stripPromptSyntaxClosingParens(query);
+  query = query.replace(/:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\s*$/, "");
+  query = stripPromptSyntaxClosingParens(query);
   return { query, artistOnly };
 }
 
@@ -843,7 +867,7 @@ function strictAutocompleteResults(context, token, state, results) {
     const candidate = promptTagText(entry?.tag);
     const candidateKey = normalizePromptTagText(candidate).trim().toLocaleLowerCase();
     const descriptionKey = normalizePromptTagText(entry?.description || "").trim().toLocaleLowerCase();
-    return candidateKey.startsWith(query) || descriptionKey.includes(query);
+    return candidateKey.startsWith(query) || candidateKey.includes(query) || descriptionKey.includes(query);
   });
 }
 
@@ -1044,6 +1068,19 @@ function setActive(index) {
   });
   scrollActiveAutocompleteItemIntoView(menu, activeState.index);
   updateAutocompletePreview();
+}
+
+function resetActiveAutocompleteMenu(menu) {
+  if (!activeState) {
+    return;
+  }
+  activeState.index = 0;
+  [...(menu?.children || [])].forEach((child, childIndex) => {
+    child.classList.toggle("active", childIndex === activeState.index);
+  });
+  if (menu) {
+    menu.scrollTop = 0;
+  }
 }
 
 function endsWithSentencePeriod(value) {
@@ -1523,18 +1560,16 @@ function syncWidgetValue(state) {
 
 function renderResults(state, results, signature = "") {
   const menu = ensurePopup();
+  menu.scrollTop = 0;
   if (activeState?.input && activeState.input !== state.input) {
     clearAutocompletePreview(activeState.input);
   }
-  const previousIndex = activeState?.input === state.input && activeState?.signature === signature
-    ? activeState.index
-    : 0;
   menu.replaceChildren();
   activeState = {
     ...state,
     results,
     signature,
-    index: results.length ? clamp(previousIndex, 0, results.length - 1) : 0,
+    index: 0,
   };
 
   if (!results.length) {
@@ -1578,6 +1613,7 @@ function renderResults(state, results, signature = "") {
     });
     menu.append(item);
   }
+  resetActiveAutocompleteMenu(menu);
 
   positionPopup(state.input);
   hideTrainedTagTooltips();
@@ -1635,6 +1671,11 @@ function hookInput(input, options = {}) {
     scope: autocompleteScope(options),
     forceArtistOnly: !!options.forceArtistOnly,
     onCommit: typeof options.onCommit === "function" ? options.onCommit : null,
+    lastAutocompleteSignature: undefined,
+  };
+
+  const markAutocompleteInactive = () => {
+    state.lastAutocompleteSignature = "";
   };
 
   const updateNow = async () => {
@@ -1645,22 +1686,26 @@ function hookInput(input, options = {}) {
       return;
     }
     if (shouldSuppressAutocomplete(input)) {
+      markAutocompleteInactive();
       if (activeState?.input === input) {
         hidePopup();
       }
       return;
     }
     if (isCaretInComment(input.value || "", input.selectionStart ?? 0)) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
     if (isCaretInPromptTranslationMarker(input)) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
     const wildcardToken = currentWildcardToken(input);
     const token = wildcardToken || currentToken(input);
     if (!token?.active) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
@@ -1668,11 +1713,17 @@ function hookInput(input, options = {}) {
       ? wildcardAutocompleteQuery(wildcardToken)
       : autocompleteQuery(token, state.forceArtistOnly);
     if (context.kind !== "wildcard" && context.query.length < MIN_QUERY_LENGTH) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
     const signature = autocompleteStateSignature(token, context, state);
+    const previousSignature = state.lastAutocompleteSignature;
+    state.lastAutocompleteSignature = signature;
     if (activeState?.input === input && activeState.signature === signature) {
+      if (previousSignature !== undefined && previousSignature !== signature) {
+        resetActiveAutocompleteMenu(ensurePopup());
+      }
       positionPopup(input);
       updateAutocompletePreview();
       return;
@@ -1925,6 +1976,20 @@ document.addEventListener("wheel", (event) => {
   }
   scheduleActiveRefresh();
 }, true);
+function handleOutsideAutocompletePointer(event) {
+  if (!activeState || popup?.contains(event.target)) {
+    return;
+  }
+  const input = activeState.input;
+  if (event.target === input || input?.contains?.(event.target)) {
+    return;
+  }
+  markAutocompleteInputInactive(input);
+  hidePopup();
+}
+
+document.addEventListener("pointerdown", handleOutsideAutocompletePointer, true);
+document.addEventListener("mousedown", handleOutsideAutocompletePointer, true);
 document.addEventListener("selectionchange", scheduleActiveRefresh);
 window.addEventListener("resize", scheduleActiveRefresh);
 window.addEventListener("easyuse-anima-settings-updated", (event) => {

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -361,6 +361,7 @@ function ensureStyle() {
       min-width: 280px;
       max-height: 280px;
       overflow: auto;
+      overflow-anchor: none;
       overscroll-behavior: contain;
       border: 1px solid rgba(128, 128, 128, 0.45);
       border-radius: 7px;
@@ -416,9 +417,9 @@ function hidePopup() {
   const input = activeState?.input;
   markAutocompleteInputInactive(input);
   if (popup) {
-    popup.classList.add("hidden");
     popup.replaceChildren();
-    popup.scrollTop = 0;
+    resetAutocompleteMenuToTop(popup);
+    popup.classList.add("hidden");
   }
   clearAutocompletePreview(input);
   activeState = null;
@@ -1070,6 +1071,14 @@ function setActive(index) {
   updateAutocompletePreview();
 }
 
+function resetAutocompleteMenuToTop(menu) {
+  if (!menu) {
+    return;
+  }
+  menu.scrollTop = 0;
+  menu.scrollLeft = 0;
+}
+
 function resetActiveAutocompleteMenu(menu) {
   if (!activeState) {
     return;
@@ -1078,9 +1087,16 @@ function resetActiveAutocompleteMenu(menu) {
   [...(menu?.children || [])].forEach((child, childIndex) => {
     child.classList.toggle("active", childIndex === activeState.index);
   });
-  if (menu) {
-    menu.scrollTop = 0;
-  }
+  resetAutocompleteMenuToTop(menu);
+}
+
+function resetVisibleAutocompleteMenuSoon(menu, input) {
+  resetAutocompleteMenuToTop(menu);
+  requestAnimationFrame(() => {
+    if (popup === menu && activeState?.input === input && !menu.classList.contains("hidden")) {
+      resetAutocompleteMenuToTop(menu);
+    }
+  });
 }
 
 function endsWithSentencePeriod(value) {
@@ -1560,7 +1576,7 @@ function syncWidgetValue(state) {
 
 function renderResults(state, results, signature = "") {
   const menu = ensurePopup();
-  menu.scrollTop = 0;
+  resetAutocompleteMenuToTop(menu);
   if (activeState?.input && activeState.input !== state.input) {
     clearAutocompletePreview(activeState.input);
   }
@@ -1618,6 +1634,8 @@ function renderResults(state, results, signature = "") {
   positionPopup(state.input);
   hideTrainedTagTooltips();
   menu.classList.remove("hidden");
+  resetActiveAutocompleteMenu(menu);
+  resetVisibleAutocompleteMenuSoon(menu, state.input);
   updateAutocompletePreview();
 }
 


### PR DESCRIPTION
## 변경 요약
- 자동완성 검색어에서 프롬프트 괄호/이스케이프 문법을 제거해 `\(blue archive\)` 같은 입력이 실제 태그 검색으로 이어지게 수정
- popup이 `display:none` 상태일 때 스크롤 초기화가 무시되는 문제를 보완하기 위해 표시 이후와 다음 프레임에 scroll reset 적용
- 새 결과/외부 클릭/괄호 입력 중 popup 상태 전환에 대한 프론트엔드 소스 가드와 괄호 검색 회귀 테스트 추가

## 수정한 주요 파일
- `web/js/easyuse_anima_autocomplete.js`
- `tests/test_aio_frontend.py`
- `tests/test_prompt_corrector.py`

## 검증
- `node --check web\js\easyuse_anima_autocomplete.js` OK
- `D:\ComfyUI\ComfyUI_main\instances\ComfyUI_v0.24.0\.venv\Scripts\python.exe -m unittest discover -s tests -p test_aio_frontend.py` OK
- `D:\ComfyUI\ComfyUI_main\instances\ComfyUI_v0.24.0\.venv\Scripts\python.exe -m unittest discover -s tests -p test_prompt_corrector.py -k test_searches_escaped_literal_parentheses` OK
- `git diff --check` OK

## live ComfyUI 인스턴스 반영 여부
- `ComfyUI_v0.25.1` live 인스턴스의 `comfyui-easyuse-anima/web/js/easyuse_anima_autocomplete.js`에 반영 완료
- source/live SHA256 일치 확인
- `/extensions/comfyui-easyuse-anima/js/easyuse_anima_autocomplete.js` HTTP 응답에 새 코드 포함 확인

## 남은 위험 또는 미확인 항목
- 프론트엔드 JS만 변경했으므로 ComfyUI 재시작은 필요 없음
- 브라우저 캐시가 남아 있으면 강력 새로고침 필요

## 라벨 후보
- type: fix
- area: frontend
- status: ready