### PR TITLE
Release 0.2.7 to main

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,36 @@
 # Release Notes
 
+## 0.2.7
+
+### Fixed
+
+- Fixed global autocomplete attachment in ComfyUI Nodes 2.0 so prompt text
+  fields that are created or re-rendered after extension startup still receive
+  EasyUse Anima autocomplete behavior.
+- Fixed autocomplete search for escaped prompt parentheses so inputs such as
+  `\(blue archive\)` search the inner literal tag text, matching tags like
+  `asuna \(blue archive\)`.
+- Fixed autocomplete popup scroll reset timing after popup hide/show cycles so
+  new suggestion lists reopen at the top instead of preserving a previous
+  scrolled position.
+
+### Changed
+
+- Autocomplete popup reset now runs after the popup becomes visible and once
+  more on the next animation frame, avoiding browser scroll restoration while
+  the menu is `display: none`.
+- Disabled scroll anchoring for the autocomplete popup to keep result-list
+  replacement from preserving stale scroll offsets.
+
+### Validation Notes
+
+- Added frontend source guards for Nodes 2.0 autocomplete attachment, prompt
+  syntax stripping, popup hide/show scroll reset order, and outside-click state
+  cleanup.
+- Added regression coverage for escaped literal parenthesis search.
+- Validated the autocomplete JavaScript with syntax checks and verified the
+  focused autocomplete regression tests during 0.2.7 preparation.
+
 ## 0.2.6
 
 ### Added

--- a/docs/development/0.2.7.md
+++ b/docs/development/0.2.7.md
@@ -1,0 +1,55 @@
+# 0.2.7 Development Notes
+
+## Scope
+
+0.2.7 is the next planned patch version after the tagged 0.2.6 release. The
+release scope is limited to autocomplete reliability fixes that landed after
+`v0.2.6`.
+
+## Current Changes
+
+- Package metadata is set to `0.2.7` as the next-version marker because
+  `0.2.6` has already been released.
+- Global autocomplete attachment is restored for ComfyUI Nodes 2.0 prompt text
+  fields that appear or re-render after the EasyUse Anima extension initially
+  loads.
+- Autocomplete query parsing now strips prompt syntax before search, including
+  escaped literal parentheses such as `\(blue archive\)`, while preserving the
+  original prompt syntax for insertion behavior.
+- Autocomplete popup scroll reset now runs after the popup is visible and again
+  on the next animation frame, so a newly rendered suggestion list starts from
+  the top even after the previous list was scrolled.
+- The autocomplete popup disables scroll anchoring to prevent browser scroll
+  restoration from carrying stale offsets into new result sets.
+
+## Patch Contents
+
+- `web/js/easyuse_anima_autocomplete.js`
+  - Node 2.0/global autocomplete hook stabilization.
+  - Prompt-syntax-aware autocomplete search query normalization.
+  - Popup scroll reset timing and scroll anchoring fix.
+- `tests/test_aio_frontend.py`
+  - Source guards for global hook state, query parsing, and popup scroll reset
+    ordering.
+- `tests/test_prompt_corrector.py`
+  - Regression coverage for escaped literal parenthesis search.
+
+## Release Follow-Up
+
+- Confirm live ComfyUI 0.25.x autocomplete behavior after a browser hard
+  refresh:
+  - `\(blue archive\)` should find tags such as `asuna \(blue archive\)`.
+  - Opening a different suggestion list after scrolling a long list should
+    start from the top.
+- No ComfyUI restart is required for the frontend JavaScript changes, but a
+  browser hard refresh may be needed.
+
+## Validation Checklist
+
+- `node --check web\js\easyuse_anima_autocomplete.js`
+- `.venv\Scripts\python.exe -m unittest discover -s tests -p test_aio_frontend.py`
+- `.venv\Scripts\python.exe -m unittest discover -s tests -p test_prompt_corrector.py -k test_searches_escaped_literal_parentheses`
+- `.venv\Scripts\python.exe -m unittest discover -s tests`
+- `.venv\Scripts\python.exe -m compileall -q .`
+- `git diff --check`
+- pyproject TOML metadata sanity check

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,8 +6,8 @@ conversation.
 ## Read Order
 
 1. `docs/development/current-policies.md`
-2. Active version plan, currently `docs/development/0.2.6.md`
-3. Latest released baseline, currently `docs/development/0.2.5.md`
+2. Active version plan, currently `docs/development/0.2.7.md`
+3. Latest released baseline, currently `docs/development/0.2.6.md`
 4. Relevant topic guide:
    - workflow docs or release templates: `docs/Anima AiO/Workflow_Management.md`
    - user-facing AiO docs: `docs/Anima AiO/README.md`
@@ -19,8 +19,8 @@ conversation.
 ## Source Map
 
 - Current policy baseline: `docs/development/current-policies.md`
