### PR TITLE
fix: AiO Generator 리사이즈·휠 스크롤 소유권 정리

### DIFF
--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -6,11 +6,102 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 AIO_JS = ROOT / "web" / "js" / "easyuse_anima_aio.js"
+AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
 AUTOCOMPLETE_JS = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
 PROMPT_STUDIO_COMMON_JS = ROOT / "web" / "js" / "easyuse_anima_prompt_studio_common.js"
 
 
 class AIOFrontendSourceTests(unittest.TestCase):
+    def test_generator_panel_height_is_owned_by_comfyui(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+
+        layout_start = source.index("function applyGeneratorLayout")
+        layout_end = source.index("\nfunction scheduleGeneratorLayout", layout_start)
+        layout_body = source[layout_start:layout_end]
+        panel_start = source.index("    .easyuse-anima-aio-node-panel {")
+        panel_end = source.index("\n    .easyuse-anima-aio-node-panel *", panel_start)
+        panel_style = source[panel_start:panel_end]
+        main_start = source.index("    .easyuse-anima-aio-node-main {")
+        main_end = source.index("\n    .easyuse-anima-aio-node-card {", main_start)
+        main_style = source[main_start:main_end]
+        settings_start = source.index("    .easyuse-anima-aio-node-settings {")
+        settings_end = source.index("\n    .easyuse-anima-aio-node-settings-scroll {", settings_start)
+        settings_style = source[settings_start:settings_end]
+        scroll_start = settings_end + 1
+        scroll_end = source.index("\n    .easyuse-anima-aio-node-settings-scroll::-webkit-scrollbar", scroll_start)
+        scroll_style = source[scroll_start:scroll_end]
+        preview_start = source.index("    .easyuse-anima-aio-node-preview {")
+        preview_end = source.index("\n    .easyuse-anima-aio-node-sampler-actions {", preview_start)
+        preview_style = source[preview_start:preview_end]
+        preview_box_start = source.index("    .easyuse-anima-aio-node-preview-box {")
+        preview_box_end = source.index("\n    .easyuse-anima-aio-node-preview-box img {", preview_box_start)
+        preview_box_style = source[preview_box_start:preview_box_end]
+        panel_registration_start = source.index("function ensureGeneratorPanel")
+        panel_registration_end = source.index("\nfunction field", panel_registration_start)
+        panel_registration = source[panel_registration_start:panel_registration_end]
+
+        self.assertIn("getMinHeight: () => GENERATOR_PANEL_MIN_HEIGHT", panel_registration)
+        self.assertNotIn("getHeight:", panel_registration)
+        self.assertNotIn("computeLayoutSize", panel_registration)
+        self.assertNotIn("computedHeight =", source)
+        self.assertNotIn("generatorNodeChromeOffset", source)
+        self.assertNotIn("generatorAvailablePanelHeight", source)
+        self.assertNotIn("generatorPanelHeight", source)
+        self.assertNotIn("node.setSize?.(", layout_body)
+        self.assertNotIn("node.setSize(", layout_body)
+        self.assertNotIn("panel.style.height =", layout_body)
+        self.assertIn('panel.style.removeProperty("height")', layout_body)
+        self.assertIn('panel.style.removeProperty("max-height")', layout_body)
+
+        self.assertIn("flex: 1 1 0%;", panel_style)
+        self.assertIn("contain: size;", panel_style)
+        self.assertIn("min-height: 0;", main_style)
+        self.assertIn("overflow: hidden;", main_style)
+        self.assertNotIn("height: 100%;", main_style)
+        self.assertNotIn("min-height: 284px;", main_style)
+        self.assertNotIn("height: 100%;", settings_style)
+        self.assertIn("flex: 1 1 0%;", scroll_style)
+        self.assertIn("overflow-y: auto;", scroll_style)
+        self.assertIn("overscroll-behavior: contain;", scroll_style)
+        self.assertIn("min-height: 0;", preview_style)
+        self.assertIn("overflow: hidden;", preview_style)
+        self.assertNotIn("height: 100%;", preview_style)
+        self.assertNotIn("min-height: 284px;", preview_style)
+        self.assertIn("min-height: 0;", preview_box_style)
+        self.assertNotIn("min-height: 210px;", preview_box_style)
+
+    def test_generator_wheel_router_decides_scroll_ownership_before_canvas(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        wheel_source = AIO_WHEEL_JS.read_text(encoding="utf-8")
+        stop_start = source.index("function stopGeneratorControlPropagation")
+        stop_end = source.index("\nfunction dispatchGeneratorCanvasWheelEvent", stop_start)
+        stop_body = source[stop_start:stop_end]
+        forward_start = source.index("function forwardGeneratorPanelWheel")
+        forward_end = source.index("\nfunction installGeneratorWheelForwarder", forward_start)
+        forward_body = source[forward_start:forward_end]
+        install_start = forward_end + 1
+        install_end = source.index("\nfunction samplerModeLabel", install_start)
+        install_body = source[install_start:install_end]
+        setup_start = source.index("  async setup() {")
+        setup_end = source.index("\n  async beforeRegisterNodeDef", setup_start)
+        setup_body = source[setup_start:setup_end]
+
+        self.assertIn('from "./aio/wheel.js"', source)
+        self.assertIn('root.addEventListener("wheel", forwardGeneratorPanelWheel', stop_body)
+        self.assertIn("capture: true", stop_body)
+        self.assertIn("passive: false", stop_body)
+        self.assertIn("consumeAioPanelWheel(event, panel)", forward_body)
+        self.assertLess(
+            forward_body.index("consumeAioPanelWheel(event, panel)"),
+            forward_body.index("dispatchGeneratorCanvasWheelEvent(event)"),
+        )
+        self.assertIn('window.addEventListener("wheel", forwardGeneratorPanelWheel', install_body)
+        self.assertIn("capture: true", install_body)
+        self.assertIn("passive: false", install_body)
+        self.assertIn("installGeneratorWheelForwarder();", setup_body)
+        self.assertIn("owns the wheel even at either boundary", wheel_source)
+        self.assertIn("Canvas zoom is allowed only when neither intended scrollbar exists", wheel_source)
+
     def test_generator_keeps_native_output_preview_suppressed_after_execution(self):
         source = AIO_JS.read_text(encoding="utf-8")
         registration_start = source.index("async beforeRegisterNodeDef")

--- a/tests/test_aio_wheel.py
+++ b/tests/test_aio_wheel.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
+
+
+class AIOWheelTests(unittest.TestCase):
+    def test_scroll_owners_consume_wheel_even_at_boundaries(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        runner = textwrap.dedent(
+            r"""
+            const assert = require("assert");
+            const fs = require("fs");
+
+            global.Element = class Element {
+              constructor(classNames = []) {
+                this.classNames = new Set(classNames);
+                this.parentElement = null;
+              }
+              matches(selector) {
+                return selector.startsWith(".") && this.classNames.has(selector.slice(1));
+              }
+              closest(selector) {
+                for (let current = this; current; current = current.parentElement) {
+                  if (current.matches(selector)) return current;
+                }
+                return null;
+              }
+              contains(candidate) {
+                for (let current = candidate; current; current = current.parentElement) {
+                  if (current === this) return true;
+                }
+                return false;
+              }
+            };
+            global.HTMLElement = class HTMLElement extends Element {
+              constructor(classNames = [], geometry = {}) {
+                super(classNames);
+                Object.assign(this, {
+                  scrollHeight: 0,
+                  clientHeight: 0,
+                  scrollTop: 0,
+                  scrollWidth: 0,
+                  clientWidth: 0,
+                  scrollLeft: 0,
+                }, geometry);
+                this.queries = new Map();
+              }
+              querySelector(selector) {
+                return this.queries.get(selector) || null;
+              }
+            };
+
+            let source = fs.readFileSync(process.argv[1], "utf8");
+            source = source.replace(
+              /export\s*\{([\s\S]*?)\};\s*$/,
+              "globalThis.__aioWheelExports = {$1};",
+            );
+            eval(source);
+
+            const findPanel = globalThis.__aioWheelExports.aioPanelFromWheelEvent;
+            const consumePanelWheel = globalThis.__aioWheelExports.consumeAioPanelWheel;
+            const makeEvent = (target, path, deltaY, deltaX = 0, deltaMode = 0) => ({
+              target,
+              deltaX,
+              deltaY,
+              deltaMode,
+              prevented: 0,
+              stopped: 0,
+              stoppedImmediately: 0,
+              composedPath: () => path,
+              preventDefault() { this.prevented += 1; },
+              stopPropagation() { this.stopped += 1; },
+              stopImmediatePropagation() { this.stoppedImmediately += 1; },
+            });
+
+            const panel = new HTMLElement(["easyuse-anima-aio-node-panel"]);
+            const settings = new HTMLElement(
+              ["easyuse-anima-aio-node-settings-scroll"],
+              { scrollHeight: 600, clientHeight: 200, scrollTop: 0 },
+            );
+            settings.parentElement = panel;
+            panel.queries.set(".easyuse-anima-aio-node-settings-scroll", settings);
+            const previewTarget = new HTMLElement(["preview-target"]);
+            previewTarget.parentElement = panel;
+
+            let event = makeEvent(previewTarget, [previewTarget, panel], 120);
+            assert.strictEqual(findPanel(event), panel);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(settings.scrollTop, 120);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [1, 1, 1],
+            );
+
+            settings.scrollTop = 400;
+            event = makeEvent(previewTarget, [previewTarget, panel], 120);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(settings.scrollTop, 400);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [1, 1, 1],
+            );
+
+            settings.scrollTop = 0;
+            event = makeEvent(previewTarget, [previewTarget, panel], -120);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(settings.scrollTop, 0);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [1, 1, 1],
+            );
+
+            event = makeEvent(previewTarget, [previewTarget, panel], 2, 0, 1);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(settings.scrollTop, 32);
+
+            const feed = new HTMLElement(
+              ["easyuse-anima-aio-node-preview-feed"],
+              { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 },
+            );
+            feed.parentElement = panel;
+            settings.scrollTop = 0;
+            event = makeEvent(feed, [feed, panel], 100);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(feed.scrollLeft, 100);
+            assert.strictEqual(settings.scrollTop, 0);
+
+            feed.scrollLeft = 300;
+            event = makeEvent(feed, [feed, panel], 100);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(feed.scrollLeft, 300);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [1, 1, 1],
+            );
+
+            settings.scrollHeight = 200;
+            settings.clientHeight = 200;
+            event = makeEvent(previewTarget, [previewTarget, panel], 120);
+            assert.strictEqual(consumePanelWheel(event, panel), false);
+            assert.strictEqual(settings.scrollTop, 0);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [0, 0, 0],
+            );
+            """
+        )
+        completed = subprocess.run(
+            [node_bin, "-e", runner, str(WHEEL_JS)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/aio/wheel.js
+++ b/web/js/aio/wheel.js
@@ -1,0 +1,95 @@
+// @ts-check
+
+const AIO_PANEL_SELECTOR = ".easyuse-anima-aio-node-panel";
+const AIO_SETTINGS_SCROLL_SELECTOR = ".easyuse-anima-aio-node-settings-scroll";
+const AIO_PREVIEW_FEED_SELECTOR = ".easyuse-anima-aio-node-preview-feed";
+
+function wheelPathElement(event, selector) {
+  for (const candidate of event?.composedPath?.() || []) {
+    if (candidate instanceof Element && candidate.matches?.(selector)) {
+      return candidate;
+    }
+  }
+  const target = event?.target;
+  return target instanceof Element ? target.closest(selector) : null;
+}
+
+function aioPanelFromWheelEvent(event) {
+  return wheelPathElement(event, AIO_PANEL_SELECTOR);
+}
+
+function aioPreviewFeedFromWheelEvent(event, panel) {
+  const feed = wheelPathElement(event, AIO_PREVIEW_FEED_SELECTOR);
+  return feed && panel?.contains?.(feed) ? feed : null;
+}
+
+function aioScrollMaximum(element, axis) {
+  if (!(element instanceof HTMLElement)) {
+    return 0;
+  }
+  return axis === "x"
+    ? Math.max(0, element.scrollWidth - element.clientWidth)
+    : Math.max(0, element.scrollHeight - element.clientHeight);
+}
+
+function aioWheelDeltaPixels(event, element, axis) {
+  const delta = axis === "x"
+    ? (Number(event?.deltaX) || Number(event?.deltaY) || 0)
+    : (Number(event?.deltaY) || 0);
+  const deltaMode = Number(event?.deltaMode) || 0;
+  if (deltaMode === 1) {
+    return delta * 16;
+  }
+  if (deltaMode === 2) {
+    const viewport = axis === "x" ? element?.clientWidth : element?.clientHeight;
+    return delta * Math.max(1, Number(viewport) || 0);
+  }
+  return delta;
+}
+
+function consumeAioScrollAreaWheel(event, element, axis) {
+  const maximum = aioScrollMaximum(element, axis);
+  if (maximum <= 1) {
+    return false;
+  }
+
+  // A visible scrollbar owns the wheel even at either boundary. Do not let a
+  // no-op boundary wheel fall through to ComfyUI canvas zoom.
+  event.preventDefault?.();
+  event.stopPropagation?.();
+  event.stopImmediatePropagation?.();
+  const property = axis === "x" ? "scrollLeft" : "scrollTop";
+  const current = Number(element[property]) || 0;
+  element[property] = Math.max(
+    0,
+    Math.min(maximum, current + aioWheelDeltaPixels(event, element, axis)),
+  );
+  return true;
+}
+
+/**
+ * AiO uses one vertical scroll owner: the left settings column. Its scrollbar
+ * owns wheel input from anywhere in the panel. The preview feed remains a more
+ * local horizontal owner only while the pointer is over that overflowing feed.
+ * Canvas zoom is allowed only when neither intended scrollbar exists.
+ */
+function consumeAioPanelWheel(event, panel) {
+  const previewFeed = aioPreviewFeedFromWheelEvent(event, panel);
+  if (previewFeed && consumeAioScrollAreaWheel(event, previewFeed, "x")) {
+    return true;
+  }
+  const settingsScroll = panel?.querySelector?.(AIO_SETTINGS_SCROLL_SELECTOR);
+  return consumeAioScrollAreaWheel(event, settingsScroll, "y");
+}
+
+export {
+  AIO_PANEL_SELECTOR,
+  AIO_PREVIEW_FEED_SELECTOR,
+  AIO_SETTINGS_SCROLL_SELECTOR,
+  aioPanelFromWheelEvent,
+  aioPreviewFeedFromWheelEvent,
+  aioScrollMaximum,
+  aioWheelDeltaPixels,
+  consumeAioPanelWheel,
+  consumeAioScrollAreaWheel,
+};

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -2,6 +2,7 @@ import { app } from "../../../scripts/app.js";
 import { api } from "../../../scripts/api.js";
 import { easyuseAnimaFetchComfyJson, easyuseAnimaFetchText } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
+import { aioPanelFromWheelEvent, consumeAioPanelWheel } from "./aio/wheel.js";
 
 const INPUT_NODE_TYPE = "EasyUseAnimaInput";
 const GENERATOR_NODE_TYPE = "EasyUseAnimaAIOGenerator";
@@ -3180,6 +3181,8 @@ function ensureStyle() {
       font: 12px "Segoe UI", sans-serif;
       display: flex;
       flex-direction: column;
+      flex: 1 1 0%;
+      contain: size;
       overflow: hidden;
       user-select: none;
     }
@@ -3201,9 +3204,10 @@ function ensureStyle() {
       display: grid;
       grid-template-columns: 260px minmax(0, 1fr);
       gap: 8px;
-      flex: 1 1 auto;
-      min-height: 284px;
-      height: 100%;
+      flex: 1 1 0%;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
     }
     .easyuse-anima-aio-node-card {
       min-width: 0;
@@ -3216,14 +3220,14 @@ function ensureStyle() {
       display: flex;
       flex-direction: column;
       min-height: 0;
-      height: 100%;
       overflow: hidden;
     }
     .easyuse-anima-aio-node-settings-scroll {
-      flex: 1 1 auto;
+      flex: 1 1 0%;
       min-height: 0;
       overflow-y: auto;
       overflow-x: hidden;
+      overscroll-behavior: contain;
       padding-right: 4px;
     }
     .easyuse-anima-aio-node-settings-scroll::-webkit-scrollbar {
@@ -3490,8 +3494,8 @@ function ensureStyle() {
     .easyuse-anima-aio-node-preview {
       display: flex;
       flex-direction: column;
-      height: 100%;
       min-height: 0;
+      overflow: hidden;
     }
     .easyuse-anima-aio-node-sampler-actions {
       display: grid;
@@ -3510,14 +3514,11 @@ function ensureStyle() {
       padding-right: 5px;
       text-align: center;
     }
-    .easyuse-anima-aio-node-preview {
-      min-height: 284px;
-    }
     .easyuse-anima-aio-node-preview-box {
       position: relative;
-      flex: 1 1 auto;
+      flex: 1 1 0%;
       height: auto;
-      min-height: 210px;
+      min-height: 0;
       overflow: hidden;
       border: 1px solid #3c4952;
       border-radius: 6px;
@@ -4425,46 +4426,71 @@ function stopGeneratorControlPropagation(root) {
   ]) {
     root.addEventListener(eventName, stop);
   }
-  root.addEventListener("wheel", (event) => {
-    const previewFeed = event.target?.closest?.(".easyuse-anima-aio-node-preview-feed");
-    if (previewFeed && previewFeed.scrollWidth > previewFeed.clientWidth) {
-      event.preventDefault();
-      event.stopPropagation();
-      previewFeed.scrollLeft += event.deltaX || event.deltaY;
-      return;
-    }
-    const scrollArea = event.target?.closest?.(".easyuse-anima-aio-node-settings-scroll");
-    if (scrollArea && scrollArea.scrollHeight > scrollArea.clientHeight) {
-      event.stopPropagation();
-      return;
-    }
-    if (event.target?.closest?.(GENERATOR_PANEL_CONTROL_SELECTOR)) {
-      return;
-    }
-    const canvas = app?.canvas?.canvas;
-    if (!canvas) {
-      return;
-    }
-    event.preventDefault();
-    event.stopPropagation();
-    canvas.dispatchEvent(new WheelEvent("wheel", {
-      bubbles: true,
-      cancelable: true,
-      deltaX: event.deltaX,
-      deltaY: event.deltaY,
-      deltaZ: event.deltaZ,
-      deltaMode: event.deltaMode,
-      clientX: event.clientX,
-      clientY: event.clientY,
-      screenX: event.screenX,
-      screenY: event.screenY,
-      ctrlKey: event.ctrlKey,
-      shiftKey: event.shiftKey,
-      altKey: event.altKey,
-      metaKey: event.metaKey,
-    }));
-  }, { passive: false });
+  // Legacy canvas bubbles DOM-widget wheel events through the panel. Keep this
+  // local guard as a fallback; Node 2.0 still needs the window capture router
+  // installed below because its Vue ancestor can handle wheel first.
+  root.addEventListener("wheel", forwardGeneratorPanelWheel, {
+    capture: true,
+    passive: false,
+  });
   root.__easyuseAnimaAioStopPropagation = true;
+}
+
+function dispatchGeneratorCanvasWheelEvent(sourceEvent) {
+  const canvas = app?.canvas?.canvas;
+  if (!canvas) {
+    return;
+  }
+  const event = new WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+    deltaX: sourceEvent.deltaX,
+    deltaY: sourceEvent.deltaY,
+    deltaZ: sourceEvent.deltaZ,
+    deltaMode: sourceEvent.deltaMode,
+    clientX: sourceEvent.clientX,
+    clientY: sourceEvent.clientY,
+    screenX: sourceEvent.screenX,
+    screenY: sourceEvent.screenY,
+    ctrlKey: sourceEvent.ctrlKey,
+    shiftKey: sourceEvent.shiftKey,
+    altKey: sourceEvent.altKey,
+    metaKey: sourceEvent.metaKey,
+  });
+  Object.defineProperty(event, "__easyuseAnimaForwarded", { value: true });
+  canvas.dispatchEvent(event);
+}
+
+function forwardGeneratorPanelWheel(event) {
+  if (event.__easyuseAnimaForwarded) {
+    return false;
+  }
+  const panel = aioPanelFromWheelEvent(event);
+  if (!panel) {
+    return false;
+  }
+  if (consumeAioPanelWheel(event, panel)) {
+    return true;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation?.();
+  dispatchGeneratorCanvasWheelEvent(event);
+  return true;
+}
+
+function installGeneratorWheelForwarder() {
+  if (window.__easyuseAnimaAioWheelForwarderInstalled) {
+    return;
+  }
+  window.__easyuseAnimaAioWheelForwarderInstalled = true;
+  // Node 2.0 handles wheel on an ancestor of the DOM widget, so ownership must
+  // be decided during window capture before that ancestor can zoom the canvas.
+  window.addEventListener("wheel", forwardGeneratorPanelWheel, {
+    capture: true,
+    passive: false,
+  });
 }
 
 function samplerModeLabel(settingsOrBackend) {
@@ -4499,75 +4525,20 @@ function generatorPanelWidth(node) {
   return Math.max(240, Math.floor((Number(node?.size?.[0]) || GENERATOR_NODE_DEFAULT_WIDTH) - 20));
 }
 
-function generatorPanelWidget(node) {
-  return node?.__easyuseAnimaGeneratorPanelWidget
-    || node?.widgets?.find?.((widget) => widget?.name === GENERATOR_DOM_WIDGET)
-    || null;
-}
-
-function generatorNodeChromeOffset(node) {
-  const widget = generatorPanelWidget(node);
-  const widgetY = Math.max(Number(widget?.last_y) || 0, Number(widget?.y) || 0);
-  return Math.ceil(Math.max(70, widgetY + 12));
-}
-
-function generatorPanelHeight(node) {
-  return Math.max(GENERATOR_PANEL_MIN_HEIGHT, Number(node?.__easyuseAnimaGeneratorPanelHeight) || 0);
-}
-
-function generatorPanelMinHeight(node) {
-  return Math.max(GENERATOR_PANEL_MIN_HEIGHT, Number(node?.__easyuseAnimaGeneratorPanelMinHeight) || 0);
-}
-
-function generatorAvailablePanelHeight(node) {
-  const nodeHeight = Number(node?.size?.[1]) || 0;
-  if (nodeHeight <= 0) {
-    return 0;
-  }
-  return Math.max(0, Math.floor(nodeHeight - generatorNodeChromeOffset(node)));
-}
-
-function measureGeneratorPanelContentHeight(node) {
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  if (!panel) {
-    return GENERATOR_PANEL_MIN_HEIGHT;
-  }
-  const minHeight = GENERATOR_PANEL_MIN_HEIGHT;
-  node.__easyuseAnimaGeneratorPanelMinHeight = minHeight;
-  return minHeight;
-}
-
-function generatorMinimumNodeHeight(node) {
-  return Math.ceil(generatorPanelMinHeight(node) + generatorNodeChromeOffset(node));
-}
-
 function applyGeneratorLayout(node) {
   const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  if (!panel || !node.size || node.__easyuseAnimaGeneratorApplyingLayout) {
+  if (!panel) {
     return;
   }
-  node.__easyuseAnimaGeneratorApplyingLayout = true;
-  try {
-    const width = generatorPanelWidth(node);
-    panel.style.width = `${width}px`;
-    panel.style.maxWidth = `${width}px`;
-    const minPanelHeight = measureGeneratorPanelContentHeight(node);
-    const panelHeight = Math.max(minPanelHeight, generatorAvailablePanelHeight(node));
-    node.__easyuseAnimaGeneratorPanelHeight = panelHeight;
-    panel.style.height = `${panelHeight}px`;
-    const currentWidth = Number(node.size[0]) || GENERATOR_NODE_DEFAULT_WIDTH;
-    const currentHeight = Number(node.size[1]) || 0;
-    const minHeight = generatorMinimumNodeHeight(node);
-    if (currentHeight < minHeight - 1 || currentWidth < GENERATOR_NODE_MIN_WIDTH) {
-      node.setSize?.([
-        Math.max(currentWidth, GENERATOR_NODE_DEFAULT_WIDTH),
-        Math.max(currentHeight, minHeight),
-      ]);
-    }
-    markNodeDirty(node);
-  } finally {
-    node.__easyuseAnimaGeneratorApplyingLayout = false;
-  }
+  const width = generatorPanelWidth(node);
+  panel.style.width = `${width}px`;
+  panel.style.maxWidth = `${width}px`;
+  // ComfyUI owns the node and DOM-widget viewport height. AiO owns only child
+  // content: the settings column scrolls while the preview stays in that host
+  // viewport. Never derive height from node.size or write node.setSize here.
+  panel.style.removeProperty("height");
+  panel.style.removeProperty("max-height");
+  markNodeDirty(node);
 }
 
 function scheduleGeneratorLayout(node) {
@@ -6201,20 +6172,11 @@ function ensureGeneratorPanel(node) {
     const panel = document.createElement("div");
     panel.className = "easyuse-anima-aio-node-panel";
     node.__easyuseAnimaGeneratorPanelEl = panel;
-    const widget = node.addDOMWidget?.(GENERATOR_DOM_WIDGET, "EasyUseAnimaGeneratorPanel", panel, {
+    node.addDOMWidget?.(GENERATOR_DOM_WIDGET, "EasyUseAnimaGeneratorPanel", panel, {
       serialize: false,
       hideOnZoom: false,
-      getMinHeight: () => generatorPanelMinHeight(node),
-      getHeight: () => generatorPanelHeight(node),
+      getMinHeight: () => GENERATOR_PANEL_MIN_HEIGHT,
     });
-    if (widget) {
-      node.__easyuseAnimaGeneratorPanelWidget = widget;
-      widget.computeLayoutSize = () => ({
-        minHeight: generatorPanelMinHeight(node),
-        height: generatorPanelHeight(node),
-        minWidth: GENERATOR_NODE_MIN_WIDTH - 18,
-      });
-    }
   }
   markGeneratorNativeLivePreviewHidden(node);
   renderGeneratorPanel(node);
@@ -8462,6 +8424,7 @@ app.registerExtension({
   name: "easyuse-anima.aio",
   async setup() {
     ensureStyle();
+    installGeneratorWheelForwarder();
     installGeneratorQueuePromptHook();
     easyuseAnimaWatchLocale(refreshGeneratorPanels);
     api.addEventListener(GENERATOR_PREVIEW_EVENT, handleGeneratorPreviewEvent);


### PR DESCRIPTION
## 변경 요약

- AiO Generator DOM 위젯은 고정 최소 높이만 선언하고, 현재 노드/위젯 viewport 높이는 ComfyUI가 소유하도록 정리했습니다.
- 과거 AiO 높이 역산 경로를 제거했습니다.
  - `getHeight`
  - 확장 코드의 `widget.computeLayoutSize` 덮어쓰기
  - node chrome offset 및 panel height 상태
  - `panel.style.height`
  - layout 중 `node.setSize()`
- CSS 수축 체인을 정리해 노드를 줄였을 때 왼쪽 settings만 스크롤되고 오른쪽 preview는 같은 viewport 안에 유지됩니다.
- AiO panel에 의도한 스크롤바가 있으면 휠은 해당 스크롤바가 항상 소유합니다.
  - settings scrollbar는 패널 어느 위치에서 휠을 사용해도 세로 스크롤을 소유합니다.
  - 최상단/최하단에서도 이벤트를 소비해 캔버스 zoom으로 넘어가지 않습니다.
  - preview feed에 가로 scrollbar가 있고 그 위에서 휠을 사용하면 feed가 우선 소유합니다.
  - 의도한 scrollbar가 하나도 없을 때만 캔버스로 휠을 전달합니다.
- Node 2.0 상위 Vue 컨테이너보다 먼저 소유권을 결정하는 window capture router와 legacy panel guard를 함께 사용합니다.
- 동작 의도를 코드 주석과 source/dynamic 회귀 테스트로 고정했습니다.

## 원인

AiO는 `getHeight`, 비공식 높이 반환이 포함된 `computeLayoutSize`, panel pixel height, node height 역산, `node.setSize()`가 같은 높이를 동시에 갱신하고 있었습니다. Node 2.0의 DOM 기반 resize 측정과 충돌할 수 있고, child min-height 및 `height: 100%` 체인이 settings 내용과 preview 최소 높이를 다시 노드 높이로 밀어 올렸습니다.

기존 wheel listener는 panel 내부 bubble 단계에서만 실행됐기 때문에 Node 2.0의 상위 컨테이너가 캔버스 zoom을 먼저 처리할 수 있었습니다. 또한 scrollbar 경계에서 휠을 명시적으로 소비하지 않았습니다.

## 주요 파일

- `web/js/easyuse_anima_aio.js`
- `web/js/aio/wheel.js`
- `tests/test_aio_frontend.py`
- `tests/test_aio_wheel.py`

## 검증

- `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -B -m unittest discover -s tests -q`: 307개 통과
- 관련 frontend/unit 테스트: 44개 통과
- 전체 `web/js/**/*.js` `node --check`: 통과
- `git diff --check`: 통과
- 높이 소유권 회귀 가드:
  - AiO 확장 코드의 `widget.computedHeight` 할당 없음
  - layout 경로의 `node.setSize()` 없음
  - panel inline height 쓰기 없음
  - 과거 chrome offset/panel height 역산 함수 없음
- ComfyUI 0.27.0 Codex test instance, legacy canvas 실제 브라우저 smoke:
  - 노드 높이 축소 후 settings scrollbar 생성
  - preview 위 휠에서 settings만 이동하고 canvas zoom 고정
  - 최하단 추가 휠에서 settings/zoom 모두 고정
  - scrollbar가 없을 때 settings는 고정되고 canvas zoom만 변경
- ComfyUI 0.27.0 Codex test instance, Node 2.0 실제 브라우저 smoke:
  - 실제 resize handle로 축소, settings만 overflow
  - preview는 자체 scroll 영역이 되지 않고 panel 안에 유지
  - scrollbar wheel 및 최하단 wheel에서 canvas zoom 고정
  - scrollbar가 없을 때만 canvas zoom 동작
  - 실제 resize 20회 반복 후 누적 높이 증가 없음
  - ResizeObserver/Vue/EasyUseAnima 관련 신규 콘솔 오류 없음

## 남은 확인

- ComfyUI v0.27.0 사용자 인스턴스 수동 확인이 필요합니다.
- 실제 생성 이미지가 표시된 preview/feed 상태와 물리 트랙패드 관성 스크롤은 자동화 범위에 포함하지 않았습니다.
- workflow queue는 이번 frontend layout/scroll PR에서 실행하지 않았습니다.

Refs #21
Refs #14