### PR TITLE
0.3.1 릴리즈 준비

### DIFF
--- a/.github/registry/changelogs/0.3.1.txt
+++ b/.github/registry/changelogs/0.3.1.txt
@@ -1,0 +1,10 @@
+EasyUse Anima 0.3.1 focuses on final-stage AiO upscaling and postprocess controls.
+
+User-visible changes:
+1. Anima AiO Generator can now run one final Upscale pass after Detailer and before Save. Choose either USDU or ResShift for that final pass.
+2. USDU settings are easier to use. Auto tile sizing defaults to a 1024 target with configurable min/max bounds, the sampler step and denoise controls are visible from the main settings, and terminal info logs report resolved tile and sampler decisions.
+3. USDU prompt mode can rebuild prompts without general content tags while keeping quality tags, artist tags, and LoRA trigger fields. This helps reduce small-tile artifacts without dropping style or trigger information.
+4. Final size fitting now lives in a separate Postprocess stage after Upscale. It can cap output size by max long edge or megapixels before Save.
+5. Image Saver metadata can omit positive/negative prompt text when Save prompt metadata is disabled.
+6. AiO Generator now exposes Anima Safe PAG model patch controls.
+7. Wildcard syntax reference tables now render literal pipe syntax correctly in the English and Korean docs.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,6 +19,11 @@
   },
   "versions": [
     {
+      "version": "0.3.1",
+      "deprecated": false,
+      "changelog_file": "changelogs/0.3.1.txt"
+    },
+    {
       "version": "0.3.0",
       "deprecated": false,
       "changelog_file": "changelogs/0.3.0.txt"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,45 @@
 # Release Notes
 
+## 0.3.1
+
+### Added
+
+- Added the AiO Generator final Upscale stage after Detailer and before Save,
+  with mutually exclusive USDU and ResShift backends.
+- Added USDU helpers for practical final upscaling: automatic tile sizing with
+  target/min/max controls, no-general prompt rebuilding that keeps quality,
+  artist, and trigger fields, required sampler controls in the main settings,
+  per-USDU Spectrum/DCW settings, and info logs for resolved tile and sampler
+  decisions.
+- Added a Postprocess stage for final size fitting after Detailer/Upscale and
+  before Save, with long-edge and megapixel caps.
+- Added AiO Generator controls for the Anima Safe PAG model patch.
+- Added an Image Saver prompt metadata toggle so positive/negative prompt text
+  can be omitted from saved metadata when needed.
+
+### Changed
+
+- Moved legacy Upscale final-fit settings into the dedicated Postprocess stage
+  during settings normalization.
+- Registry publishing now uses checked-in plain text changelog files for the
+  release changelog path.
+
+### Fixed
+
+- Fixed wildcard syntax reference table rendering by escaping literal pipe
+  characters in the English and Korean wildcard docs.
+
+### Validation Notes
+
+- Added AiO Generator regression coverage for final Upscale, USDU tile
+  normalization and logging, ResShift dispatch, Postprocess final-fit ordering,
+  Safe PAG patch routing, and Image Saver prompt metadata toggling.
+- Added frontend source guards for the new Upscale/Postprocess dialogs, USDU
+  sampler controls, Safe PAG labels, and Image Saver metadata toggle.
+- Validated during 0.3.1 release preparation with Python unit tests, compile
+  checks, JavaScript syntax checks, JSON/TOML metadata checks, Registry
+  changelog extraction, and `git diff --check`.
+
 ## 0.3.0
 
 ### Changed

--- a/docs/development/0.3.1.md
+++ b/docs/development/0.3.1.md
@@ -1,0 +1,53 @@
+# 0.3.1 Development Notes
+
+## Scope
+
+0.3.1 is the release-prep version after 0.3.0. It collects the AiO Generator
+final-upscale work, Safe PAG model patch controls, the wildcard documentation
+fix, and the Registry changelog-file publish path.
+
+## Current Changes
+
+- AiO Generator has a final Upscale stage that runs after Detailer and before
+  Save. Only one final upscale backend is selected at a time.
+- Final Upscale supports USDU and ResShift. USDU depends on Ultimate SD Upscale;
+  ResShift depends on `sorryhyun/ComfyUI-Distilled-ResShift`.
+- USDU provides automatic tile sizing with user-visible target/min/max controls.
+  The default target is 1024 and the default max is 2048, matching the
+  recommended Anima range.
+- USDU prompt mode can remove general content fields while preserving quality,
+  artist, and trigger fields. When Mod Guidance already supplies quality tags,
+  the USDU prompt avoids duplicating them.
+- USDU exposes required sampler controls from the main AiO settings and keeps
+  separate Spectrum/DCW settings for the USDU pass.
+- AiO terminal info logs now report EasyUseAnima-owned stage decisions such as
+  resolved USDU tile size, sampler settings, and Postprocess final-fit results.
+- Final image size fitting now belongs to the Postprocess stage, after Detailer
+  and Upscale and before Save. Legacy `upscale.fit` settings are migrated during
+  settings normalization.
+- Image Saver metadata can skip positive/negative prompt text through the Save
+  prompt metadata toggle.
+- AiO Generator exposes Anima Safe PAG model patch controls before KJNodes
+  optimization and Torch Compile.
+- Wildcard syntax reference tables escape literal pipe syntax in both English
+  and Korean docs.
+- Registry changelog extraction uses checked-in plain text changelog files.
+
+## Release Follow-Up
+
+- `pyproject.toml` is bumped to `0.3.1` for release prep.
+- `RELEASE.md` includes the final 0.3.1 notes from the post-0.3.0 change set.
+- `.github/registry/metadata.json` points 0.3.1 to
+  `.github/registry/changelogs/0.3.1.txt`.
+- Registry publishing and tag/GitHub Release creation remain explicit follow-up
+  steps after the main merge.
+
+## Validation Checklist
+
+- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m unittest discover -s tests`
+- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m compileall -q .`
+- `node --check web/js/easyuse_anima_aio.js`
+- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m json.tool locales\ko\nodeDefs.json`
+- Registry changelog extraction for 0.3.1
+- TOML/Registry metadata sanity check
+- `git diff --check`

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,8 +6,8 @@ conversation.
 ## Read Order
 
 1. `docs/development/current-policies.md`
-2. Active version plan, currently `docs/development/0.3.0.md`
-3. Latest released baseline, currently `docs/development/0.2.7.md`
+2. Active version plan, currently `docs/development/0.3.1.md`
+3. Latest released baseline, currently `docs/development/0.3.0.md`
 4. Relevant topic guide:
    - Registry publish or flagged-version prevention:
      `docs/development/registry-scanner-safety.md`
@@ -25,8 +25,8 @@ conversation.
 ## Source Map
 
 - Current policy baseline: `docs/development/current-policies.md`
-- Active next-version plan: `docs/development/0.3.0.md`
-- Latest released baseline: `docs/development/0.2.7.md`
+- Active next-version plan: `docs/development/0.3.1.md`
+- Latest released baseline: `docs/development/0.3.0.md`
 - Registry scanner safety: `docs/development/registry-scanner-safety.md`
 - Older implementation history: `docs/version-plans/`
 - Public workflow JSON templates and preview/source images: `docs/example_workflows/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "0.3.0"
+version = "0.3.1"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## 변경 요약

- 패키지 버전을 `0.3.1`로 갱신했습니다.
- `RELEASE.md`에 0.3.1 릴리즈 노트를 추가했습니다.
- Registry metadata에 0.3.1 버전과 plain text changelog 파일을 추가했습니다.
- 개발 문서 엔트리를 0.3.1 계획과 0.3.0 최신 릴리즈 기준으로 갱신했습니다.

## 수정한 주요 파일

- `pyproject.toml`
- `RELEASE.md`
- `docs/development/README.md`
- `docs/development/0.3.1.md`
- `.github/registry/metadata.json`
- `.github/registry/changelogs/0.3.1.txt`

## 검증

- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m unittest discover -s tests` 통과, 293 tests
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m compileall -q .` 통과
- `node --check web\js\easyuse_anima_aio.js` 통과
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m json.tool .github\registry\metadata.json` 통과
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m json.tool locales\ko\nodeDefs.json` 통과
- `.github/scripts/extract_release_changelog.py --version 0.3.1` 통과
- TOML/Registry metadata sanity check 통과
- `git diff --check` 통과

## 테스트한 ComfyUI 표면

- ComfyUI runtime smoke: not run
- Repository validation: Python unit/static tests and frontend syntax checks

## 남은 위험 또는 미확인 항목

- Registry publish, tag, GitHub Release 생성은 이 PR 범위가 아니며 main 머지 이후 별도 명시 단계로 진행해야 합니다.
- 실제 USDU/ResShift 모델을 로드하는 라이브 ComfyUI 생성 smoke는 이번 release-prep PR에서 실행하지 않았습니다.

## 라벨 후보

- `type: chore`
- `area: docs`
- `area: workflow`
- `status: ready`