### PR TITLE
chore: 프로젝트 검증 명령 계약 통합

### DIFF
--- a/CONTRIBUTING.ko.md
+++ b/CONTRIBUTING.ko.md
@@ -117,8 +117,17 @@ node --check web/js/<changed-file>.js
 워크플로우 템플릿을 변경했다면:
 
 ```bash
-python -m unittest tests.test_workflows
+python -m unittest discover -s tests -p test_workflows.py
 ```
+
+PowerShell에서는 다음 명령으로 저장소 전체 검증을 실행할 수 있습니다.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+```
+
+Python suite의 공식 runner는 `unittest`입니다. 이 custom-node package
+구조에서는 pytest를 full-suite runner로 지원하지 않습니다.
 
 변경이 실제 ComfyUI 동작에 의존한다면 실제 ComfyUI 인스턴스에서도 테스트하고,
 PR에 테스트한 ComfyUI 버전을 적어 주세요.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,17 @@ node --check web/js/<changed-file>.js
 For changed workflow templates:
 
 ```bash
-python -m unittest tests.test_workflows
+python -m unittest discover -s tests -p test_workflows.py
 ```
+
+On PowerShell, the complete repository check is available as:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+```
+
+The Python suite uses `unittest`. Pytest is not a supported full-suite runner
+for this custom-node package layout.
 
 If a change depends on live ComfyUI behavior, also test it in a real ComfyUI
 instance and mention the tested ComfyUI version in the PR.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -63,17 +63,26 @@ This repository is prepared for future ComfyUI Manager / Comfy Registry registra
 
 ## Checks
 
-Run from `D:\ComfyUI\custom_nodes_workplace`:
+Run the checked-in validation entrypoint from the repository root:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File tools\check_custom_node.ps1 -Project ComfyUI-EasyUseAnima
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
 ```
 
-Before publishing, also test installation in the active ComfyUI instance:
+Use `-Profile quick` for Python compile, frontend, and diff checks. The `full`
+profile additionally runs the complete Python suite. Pass
+`-Python <path-to-python>` when the ComfyUI environment is not the default
+`python` command.
 
-```text
-D:\ComfyUI\ComfyUI_main\instances\ComfyUI_v0.24.0\custom_nodes
-```
+The checked-in Python suite is based on `unittest`. Do not substitute
+`python -m pytest tests -q`: with this custom-node package layout, pytest tries
+to import the repository-root `__init__.py` as a top-level module and fails
+before test bodies run. Supporting pytest would require a separate package and
+runner design change.
+
+Before publishing, also install and test the node pack in a supported ComfyUI
+instance. Record the tested ComfyUI and frontend versions instead of relying on
+a fixed local instance path.
 
 ## Comfy Registry Release Procedure
 
@@ -109,21 +118,12 @@ Use this procedure when publishing a release to Comfy Registry / ComfyUI Manager
 Run from repository root:
 
 ```powershell
