### PR TITLE
fix: Prompt Studio 폭 변화 후 최소 높이 재측정

### DIFF
--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -606,6 +606,25 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(module="extension_runtime", symbol=name):
                 self.assertIn(f"  {name},", extension_runtime_source)
 
+    def test_advanced_layout_remeasures_after_scrollbar_changes_width_or_wrapping(self):
+        source = (PROMPT_STUDIO_MODULES / "advanced_layout_controller.js").read_text(
+            encoding="utf-8"
+        )
+        metrics_start = source.index("function advancedEditorLayoutMetrics")
+        metrics_end = source.index("\nfunction scheduleAdvancedScrollbarRemeasure", metrics_start)
+        metrics_body = source[metrics_start:metrics_end]
+        apply_start = source.index("function applyAdvancedLayout")
+        apply_end = source.index("\nconst ADVANCED_LAYOUT_REASON_PRIORITY", apply_start)
+        apply_body = source[apply_start:apply_end]
+
+        self.assertIn("editor?.clientWidth", metrics_body)
+        self.assertIn("editor?.scrollHeight", metrics_body)
+        self.assertIn("advancedEditorLayoutMetricsChanged", metrics_body)
+        self.assertIn("scheduleAdvancedScrollbarRemeasure", apply_body)
+        self.assertIn('scheduleAdvancedLayout(node, "scrollbar", hooks)', source)
+        self.assertIn("scrollbar: 2", source)
+        self.assertIn('reason !== "scrollbar"', apply_body)
+
     def test_prompt_studio_phase_3_typedefs_are_documented(self):
         types_source = (PROMPT_STUDIO_MODULES / "types.js").read_text(
             encoding="utf-8"

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -480,8 +480,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         for name in (
             "applyAdvancedLayout",
             "clearAdvancedResizeEndListeners",
+            "disconnectAdvancedEditorWidthObserver",
             "finalizeAdvancedResize",
             "installAdvancedResizeEndListeners",
+            "observeAdvancedEditorWidth",
             "scheduleAdvancedLayout",
             "scheduleAdvancedResizeFinalize",
         ):
@@ -606,7 +608,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(module="extension_runtime", symbol=name):
                 self.assertIn(f"  {name},", extension_runtime_source)
 
-    def test_advanced_layout_remeasures_after_scrollbar_changes_width_or_wrapping(self):
+    def test_advanced_layout_remeasures_after_scrollbar_or_editor_width_changes(self):
         source = (PROMPT_STUDIO_MODULES / "advanced_layout_controller.js").read_text(
             encoding="utf-8"
         )
@@ -622,8 +624,23 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("advancedEditorLayoutMetricsChanged", metrics_body)
         self.assertIn("scheduleAdvancedScrollbarRemeasure", apply_body)
         self.assertIn('scheduleAdvancedLayout(node, "scrollbar", hooks)', source)
+        self.assertIn("new ResizeObserver", source)
+        self.assertIn("scheduleAdvancedWidthRemeasure(node, hooks)", source)
+        self.assertIn('scheduleAdvancedLayout(node, "width", hooks)', source)
+        self.assertIn("ADVANCED_RESIZE_SETTLE_DELAY", source)
         self.assertIn("scrollbar: 2", source)
+        self.assertIn("width: 2", source)
         self.assertIn('reason !== "scrollbar"', apply_body)
+        self.assertIn('reason !== "width"', apply_body)
+
+        advanced_node_ui_source = (
+            PROMPT_STUDIO_MODULES / "advanced_node_ui.js"
+        ).read_text(encoding="utf-8")
+        node_hooks_source = (PROMPT_STUDIO_MODULES / "node_hooks.js").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("observeAdvancedEditorWidth(node);", advanced_node_ui_source)
+        self.assertIn("disconnectAdvancedEditorWidthObserver?.(this);", node_hooks_source)
 
     def test_prompt_studio_phase_3_typedefs_are_documented(self):
         types_source = (PROMPT_STUDIO_MODULES / "types.js").read_text(

--- a/web/js/prompt_studio/advanced_layout_controller.js
+++ b/web/js/prompt_studio/advanced_layout_controller.js
@@ -10,6 +10,35 @@ import {
   getAdvancedEditorElement,
 } from "./state.js";
 
+function advancedEditorLayoutMetrics(editor) {
+  return {
+    clientWidth: Math.ceil(Number(editor?.clientWidth) || 0),
+    scrollHeight: Math.ceil(Number(editor?.scrollHeight) || 0),
+  };
+}
+
+function advancedEditorLayoutMetricsChanged(previous, current) {
+  return Math.abs(current.clientWidth - previous.clientWidth) > 1
+    || Math.abs(current.scrollHeight - previous.scrollHeight) > 1;
+}
+
+function scheduleAdvancedScrollbarRemeasure(node, editor, previousMetrics, hooks = {}) {
+  cancelAnimationFrame(node?.__easyuseAnimaAdvancedScrollbarMeasureFrame);
+  if (!node || !editor?.isConnected) {
+    return;
+  }
+  node.__easyuseAnimaAdvancedScrollbarMeasureFrame = requestAnimationFrame(() => {
+    node.__easyuseAnimaAdvancedScrollbarMeasureFrame = null;
+    if (!node.graph || !editor.isConnected) {
+      return;
+    }
+    const currentMetrics = advancedEditorLayoutMetrics(editor);
+    if (advancedEditorLayoutMetricsChanged(previousMetrics, currentMetrics)) {
+      scheduleAdvancedLayout(node, "scrollbar", hooks);
+    }
+  });
+}
+
 function clearAdvancedResizeEndListeners(node) {
   const handler = node?.__easyuseAnimaAdvancedResizeEndHandler;
   if (!handler) {
@@ -74,6 +103,7 @@ function applyAdvancedLayout(node, reason = "layout", hooks = {}) {
   node.__easyuseAnimaApplyingLayout = true;
   try {
     updateAdvancedEditorWidth(node);
+    const previousMetrics = advancedEditorLayoutMetrics(editor);
 
     const currentWidth = Number(node.size[0]) || 360;
     const currentHeight = Number(node.size[1]) || 0;
@@ -89,12 +119,16 @@ function applyAdvancedLayout(node, reason = "layout", hooks = {}) {
       node.setSize([currentWidth, minimumHeight]);
     }
 
+    scheduleAdvancedScrollbarRemeasure(node, editor, previousMetrics, hooks);
+
     hooks.markGraphDirty?.();
     requestAnimationFrame(() => hooks.markGraphDirty?.());
   } finally {
     node.__easyuseAnimaApplyingLayout = false;
   }
-  hooks.scheduleAdvancedHighlights?.(node, { classify: reason !== "resize" });
+  hooks.scheduleAdvancedHighlights?.(node, {
+    classify: reason !== "resize" && reason !== "scrollbar",
+  });
 }
 
 const ADVANCED_LAYOUT_REASON_PRIORITY = {
@@ -104,6 +138,7 @@ const ADVANCED_LAYOUT_REASON_PRIORITY = {
   connections: 1,
   executed: 1,
   settings: 1,
+  scrollbar: 2,
   resize: 3,
 };
 

--- a/web/js/prompt_studio/advanced_layout_controller.js
+++ b/web/js/prompt_studio/advanced_layout_controller.js
@@ -10,6 +10,8 @@ import {
   getAdvancedEditorElement,
 } from "./state.js";
 
+const ADVANCED_RESIZE_SETTLE_DELAY = 120;
+
 function advancedEditorLayoutMetrics(editor) {
   return {
     clientWidth: Math.ceil(Number(editor?.clientWidth) || 0),
@@ -20,6 +22,71 @@ function advancedEditorLayoutMetrics(editor) {
 function advancedEditorLayoutMetricsChanged(previous, current) {
   return Math.abs(current.clientWidth - previous.clientWidth) > 1
     || Math.abs(current.scrollHeight - previous.scrollHeight) > 1;
+}
+
+function disconnectAdvancedEditorWidthObserver(node) {
+  node?.__easyuseAnimaAdvancedWidthObserver?.disconnect?.();
+  if (!node) {
+    return;
+  }
+  clearTimeout(node.__easyuseAnimaAdvancedWidthRemeasureTimer);
+  node.__easyuseAnimaAdvancedWidthObserver = null;
+  node.__easyuseAnimaAdvancedWidthObserverEditor = null;
+  node.__easyuseAnimaAdvancedObservedEditorWidth = null;
+  node.__easyuseAnimaAdvancedWidthRemeasureTimer = null;
+}
+
+function scheduleAdvancedWidthRemeasure(node, hooks = {}) {
+  clearTimeout(node?.__easyuseAnimaAdvancedWidthRemeasureTimer);
+  if (!node) {
+    return;
+  }
+  node.__easyuseAnimaAdvancedWidthRemeasureTimer = setTimeout(() => {
+    node.__easyuseAnimaAdvancedWidthRemeasureTimer = null;
+    if (!node.graph || !getAdvancedEditorElement(node)?.isConnected) {
+      return;
+    }
+    scheduleAdvancedLayout(node, "width", hooks);
+  }, ADVANCED_RESIZE_SETTLE_DELAY);
+}
+
+function observeAdvancedEditorWidth(node, hooks = {}) {
+  const editor = getAdvancedEditorElement(node);
+  if (!node || !editor) {
+    return;
+  }
+  if (
+    node.__easyuseAnimaAdvancedWidthObserver
+    && node.__easyuseAnimaAdvancedWidthObserverEditor === editor
+  ) {
+    return;
+  }
+
+  disconnectAdvancedEditorWidthObserver(node);
+  node.__easyuseAnimaAdvancedWidthObserverEditor = editor;
+  node.__easyuseAnimaAdvancedObservedEditorWidth = advancedEditorLayoutMetrics(editor).clientWidth;
+  if (typeof ResizeObserver !== "function") {
+    return;
+  }
+
+  const observer = new ResizeObserver(() => {
+    if (
+      !node.graph
+      || !editor.isConnected
+      || getAdvancedEditorElement(node) !== editor
+    ) {
+      disconnectAdvancedEditorWidthObserver(node);
+      return;
+    }
+    const previousWidth = Number(node.__easyuseAnimaAdvancedObservedEditorWidth) || 0;
+    const currentWidth = advancedEditorLayoutMetrics(editor).clientWidth;
+    node.__easyuseAnimaAdvancedObservedEditorWidth = currentWidth;
+    if (Math.abs(currentWidth - previousWidth) > 1) {
+      scheduleAdvancedWidthRemeasure(node, hooks);
+    }
+  });
+  node.__easyuseAnimaAdvancedWidthObserver = observer;
+  observer.observe(editor);
 }
 
 function scheduleAdvancedScrollbarRemeasure(node, editor, previousMetrics, hooks = {}) {
@@ -88,7 +155,7 @@ function scheduleAdvancedResizeFinalize(node, hooks = {}) {
   clearTimeout(node.__easyuseAnimaAdvancedResizeFinalizeTimer);
   node.__easyuseAnimaAdvancedResizeFinalizeTimer = setTimeout(() => {
     finalizeAdvancedResize(node, hooks);
-  }, 120);
+  }, ADVANCED_RESIZE_SETTLE_DELAY);
 }
 
 function applyAdvancedLayout(node, reason = "layout", hooks = {}) {
@@ -127,7 +194,7 @@ function applyAdvancedLayout(node, reason = "layout", hooks = {}) {
     node.__easyuseAnimaApplyingLayout = false;
   }
   hooks.scheduleAdvancedHighlights?.(node, {
-    classify: reason !== "resize" && reason !== "scrollbar",
+    classify: reason !== "resize" && reason !== "scrollbar" && reason !== "width",
   });
 }
 
@@ -139,6 +206,7 @@ const ADVANCED_LAYOUT_REASON_PRIORITY = {
   executed: 1,
   settings: 1,
   scrollbar: 2,
+  width: 2,
   resize: 3,
 };
 
@@ -173,8 +241,10 @@ function scheduleAdvancedLayout(node, reason = "layout", hooks = {}) {
 export {
   applyAdvancedLayout,
   clearAdvancedResizeEndListeners,
+  disconnectAdvancedEditorWidthObserver,
   finalizeAdvancedResize,
   installAdvancedResizeEndListeners,
+  observeAdvancedEditorWidth,
   scheduleAdvancedLayout,
   scheduleAdvancedResizeFinalize,
 };

--- a/web/js/prompt_studio/advanced_node_ui.js
+++ b/web/js/prompt_studio/advanced_node_ui.js
@@ -103,6 +103,7 @@ function hookAdvancedNode(node, hooks = {}) {
   const {
     hideAdvancedControlWidgets = () => {},
     installAdvancedSaveSync = () => {},
+    observeAdvancedEditorWidth = () => {},
   } = hooks;
   ensureAdvancedStyle();
   installAdvancedSaveSync();
@@ -141,6 +142,7 @@ function hookAdvancedNode(node, hooks = {}) {
       };
     }
   }
+  observeAdvancedEditorWidth(node);
   renderAdvancedEditor(node, hooks);
 }
 

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -65,6 +65,8 @@ import {
   updateAdvancedEditorWidth,
 } from "./layout.js";
 import {
+  disconnectAdvancedEditorWidthObserver,
+  observeAdvancedEditorWidth as observeAdvancedEditorWidthWithHooks,
   scheduleAdvancedLayout as scheduleAdvancedLayoutWithHooks,
   scheduleAdvancedResizeFinalize as scheduleAdvancedResizeFinalizeWithHooks,
 } from "./advanced_layout_controller.js";
@@ -262,6 +264,10 @@ function createPromptStudioExtensionRuntime(app) {
     scheduleAdvancedResizeFinalizeWithHooks(node, advancedLayoutControllerHooks());
   }
 
+  function observeAdvancedEditorWidth(node) {
+    observeAdvancedEditorWidthWithHooks(node, advancedLayoutControllerHooks());
+  }
+
   function extendSlotControlHooks() {
     return {
       expandStudioInputToContent,
@@ -314,6 +320,7 @@ function createPromptStudioExtensionRuntime(app) {
     return {
       hideAdvancedControlWidgets,
       installAdvancedSaveSync: installAdvancedSaveSyncForApp,
+      observeAdvancedEditorWidth,
       scheduleAdvancedHighlights,
       scheduleAdvancedLayout,
       writeAdvancedFields,
@@ -386,6 +393,7 @@ function createPromptStudioExtensionRuntime(app) {
         captureAdvancedConfigure: (node, serialized) => (
           captureAdvancedConfigure(node, serialized, advancedWidget(node))
         ),
+        disconnectAdvancedEditorWidthObserver,
         hookStudioNode,
         isExtendNode,
         layoutExtendPromptWidgets,

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -95,6 +95,15 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
     }
   };
 
+  const onRemoved = nodeType.prototype.onRemoved;
+  nodeType.prototype.onRemoved = function () {
+    const result = onRemoved?.apply(this, arguments);
+    if (isAdvanced) {
+      hooks.disconnectAdvancedEditorWidthObserver?.(this);
+    }
+    return result;
+  };
+
   const onConnectionsChange = nodeType.prototype.onConnectionsChange;
   nodeType.prototype.onConnectionsChange = function () {
     const result = onConnectionsChange?.apply(this, arguments);


### PR DESCRIPTION
## 변경 요약

- Prompt Studio Advanced 편집기 레이아웃 적용 전 `clientWidth`와 `scrollHeight`를 기록합니다.
- 스크롤바 발생 또는 해제로 다음 프레임의 폭/줄바꿈 높이가 달라지면 최소 높이를 다시 계산합니다.
- `ResizeObserver`로 편집기의 실제 폭을 추적해 수동 노드 폭 변경이나 ComfyUI의 후속 폭 보정도 반영합니다.
- 연속 드래그 중에는 재계산하지 않고 폭이 120ms 동안 안정된 뒤 한 번만 재배치합니다.
- 폭/스크롤바 재측정에서는 프롬프트 분류 요청을 다시 실행하지 않습니다.
- 기존 사용자 수동 높이와 현재 높이를 자동으로 줄이지 않는 동작은 유지합니다.
- Advanced 노드 제거 시 폭 관찰자와 예약 타이머를 정리합니다.

## 주요 파일

- `web/js/prompt_studio/advanced_layout_controller.js`
- `web/js/prompt_studio/advanced_node_ui.js`
- `web/js/prompt_studio/extension_runtime.js`
- `web/js/prompt_studio/node_hooks.js`
- `tests/test_frontend_modules.py`

## 검증

- `node --check` 변경 JS 4개: 통과
- `python tests/test_frontend_modules.py`: 15개 통과
- `python -m unittest discover -s tests -q`: 301개 통과
- `git diff --check`: 통과
- `python -m pytest tests -q`: 저장소 루트 `__init__.py` 상대 import 수집 오류로 테스트 본문 실행 전 301개 오류
- ComfyUI Codex test instance 0.27.0, Node 2.0 브라우저 smoke:
  - Advanced v2 편집기 수동 폭 확장 `367px -> 528px` 반영
  - 1.5초 후 폭과 높이 유지, 반복 확장 없음
  - Prompt Studio 관련 신규 콘솔 오류 없음

## 남은 위험

- 겹친 두 테스트 노드 때문에 폭 축소 방향의 독립적인 브라우저 smoke는 완료하지 못했습니다.
- Legacy canvas 수동 smoke는 수행하지 않았습니다.
- ComfyUI v0.25.1 사용자 인스턴스에서 최신 폭 관찰 변경의 수동 확인은 수행하지 않았습니다.

## 라벨 후보

저장소에 해당 라벨이 없어 다음 라벨은 생성하지 않고 후보로 남깁니다: `type: fix`, `area: frontend`, `status: draft`.

Refs #35