### PR TITLE
[codex] 와일드카드 문법 표 렌더링 수정

### DIFF
--- a/docs/wildcards.en.md
+++ b/docs/wildcards.en.md
@@ -18,10 +18,10 @@ Where to use them:
 | `__*/hair_color__` | Search any subfolder for a key whose basename is `hair_color` |
 | `__style/*__` | Select from all keys under `style/` |
 | `3#__hair_color__` | Select 3 file wildcard options and join them with `, ` |
-| `{red|blue|green}` | Select one inline option |
-| `{2::red|5::blue|green}` | Select one weighted inline option. Missing weight is 1 |
-| `{2$$red|blue|green}` | Select 2 inline options with the default `, ` separator |
-| `{1-3$$, $$red|blue|green}` | Select 1 to 3 options and join them with `, ` |
+| `{red\|blue\|green}` | Select one inline option |
+| `{2::red\|5::blue\|green}` | Select one weighted inline option. Missing weight is 1 |
+| `{2$$red\|blue\|green}` | Select 2 inline options with the default `, ` separator |
+| `{1-3$$, $$red\|blue\|green}` | Select 1 to 3 options and join them with `, ` |
 | `{2$$__hair_color__}` | Expand a file wildcard into options, then select 2 |
 
 Weighted example:

--- a/docs/wildcards.ko.md
+++ b/docs/wildcards.ko.md
@@ -18,10 +18,10 @@ EasyUse Anima 와일드카드는 프롬프트 안의 `__name__` 파일 와일드
 | `__*/hair_color__` | 어느 하위 폴더에 있든 basename이 `hair_color`인 key 검색 |
 | `__style/*__` | `style/` 아래 모든 key 후보를 합쳐 1개 선택 |
 | `3#__hair_color__` | 파일 와일드카드 후보 중 3개를 선택해 `, `로 연결 |
-| `{red|blue|green}` | inline 후보 중 1개 선택 |
-| `{2::red|5::blue|green}` | 가중치 후보 중 1개 선택. 가중치가 없으면 1로 계산 |
-| `{2$$red|blue|green}` | inline 후보 중 2개 선택, 기본 구분자 `, ` 사용 |
-| `{1-3$$, $$red|blue|green}` | 1개에서 3개까지 선택하고 `, `로 연결 |
+| `{red\|blue\|green}` | inline 후보 중 1개 선택 |
+| `{2::red\|5::blue\|green}` | 가중치 후보 중 1개 선택. 가중치가 없으면 1로 계산 |
+| `{2$$red\|blue\|green}` | inline 후보 중 2개 선택, 기본 구분자 `, ` 사용 |
+| `{1-3$$, $$red\|blue\|green}` | 1개에서 3개까지 선택하고 `, `로 연결 |
 | `{2$$__hair_color__}` | 파일 와일드카드 후보를 펼친 뒤 2개 선택 |
 
 가중치 예시:


### PR DESCRIPTION
## 변경 요약

- 와일드카드 문법 문서의 Quick Syntax Reference 표에서 inline dynamic prompt 예시의 `|` 문자를 Markdown table-safe 형태로 이스케이프했습니다.
- 한국어/영어 문서의 동일한 표 행을 함께 수정했습니다.

## 수정한 주요 파일

- `docs/wildcards.ko.md`
- `docs/wildcards.en.md`

## 원인

Markdown 표 안의 inline code에 원시 `|` 문자가 포함되어 일부 렌더러에서 컬럼 구분자로 처리되며 표가 깨질 수 있었습니다.

## 검증

- `git diff --check` 통과
- Quick Syntax Reference 표 행의 unescaped pipe 컬럼 수 검사 통과

## 테스트한 ComfyUI 표면

- 문서 전용 변경: ComfyUI runtime smoke는 실행하지 않음

## 남은 위험 또는 미확인 항목

- GitHub 렌더링 화면에서의 시각 확인은 별도로 수행하지 않았습니다.

## 라벨 후보

- `type: docs`
- `area: docs`
- `status: draft`