-node --check web\js\easyuse_anima_settings.js
-node --check web\js\easyuse_anima_prompt_studio.js
-node --check web\js\easyuse_anima_lora_preset.js
-node --check web\js\easyuse_anima_naia.js
-node --check web\js\easyuse_anima_autocomplete.js
-.venv\Scripts\python.exe -m unittest discover -s tests
-git diff --check
-git status --short
+powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full
+comfy node validate
 ```
 
-Also verify ComfyUI starts with the active test instance after copying changed files:
-
-```text
-D:\ComfyUI\ComfyUI_main\instances\ComfyUI_v0.24.0\custom_nodes\ComfyUI-EasyUseAnima
-```
+Also verify ComfyUI starts with the intended test installation after applying
+the candidate changes.
 
 ### 4. Manual Publish With Comfy CLI
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -89,6 +89,7 @@ conversation.
 
 ## Validation Shortlist
 
+- `powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile full`
 - `python -m unittest discover -s tests`
 - `python -m compileall -q .`
 - `git diff --check`

--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -146,13 +146,17 @@ Settings의 대형 분리는 별도 후속 이슈로 넘긴다.
 
 예상: 0.5일
 
-- 공식 frontend 검사는 `tools/check_frontend.ps1`로 유지한다.
-- 공식 Python full suite는 현재 저장소 계약인 `unittest discover`로 고정한다.
-- `pytest`를 지원할지, 명시적으로 비지원할지 별도 결정한다.
-- 지원한다면 root package 수집 문제를 해결한 뒤 두 runner 결과가 일치함을
-  검증한다.
-- 지원하지 않는다면 workspace 지침과 자동화가 `pytest`를 기본 full-suite로
-  안내하지 않도록 별도 승인 범위에서 정렬한다.
+결정:
+
+- 공식 project 검사는 `tools/check_project.ps1`로 통합한다.
+- 공식 frontend 검사는 이 entrypoint가 호출하는
+  `tools/check_frontend.ps1`로 유지한다.
+- 공식 Python full suite는 `unittest discover`로 고정한다.
+- `pytest`는 공식 runner로 지원하지 않는다. 현재 custom-node root package를
+  top-level `__init__` module로 수집해 test body 실행 전에 실패하며,
+  import mode, rootdir, ignore 옵션만으로 해결되지 않는다.
+- workspace의 ComfyUI 테스트 지침과 helper는 저장소가 소유한 runner 계약을
+  우선하도록 정렬한다.
 
 이 PR에는 frontend 구조 변경을 넣지 않는다.
 

--- a/tests/test_validation_contract.py
+++ b/tests/test_validation_contract.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ValidationContractTests(unittest.TestCase):
+    def test_project_check_owns_the_unittest_and_frontend_contract(self):
+        source = (ROOT / "tools" / "check_project.ps1").read_text(encoding="utf-8")
+
+        self.assertIn("-m unittest discover -s tests", source)
+        self.assertIn('Join-Path $PSScriptRoot "check_frontend.ps1"', source)
+        self.assertIn("-m compileall -q .", source)
+        self.assertIn("git diff --check", source)
+        self.assertIn("git diff --cached --check", source)
+        self.assertNotIn("-m pytest", source)
+
+    def test_maintainer_guide_uses_the_checked_in_project_check(self):
+        source = (ROOT / "MAINTAINING.md").read_text(encoding="utf-8")
+
+        self.assertIn("tools\\check_project.ps1 -Profile full", source)
+        self.assertIn("unittest", source)
+        self.assertIn("pytest", source)
+        self.assertNotIn("tools\\check_custom_node.ps1", source)
+
+    def test_frontend_roadmap_records_the_runner_decision(self):
+        source = (
+            ROOT / "docs" / "development" / "frontend-maintenance-roadmap.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("공식 Python full suite는 `unittest discover`", source)
+        self.assertIn("`pytest`는 공식 runner로 지원하지 않는다", source)
+
+    def test_contributor_guides_use_discovery_for_focused_workflow_tests(self):
+        for name in ("CONTRIBUTING.md", "CONTRIBUTING.ko.md"):
+            with self.subTest(name=name):
+                source = (ROOT / name).read_text(encoding="utf-8")
+                self.assertIn(
+                    "python -m unittest discover -s tests -p test_workflows.py",
+                    source,
+                )
+                self.assertNotIn("python -m unittest tests.test_workflows", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_project.ps1
+++ b/tools/check_project.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("quick", "full")]
+    [string]$Profile = "quick",
+    [string]$Python = "python",
+    [string]$TypeScriptVersion = "6.0.3"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$originalLocation = (Get-Location).Path
+$pythonCommand = if (Test-Path -LiteralPath $Python) {
+    (Resolve-Path -LiteralPath $Python -ErrorAction Stop).ProviderPath
+} else {
+    (Get-Command $Python -ErrorAction Stop).Source
+}
+
+try {
+    Set-Location -LiteralPath $repoRoot
+
+    Write-Host "== EasyUse Anima project check =="
+    Write-Host "Profile: $Profile"
+    Write-Host "Python:  $pythonCommand"
+
+    Write-Host "`n== Python compile =="
+    & $pythonCommand -m compileall -q .
+    if ($LASTEXITCODE -ne 0) {
+        throw "Python compile failed with exit code $LASTEXITCODE."
+    }
+
+    if ($Profile -eq "full") {
+        Write-Host "`n== Python unittest =="
+        & $pythonCommand -m unittest discover -s tests
+        if ($LASTEXITCODE -ne 0) {
+            throw "Python unittest failed with exit code $LASTEXITCODE."
+        }
+    }
+
+    Write-Host "`n== Frontend =="
+    & (Join-Path $PSScriptRoot "check_frontend.ps1") -TypeScriptVersion $TypeScriptVersion
+
+    Write-Host "`n== Git diff check =="
+    & git diff --check
+    if ($LASTEXITCODE -ne 0) {
+        throw "Working-tree diff check failed with exit code $LASTEXITCODE."
+    }
+    & git diff --cached --check
+    if ($LASTEXITCODE -ne 0) {
+        throw "Staged diff check failed with exit code $LASTEXITCODE."
+    }
+
+    Write-Host "`nProject checks passed ($Profile)."
+}
+finally {
+    Set-Location -LiteralPath $originalLocation
+}


