### PR TITLE
fix: AiO 의존성 조회 결과를 사용자에게 표시

### DIFF
--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -122,6 +122,39 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("upscaleBackendMissingPacks(next.upscale.backend).length", body)
         self.assertIn("next.upscale.enabled = false", body)
 
+    def test_optional_dependency_query_reports_results_without_treating_errors_as_missing(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        fetch_start = source.index("async function fetchGeneratorOptionalDependencies")
+        fetch_end = source.index("\nfunction optionalDependencyResultLabel", fetch_start)
+        fetch_body = source[fetch_start:fetch_end]
+        available_start = source.index("function optionalDependencyAvailable")
+        available_end = source.index("\nfunction backendDependencyMissing", available_start)
+        available_body = source[available_start:available_end]
+        report_start = source.index("function reportGeneratorOptionalDependencyStatus")
+        report_end = source.index("\nfunction loadGeneratorOptionalDependencies", report_start)
+        report_body = source[report_start:report_end]
+
+        self.assertIn('nextStatus[key] = "error"', fetch_body)
+        self.assertNotIn("next[key] = false", fetch_body)
+        self.assertIn('optionalDependencyStatus(key) !== "missing"', available_body)
+        self.assertIn('console.info("[EasyUseAnima] AiO optional dependency query result", rows)', report_body)
+        self.assertIn('severity: failed.length ? "warn" : "info"', report_body)
+        self.assertIn("app.ui.dialog.show", report_body)
+
+    def test_optional_dependency_query_retries_errors_before_queueing(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        load_start = source.index("function loadGeneratorOptionalDependencies")
+        load_end = source.index("\nfunction optionalDependencyStatus", load_start)
+        load_body = source[load_start:load_end]
+        queue_start = source.index("function installGeneratorQueuePromptHook")
+        queue_end = source.index("\nfunction ensureButton", queue_start)
+        queue_body = source[queue_start:queue_end]
+
+        self.assertIn("retryErrors = false", load_body)
+        self.assertIn('includes("error")', load_body)
+        self.assertIn("generatorOptionalDependencyState.loading = null", load_body)
+        self.assertIn("loadGeneratorOptionalDependencies({ retryErrors: true })", queue_body)
+
     def test_generator_panel_renders_upscale_after_detailer(self):
         source = AIO_JS.read_text(encoding="utf-8")
         start = source.index("function renderGeneratorPanel")

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -1436,6 +1436,10 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileVram": "Disables ComfyUI dynamic VRAM handling around compiled model execution when enabled.",
     "tip.samplerBackend": "Selects the actual first-pass execution path. Model patches selected in Advanced Options are applied before this backend runs. SPD/SPEED is Euler-only, so its sampler is normalized to euler.",
     "warning.optionalDependencyMissing": "{backend} is locked because {pack} is not installed.",
+    "info.optionalDependency.title": "EasyUseAnima AiO dependency check",
+    "info.optionalDependency.complete": "Available: {available}/{total}.",
+    "info.optionalDependency.missing": "Missing: {items}. Related features will be disabled or changed before queueing.",
+    "info.optionalDependency.error": "Query failed: {items}. Settings were kept unchanged and will be checked again before queueing.",
     "tip.modMode": "Controls whether Mod Guidance follows prompt_data, is forced on, or is disabled.",
     "tip.modProfile": "Preset layer profile for Anima Mod Guidance. Off disables Mod Guidance even when prompt_data asks for it.",
     "tip.modAdapter": "Adapter name passed to Spectrum Mod Guidance. Auto-download default uses the node pack default adapter.",
@@ -1542,6 +1546,10 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileVram": "켜면 compiled model 실행 중 ComfyUI dynamic VRAM 처리를 끕니다.",
     "tip.samplerBackend": "실제 1차 샘플링 경로를 선택합니다. Advanced Options에서 선택한 모델 패치는 이 백엔드 실행 전에 적용됩니다. SPD/SPEED는 Euler 전용이라 내부 sampler는 euler로 정규화됩니다.",
     "warning.optionalDependencyMissing": "{pack}이 설치되지 않아 {backend} 옵션을 잠갔습니다.",
+    "info.optionalDependency.title": "EasyUseAnima AiO 의존성 조회",
+    "info.optionalDependency.complete": "사용 가능: {available}/{total}.",
+    "info.optionalDependency.missing": "미설치: {items}. 관련 기능은 큐 실행 전에 비활성화되거나 대체됩니다.",
+    "info.optionalDependency.error": "조회 실패: {items}. 설정을 변경하지 않았으며 다음 큐 실행 전에 다시 조회합니다.",
     "tip.modMode": "Mod Guidance를 prompt_data에 따르게 할지, 강제로 켤지, 끌지 정합니다.",
     "tip.modProfile": "Anima Mod Guidance 레이어 프리셋입니다. off는 prompt_data가 켜져 있어도 Mod Guidance를 비활성화합니다.",
     "tip.modAdapter": "Spectrum Mod Guidance에 전달할 adapter입니다. auto-download default는 노드팩 기본 adapter를 사용합니다.",
@@ -1648,6 +1656,10 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileVram": "有効時、compiled model 実行中の ComfyUI dynamic VRAM 処理を無効化します。",
     "tip.samplerBackend": "一回目の実行経路を選択します。Advanced Options で選んだ model patch は、この backend 実行前に適用されます。SPD/SPEED は Euler 専用のため、sampler は内部で euler に正規化されます。",
     "warning.optionalDependencyMissing": "{pack} が未インストールのため {backend} をロックしました。",
+    "info.optionalDependency.title": "EasyUseAnima AiO 依存関係チェック",
+    "info.optionalDependency.complete": "利用可能: {available}/{total}。",
+    "info.optionalDependency.missing": "未インストール: {items}。関連機能はキュー実行前に無効化または変更されます。",
+    "info.optionalDependency.error": "照会失敗: {items}。設定は変更せず、次回のキュー実行前に再確認します。",
     "tip.modMode": "Mod Guidance を prompt_data に従わせるか、強制有効または無効にするかを選択します。",
     "tip.modProfile": "Anima Mod Guidance の layer profile です。off は prompt_data が有効でも Mod Guidance を無効化します。",
     "tip.modAdapter": "Spectrum Mod Guidance に渡す adapter です。auto-download default は node pack の既定 adapter を使います。",
@@ -1745,6 +1757,10 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileVram": "启用后，在 compiled model 执行期间关闭 ComfyUI dynamic VRAM 处理。",
     "tip.samplerBackend": "选择第一次采样的实际执行路径。Advanced Options 中选择的 model patch 会在此 backend 执行前应用。SPD/SPEED 仅支持 Euler，因此内部 sampler 会规范化为 euler。",
     "warning.optionalDependencyMissing": "{pack} 未安装，因此已锁定 {backend} 选项。",
+    "info.optionalDependency.title": "EasyUseAnima AiO 依赖项检查",
+    "info.optionalDependency.complete": "可用: {available}/{total}。",
+    "info.optionalDependency.missing": "未安装: {items}。相关功能将在加入队列前被禁用或替换。",
+    "info.optionalDependency.error": "查询失败: {items}。设置未被修改，并将在下次加入队列前重新检查。",
     "tip.modMode": "选择 Mod Guidance 跟随 prompt_data、强制开启或关闭。",
     "tip.modProfile": "Anima Mod Guidance layer profile。off 会禁用 Mod Guidance，即使 prompt_data 要求启用。",
     "tip.modAdapter": "传给 Spectrum Mod Guidance 的 adapter。auto-download default 使用节点包默认 adapter。",
@@ -2247,7 +2263,10 @@ const generatorOptionalDependencyState = {
   loaded: false,
   loading: null,
   available: {},
+  status: {},
   nodeInfo: {},
+  errors: {},
+  reportedSignature: "",
 };
 
 function uniqueStrings(values) {
@@ -2313,44 +2332,119 @@ function loadGeneratorSamplerOptions() {
 
 async function fetchGeneratorOptionalDependencies() {
   const next = {};
+  const nextStatus = {};
   const nextInfo = {};
+  const nextErrors = {};
   for (const [key, spec] of Object.entries(GENERATOR_OPTIONAL_DEPENDENCY_SPECS)) {
     try {
       const data = await easyuseAnimaFetchComfyJson(api, `/object_info/${encodeURIComponent(spec.nodeId)}`);
       const info = data?.[spec.nodeId] || null;
       next[key] = !!info;
+      nextStatus[key] = info ? "available" : "missing";
       nextInfo[key] = info;
-    } catch {
-      next[key] = false;
+    } catch (error) {
+      nextStatus[key] = "error";
       nextInfo[key] = null;
+      nextErrors[key] = error instanceof Error ? error.message : String(error || "Unknown error");
     }
   }
   generatorOptionalDependencyState.available = next;
+  generatorOptionalDependencyState.status = nextStatus;
   generatorOptionalDependencyState.nodeInfo = nextInfo;
+  generatorOptionalDependencyState.errors = nextErrors;
 }
 
-function loadGeneratorOptionalDependencies() {
-  if (generatorOptionalDependencyState.loaded) {
+function optionalDependencyResultLabel(key) {
+  const spec = GENERATOR_OPTIONAL_DEPENDENCY_SPECS[key];
+  return spec ? `${spec.nodeId} (${spec.pack})` : key;
+}
+
+function reportGeneratorOptionalDependencyStatus() {
+  const rows = Object.entries(GENERATOR_OPTIONAL_DEPENDENCY_SPECS).map(([key, spec]) => ({
+    key,
+    node: spec.nodeId,
+    pack: spec.pack,
+    status: generatorOptionalDependencyState.status[key] || "error",
+    error: generatorOptionalDependencyState.errors[key] || "",
+  }));
+  const available = rows.filter((row) => row.status === "available");
+  const missing = rows.filter((row) => row.status === "missing");
+  const failed = rows.filter((row) => row.status === "error");
+  console.info("[EasyUseAnima] AiO optional dependency query result", rows);
+
+  const details = [aioFormat("info.optionalDependency.complete", {
+    available: available.length,
+    total: rows.length,
+  })];
+  if (missing.length) {
+    details.push(aioFormat("info.optionalDependency.missing", {
+      items: missing.map((row) => optionalDependencyResultLabel(row.key)).join(", "),
+    }));
+  }
+  if (failed.length) {
+    details.push(aioFormat("info.optionalDependency.error", {
+      items: failed.map((row) => optionalDependencyResultLabel(row.key)).join(", "),
+    }));
+  }
+
+  const signature = rows.map((row) => `${row.key}:${row.status}:${row.error}`).join("|");
+  if (signature === generatorOptionalDependencyState.reportedSignature) {
+    return;
+  }
+  generatorOptionalDependencyState.reportedSignature = signature;
+  const summary = aioText("info.optionalDependency.title");
+  const detail = details.join(" ");
+  const toast = app?.extensionManager?.toast;
+  if (typeof toast?.add === "function") {
+    toast.add({
+      severity: failed.length ? "warn" : "info",
+      summary,
+      detail,
+      life: failed.length || missing.length ? 10000 : 5000,
+    });
+  } else if (typeof app?.ui?.dialog?.show === "function") {
+    app.ui.dialog.show(`${summary}\n${detail}`);
+  }
+}
+
+function loadGeneratorOptionalDependencies({ retryErrors = false } = {}) {
+  const hasQueryErrors = Object.values(generatorOptionalDependencyState.status).includes("error");
+  if (generatorOptionalDependencyState.loaded && (!retryErrors || !hasQueryErrors)) {
     return Promise.resolve(generatorOptionalDependencyState);
   }
   if (!generatorOptionalDependencyState.loading) {
     generatorOptionalDependencyState.loading = fetchGeneratorOptionalDependencies()
       .catch((error) => {
         console.warn("[EasyUseAnima] Failed to load optional dependency status.", error);
+        const message = error instanceof Error ? error.message : String(error || "Unknown error");
+        generatorOptionalDependencyState.status = Object.fromEntries(
+          Object.keys(GENERATOR_OPTIONAL_DEPENDENCY_SPECS).map((key) => [key, "error"]),
+        );
+        generatorOptionalDependencyState.errors = Object.fromEntries(
+          Object.keys(GENERATOR_OPTIONAL_DEPENDENCY_SPECS).map((key) => [key, message]),
+        );
+      })
+      .then(() => {
+        generatorOptionalDependencyState.loaded = true;
+        reportGeneratorOptionalDependencyStatus();
+        return generatorOptionalDependencyState;
       })
       .finally(() => {
-        generatorOptionalDependencyState.loaded = true;
-      })
-      .then(() => generatorOptionalDependencyState);
+        generatorOptionalDependencyState.loading = null;
+      });
   }
   return generatorOptionalDependencyState.loading;
 }
 
-function optionalDependencyAvailable(key) {
+function optionalDependencyStatus(key) {
   if (!key || !generatorOptionalDependencyState.loaded) {
-    return true;
+    return "unknown";
   }
-  return !!generatorOptionalDependencyState.available[key];
+  return generatorOptionalDependencyState.status[key] || "unknown";
+}
+
+function optionalDependencyAvailable(key) {
+  return optionalDependencyStatus(key) !== "missing";
 }
 
 function backendDependencyMissing(backend) {
@@ -2406,10 +2500,11 @@ function nodeInputChoiceOptions(dependencyKey, inputName, current, fallback = []
 }
 
 function nodeInputSupported(dependencyKey, inputName) {
-  if (!generatorOptionalDependencyState.loaded) {
+  const status = optionalDependencyStatus(dependencyKey);
+  if (status === "unknown" || status === "error") {
     return true;
   }
-  if (!optionalDependencyAvailable(dependencyKey)) {
+  if (status === "missing") {
     return false;
   }
   return !!nodeInputSpec(dependencyKey, inputName);
@@ -8168,7 +8263,7 @@ function installGeneratorQueuePromptHook() {
   }
   const queuePrompt = api.queuePrompt;
   api.queuePrompt = async function (number, prompt, ...args) {
-    await loadGeneratorOptionalDependencies();
+    await loadGeneratorOptionalDependencies({ retryErrors: true });
     prepareGeneratorPromptForQueue(prompt);
     return queuePrompt.call(this, number, prompt, ...args);
   };


### PR DESCRIPTION
## 변경 요약

- AiO 선택 의존성 조회 상태를 `사용 가능`, `미설치`, `조회 실패`로 구분했습니다.
- 조회 결과를 ComfyUI 정보 알림과 브라우저 `console.info`에 노드 및 노드팩 단위로 출력합니다.
- 네트워크/API 조회 실패를 미설치로 간주하지 않아 샘플러, Detailer, Upscale 설정이 조용히 비활성화되지 않게 했습니다.
- 조회 실패 항목은 설정을 유지하고 다음 큐 실행 전에 다시 조회합니다.

## 주요 파일

- `web/js/easyuse_anima_aio.js`
- `tests/test_aio_frontend.py`

## 검증

- `node --check web/js/easyuse_anima_aio.js`: 통과
- `python -m unittest tests.test_aio_frontend -v`: 24개 통과
- `python -m unittest discover -s tests -v`: 300개 통과
- ComfyUI Codex test instance 0.27.0: AiO 큐 실행 시 의존성 정보 알림 및 `console.info` 출력 확인
- `python -m pytest tests -q`: 저장소 루트 `__init__.py`를 독립 모듈로 수집하면서 상대 import가 실패해 테스트 본문 실행 전 수집 오류 발생

## 남은 위험

- 실제 전송 오류를 강제로 만든 브라우저 smoke는 수행하지 않았으며, 조회 실패 상태는 회귀 테스트와 코드 경로로 검증했습니다.
- ComfyUI v0.25.1 사용자 인스턴스의 수동 브라우저 확인은 필요합니다.

## 라벨 후보

저장소에 해당 라벨이 없어 다음 라벨은 생성하지 않고 후보로 남깁니다: `type: fix`, `area: frontend`, `status: draft`.

Refs #38