### PR TITLE
[codex] Expose AiO final images and hide legacy canvas label

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -10506,6 +10506,8 @@ class EasyUseAnimaAIOGenerator:
             "easyuse_anima_run_id": [preview_run_id],
         }
         preview_payload = preview_images + final_preview
+        if final_preview:
+            ui["images"] = final_preview
         if preview_payload:
             ui["easyuse_anima_preview"] = preview_payload
         return {

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -22,6 +22,8 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("nodeType.prototype.hideOutputImages = true", source)
         self.assertIn("module?.useNodeOutputStore || module?.cn || module?.L", source)
         self.assertIn("outputStore.revokePreviewsByLocatorId?.(locator);", source)
+        self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .text-node-component-header-text", source)
+        self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground", source)
         self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)
         self.assertIn("updateGeneratorExecutedStatus(this, message);", body)
         self.assertNotIn("onExecuted?.apply", body)

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -11,6 +11,19 @@ PROMPT_STUDIO_COMMON_JS = ROOT / "web" / "js" / "easyuse_anima_prompt_studio_com
 
 
 class AIOFrontendSourceTests(unittest.TestCase):
+    def test_generator_keeps_native_output_preview_suppressed_after_execution(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        registration_start = source.index("async beforeRegisterNodeDef")
+        generator_block = source[source.index("if (nodeData.name === GENERATOR_NODE_TYPE)", registration_start):]
+        start = generator_block.index("nodeType.prototype.onExecuted = function")
+        end = generator_block.index("\n      const onResize", start)
+        body = generator_block[start:end]
+
+        self.assertIn("nodeType.prototype.hideOutputImages = true", source)
+        self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)
+        self.assertIn("updateGeneratorExecutedStatus(this, message);", body)
+        self.assertNotIn("onExecuted?.apply", body)
+
     def test_detailer_target_editor_builds_optimization_before_visibility_refresh(self):
         source = AIO_JS.read_text(encoding="utf-8")
         start = source.index("function createDetailerTargetEditor")

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -26,6 +26,19 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("updateGeneratorExecutedStatus(this, message);", body)
         self.assertNotIn("onExecuted?.apply", body)
 
+    def test_generator_preview_meta_does_not_show_resolution(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        start = source.index("function updateGeneratorDomPreview")
+        end = source.index("\nfunction cssEscape", start)
+        body = source[start:end]
+        meta_start = body.index("const parts = [")
+        meta_end = body.index("].filter", meta_start)
+        meta_parts = body[meta_start:meta_end]
+
+        self.assertIn("generatorPreviewImageName(currentImage)", meta_parts)
+        self.assertIn("generatorPreviewFileSize(currentImage)", meta_parts)
+        self.assertNotIn("generatorPreviewResolution(currentImage)", meta_parts)
+
     def test_detailer_target_editor_builds_optimization_before_visibility_refresh(self):
         source = AIO_JS.read_text(encoding="utf-8")
         start = source.index("function createDetailerTargetEditor")

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -20,6 +20,8 @@ class AIOFrontendSourceTests(unittest.TestCase):
         body = generator_block[start:end]
 
         self.assertIn("nodeType.prototype.hideOutputImages = true", source)
+        self.assertIn("module?.useNodeOutputStore || module?.cn || module?.L", source)
+        self.assertIn("outputStore.revokePreviewsByLocatorId?.(locator);", source)
         self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)
         self.assertIn("updateGeneratorExecutedStatus(this, message);", body)
         self.assertNotIn("onExecuted?.apply", body)

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -22,13 +22,15 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("nodeType.prototype.hideOutputImages = true", source)
         self.assertIn("module?.useNodeOutputStore || module?.cn || module?.L", source)
         self.assertIn("outputStore.revokePreviewsByLocatorId?.(locator);", source)
+        self.assertIn('Object.defineProperty(node, "imgs"', source)
+        self.assertIn("lockGeneratorLegacyCanvasPreview(node);", source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .text-node-component-header-text", source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground", source)
         self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)
         self.assertIn("updateGeneratorExecutedStatus(this, message);", body)
         self.assertNotIn("onExecuted?.apply", body)
 
