### PR TITLE
프론트엔드 미사용 코드 검사 강화

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,6 +8,8 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "strict": false
   },
   "include": [

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 JSCONFIG = ROOT / "jsconfig.json"
+FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 WEB_JS = ROOT / "web" / "js"
 API_JS = WEB_JS / "easyuse_anima_api.js"
 PROMPT_STUDIO_JS = WEB_JS / "easyuse_anima_prompt_studio.js"
@@ -799,6 +800,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(config["compilerOptions"]["allowJs"])
         self.assertTrue(config["compilerOptions"]["checkJs"])
         self.assertTrue(config["compilerOptions"]["noEmit"])
+        self.assertTrue(config["compilerOptions"]["noUnusedLocals"])
+        self.assertTrue(config["compilerOptions"]["noUnusedParameters"])
 
         for path in (
             "web/js/easyuse_anima_prompt_studio.js",
@@ -806,6 +809,14 @@ class FrontendModuleStructureTests(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 self.assertIn(path, config["include"])
+
+    def test_frontend_check_script_runs_syntax_and_typecheck(self):
+        source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn('Get-ChildItem -File -Recurse -Path "web\\js"', source)
+        self.assertIn("& node --check", source)
+        self.assertIn('"typescript@$TypeScriptVersion"', source)
+        self.assertIn("tsc -p jsconfig.json", source)
 
     def test_prompt_studio_split_modules_start_with_ts_check(self):
         for path in sorted(PROMPT_STUDIO_MODULES.glob("*.js")):

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding()]
+param(
+    [string]$TypeScriptVersion = "6.0.3"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$originalLocation = (Get-Location).Path
+
+try {
+    Set-Location -LiteralPath $repoRoot
+    Get-Command node -ErrorAction Stop | Out-Null
+    Get-Command npx -ErrorAction Stop | Out-Null
+
+    $jsFiles = @(
+        Get-ChildItem -File -Recurse -Path "web\js" -Filter "*.js" |
+            Sort-Object FullName
+    )
+    if ($jsFiles.Count -eq 0) {
+        throw "No frontend JavaScript files were found under web\js."
+    }
+
+    foreach ($file in $jsFiles) {
+        & node --check $file.FullName
+        if ($LASTEXITCODE -ne 0) {
+            throw "JavaScript syntax check failed: $($file.FullName)"
+        }
+    }
+
+    & npx --yes --package "typescript@$TypeScriptVersion" -- tsc -p jsconfig.json
+    if ($LASTEXITCODE -ne 0) {
+        throw "TypeScript check failed with exit code $LASTEXITCODE."
+    }
+
+    Write-Host "Frontend checks passed: $($jsFiles.Count) JavaScript files, TypeScript $TypeScriptVersion."
+}
+finally {
+    Set-Location -LiteralPath $originalLocation
+}

--- a/web/js/prompt_studio/advanced_fields_state.js
+++ b/web/js/prompt_studio/advanced_fields_state.js
@@ -166,7 +166,7 @@ function writeAdvancedFields(node, fields, { render = false, syncInputs = true }
   }
 }
 
-function applyAdvancedNaiaGeneralAutoToggle(node, fields) {
+function applyAdvancedNaiaGeneralAutoToggle(fields) {
   if (!PROMPT_STUDIO_SETTINGS.naiaGeneralAboveAutoToggle || !Array.isArray(fields)) {
     return false;
   }

--- a/web/js/prompt_studio/advanced_fields_ui.js
+++ b/web/js/prompt_studio/advanced_fields_ui.js
@@ -191,7 +191,7 @@ function createAdvancedFieldElement(node, field, hooks = {}) {
       const nextValue = !findWidget(node, "use_naia")?.value;
       setAdvancedControlValue(node, "consume_naia_on_queue", true);
       setAdvancedControlValue(node, "use_naia", nextValue);
-      hooks.applyAdvancedNaiaGeneralAutoToggle?.(node, currentFields);
+      hooks.applyAdvancedNaiaGeneralAutoToggle?.(currentFields);
       hooks.writeAdvancedFields?.(node, currentFields, { render: true });
     }, linkedUseNaia || field.enabled === false, field.enabled !== false && !!useNaiaWidget?.value);
     fillButton.classList.add("easyuse-anima-naia-fill");

--- a/web/js/prompt_studio/advanced_node_ui.js
+++ b/web/js/prompt_studio/advanced_node_ui.js
@@ -74,7 +74,7 @@ function renderAdvancedEditor(node, hooks = {}) {
     return;
   }
   const fields = setAdvancedFields(node, parseAdvancedFields(node));
-  applyAdvancedNaiaGeneralAutoToggle(node, fields);
+  applyAdvancedNaiaGeneralAutoToggle(fields);
   editor.innerHTML = "";
   updateAdvancedEditorWidth(node);
   const panes = document.createElement("div");

--- a/web/js/prompt_studio/advanced_values.js
+++ b/web/js/prompt_studio/advanced_values.js
@@ -68,7 +68,7 @@ function applyAdvancedExecutedInputs(node, message, hooks = {}) {
     syncAdvancedFieldsBackup(node, widget.value);
   }
   const fields = hooks.parseAdvancedFields?.(node) || [];
-  if (mergeAdvancedFieldInputValues(node, fields, node.__easyuseAnimaAdvancedFieldInputValues)) {
+  if (mergeAdvancedFieldInputValues(fields, node.__easyuseAnimaAdvancedFieldInputValues)) {
     hooks.writeAdvancedFields?.(node, fields, { syncInputs: false });
   } else {
     setAdvancedFields(node, fields);

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -95,7 +95,6 @@ import {
   remeasureAdvancedTextareaHeightsForWidth as remeasureAdvancedTextareaHeightsForWidthWithHooks,
 } from "./advanced_fields_ui.js";
 import {
-  hookAdvancedNode as hookAdvancedNodeWithHooks,
   renderAdvancedEditor as renderAdvancedEditorWithHooks,
   scheduleHookAdvancedNode as scheduleHookAdvancedNodeWithHooks,
 } from "./advanced_node_ui.js";
@@ -341,10 +340,6 @@ function createPromptStudioExtensionRuntime(app) {
 
   function renderAdvancedEditor(node) {
     renderAdvancedEditorWithHooks(node, advancedNodeUiHooks());
-  }
-
-  function hookAdvancedNode(node) {
-    hookAdvancedNodeWithHooks(node, advancedNodeUiHooks());
   }
 
   function scheduleHookAdvancedNode(node) {

--- a/web/js/prompt_studio/serialization.js
+++ b/web/js/prompt_studio/serialization.js
@@ -217,7 +217,7 @@ function advancedFieldDisplayText(node, field) {
   return String(field?.text || "");
 }
 
-function mergeAdvancedFieldInputValues(node, fields, values) {
+function mergeAdvancedFieldInputValues(fields, values) {
   if (!values || typeof values !== "object" || !Array.isArray(fields)) {
     return false;
   }

--- a/web/js/prompt_studio/studio_node_ui.js
+++ b/web/js/prompt_studio/studio_node_ui.js
@@ -108,7 +108,7 @@ function hookStudioNode(node, attempt = 0, hooks = {}) {
 
     if (!widget.__easyuseAnimaStudioHooked) {
       const callback = widget.callback;
-      widget.callback = function (value) {
+      widget.callback = function (_value) {
         const result = callback?.apply(this, arguments);
         widget.__easyuseAnimaExecutedText = null;
         updateHighlight(node, widget);

--- a/web/js/prompt_studio/studio_textareas.js
+++ b/web/js/prompt_studio/studio_textareas.js
@@ -52,7 +52,7 @@ function studioVisualMinimumHeight(widget) {
   return Math.min(studioDefaultHeight(widget), 54);
 }
 
-function studioMinimumHeight(widget, input = findStudioInput(widget)) {
+function studioMinimumHeight(widget) {
   return studioVisualMinimumHeight(widget);
 }
 
@@ -79,7 +79,7 @@ function setStudioInputHeight(node, widget, height, refresh = false, hooks = {})
   if (!input) {
     return;
   }
-  const minimumHeight = studioMinimumHeight(widget, input);
+  const minimumHeight = studioMinimumHeight(widget);
   const nextHeight = Math.max(minimumHeight, Math.round(Number(height) || 0));
   widget.__easyuseAnimaLayoutHeight = nextHeight + STUDIO_WIDGET_VERTICAL_GAP;
   if (Math.abs(nextHeight - (widget.__easyuseAnimaHeight || 0)) > 1) {


### PR DESCRIPTION
## 변경 요약

- Prompt Studio no-build 타입 검사에 `noUnusedLocals`와 `noUnusedParameters`를 추가했습니다.
- 검사에서 확인된 미사용 내부 인자, 호출 인자, dead runtime wrapper를 제거했습니다.
- `tools/check_frontend.ps1`을 추가해 전체 frontend JavaScript 문법 검사와 고정 버전 TypeScript 검사를 한 명령으로 실행할 수 있게 했습니다.
- 검사 설정과 검증 스크립트가 유지되도록 frontend module 구조 테스트를 보강했습니다.

## 변경 이유

Issue #14에서 Prompt Studio 모듈 분리와 no-build 타입 검사를 도입했지만, 미사용 코드 검사는 강제되지 않았고 전체 frontend 정적 검증도 여러 명령으로 분산돼 있었습니다. 이번 변경은 사용자 동작이나 워크플로 직렬화 계약을 바꾸지 않고, 이후 모듈 정리 전에 회귀 방지 기준을 강화합니다.

## 주요 파일

- `jsconfig.json`
- `tools/check_frontend.ps1`
- `tests/test_frontend_modules.py`
- `web/js/prompt_studio/*.js` 내부 배선 정리

## 검증

- `powershell -ExecutionPolicy Bypass -File tools/check_frontend.ps1`
  - JavaScript 51개 `node --check` 통과
  - TypeScript 6.0.3 no-build typecheck 통과
- `D:\ComfyUI\ComfyUI_main\instances\ComfyUI_codex_test\.venv\Scripts\python.exe -m unittest tests.test_frontend_modules -q`
  - 18 tests OK
- `powershell -ExecutionPolicy Bypass -File tools/check_custom_node.ps1 -Project <target-worktree> -Profile full`
  - Python compile OK
  - 314 tests OK
  - JavaScript syntax OK
  - `git diff --check` OK
- ComfyUI Codex test instance: static/module/full unittest
- Live ComfyUI browser smoke: not run

## 영향과 남은 범위

- Python 노드, API route, widget 이름, socket 이름, `widgets_values`, workflow property는 변경하지 않았습니다.
- Vite/TypeScript 빌드 전환과 `strict: true` 전환은 포함하지 않았습니다.
- Prompt Studio 공통 highlighting 중복 제거와 AiO/Regional/LoRA 대형 파일 분리는 후속 PR 범위입니다.
- 브라우저 hard-refresh smoke는 사용자 동작 변경이 없는 정적 정리이므로 이번 PR에서는 실행하지 않았습니다.

## 라벨 후보

- `type: chore`
- `area: frontend`
- `status: draft`

Refs #14
