### PR TITLE
Use plain Registry changelog text

### DIFF
--- a/.github/registry/changelogs/0.3.0.txt
+++ b/.github/registry/changelogs/0.3.0.txt
@@ -1,0 +1,7 @@
+EasyUse Anima 0.3.0 focuses on safer first-run behavior and clearer AiO output metadata.
+
+User-visible changes:
+1. Anima AiO Generator now sends Prompt Studio metadata prompts to Image Saver when they are available. Saved image metadata should better match the final prompt text users expect to see.
+2. Release workflows now start with safer optimization defaults. SageAttention, Sage compile, TorchCompile, and FP16 accumulation are off by default. Enable them only after confirming your local PyTorch, CUDA, and Triton setup.
+3. Optional integration features are more explicit. Prompt translation stays off until selected, NAIA remote hosts require the remote API allow setting, and API keys are no longer auto-read from environment variables.
+4. Standalone SAM3 Context and SAM3 Detailer nodes are no longer listed as public nodes. The AiO Generator detailer settings still keep the internal SAM3 detailer path.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,6 +19,11 @@
   },
   "versions": [
     {
+      "version": "0.3.0",
+      "deprecated": false,
+      "changelog_file": "changelogs/0.3.0.txt"
+    },
+    {
       "version": "0.2.7",
       "deprecated": false,
       "changelog": "### Fixed\n\n- Fixed global autocomplete attachment in ComfyUI Nodes 2.0 for prompt fields created or re-rendered after extension startup.\n- Fixed escaped prompt parenthesis search so literal tags such as `\\(blue archive\\)` match correctly.\n- Fixed autocomplete popup scroll reset timing after hide/show cycles.\n\n### Changed\n\n- Hardened popup reset timing and disabled scroll anchoring for stable suggestion list reopening."

--- a/.github/scripts/extract_release_changelog.py
+++ b/.github/scripts/extract_release_changelog.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 import tomllib
@@ -33,18 +34,58 @@ def _extract_section(release_path: Path, version: str) -> str:
     return section + "\n"
 
 
+def _registry_changelog_file(changelog_dir: Path, version: str) -> str | None:
+    path = changelog_dir / f"{version}.txt"
+    if not path.exists():
+        return None
+    changelog = path.read_text(encoding="utf-8").strip()
+    return changelog + "\n" if changelog else None
+
+
+def _read_metadata_changelog_file(metadata_path: Path, value: str) -> str:
+    path = Path(value)
+    if not path.is_absolute():
+        path = metadata_path.parent / path
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _metadata_changelog(metadata_path: Path, version: str) -> str | None:
+    if not metadata_path.exists():
+        return None
+    data = json.loads(metadata_path.read_text(encoding="utf-8"))
+    versions = data.get("versions")
+    if not isinstance(versions, list):
+        return None
+    for item in versions:
+        if not isinstance(item, dict) or str(item.get("version") or "") != version:
+            continue
+        changelog_file = item.get("changelog_file")
+        if isinstance(changelog_file, str) and changelog_file.strip():
+            changelog = _read_metadata_changelog_file(metadata_path, changelog_file)
+            return changelog + "\n" if changelog else None
+        changelog = str(item.get("changelog") or "").strip()
+        return changelog + "\n" if changelog else None
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pyproject", type=Path, default=Path("pyproject.toml"))
     parser.add_argument("--release", type=Path, default=Path("RELEASE.md"))
+    parser.add_argument("--metadata", type=Path, default=Path(".github/registry/metadata.json"))
+    parser.add_argument("--registry-changelog-dir", type=Path, default=Path(".github/registry/changelogs"))
     parser.add_argument("--version", default="", help="Version to extract. Defaults to pyproject version.")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
 
     version = args.version.strip() or _pyproject_version(args.pyproject)
-    changelog = _extract_section(args.release, version)
+    changelog = (
+        _registry_changelog_file(args.registry_changelog_dir, version)
+        or _metadata_changelog(args.metadata, version)
+        or _extract_section(args.release, version)
+    )
     args.output.write_text(changelog, encoding="utf-8")
-    print(f"Extracted RELEASE.md changelog for {version} to {args.output}")
+    print(f"Extracted Registry changelog for {version} to {args.output}")
     return 0
 
 

--- a/.github/scripts/sync_comfy_registry_metadata.py
+++ b/.github/scripts/sync_comfy_registry_metadata.py
@@ -57,6 +57,16 @@ def _load_metadata(path: Path) -> dict[str, Any]:
             raise ValueError(f"Missing required metadata key: {key}")
     if not isinstance(data["versions"], list):
         raise ValueError("metadata.versions must be a list")
+    for item in data["versions"]:
+        if not isinstance(item, dict):
+            continue
+        changelog_file = item.get("changelog_file")
+        if not isinstance(changelog_file, str) or not changelog_file.strip():
+            continue
+        file_path = Path(changelog_file)
+        if not file_path.is_absolute():
+            file_path = path.parent / file_path
+        item["changelog"] = file_path.read_text(encoding="utf-8").strip()
     return data
 
 

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -12,7 +12,7 @@ on:
           - "publish"
           - "metadata"
       version:
-        description: "Optional RELEASE.md version section to use. Defaults to pyproject.toml [project].version."
+        description: "Optional version to publish. Uses .github/registry/changelogs first, then RELEASE.md."
         required: false
         default: ""
       dry_run:


### PR DESCRIPTION
## 변경 요약

- 0.3.0 Comfy Registry changelog를 별도 plain text 파일 `.github/registry/changelogs/0.3.0.txt`로 분리했습니다.
- Registry 표시 문구에서 Markdown heading/backtick/link 형식을 제거했습니다.
- publish 액션과 metadata sync 스크립트가 Registry 전용 changelog 파일을 우선 사용하도록 수정했습니다.

## 검증

- `python -m json.tool .github\registry\metadata.json` -> OK
- `python -m py_compile .github\scripts\extract_release_changelog.py .github\scripts\sync_comfy_registry_metadata.py` -> OK
- `python .github\scripts\extract_release_changelog.py --version 0.3.0 --output ...` -> OK
- Registry changelog token check: `###`, backtick, markdown link token 없음
- `git diff --check` -> OK

## 범위

- Registry publish/metadata 문구만 변경합니다.
- GitHub Release note와 `RELEASE.md`는 변경하지 않습니다.