-    def test_generator_preview_meta_does_not_show_resolution(self):
+    def test_generator_preview_meta_keeps_dedicated_resolution_label(self):
         source = AIO_JS.read_text(encoding="utf-8")
         start = source.index("function updateGeneratorDomPreview")
         end = source.index("\nfunction cssEscape", start)
@@ -38,8 +40,8 @@ class AIOFrontendSourceTests(unittest.TestCase):
         meta_parts = body[meta_start:meta_end]
 
         self.assertIn("generatorPreviewImageName(currentImage)", meta_parts)
+        self.assertIn("generatorPreviewResolution(currentImage)", meta_parts)
         self.assertIn("generatorPreviewFileSize(currentImage)", meta_parts)
-        self.assertNotIn("generatorPreviewResolution(currentImage)", meta_parts)
 
     def test_detailer_target_editor_builds_optimization_before_visibility_refresh(self):
         source = AIO_JS.read_text(encoding="utf-8")

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -1846,7 +1846,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             "input_settings": {},
         }
 
-    def test_generator_uses_custom_preview_key_instead_of_default_images(self):
+    def test_generator_exposes_standard_images_and_custom_preview_key(self):
         context = self._context()
 
         with (
@@ -1868,7 +1868,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
                 lora_stack=[("a.safetensors", 1.0, 1.0)],
             )
 
-        self.assertNotIn("images", result["ui"])
+        self.assertEqual(result["ui"]["images"][0]["filename"], "preview.webp")
         self.assertEqual(result["ui"]["easyuse_anima_preview"][0]["filename"], "preview.webp")
         self.assertEqual(result["ui"]["sampler_backend"], ["comfy_ksampler"])
         self.assertIn("easyuse_anima_run_id", result["ui"])
@@ -2351,7 +2351,8 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
                 }),
             )
 
