### PR TITLE
[codex] Add Safe PAG option to AiO Generator

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -295,6 +295,17 @@ AIO_GENERATION_DEFAULT_SETTINGS = {
             "strength": 0.30,
             "tau": 0.10,
         },
+        "safe_pag": {
+            "enabled": False,
+            "scale": 4.0,
+            "block_indices": "18",
+            "perturbation_strength": 0.75,
+            "head_indices": "",
+            "start_percent": 0.0,
+            "end_percent": 0.7,
+            "rescale": 0.2,
+            "rescale_mode": "full",
+        },
         "kj": {
             "fp16_accumulation": False,
             "sage_attention": "disabled",
@@ -1301,6 +1312,38 @@ def _normalize_aio_generation_settings(value) -> dict[str, Any]:
         0.0,
         min(1.0, _as_float(dave.get("tau"), default_dave["tau"])),
     )
+    safe_pag = model_patches.setdefault("safe_pag", {})
+    if not isinstance(safe_pag, dict):
+        safe_pag = {}
+        model_patches["safe_pag"] = safe_pag
+    default_safe_pag = AIO_GENERATION_DEFAULT_SETTINGS["model_patches"]["safe_pag"]
+    safe_pag["enabled"] = _as_bool(safe_pag.get("enabled"), default_safe_pag["enabled"])
+    safe_pag["scale"] = max(
+        0.0,
+        min(100.0, _as_float(safe_pag.get("scale"), default_safe_pag["scale"])),
+    )
+    safe_pag["block_indices"] = str(safe_pag.get("block_indices") or default_safe_pag["block_indices"])
+    safe_pag["perturbation_strength"] = max(
+        0.0,
+        min(
+            1.0,
+            _as_float(safe_pag.get("perturbation_strength"), default_safe_pag["perturbation_strength"]),
+        ),
+    )
+    safe_pag["head_indices"] = str(safe_pag.get("head_indices") or default_safe_pag["head_indices"])
+    safe_pag["start_percent"] = max(
+        0.0,
+        min(1.0, _as_float(safe_pag.get("start_percent"), default_safe_pag["start_percent"])),
+    )
+    safe_pag["end_percent"] = max(
+        0.0,
+        min(1.0, _as_float(safe_pag.get("end_percent"), default_safe_pag["end_percent"])),
+    )
+    safe_pag["rescale"] = max(
+        0.0,
+        min(1.0, _as_float(safe_pag.get("rescale"), default_safe_pag["rescale"])),
+    )
+    safe_pag["rescale_mode"] = _choice(safe_pag.get("rescale_mode"), ("full", "partial"), "full")
     kj = model_patches.setdefault("kj", {})
     if not isinstance(kj, dict):
         kj = {}
@@ -2395,6 +2438,9 @@ def _apply_aio_model_patches(model, settings: dict[str, Any]):
     dave_settings = model_patches.get("dave", {})
     if isinstance(dave_settings, dict) and _as_bool(dave_settings.get("enabled"), False):
         patched = _apply_aio_anima_dave_patch(patched, dave_settings)
+    safe_pag_settings = model_patches.get("safe_pag", {})
+    if isinstance(safe_pag_settings, dict) and _as_bool(safe_pag_settings.get("enabled"), False):
+        patched = _apply_aio_safe_pag_patch(patched, safe_pag_settings)
     kj_settings = model_patches.get("kj", {})
     if isinstance(kj_settings, dict):
         patched = _apply_aio_kj_model_patches(patched, kj_settings)
@@ -2938,6 +2984,31 @@ def _apply_aio_anima_dave_patch(model, dave_settings: dict[str, Any]):
     values = _node_output_tuple(result)
     if not values:
         raise RuntimeError("[EasyUseAnima] AnimaDAVE returned no MODEL.")