### PR DESCRIPTION
## 변경 요약

- 저장소가 소유하는 검증 entrypoint `tools/check_project.ps1`을 추가했습니다.
- `quick` profile은 Python compile, frontend 통합 검사, staged/unstaged diff 검사를 실행합니다.
- `full` profile은 여기에 전체 `unittest discover` suite를 추가합니다.
- maintainer/contributor 문서와 Issue #14 로드맵을 같은 runner 계약으로 정렬했습니다.
- 검증 계약이 다시 `pytest`로 바뀌거나 존재하지 않는 workspace helper를 가리키지 않도록 회귀 테스트를 추가했습니다.
- 잘못된 focused workflow 명령을 file discovery 형식으로 수정했습니다.

## 결정과 원인

이 저장소의 공식 Python runner는 `unittest`입니다.

기존 workspace 지침 일부는 `python -m pytest tests -q`를 full suite로 안내했지만, 실제 저장소와 `check_custom_node` helper는 `unittest discover`를 사용했습니다. pytest는 custom-node root `__init__.py`를 top-level module로 import해 상대 import가 실패하며, 315개 test body가 실행되기 전에 setup error가 발생했습니다.

다음 옵션도 같은 setup error를 재현했습니다.

- `--import-mode=importlib`
- `--rootdir=tests`
- `--ignore=__init__.py`

테스트 runner를 위해 runtime package import shim을 추가하지 않고, 기존에 정상 동작하는 unittest 계약을 명시적으로 유지합니다.

## 주요 파일

- `tools/check_project.ps1`
- `tests/test_validation_contract.py`
- `MAINTAINING.md`
- `CONTRIBUTING.md`
- `CONTRIBUTING.ko.md`
- `docs/development/frontend-maintenance-roadmap.md`

## 검증

- `tools/check_project.ps1 -Profile quick`
  - Python compile 통과
  - highlight core semantic smoke 통과
  - frontend JavaScript 52개 문법 검사 통과
  - TypeScript 6.0.3 no-build typecheck 통과
  - staged/unstaged diff check 통과
- `tools/check_project.ps1 -Profile full`
  - Python unittest 319 tests OK
  - quick profile 전체 검사 통과
- `python -m unittest discover -s tests -p test_validation_contract.py -v`
  - 4 tests OK
- `git diff --cached --check` 통과

## 호환성

- Python runtime, frontend runtime, API, node/widget/socket, workflow serialization 변경 없음
- ComfyUI runtime/browser smoke: 실행하지 않음. 검증 도구와 문서만 변경
- 별도 Python/Node 의존성 추가 없음

## 라벨 후보

- `type: chore`
- `area: docs`
- `area: frontend`
- `status: draft`

Refs #14