-        self.assertNotIn("images", result["ui"])
+        self.assertEqual([item["stage"] for item in result["ui"]["images"]], ["final"])
+        self.assertEqual(result["ui"]["images"][0]["filename"], "final.webp")
         self.assertEqual(preview_calls, [("first_pass", "image")])
         self.assertEqual(
             [item["stage"] for item in result["ui"]["easyuse_anima_preview"]],

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -4647,6 +4647,7 @@ function updateGeneratorDomPreview(node) {
   if (metaEl) {
     const parts = [
       generatorPreviewImageName(currentImage),
+      generatorPreviewResolution(currentImage),
       generatorPreviewFileSize(currentImage),
     ].filter((part) => part && part !== "-");
     const metaText = parts.length ? parts.join(" · ") : "-";
@@ -5096,6 +5097,7 @@ function suppressGeneratorDefaultPreview(node, options = {}) {
   if (!node) {
     return;
   }
+  lockGeneratorLegacyCanvasPreview(node);
   const shouldMarkDirty = options.markDirty !== false;
   let changed = false;
   if (node.hideOutputImages !== true) {
@@ -5120,6 +5122,28 @@ function suppressGeneratorDefaultPreview(node, options = {}) {
   }
   if (changed && shouldMarkDirty) {
     markNodeDirty(node);
+  }
+}
+
+function lockGeneratorLegacyCanvasPreview(node) {
+  if (!node || node.__easyuseAnimaLegacyCanvasPreviewLocked) {
+    return;
+  }
+  node.__easyuseAnimaLegacyCanvasPreviewLocked = true;
+  try {
+    Object.defineProperty(node, "imgs", {
+      configurable: true,
+      enumerable: false,
+      get() {
+        return [];
+      },
+      set() {
+        // Comfy syncs ui.images into node.imgs for legacy canvas previews.
+        // AiO keeps queue/history images but renders its own in-node preview.
+      },
+    });
+  } catch {
+    node.imgs = [];
   }
 }
 

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -4643,7 +4643,6 @@ function updateGeneratorDomPreview(node) {
   if (metaEl) {
     const parts = [
       generatorPreviewImageName(currentImage),
-      generatorPreviewResolution(currentImage),
       generatorPreviewFileSize(currentImage),
     ].filter((part) => part && part !== "-");
     const metaText = parts.length ? parts.join(" · ") : "-";

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -4952,7 +4952,7 @@ async function generatorNativePreviewStores() {
       try {
         const module = await import(url);
         return {
-          useNodeOutputStore: module?.useNodeOutputStore || module?.L,
+          useNodeOutputStore: module?.useNodeOutputStore || module?.cn || module?.L,
           useWorkflowStore: module?.useWorkflowStore || module?.M,
         };
       } catch {

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -3472,6 +3472,10 @@ function ensureStyle() {
     .${GENERATOR_VUE_NODE_CLASS} img.pointer-events-none.object-contain + .text-node-component-header-text,
     .${GENERATOR_VUE_NODE_CLASS} .text-node-component-header-text,
     .${GENERATOR_VUE_NODE_CLASS} .text-node-component-header-text.mt-1.text-center.text-xs,
+    .lg-node:has(.easyuse-anima-aio-node-panel) .text-node-component-header-text,
+    .lg-node:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground,
+    [data-node-id]:has(.easyuse-anima-aio-node-panel) .text-node-component-header-text,
+    [data-node-id]:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground,
     .${GENERATOR_VUE_NODE_CLASS} [data-testid="main-image"],
     .${GENERATOR_VUE_NODE_CLASS} .easyuse-anima-aio-native-live-preview-hidden {
       display: none !important;


### PR DESCRIPTION
## 변경 요약
- `Anima AiO Generator`가 최종 생성 이미지를 Comfy 표준 `ui.images`에도 노출하도록 유지했습니다.
- AiO 전용 노드 프리뷰/피드는 유지하고, 전용 메타의 이미지명/해상도/파일 크기 표시도 복원했습니다.
- Comfy가 `ui.images`를 legacy `node.imgs`로 다시 동기화한 뒤 canvas에 그리던 노드 최하단 해상도 라벨만 차단했습니다.

## 수정한 주요 파일
- `nodes.py`
- `web/js/easyuse_anima_aio.js`
- `tests/test_aio_nodes.py`
- `tests/test_aio_frontend.py`

## 원인
AiO Generator는 최종 이미지를 Comfy 작업 대기열/히스토리에 보이게 하려면 표준 `ui.images`를 반환해야 합니다. 그런데 Comfy v0.25.1 frontend는 backward compatibility로 `ui.images`를 다시 `node.imgs`에 동기화하고, legacy image preview widget이 이 값을 canvas에 그리면서 노드 최하단에 잘린 해상도 텍스트를 표시합니다.

CSS/DOM 숨김은 Vue/DOM 미리보기에는 적용되지만, 이 하단 라벨은 canvas drawing이라 영향을 받지 않았습니다. 그래서 AiO Generator 노드에 한정해 legacy `node.imgs` 런타임 슬롯을 비워 두도록 잠그고, queue/history용 `ui.images`와 AiO 전용 DOM 프리뷰는 유지했습니다.

## 검증
- `node --check web/js/easyuse_anima_aio.js` -> 통과
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m unittest tests.test_aio_frontend -q` -> 통과, 22 tests
- `git diff --check` -> 통과
- `powershell -ExecutionPolicy Bypass -File tools\check_custom_node.ps1 -Project D:\ComfyUI\custom_nodes_workplace\worktrees\ComfyUI-EasyUseAnima\codex\fix-aio-standard-images -Profile full` -> 통과
  - Python compile 통과
  - unittest discover 통과, 298 tests
  - git diff --check 통과
  - 전체 `web/js/**/*.js` node syntax check 통과

## 테스트한 ComfyUI 표면
- ComfyUI Codex test instance: API/module/static validation, served frontend asset check
- ComfyUI v0.25.1 user instance: served frontend asset check
- Live browser workflow smoke: not run; local Chrome spawn was blocked with `EPERM`

## 남은 위험
- 실제 브라우저에서 기존 탭이 캐시한 이전 JS를 들고 있으면 강력 새로고침이 필요합니다.

## 라벨 후보
- `type: fix`
- `area: backend`
- `area: frontend`
- `status: draft`