+    return values[0]
+
+
+def _apply_aio_safe_pag_patch(model, safe_pag_settings: dict[str, Any]):
+    safe_pag_cls = _require_custom_node_class(
+        "AnimaSafePAG",
+        "Anima Safe PAG",
+        "Repository: https://github.com/iljung1106/comfyui-anima-safe-pag",
+    )
+    if not isinstance(safe_pag_settings, dict):
+        safe_pag_settings = {}
+    result = safe_pag_cls().patch(
+        model,
+        _as_float(safe_pag_settings.get("scale"), 4.0),
+        str(safe_pag_settings.get("block_indices") or "18"),
+        _as_float(safe_pag_settings.get("perturbation_strength"), 0.75),
+        str(safe_pag_settings.get("head_indices") or ""),
+        _as_float(safe_pag_settings.get("start_percent"), 0.0),
+        _as_float(safe_pag_settings.get("end_percent"), 0.7),
+        _as_float(safe_pag_settings.get("rescale"), 0.2),
+        str(safe_pag_settings.get("rescale_mode") or "full"),
+    )
+    values = _node_output_tuple(result)
+    if not values:
+        raise RuntimeError("[EasyUseAnima] AnimaSafePAG returned no MODEL.")
     return values[0]
 
 

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -35,6 +35,23 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("next.highres.spectrum = mergeDefaults", body)
         self.assertNotIn("next.highres.dit_corrections = mergeDefaults", body)
 