-- Active next-version plan: `docs/development/0.2.6.md`
-- Latest released baseline: `docs/development/0.2.5.md`
+- Active next-version plan: `docs/development/0.2.7.md`
+- Latest released baseline: `docs/development/0.2.6.md`
 - Older implementation history: `docs/version-plans/`
 - Public workflow JSON templates and preview/source images: `docs/example_workflows/`
 - User-facing workflow documentation: `docs/Anima AiO/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and detailer helpers for ComfyUI."
-version = "0.2.6"
+version = "0.2.7"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -55,6 +55,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
         self.assertIn("descriptionKey.includes(query)", body)
         self.assertIn("candidateKey.startsWith(query)", body)
+        self.assertIn("candidateKey.includes(query)", body)
 
     def test_autocomplete_refreshes_during_ime_composition_without_committing(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
@@ -124,6 +125,85 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("const menu = ensurePopup();", set_active_body)
         self.assertIn("scrollActiveAutocompleteItemIntoView(menu, activeState.index);", set_active_body)
 
+    def test_autocomplete_resets_scroll_for_new_result_sets(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        start = source.index("function hidePopup")
+        end = source.index("\nfunction hideTrainedTagTooltips", start)
+        hide_body = source[start:end]
+
+        self.assertIn("markAutocompleteInputInactive(input);", hide_body)
+        self.assertIn("resetAutocompleteMenuToTop(popup);", hide_body)
+        self.assertLess(hide_body.index("popup.replaceChildren();"), hide_body.index("resetAutocompleteMenuToTop(popup);"))
+        self.assertLess(hide_body.index("resetAutocompleteMenuToTop(popup);"), hide_body.index('popup.classList.add("hidden");'))
+
+        start = source.index("function markAutocompleteInputInactive")
+        end = source.index("\nfunction hideTrainedTagTooltips", start)
+        inactive_body = source[start:end]
+
+        self.assertIn('state.lastAutocompleteSignature = "";', inactive_body)
+
+        self.assertIn("overflow-anchor: none;", source)
+
+        start = source.index("function resetAutocompleteMenuToTop")
+        end = source.index("\nfunction resetActiveAutocompleteMenu", start)
+        reset_top_body = source[start:end]
+
+        self.assertIn("menu.scrollTop = 0;", reset_top_body)
+        self.assertIn("menu.scrollLeft = 0;", reset_top_body)
+
+        start = source.index("function resetActiveAutocompleteMenu")
+        end = source.index("\nfunction resetVisibleAutocompleteMenuSoon", start)
+        reset_body = source[start:end]
+
+        self.assertIn("activeState.index = 0;", reset_body)
+        self.assertIn("resetAutocompleteMenuToTop(menu);", reset_body)
+
+        start = source.index("function resetVisibleAutocompleteMenuSoon")
+        end = source.index("\nfunction endsWithSentencePeriod", start)
+        visible_reset_body = source[start:end]
+
+        self.assertIn("resetAutocompleteMenuToTop(menu);", visible_reset_body)
+        self.assertIn("requestAnimationFrame(() => {", visible_reset_body)
+        self.assertIn('!menu.classList.contains("hidden")', visible_reset_body)
+        self.assertNotIn("resetActiveAutocompleteMenu(menu);", visible_reset_body)
+
+        start = source.index("function renderResults")
+        end = source.index("\nfunction isCaretInComment", start)
+        body = source[start:end]
+
+        self.assertIn("resetAutocompleteMenuToTop(menu);", body)
+        self.assertIn("index: 0,", body)
+        self.assertIn('menu.classList.remove("hidden");', body)
+        self.assertIn("resetActiveAutocompleteMenu(menu);", body)
+        self.assertIn("resetVisibleAutocompleteMenuSoon(menu, state.input);", body)
+        self.assertLess(body.index("resetAutocompleteMenuToTop(menu);"), body.index("menu.replaceChildren();"))
+        self.assertLess(body.index("menu.replaceChildren();"), body.index("resetActiveAutocompleteMenu(menu);"))
+        self.assertLess(body.index("resetActiveAutocompleteMenu(menu);"), body.index("positionPopup(state.input);"))
+        self.assertLess(body.index('menu.classList.remove("hidden");'), body.rindex("resetActiveAutocompleteMenu(menu);"))
+        self.assertLess(body.index('menu.classList.remove("hidden");'), body.index("resetVisibleAutocompleteMenuSoon(menu, state.input);"))
+        self.assertLess(body.index("resetVisibleAutocompleteMenuSoon(menu, state.input);"), body.index("updateAutocompletePreview();"))
+
+        start = source.index("  const updateNow = async () => {")
+        end = source.index("    const seq = ++updateSeq;", start)
+        update_body = source[start:end]
+
+        self.assertIn("lastAutocompleteSignature: undefined", source)
+        self.assertIn("const previousSignature = state.lastAutocompleteSignature;", update_body)
+        self.assertIn("state.lastAutocompleteSignature = signature;", update_body)
+        self.assertIn("previousSignature !== undefined && previousSignature !== signature", update_body)
+        self.assertIn("resetActiveAutocompleteMenu(ensurePopup());", update_body)
+
+        start = source.index("function handleOutsideAutocompletePointer")
+        end = source.index("\ndocument.addEventListener(\"pointerdown\"", start)
+        pointer_body = source[start:end]
+
+        self.assertIn("popup?.contains(event.target)", pointer_body)
+        self.assertIn("event.target === input", pointer_body)
+        self.assertIn("markAutocompleteInputInactive(input);", pointer_body)
+        self.assertIn("hidePopup();", pointer_body)
+        self.assertIn('document.addEventListener("pointerdown", handleOutsideAutocompletePointer, true);', source)
+        self.assertIn('document.addEventListener("mousedown", handleOutsideAutocompletePointer, true);', source)
+
     def test_autocomplete_wildcards_accept_empty_and_unicode_queries(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
         start = source.index("function currentWildcardToken")
@@ -153,6 +233,35 @@ class AIOFrontendSourceTests(unittest.TestCase):
         strict_body = source[start:end]
 
         self.assertIn('return context.kind === "wildcard" ? results : [];', strict_body)
+
+    def test_autocomplete_strips_prompt_syntax_from_search_query(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+
+        start = source.index("function autocompleteQuery")
+        end = source.index("\nfunction wildcardAutocompleteQuery", start)
+        query_body = source[start:end]
+
+        self.assertIn("const query = parsed.query;", query_body)
+        self.assertNotIn("artistOnly ? parsed.query : raw.trim()", query_body)
+
+        start = source.index("function parseAutocompleteText")
+        end = source.index("\nfunction normalizeWildcardSearchText", start)
+        parse_body = source[start:end]
+
+        self.assertIn('query = query.replace(/^\\[\\[\\s*/g, "");', parse_body)
+        self.assertIn('query = query.replace(/^\\(\\s*/g, "");', parse_body)
+        self.assertIn("query = stripPromptSyntaxClosingParens(query);", parse_body)
+        self.assertIn(
+            'query = query.replace(/:\\s*[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*$/, "");',
+            parse_body,
+        )
+        self.assertNotIn('query = query.replace(/\\)+\\s*$/, "");', parse_body)
+
+        start = source.index("function trimPromptSyntaxSuffix")
+        end = source.index("\nfunction currentToken", start)
+        trim_body = source[start:end]
+
+        self.assertIn('value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)', trim_body)
 
     def test_autocomplete_supports_nodes_v2_specs_and_dom_widgets(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -66,7 +66,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("composing || document.activeElement", update_body)
         self.assertIn('input.addEventListener("compositionupdate", update);', source)
 
-        autocomplete_done = source.index("  input.__easyuseAnimaAutocomplete = true;")
+        autocomplete_done = source.index("  input.__easyuseAnimaAutocompleteHooked = true;")
         keydown_start = source.rindex('  input.addEventListener("keydown", (event) => {', 0, autocomplete_done)
         keydown_end = source.index("  });", keydown_start)
         keydown_body = source[keydown_start:keydown_end]
@@ -77,6 +77,35 @@ class AIOFrontendSourceTests(unittest.TestCase):
             keydown_body.index("event.isComposing"),
             keydown_body.index("!activeState"),
         )
+
+    def test_autocomplete_public_flag_tracks_enabled_state(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+
+        self.assertIn("const hookedAutocompleteInputs = new Set();", source)
+        self.assertIn("input.__easyuseAnimaAutocompleteHooked", source)
+        self.assertNotIn("if (input.__easyuseAnimaAutocomplete) {", source)
+
+        start = source.index("function syncAutocompleteInputFlag")
+        end = source.index("\nasync function refreshAutocompleteSettings", start)
+        sync_body = source[start:end]
+
+        self.assertIn("input.__easyuseAnimaAutocomplete = autocompleteEnabledForState(state);", sync_body)
+        self.assertIn("hookedAutocompleteInputs.delete(input);", sync_body)
+
+        start = source.index("function setAutocompleteMode")
+        end = source.index("\nfunction isEasyUseAnimaNode", start)
+        mode_body = source[start:end]
+
+        self.assertIn("syncAutocompleteInputFlags();", mode_body)
+
+        start = source.index("function hookInput")
+        end = source.index("\nfunction hookWidget", start)
+        hook_body = source[start:end]
+
+        self.assertIn("if (input.__easyuseAnimaAutocompleteHooked) {", hook_body)
+        self.assertIn("syncAutocompleteInputFlag(input, existing);", hook_body)
+        self.assertIn("hookedAutocompleteInputs.add(input);", hook_body)
+        self.assertIn("syncAutocompleteInputFlag(input, state);", hook_body)
 
     def test_autocomplete_arrow_navigation_keeps_adjacent_items_visible(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
@@ -124,6 +153,54 @@ class AIOFrontendSourceTests(unittest.TestCase):
         strict_body = source[start:end]
 
         self.assertIn('return context.kind === "wildcard" ? results : [];', strict_body)
+
+    def test_autocomplete_supports_nodes_v2_specs_and_dom_widgets(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+
+        start = source.index("function inputTypeName")
+        end = source.index("\nfunction isExcludedInput", start)
+        spec_body = source[start:end]
+
+        self.assertIn("inputSpec.widgetType || inputSpec.type", spec_body)
+        self.assertIn("nodeData?.inputs", spec_body)
+        self.assertIn("inputSpec.options || {}", spec_body)
+        self.assertIn("typeNames.some((item) => item === \"STRING\" || item === \"TEXTAREA\")", source)
+        self.assertIn("typeNames.includes(\"TEXTAREA\")", source)
+
+        start = source.index("function findInputEl")
+        end = source.index("\nfunction isEscaped", start)
+        input_body = source[start:end]
+
+        self.assertIn("widget?.inputEl || widget?.element", input_body)
+        self.assertIn('querySelector?.("textarea, input")', input_body)
+
+    def test_autocomplete_avoids_double_callback_for_nodes_v2_dom_widgets(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        start = source.index("function widgetValueSetterCallsCallback")
+        end = source.index("\nfunction renderResults", start)
+        sync_body = source[start:end]
+
+        self.assertIn("return !!widget?.element;", sync_body)
+        self.assertIn("state.widget.value = state.input.value;", sync_body)
+        self.assertIn("if (!widgetValueSetterCallsCallback(state.widget))", sync_body)
+        self.assertIn("syncWidgetValue(state);", source)
+        self.assertNotIn("state.widget.callback?.(state.input.value);", source[:source.index("function widgetValueSetterCallsCallback")])
+
+    def test_autocomplete_hooks_focused_nodes_v2_dom_inputs(self):
+        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        start = source.index("function hookFocusedDomInput")
+        end = source.index("\nfunction installExternalInputHook", start)
+        focus_body = source[start:end]
+
+        self.assertIn("isAutocompleteDomInput(input)", focus_body)
+        self.assertIn("const node = nodeFromDomElement(input);", focus_body)
+        self.assertIn("if (!node)", focus_body)
+        self.assertIn("const targets = nodeData ? targetWidgets(nodeData) : null;", focus_body)
+        self.assertIn("const widget = widgetForDomInput(node, input);", focus_body)
+        self.assertIn("hookInput(input", focus_body)
+        self.assertIn('document.addEventListener("focusin"', source)
+        self.assertIn("hookFocusedDomInput(document.activeElement);", source)
+        self.assertNotIn("easyuseAnimaDebugAutocomplete", source)
 
     def test_prompt_highlight_wildcards_accept_unicode_keys(self):
         source = PROMPT_STUDIO_COMMON_JS.read_text(encoding="utf-8")

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -3009,6 +3009,18 @@ class AutocompleteDatasetTests(unittest.TestCase):
         self.assertEqual(korean["results"][0]["category"], "character")
         self.assertEqual(status["count"], 2)
 
+    def test_searches_escaped_literal_parentheses(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tags.csv"
+            path.write_text(
+                'asuna (blue archive),4,100,"[캐릭터] asuna blue archive"\n',
+                encoding="utf-8",
+            )
+
+            result = search_autocomplete(r"\(blue archive\)", path=path)
+
+        self.assertEqual(result["results"][0]["tag"], "asuna (blue archive)")
+
     def test_autocomplete_cache_reloads_when_csv_mtime_changes(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tags.csv"

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -361,6 +361,7 @@ function ensureStyle() {
       min-width: 280px;
       max-height: 280px;
       overflow: auto;
+      overflow-anchor: none;
       overscroll-behavior: contain;
       border: 1px solid rgba(128, 128, 128, 0.45);
       border-radius: 7px;
@@ -414,12 +415,21 @@ function ensurePopup() {
 
 function hidePopup() {
   const input = activeState?.input;
+  markAutocompleteInputInactive(input);
   if (popup) {
-    popup.classList.add("hidden");
     popup.replaceChildren();
+    resetAutocompleteMenuToTop(popup);
+    popup.classList.add("hidden");
   }
   clearAutocompletePreview(input);
   activeState = null;
+}
+
+function markAutocompleteInputInactive(input) {
+  const state = input?.__easyuseAnimaAutocompleteState;
+  if (state) {
+    state.lastAutocompleteSignature = "";
+  }
 }
 
 function hideTrainedTagTooltips() {
@@ -643,7 +653,7 @@ function trimPromptSyntaxSuffix(value, start, end) {
       cursor -= 1;
     }
   }
-  if (value[cursor - 1] === ")") {
+  if (value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
     cursor -= 1;
     while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
       cursor -= 1;
@@ -768,7 +778,7 @@ function autocompleteQuery(token, forceArtistOnly = false) {
   const raw = String(token.query || "");
   const parsed = parseAutocompleteText(raw);
   const artistOnly = forceArtistOnly || parsed.artistOnly;
-  const query = artistOnly ? parsed.query : raw.trim();
+  const query = parsed.query;
   const category = artistOnly ? "artist" : "";
   return { query, artistOnly, category };
 }
@@ -800,6 +810,20 @@ function autocompleteStateSignature(token, context, state) {
   });
 }
 
+function stripPromptSyntaxClosingParens(value) {
+  let cursor = String(value || "").length;
+  while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
+    cursor -= 1;
+  }
+  while (cursor > 0 && value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
+    cursor -= 1;
+    while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
+      cursor -= 1;
+    }
+  }
+  return value.slice(0, cursor);
+}
+
 function parseAutocompleteText(value) {
   let query = String(value || "").trim();
   query = query.replace(/^\[\[\s*/g, "");
@@ -807,9 +831,10 @@ function parseAutocompleteText(value) {
   const artistOnly = query.startsWith("@");
   if (artistOnly) {
     query = query.slice(1).trimStart();
-    query = query.replace(/:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\)?\s*$/, "");
-    query = query.replace(/\)+\s*$/, "");
   }
+  query = stripPromptSyntaxClosingParens(query);
+  query = query.replace(/:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\s*$/, "");
+  query = stripPromptSyntaxClosingParens(query);
   return { query, artistOnly };
 }
 
@@ -843,7 +868,7 @@ function strictAutocompleteResults(context, token, state, results) {
     const candidate = promptTagText(entry?.tag);
     const candidateKey = normalizePromptTagText(candidate).trim().toLocaleLowerCase();
     const descriptionKey = normalizePromptTagText(entry?.description || "").trim().toLocaleLowerCase();
-    return candidateKey.startsWith(query) || descriptionKey.includes(query);
+    return candidateKey.startsWith(query) || candidateKey.includes(query) || descriptionKey.includes(query);
   });
 }
 
@@ -1044,6 +1069,34 @@ function setActive(index) {
   });
   scrollActiveAutocompleteItemIntoView(menu, activeState.index);
   updateAutocompletePreview();
+}
+
+function resetAutocompleteMenuToTop(menu) {
+  if (!menu) {
+    return;
+  }
+  menu.scrollTop = 0;
+  menu.scrollLeft = 0;
+}
+
+function resetActiveAutocompleteMenu(menu) {
+  if (!activeState) {
+    return;
+  }
+  activeState.index = 0;
+  [...(menu?.children || [])].forEach((child, childIndex) => {
+    child.classList.toggle("active", childIndex === activeState.index);
+  });
+  resetAutocompleteMenuToTop(menu);
+}
+
+function resetVisibleAutocompleteMenuSoon(menu, input) {
+  resetAutocompleteMenuToTop(menu);
+  requestAnimationFrame(() => {
+    if (popup === menu && activeState?.input === input && !menu.classList.contains("hidden")) {
+      resetAutocompleteMenuToTop(menu);
+    }
+  });
 }
 
 function endsWithSentencePeriod(value) {
@@ -1523,18 +1576,16 @@ function syncWidgetValue(state) {
 
 function renderResults(state, results, signature = "") {
   const menu = ensurePopup();
+  resetAutocompleteMenuToTop(menu);
   if (activeState?.input && activeState.input !== state.input) {
     clearAutocompletePreview(activeState.input);
   }
-  const previousIndex = activeState?.input === state.input && activeState?.signature === signature
-    ? activeState.index
-    : 0;
   menu.replaceChildren();
   activeState = {
     ...state,
     results,
     signature,
-    index: results.length ? clamp(previousIndex, 0, results.length - 1) : 0,
+    index: 0,
   };
 
   if (!results.length) {
@@ -1578,10 +1629,13 @@ function renderResults(state, results, signature = "") {
     });
     menu.append(item);
   }
+  resetActiveAutocompleteMenu(menu);
 
   positionPopup(state.input);
   hideTrainedTagTooltips();
   menu.classList.remove("hidden");
+  resetActiveAutocompleteMenu(menu);
+  resetVisibleAutocompleteMenuSoon(menu, state.input);
   updateAutocompletePreview();
 }
 
@@ -1635,6 +1689,11 @@ function hookInput(input, options = {}) {
     scope: autocompleteScope(options),
     forceArtistOnly: !!options.forceArtistOnly,
     onCommit: typeof options.onCommit === "function" ? options.onCommit : null,
+    lastAutocompleteSignature: undefined,
+  };
+
+  const markAutocompleteInactive = () => {
+    state.lastAutocompleteSignature = "";
   };
 
   const updateNow = async () => {
@@ -1645,22 +1704,26 @@ function hookInput(input, options = {}) {
       return;
     }
     if (shouldSuppressAutocomplete(input)) {
+      markAutocompleteInactive();
       if (activeState?.input === input) {
         hidePopup();
       }
       return;
     }
     if (isCaretInComment(input.value || "", input.selectionStart ?? 0)) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
     if (isCaretInPromptTranslationMarker(input)) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
     const wildcardToken = currentWildcardToken(input);
     const token = wildcardToken || currentToken(input);
     if (!token?.active) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
@@ -1668,11 +1731,17 @@ function hookInput(input, options = {}) {
       ? wildcardAutocompleteQuery(wildcardToken)
       : autocompleteQuery(token, state.forceArtistOnly);
     if (context.kind !== "wildcard" && context.query.length < MIN_QUERY_LENGTH) {
+      markAutocompleteInactive();
       hidePopup();
       return;
     }
     const signature = autocompleteStateSignature(token, context, state);
+    const previousSignature = state.lastAutocompleteSignature;
+    state.lastAutocompleteSignature = signature;
     if (activeState?.input === input && activeState.signature === signature) {
+      if (previousSignature !== undefined && previousSignature !== signature) {
+        resetActiveAutocompleteMenu(ensurePopup());
+      }
       positionPopup(input);
       updateAutocompletePreview();
       return;
@@ -1925,6 +1994,20 @@ document.addEventListener("wheel", (event) => {
   }
   scheduleActiveRefresh();
 }, true);
+function handleOutsideAutocompletePointer(event) {
+  if (!activeState || popup?.contains(event.target)) {
+    return;
+  }
+  const input = activeState.input;
+  if (event.target === input || input?.contains?.(event.target)) {
+    return;
+  }
+  markAutocompleteInputInactive(input);
+  hidePopup();
+}
+
+document.addEventListener("pointerdown", handleOutsideAutocompletePointer, true);
+document.addEventListener("mousedown", handleOutsideAutocompletePointer, true);
 document.addEventListener("selectionchange", scheduleActiveRefresh);
 window.addEventListener("resize", scheduleActiveRefresh);
 window.addEventListener("easyuse-anima-settings-updated", (event) => {

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -166,6 +166,7 @@ let popup = null;
 let activeState = null;
 let activeRefreshFrame = null;
 let middlePanForwardActive = false;
+const hookedAutocompleteInputs = new Set();
 window.__easyuseAnimaPendingAutocompleteInputs ||= [];
 
 function clamp(value, min, max) {
@@ -262,6 +263,7 @@ function setAutocompleteMode(value) {
     return;
   }
   autocompleteMode = nextMode;
+  syncAutocompleteInputFlags();
   if (!autocompleteEnabledForState(activeState)) {
     hidePopup();
   }
@@ -301,6 +303,24 @@ function autocompleteEnabledForScope(scope) {
 
 function autocompleteEnabledForState(state) {
   return !!state && autocompleteEnabledForScope(state.scope || "compatible");
+}
+
+function syncAutocompleteInputFlag(input, state = input?.__easyuseAnimaAutocompleteState) {
+  if (!input) {
+    return;
+  }
+  input.__easyuseAnimaAutocomplete = autocompleteEnabledForState(state);
+}
+
+function syncAutocompleteInputFlags() {
+  for (const input of [...hookedAutocompleteInputs]) {
+    const state = input?.__easyuseAnimaAutocompleteState;
+    if (!state) {
+      hookedAutocompleteInputs.delete(input);
+      continue;
+    }
+    syncAutocompleteInputFlag(input, state);
+  }
 }
 
 async function refreshAutocompleteSettings() {
@@ -431,6 +451,9 @@ function inputTypeName(inputSpec) {
   if (Array.isArray(inputSpec)) {
     return String(inputSpec[0] || "");
   }
+  if (typeof inputSpec === "object" && inputSpec !== null) {
+    return String(inputSpec.widgetType || inputSpec.type || "");
+  }
   return String(inputSpec || "");
 }
 
@@ -438,15 +461,28 @@ function inputOptions(inputSpec) {
   if (Array.isArray(inputSpec) && typeof inputSpec[1] === "object" && inputSpec[1] !== null) {
     return inputSpec[1];
   }
+  if (typeof inputSpec === "object" && inputSpec !== null) {
+    return {
+      ...inputSpec,
+      ...(inputSpec.options || {}),
+    };
+  }
   return {};
 }
 
 function allInputSpecs(nodeData) {
-  const inputs = nodeData?.input || {};
   const specs = [];
+  const v2Inputs = nodeData?.inputs || {};
+  for (const [name, spec] of Object.entries(v2Inputs)) {
+    specs.push([name, spec]);
+  }
+  const inputs = nodeData?.input || {};
   for (const group of ["required", "optional"]) {
     const values = inputs[group] || {};
     for (const [name, spec] of Object.entries(values)) {
+      if (v2Inputs[name]) {
+        continue;
+      }
       specs.push([name, spec]);
     }
   }
@@ -479,13 +515,14 @@ function isPromptLikeWidgetName(name) {
 function isTargetStringInput(nodeData, name, inputSpec) {
   const type = inputTypeName(inputSpec);
   const options = inputOptions(inputSpec);
-  if (!type.split(",").map((item) => item.trim()).includes("STRING")) {
+  const typeNames = type.split(",").map((item) => item.trim().toUpperCase());
+  if (!typeNames.some((item) => item === "STRING" || item === "TEXTAREA")) {
     return false;
   }
   if (isExcludedInput(inputSpec)) {
     return false;
   }
-  if (options.multiline === true) {
+  if (typeNames.includes("TEXTAREA") || options.multiline === true) {
     return isGenericStringNode(nodeData) || isPromptLikeWidgetName(name);
   }
   return isGenericStringNode(nodeData) && isPromptLikeWidgetName(name);
@@ -523,9 +560,13 @@ function shouldSkipNode(node, nodeData) {
 }
 
 function findInputEl(widget) {
-  const input = widget?.inputEl;
+  const input = widget?.inputEl || widget?.element;
   if (input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement) {
     return input;
+  }
+  const nested = input?.querySelector?.("textarea, input");
+  if (nested instanceof HTMLTextAreaElement || nested instanceof HTMLInputElement) {
+    return nested;
   }
   return null;
 }
@@ -1213,10 +1254,7 @@ function commitSuggestion(state, entry, options = {}) {
   if (wildcardToken) {
     const replacement = `__${String(entry.tag || "").replace(/^__|__$/g, "")}__`;
     replaceInputRange(state.input, wildcardToken.start, wildcardToken.end, replacement, replacement.length);
-    if (state.widget) {
-      state.widget.value = state.input.value;
-      state.widget.callback?.(state.input.value);
-    }
+    syncWidgetValue(state);
     state.onCommit?.(state.input.value);
     if (options.suppressPopup) {
       suppressAutocompleteUntilInputChanges(state.input);
@@ -1235,10 +1273,7 @@ function commitSuggestion(state, entry, options = {}) {
     + insert.length
     + suffixPlan.caretExtra;
   replaceInputRange(state.input, token.start, token.end + suffixPlan.consumeAfter, replacement, caretOffset);
-  if (state.widget) {
-    state.widget.value = state.input.value;
-    state.widget.callback?.(state.input.value);
-  }
+  syncWidgetValue(state);
   state.onCommit?.(state.input.value);
   if (options.suppressPopup) {
     suppressAutocompleteUntilInputChanges(state.input);
@@ -1430,13 +1465,6 @@ function updateAutocompletePreview() {
   refreshAutocompleteHighlightPreview(input);
 }
 
-function syncWidgetValue(state) {
-  if (state?.widget) {
-    state.widget.value = state.input.value;
-    state.widget.callback?.(state.input.value);
-  }
-}
-
 function insertBracketPair(state, event, open, close, replacement = null, caretOffset = null) {
   if (!autocompletePreviewClosingBrackets || event.defaultPrevented || event.ctrlKey || event.metaKey || event.altKey) {
     return false;
@@ -1478,6 +1506,19 @@ function handleBracketPreviewKeydown(state, event) {
     return true;
   }
   return false;
+}
+
+function widgetValueSetterCallsCallback(widget) {
+  return !!widget?.element;
+}
+
+function syncWidgetValue(state) {
+  if (state?.widget) {
+    state.widget.value = state.input.value;
+    if (!widgetValueSetterCallsCallback(state.widget)) {
+      state.widget.callback?.(state.input.value);
+    }
+  }
 }
 
 function renderResults(state, results, signature = "") {
@@ -1572,7 +1613,7 @@ function hookInput(input, options = {}) {
   if (!input) {
     return;
   }
-  if (input.__easyuseAnimaAutocomplete) {
+  if (input.__easyuseAnimaAutocompleteHooked) {
     const existing = input.__easyuseAnimaAutocompleteState;
     if (existing) {
       existing.node = options.node || existing.node || null;
@@ -1580,6 +1621,7 @@ function hookInput(input, options = {}) {
       existing.scope = autocompleteScope(options);
       existing.forceArtistOnly = !!options.forceArtistOnly;
       existing.onCommit = typeof options.onCommit === "function" ? options.onCommit : existing.onCommit;
+      syncAutocompleteInputFlag(input, existing);
     }
     return;
   }
@@ -1743,8 +1785,10 @@ function hookInput(input, options = {}) {
     }
   });
 
-  input.__easyuseAnimaAutocomplete = true;
+  input.__easyuseAnimaAutocompleteHooked = true;
   input.__easyuseAnimaAutocompleteState = state;
+  hookedAutocompleteInputs.add(input);
+  syncAutocompleteInputFlag(input, state);
 }
 
 function hookWidget(node, widget, scope = "compatible") {
@@ -1754,6 +1798,81 @@ function hookWidget(node, widget, scope = "compatible") {
     widget,
     scope,
     forceArtistOnly: !!node.__easyuseAnimaArtistOnlyWidgets?.has(widget.name),
+  });
+}
+
+function autocompleteGraphNodes() {
+  const graph = app?.canvas?.graph || app?.graph || app?.rootGraph;
+  return Array.isArray(graph?.nodes) ? graph.nodes.filter(Boolean) : [];
+}
+
+function findGraphNodeById(id) {
+  if (id == null || id === "") {
+    return null;
+  }
+  const graph = app?.canvas?.graph || app?.graph || app?.rootGraph;
+  const normalized = String(id);
+  return graph?.getNodeById?.(id)
+    || graph?.getNodeById?.(Number(id))
+    || autocompleteGraphNodes().find((node) => String(node?.id) === normalized)
+    || null;
+}
+
+function nodeFromDomElement(element) {
+  if (!(element instanceof Element)) {
+    return null;
+  }
+  const root = element.closest?.("[data-node-id], .lg-node");
+  const id = root?.getAttribute?.("data-node-id")
+    || root?.dataset?.nodeId
+    || root?.id?.match?.(/\d+/)?.[0];
+  return findGraphNodeById(id);
+}
+
+function isAutocompleteDomInput(input) {
+  if (input instanceof HTMLTextAreaElement) {
+    return !input.disabled && !input.readOnly;
+  }
+  if (!(input instanceof HTMLInputElement) || input.disabled || input.readOnly) {
+    return false;
+  }
+  const type = String(input.type || "text").toLocaleLowerCase();
+  return ["", "text", "search"].includes(type);
+}
+
+function widgetForDomInput(node, input) {
+  for (const widget of node?.widgets || []) {
+    const widgetInput = findInputEl(widget);
+    if (widgetInput === input || widget?.element?.contains?.(input)) {
+      return widget;
+    }
+  }
+  return null;
+}
+
+function hookFocusedDomInput(input) {
+  if (!isAutocompleteDomInput(input) || popup?.contains(input)) {
+    return;
+  }
+  const node = nodeFromDomElement(input);
+  if (!node) {
+    return;
+  }
+  const nodeData = node?.constructor?.nodeData || null;
+  const targets = nodeData ? targetWidgets(nodeData) : null;
+  if (nodeData && (!targets || (!hasExplicitTargets(nodeData) && shouldSkipNode(node, nodeData)))) {
+    return;
+  }
+  const widget = widgetForDomInput(node, input);
+  if (targets && widget?.name && !targets.has(widget.name)) {
+    return;
+  }
+  const scope = nodeData && hasExplicitTargets(nodeData) ? "easyuse" : autocompleteScope({ node });
+  hookInput(input, {
+    node,
+    widget,
+    scope,
+    forceArtistOnly: !!(widget?.name && node?.__easyuseAnimaArtistOnlyWidgets?.has(widget.name)),
   });
 }
 
@@ -1767,6 +1886,10 @@ function installExternalInputHook() {
   for (const item of pending) {
     hookInput(item?.input, item?.options || {});
   }
+  document.addEventListener("focusin", (event) => {
+    hookFocusedDomInput(event.target);
+  }, true);
+  hookFocusedDomInput(document.activeElement);
 }
 
 function hookNode(node, nodeData, attempt = 0) {


### PR DESCRIPTION
## 릴리즈 범위
- 0.2.7 patch 준비 및 `pyproject.toml` 버전 `0.2.7` 반영
- ComfyUI Nodes 2.0에서 전역 자동완성 hook이 누락되는 문제 수정
- `\(blue archive\)` 같은 escaped literal parenthesis 검색 정규화 수정
- 자동완성 popup hide/show 후 이전 scrollTop이 유지되는 문제 수정

## 포함된 PR/커밋
- #15 `Fix autocomplete search and popup scroll reset`
- #16 `Prepare 0.2.7 release notes`
- `f21d6fd` Fix global autocomplete in Nodes 2.0
- `27b9f43` Fix autocomplete search and popup scroll reset
- `8a518bb` Prepare 0.2.7 release notes

## 검증 결과
- pyproject TOML metadata sanity check OK
- `node --check web\js\easyuse_anima_autocomplete.js` OK
- `python -m unittest discover -s tests -p test_aio_frontend.py` OK
- `python -m unittest discover -s tests -p test_prompt_corrector.py -k test_searches_escaped_literal_parentheses` OK
- `python -m unittest discover -s tests` OK, 252 tests
- `python -m compileall -q .` OK
- `Get-ChildItem -File web\js\*.js | ForEach-Object { node --check $_.FullName }` OK
- `git diff --check` OK

## live 인스턴스 반영 여부
- 자동완성 JS 수정은 `ComfyUI_v0.25.1` live 인스턴스에 이미 반영 완료
- source/live SHA256 일치 및 `/extensions/comfyui-easyuse-anima/js/easyuse_anima_autocomplete.js` HTTP 응답에서 새 코드 포함 확인 완료
- 이번 main PR 자체의 추가 변경은 release metadata/docs라 live 재동기화 대상 없음

## 롤백 방법
- 문제가 있으면 main에서 이 merge commit을 revert하고, 필요 시 live 인스턴스의 `web/js/easyuse_anima_autocomplete.js`를 이전 release 파일로 되돌린다.
- frontend-only 변경이므로 ComfyUI 서버 재시작보다 브라우저 강력 새로고침 여부를 먼저 확인한다.

## 남은 항목
- `v0.2.7` 태그 생성과 GitHub Release 발행은 이 PR 머지 후 별도 단계로 진행 가능