### PR TITLE
Release 0.3.2 hotfix

### DIFF
--- a/.github/registry/changelogs/0.3.2.txt
+++ b/.github/registry/changelogs/0.3.2.txt
@@ -1,0 +1,6 @@
+EasyUse Anima 0.3.2 is a dependency hotfix for Google prompt translation.
+
+User-visible changes:
+1. Google prompt translation now declares googletrans-py 4.0.0 in both package metadata files.
+2. Registry and Manager installs should install the supported googletrans-py package instead of relying on a loose or missing dependency declaration.
+3. Node behavior and workflow formats are unchanged in this hotfix.

--- a/.github/registry/metadata.json
+++ b/.github/registry/metadata.json
@@ -19,6 +19,11 @@
   },
   "versions": [
     {
+      "version": "0.3.2",
+      "deprecated": false,
+      "changelog_file": "changelogs/0.3.2.txt"
+    },
+    {
       "version": "0.3.1",
       "deprecated": false,
       "changelog_file": "changelogs/0.3.1.txt"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 0.3.2
+
+### Fixed
+
+- Fixed Registry and Manager dependency metadata for Google prompt translation
+  by declaring `googletrans-py==4.0.0` in both `pyproject.toml` and
+  `requirements.txt`.
+
+### Validation Notes
+
+- Verified `pyproject.toml` parsing and dependency metadata alignment.
+- Verified the release diff with `git diff --check`.
+
 ## 0.3.1
 
 ### Added

--- a/docs/development/0.3.2.md
+++ b/docs/development/0.3.2.md
@@ -1,0 +1,28 @@
+# 0.3.2 Development Notes
+
+## Scope
+
+0.3.2 is a hotfix release after 0.3.1. It fixes dependency metadata for Google
+prompt translation installs.
+
+## Current Changes
+
+- `pyproject.toml` now declares `googletrans-py==4.0.0`.
+- `requirements.txt` now pins `googletrans-py==4.0.0`.
+- Runtime node behavior and workflow formats are unchanged.
+
+## Release Follow-Up
+
+- Publish as a patch release from `main`.
+- Use the plain-text Registry changelog at
+  `.github/registry/changelogs/0.3.2.txt`.
+- After publishing, confirm Comfy Registry reports 0.3.2 as active.
+
+## Validation Checklist
+
+- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"`
+- Dependency metadata alignment check for `pyproject.toml` and `requirements.txt`
+- Registry metadata/changelog extraction for 0.3.2
+- Registry scanner grep checks
+- `comfy node validate`
+- `git diff --check`

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,8 +6,8 @@ conversation.
 ## Read Order
 
 1. `docs/development/current-policies.md`
-2. Active version plan, currently `docs/development/0.3.1.md`
-3. Latest released baseline, currently `docs/development/0.3.0.md`
+2. Active version plan, currently `docs/development/0.3.2.md`
+3. Latest released baseline, currently `docs/development/0.3.1.md`
 4. Relevant topic guide:
    - Registry publish or flagged-version prevention:
      `docs/development/registry-scanner-safety.md`
@@ -25,8 +25,8 @@ conversation.
 ## Source Map
 
 - Current policy baseline: `docs/development/current-policies.md`
-- Active next-version plan: `docs/development/0.3.1.md`
-- Latest released baseline: `docs/development/0.3.0.md`
+- Active next-version plan: `docs/development/0.3.2.md`
+- Latest released baseline: `docs/development/0.3.1.md`
 - Registry scanner safety: `docs/development/registry-scanner-safety.md`
 - Older implementation history: `docs/version-plans/`
 - Public workflow JSON templates and preview/source images: `docs/example_workflows/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "requests>=2.28",
+    "googletrans-py==4.0.0",
 ]
 classifiers = [
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-easyuse-anima"
 description = "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
-version = "0.3.1"
+version = "0.3.2"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.28
-googletrans-py
+googletrans-py==4.0.0


### PR DESCRIPTION
## 변경 요약

- 0.3.2 dependency hotfix release 준비.
- Google prompt translation 의존성을 `googletrans-py==4.0.0`으로 고정.
- Registry publish용 0.3.2 metadata/changelog 추가.

## 주요 파일

- `pyproject.toml`
- `requirements.txt`
- `RELEASE.md`
- `docs/development/0.3.2.md`
- `docs/development/README.md`
- `.github/registry/metadata.json`
- `.github/registry/changelogs/0.3.2.txt`

## 검증

- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -c <metadata/dependency alignment check>`: passed
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m unittest discover -s tests`: 296 tests passed
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m compileall -q .`: passed
- `node --check web/js/*.js`: passed
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -m json.tool locales\ko\nodeDefs.json`: passed
- Registry scanner grep checks: passed; only expected `requests.post` use remains in `nodes.py`
- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\comfy.exe --skip-prompt node validate`: passed
- `git diff --check`: passed

## 테스트한 ComfyUI 표면

- ComfyUI Registry validation: `comfy node validate`
- Live ComfyUI smoke: not run; dependency metadata-only hotfix

## 남은 위험 또는 미확인 항목

- Registry publish는 이 PR이 `main`에 merge된 뒤 `publish_action.yml`로 진행해야 함.

## 라벨 후보

저장소에 세분 라벨이 없어 본문에 후보만 남김: `type: fix`, `area: backend`, `area: docs`, `status: ready`.