+    def test_safe_pag_advanced_labels_do_not_reuse_generic_labels(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        start = source.index("function openAdvancedSettings")
+        end = source.index("\nfunction openGeneratorSettings", start)
+        body = source[start:end]
+
+        self.assertIn('"Safe PAG scale"', body)
+        self.assertIn('"Safe PAG blocks"', body)
+        self.assertIn('"PAG perturbation"', body)
+        self.assertIn('"PAG start percent"', body)
+        self.assertIn('"PAG end percent"', body)
+        self.assertIn('"PAG rescale"', body)
+        self.assertNotIn('field(safePag, "Scale"', body)
+        self.assertNotIn('field(safePag, "Start"', body)
+        self.assertNotIn('field(safePag, "End"', body)
+        self.assertNotIn('field(safePag, "Rescale"', body)
+
     def test_detailer_settings_support_custom_blocks(self):
         source = AIO_JS.read_text(encoding="utf-8")
         start = source.index("function openDetailerSettings")

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -118,6 +118,8 @@ class AIOSettingsStorageTests(unittest.TestCase):
         self.assertEqual(settings["sampler"]["future_sampler_key"], "kept")
         self.assertNotIn("enabled", settings["model_patches"]["aura_flow"])
         self.assertEqual(settings["model_patches"]["aura_flow"]["shift"], 3.0)
+        self.assertFalse(settings["model_patches"]["safe_pag"]["enabled"])
+        self.assertEqual(settings["model_patches"]["safe_pag"]["block_indices"], "18")
         self.assertEqual(settings["model_patches"]["kj"]["torch_compile"]["mode"], "max-autotune-no-cudagraphs")
         self.assertTrue(settings["save"]["enabled"])
         self.assertEqual(settings["save"]["backend"], "image_saver")
@@ -913,6 +915,72 @@ class AIOSamplerDependencyTests(unittest.TestCase):
         self.assertEqual(result, "dave_model")
         self.assertEqual(calls, [("base_model", "custom_mask.npz", 0.42, 0.08)])
 
+    def test_safe_pag_patch_uses_anima_safe_pag_node_settings(self):
+        calls = []
+
+        class FakeAnimaSafePAG:
+            def patch(self, *args):
+                calls.append(args)
+                return ("safe_pag_model",)
+
+        settings = nodes._normalize_aio_generation_settings(json.dumps({
+            "model_patches": {
+                "safe_pag": {
+                    "enabled": True,
+                    "scale": 5.5,
+                    "block_indices": "12,18",
+                    "perturbation_strength": 0.61,
+                    "head_indices": "0,2",
+                    "start_percent": 0.1,
+                    "end_percent": 0.8,
+                    "rescale": 0.35,
+                    "rescale_mode": "partial",
+                },
+            },
+        }))
+
+        with patch.object(nodes, "_require_custom_node_class", return_value=FakeAnimaSafePAG):
+            result = nodes._apply_aio_safe_pag_patch("base_model", settings["model_patches"]["safe_pag"])
+
+        self.assertEqual(result, "safe_pag_model")
+        self.assertEqual(calls, [(
+            "base_model",
+            5.5,
+            "12,18",
+            0.61,
+            "0,2",
+            0.1,
+            0.8,
+            0.35,
+            "partial",
+        )])
+
+    def test_safe_pag_settings_are_clamped_to_node_ranges(self):
+        settings = nodes._normalize_aio_generation_settings(json.dumps({
+            "model_patches": {
+                "safe_pag": {
+                    "enabled": True,
+                    "scale": 250,
+                    "block_indices": "",
+                    "perturbation_strength": 9,
+                    "start_percent": -1,
+                    "end_percent": 3,
+                    "rescale": 4,
+                    "rescale_mode": "invalid",
+                },
+            },
+        }))
+
+        safe_pag = settings["model_patches"]["safe_pag"]
+        self.assertTrue(safe_pag["enabled"])
+        self.assertEqual(safe_pag["scale"], 100.0)
+        self.assertEqual(safe_pag["block_indices"], "18")
+        self.assertEqual(safe_pag["perturbation_strength"], 1.0)
+        self.assertEqual(safe_pag["start_percent"], 0.0)
+        self.assertEqual(safe_pag["end_percent"], 1.0)
+        self.assertEqual(safe_pag["rescale"], 1.0)
+        self.assertEqual(safe_pag["rescale_mode"], "full")
+
     def test_model_patches_apply_anima_dave_as_advanced_option(self):
         settings = nodes._normalize_aio_generation_settings(json.dumps({
             "model_patches": {
@@ -928,6 +996,7 @@ class AIOSamplerDependencyTests(unittest.TestCase):
         with (
             patch.object(nodes, "_patch_model_sampling_aura_flow", return_value="aura_model") as aura,
             patch.object(nodes, "_apply_aio_anima_dave_patch", return_value="dave_model") as dave,
+            patch.object(nodes, "_apply_aio_safe_pag_patch", return_value="safe_pag_model") as safe_pag,
             patch.object(nodes, "_apply_aio_kj_model_patches", return_value="kj_model") as kj,
         ):
             result = nodes._apply_aio_model_patches("base_model", settings)
@@ -936,7 +1005,33 @@ class AIOSamplerDependencyTests(unittest.TestCase):
         self.assertEqual(aura.call_args.args[0], "base_model")
         self.assertEqual(dave.call_args.args[0], "aura_model")
         self.assertEqual(dave.call_args.args[1]["mask"], "custom_mask.npz")
+        safe_pag.assert_not_called()
         self.assertEqual(kj.call_args.args[0], "dave_model")
+
+    def test_model_patches_apply_safe_pag_before_kj_compile(self):
+        settings = nodes._normalize_aio_generation_settings(json.dumps({
+            "model_patches": {
+                "safe_pag": {
+                    "enabled": True,
+                    "scale": 4.5,
+                },
+            },
+        }))
+
+        with (
+            patch.object(nodes, "_patch_model_sampling_aura_flow", return_value="aura_model") as aura,
+            patch.object(nodes, "_apply_aio_anima_dave_patch", return_value="dave_model") as dave,
+            patch.object(nodes, "_apply_aio_safe_pag_patch", return_value="safe_pag_model") as safe_pag,
+            patch.object(nodes, "_apply_aio_kj_model_patches", return_value="kj_model") as kj,
+        ):
+            result = nodes._apply_aio_model_patches("base_model", settings)
+
+        self.assertEqual(result, "kj_model")
+        self.assertEqual(aura.call_args.args[0], "base_model")
+        dave.assert_not_called()
+        self.assertEqual(safe_pag.call_args.args[0], "aura_model")
+        self.assertEqual(safe_pag.call_args.args[1]["scale"], 4.5)
+        self.assertEqual(kj.call_args.args[0], "safe_pag_model")
 
 
 class AIOHighresDetailerStageTests(unittest.TestCase):

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -86,6 +86,10 @@ const GENERATOR_OPTIONAL_DEPENDENCY_SPECS = {
     nodeId: "AnimaDAVE",
     pack: "ComfyUI-Anima-DAVE",
   },
+  safePag: {
+    nodeId: "AnimaSafePAG",
+    pack: "Anima Safe PAG",
+  },
   imageSaver: {
     nodeId: "Image Saver",
     pack: "ComfyUI-Image-Saver",
@@ -240,6 +244,17 @@ const DEFAULT_GENERATION_SETTINGS = {
       mask: "dave_alpha.npz",
       strength: 0.30,
       tau: 0.10,
+    },
+    safe_pag: {
+      enabled: false,
+      scale: 4.0,
+      block_indices: "18",
+      perturbation_strength: 0.75,
+      head_indices: "",
+      start_percent: 0.0,
+      end_percent: 0.7,
+      rescale: 0.2,
+      rescale_mode: "full",
     },
     kj: {
       fp16_accumulation: false,
@@ -560,6 +575,7 @@ const AIO_TEXT = {
     "section.imageSaverMetadata": "Image Saver Metadata",
     "section.modelPatchOptimization": "Model Patch / Optimization",
     "section.animaDave": "Anima DAVE",
+    "section.safePag": "Anima Safe PAG",
     "section.kjNodesOptimization": "KJNodes Optimization",
     "section.sageAttention": "SageAttention (KJNodes)",
     "section.torchCompile": "Torch Compile (KJNodes)",
@@ -652,6 +668,15 @@ const AIO_TEXT = {
     "field.mask": "Mask",
     "field.daveStrength": "DAVE strength",
     "field.daveTau": "DAVE tau",
+    "field.useSafePag": "Use Safe PAG",
+    "field.pagScale": "Safe PAG scale",
+    "field.blockIndices": "Safe PAG blocks",
+    "field.perturbationStrength": "PAG perturbation",
+    "field.headIndices": "PAG heads",
+    "field.startPercent": "PAG start percent",
+    "field.endPercent": "PAG end percent",
+    "field.rescale": "PAG rescale",
+    "field.rescaleMode": "PAG rescale mode",
     "field.kjFp16Accum": "KJNodes FP16 accum",
     "field.allowCompile": "Allow compile",
     "field.useTorchCompile": "Use Torch compile",
@@ -797,6 +822,7 @@ const AIO_TEXT = {
     "section.imageSaverMetadata": "Image Saver 메타데이터",
     "section.modelPatchOptimization": "모델 패치 / 최적화",
     "section.animaDave": "Anima DAVE",
+    "section.safePag": "Anima Safe PAG",
     "section.kjNodesOptimization": "KJNodes 최적화",
     "section.sageAttention": "SageAttention (KJNodes)",
     "section.torchCompile": "Torch Compile (KJNodes)",
@@ -889,6 +915,15 @@ const AIO_TEXT = {
     "field.mask": "마스크",
     "field.daveStrength": "DAVE 강도",
     "field.daveTau": "DAVE tau",
+    "field.useSafePag": "Safe PAG 사용",
+    "field.pagScale": "Safe PAG scale",
+    "field.blockIndices": "Safe PAG 블럭",
+    "field.perturbationStrength": "PAG perturbation",
+    "field.headIndices": "PAG 헤드",
+    "field.startPercent": "PAG 시작 percent",
+    "field.endPercent": "PAG 끝 percent",
+    "field.rescale": "PAG rescale",
+    "field.rescaleMode": "PAG rescale 모드",
     "field.kjFp16Accum": "KJNodes FP16 accumulation",
     "field.allowCompile": "컴파일 허용",
     "field.useTorchCompile": "Torch compile 사용",
@@ -1204,6 +1239,15 @@ const AIO_TOOLTIP_TEXT = {
     "tip.daveMask": "DAVE pool mask file passed to AnimaDAVE. The bundled default is dave_alpha.npz.",
     "tip.daveStrength": "DAVE DC-removal dose. Start near 0.30, or sweep lower values for layout diversity.",
     "tip.daveTau": "Early denoising fraction where DAVE is active. Keep at or below 0.10 for legibility.",
+    "tip.safePagEnabled": "Applies Anima Safe PAG before KJNodes optimization and Torch Compile.",
+    "tip.safePagScale": "Safe PAG guidance scale. 0 disables the guidance contribution.",
+    "tip.safePagBlocks": "Comma-separated transformer block indices passed to AnimaSafePAG.",
+    "tip.safePagPerturbation": "Attention perturbation blend strength. 1.0 is closest to hard PAG.",
+    "tip.safePagHeads": "Optional comma-separated attention head indices. Empty targets all heads.",
+    "tip.safePagStart": "Sampling percent where Safe PAG starts.",
+    "tip.safePagEnd": "Sampling percent where Safe PAG ends.",
+    "tip.safePagRescale": "Guidance rescale amount after Safe PAG correction.",
+    "tip.safePagRescaleMode": "Rescale mode passed to AnimaSafePAG.",
     "tip.highresMethod": "Upscale method used before the Highres second pass.",
     "tip.highresMultiple": "Snaps Highres dimensions to this multiple before resampling.",
     "tip.detailerPrompt": "SAM3 text prompt used to detect the target region for this block.",
@@ -1300,6 +1344,15 @@ const AIO_TOOLTIP_TEXT = {
     "tip.daveMask": "AnimaDAVE에 전달할 DAVE pool mask 파일입니다. 기본 번들 파일은 dave_alpha.npz입니다.",
     "tip.daveStrength": "DAVE DC 제거 강도입니다. 기본은 0.30이며, 레이아웃 다양성 비교는 더 낮은 값부터 스윕합니다.",
     "tip.daveTau": "DAVE가 활성화되는 초기 denoising 비율입니다. 가독성을 위해 0.10 이하를 권장합니다.",
+    "tip.safePagEnabled": "KJNodes 최적화와 Torch Compile 전에 Anima Safe PAG를 적용합니다.",
+    "tip.safePagScale": "Safe PAG guidance scale입니다. 0이면 guidance 기여를 비활성화합니다.",
+    "tip.safePagBlocks": "AnimaSafePAG에 전달할 transformer block 인덱스입니다. 쉼표로 여러 개를 지정합니다.",
+    "tip.safePagPerturbation": "attention perturbation 혼합 강도입니다. 1.0은 hard PAG에 가장 가깝습니다.",
+    "tip.safePagHeads": "선택 attention head 인덱스입니다. 비우면 모든 head를 대상으로 합니다.",
+    "tip.safePagStart": "Safe PAG가 시작되는 샘플링 percent입니다.",
+    "tip.safePagEnd": "Safe PAG가 끝나는 샘플링 percent입니다.",
+    "tip.safePagRescale": "Safe PAG 보정 뒤 guidance를 rescale하는 양입니다.",
+    "tip.safePagRescaleMode": "AnimaSafePAG에 전달할 rescale 모드입니다.",
     "tip.highresMethod": "Highres 2차 패스 전에 사용할 업스케일 방법입니다.",
     "tip.highresMultiple": "Highres 크기를 이 배수에 맞춰 보정합니다.",
     "tip.detailerPrompt": "이 블럭의 대상 영역을 찾기 위해 SAM3에 전달할 텍스트 프롬프트입니다.",
@@ -1603,6 +1656,15 @@ const AIO_FIELD_TOOLTIP_KEYS = {
   "Mask": "tip.daveMask",
   "DAVE strength": "tip.daveStrength",
   "DAVE tau": "tip.daveTau",
+  "Use Safe PAG": "tip.safePagEnabled",
+  "Safe PAG scale": "tip.safePagScale",
+  "Safe PAG blocks": "tip.safePagBlocks",
+  "PAG perturbation": "tip.safePagPerturbation",
+  "PAG heads": "tip.safePagHeads",
+  "PAG start percent": "tip.safePagStart",
+  "PAG end percent": "tip.safePagEnd",
+  "PAG rescale": "tip.safePagRescale",
+  "PAG rescale mode": "tip.safePagRescaleMode",
   "Enable highres": "tip.highresEnabled",
   "Scale by": "tip.highresScale",
   "Method": "tip.highresMethod",
@@ -1686,6 +1748,7 @@ const AIO_STATIC_TEXT_KEYS = {
   "Image Saver Metadata": "section.imageSaverMetadata",
   "Model Patch / Optimization": "section.modelPatchOptimization",
   "Anima DAVE": "section.animaDave",
+  "Anima Safe PAG": "section.safePag",
   "KJNodes Optimization": "section.kjNodesOptimization",
   "SageAttention (KJNodes)": "section.sageAttention",
   "Torch Compile (KJNodes)": "section.torchCompile",
@@ -1791,6 +1854,15 @@ const AIO_FIELD_LABEL_KEYS = {
   "Mask": "field.mask",
   "DAVE strength": "field.daveStrength",
   "DAVE tau": "field.daveTau",
+  "Use Safe PAG": "field.useSafePag",
+  "Safe PAG scale": "field.pagScale",
+  "Safe PAG blocks": "field.blockIndices",
+  "PAG perturbation": "field.perturbationStrength",
+  "PAG heads": "field.headIndices",
+  "PAG start percent": "field.startPercent",
+  "PAG end percent": "field.endPercent",
+  "PAG rescale": "field.rescale",
+  "PAG rescale mode": "field.rescaleMode",
   "KJNodes FP16 accum": "field.kjFp16Accum",
   "Allow compile": "field.allowCompile",
   "Use Torch compile": "field.useTorchCompile",
@@ -2178,6 +2250,9 @@ function sanitizeGeneratorSettingsForOptionalDependencies(settings) {
   }
   if (!optionalDependencyAvailable("dave")) {
     next.model_patches.dave.enabled = false;
+  }
+  if (!optionalDependencyAvailable("safePag")) {
+    next.model_patches.safe_pag.enabled = false;
   }
   if (!optionalDependencyAvailable("imageSaver") && next.save.backend === "image_saver") {
     next.save.backend = "comfy_save_image";
@@ -6808,6 +6883,48 @@ function openAdvancedSettings(node) {
   daveTau.min = "0";
   daveTau.max = "1";
 
+  const safePag = makeSubsection("Anima Safe PAG");
+  const safePagSettings = settings.model_patches.safe_pag || DEFAULT_GENERATION_SETTINGS.model_patches.safe_pag;
+  const safePagEnabled = field(safePag, "Use Safe PAG", checkbox(safePagSettings.enabled), "tip.safePagEnabled");
+  const safePagScale = field(safePag, "Safe PAG scale", numberInput(safePagSettings.scale ?? 4.0, "0.1"), "tip.safePagScale");
+  const safePagBlocks = field(safePag, "Safe PAG blocks", textInput(safePagSettings.block_indices || "18"), "tip.safePagBlocks");
+  const safePagPerturbation = field(
+    safePag,
+    "PAG perturbation",
+    numberInput(safePagSettings.perturbation_strength ?? 0.75, "0.01"),
+    "tip.safePagPerturbation",
+  );
+  const safePagHeads = field(safePag, "PAG heads", textInput(safePagSettings.head_indices || ""), "tip.safePagHeads");
+  const safePagStart = field(
+    safePag,
+    "PAG start percent",
+    numberInput(safePagSettings.start_percent ?? 0.0, "0.001"),
+    "tip.safePagStart",
+  );
+  const safePagEnd = field(
+    safePag,
+    "PAG end percent",
+    numberInput(safePagSettings.end_percent ?? 0.7, "0.001"),
+    "tip.safePagEnd",
+  );
+  const safePagRescale = field(safePag, "PAG rescale", numberInput(safePagSettings.rescale ?? 0.2, "0.01"), "tip.safePagRescale");
+  const safePagRescaleMode = field(
+    safePag,
+    "PAG rescale mode",
+    selectInput(["full", "partial"], safePagSettings.rescale_mode || "full"),
+    "tip.safePagRescaleMode",
+  );
+  safePagScale.min = "0";
+  safePagScale.max = "100";
+  safePagPerturbation.min = "0";
+  safePagPerturbation.max = "1";
+  safePagStart.min = "0";
+  safePagStart.max = "1";
+  safePagEnd.min = "0";
+  safePagEnd.max = "1";
+  safePagRescale.min = "0";
+  safePagRescale.max = "1";
+
   const kj = makeSubsection("KJNodes Optimization");
   const fp16Accum = field(kj, "KJNodes FP16 accum", checkbox(settings.model_patches.kj.fp16_accumulation), "tip.kjFp16Accum");
 
@@ -6886,7 +7003,7 @@ function openAdvancedSettings(node) {
   const modelWarning = document.createElement("div");
   modelWarning.className = "easyuse-anima-aio-warning";
   modelWarning.hidden = true;
-  modelPatches.append(dave, kj, modelWarning);
+  modelPatches.append(dave, safePag, kj, modelWarning);
   body.append(modelPatches);
 
   const artistMix = document.createElement("section");
@@ -6940,6 +7057,28 @@ function openAdvancedSettings(node) {
       messages.push(aioFormat("warning.optionalDependencyMissing", {
         backend: "Anima DAVE",
         pack: optionalDependencyPack("dave"),
+      }));
+    }
+
+    const safePagMissing = !optionalDependencyAvailable("safePag");
+    setControlsDisabled([
+      safePagEnabled,
+      safePagScale,
+      safePagBlocks,
+      safePagPerturbation,
+      safePagHeads,
+      safePagStart,
+      safePagEnd,
+      safePagRescale,
+      safePagRescaleMode,
+    ], safePagMissing);
+    if (safePagMissing && safePagEnabled.checked) {
+      safePagEnabled.checked = false;
+    }
+    if (safePagMissing) {
+      messages.push(aioFormat("warning.optionalDependencyMissing", {
+        backend: "Anima Safe PAG",
+        pack: optionalDependencyPack("safePag"),
       }));
     }
 
@@ -7023,6 +7162,21 @@ function openAdvancedSettings(node) {
     next.model_patches.dave.mask = daveMask.value || "dave_alpha.npz";
     next.model_patches.dave.strength = Number(daveStrength.value || 0.30);
     next.model_patches.dave.tau = Number(daveTau.value || 0.10);
+    next.model_patches.safe_pag ||= {};
+    next.model_patches.safe_pag.enabled = safePagEnabled.checked && !safePagEnabled.disabled;
+    next.model_patches.safe_pag.scale = clampGeneratorNumber(safePagScale.value, 4.0, 0, 100);
+    next.model_patches.safe_pag.block_indices = safePagBlocks.value || "18";
+    next.model_patches.safe_pag.perturbation_strength = clampGeneratorNumber(
+      safePagPerturbation.value,
+      0.75,
+      0,
+      1,
+    );
+    next.model_patches.safe_pag.head_indices = safePagHeads.value || "";
+    next.model_patches.safe_pag.start_percent = clampGeneratorNumber(safePagStart.value, 0.0, 0, 1);
+    next.model_patches.safe_pag.end_percent = clampGeneratorNumber(safePagEnd.value, 0.7, 0, 1);
+    next.model_patches.safe_pag.rescale = clampGeneratorNumber(safePagRescale.value, 0.2, 0, 1);
+    next.model_patches.safe_pag.rescale_mode = safePagRescaleMode.value || "full";
     next.model_patches.kj.fp16_accumulation = fp16Accum.checked && !fp16Accum.disabled;
     next.model_patches.kj.sage_attention = sageAttention.disabled ? "disabled" : (sageAttention.value || "disabled");
     next.model_patches.kj.sage_allow_compile = sageAllowCompile.checked && !sageAttention.disabled;


### PR DESCRIPTION
## 변경 요약

- Anima AiO Generator 고급 옵션에 Anima Safe PAG 모델 패치 설정을 추가했습니다.
- Safe PAG는 기본 비활성 상태이며, 활성화 시 AuraFlow/DAVE 이후, KJNodes 최적화와 Torch Compile 이전에 적용됩니다.
- Safe PAG 설정 라벨은 `Safe PAG scale`, `PAG start percent`처럼 고유 라벨로 분리해 기존 `Scale`, `Start`, `Rescale` 라벨과 충돌하지 않게 했습니다.
- Safe PAG 선택 의존성이 없으면 UI에서 해당 옵션을 잠그고, backend에서는 활성화된 상태로 실행 시 명확한 missing custom node 오류를 냅니다.

## 주요 파일

- `nodes.py`
- `web/js/easyuse_anima_aio.js`
- `tests/test_aio_nodes.py`
- `tests/test_aio_frontend.py`

## 검증

- `node --check web/js/easyuse_anima_aio.js` 통과
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m unittest tests.test_aio_nodes tests.test_aio_frontend` 통과, 74 tests
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m unittest discover -s tests` 통과, 278 tests
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m compileall -q .` 통과
- `git diff --check origin/dev...HEAD` 통과

## ComfyUI 검증 표면

- ComfyUI Codex test instance: Python/module and frontend syntax checks
- Live ComfyUI smoke: not run

## 남은 위험 / 미확인 항목

- 실제 샘플링에서 Anima Safe PAG와 Torch Compile을 함께 켜는 runtime smoke는 아직 실행하지 않았습니다.
- Anima Safe PAG가 설치되지 않은 환경에서는 옵션이 잠기지만, 이미 저장된 워크플로우에서 강제로 활성화된 경우 실행 시 missing node 오류가 발생합니다.

## 라벨 후보

- `type: feature`
- `area: backend`
- `area: frontend`
- `status: draft`