### PR TITLE
Prompt Studio 하이라이트 오버레이 코어 공통화

### DIFF
--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -23,8 +23,8 @@
 
 ```text
 branch: dev
-HEAD: 2c818b6375e48f7803b29d6656b7e2a38f6747e5
-origin/dev: 2c818b6375e48f7803b29d6656b7e2a38f6747e5
+HEAD: c7897a824b3bf28b41f826f557bb0330918e40a1
+origin/dev: c7897a824b3bf28b41f826f557bb0330918e40a1
 working tree: clean
 ```
 
@@ -35,6 +35,8 @@ Issue #14는 열려 있다. 다음 변경은 `dev`에 병합됐다.
 | #18 | `4eb7992` | 공통 API helper, Prompt Studio 모듈 분리, no-build JS typecheck, Vite 보류 결정 |
 | #46 | `e75eb96` | 미사용 코드 검사, 통합 frontend 검사 스크립트 |
 | #47 | `2c818b6` | Main/Advanced와 Regional의 prompt highlight parser/renderer core 공통화 |
+| #48 | `781b4c4` | Issue #14 현재 로드맵과 종료 범위 정리 |
+| #49 | `c7897a8` | 저장소 소유 project/frontend/unittest 검증 명령 계약 통합 |
 
 ## 현재 상태
 
@@ -48,17 +50,19 @@ Issue #14는 열려 있다. 다음 변경은 `dev`에 병합됐다.
   분리됐다.
 - prompt 문법 파싱, token matching, highlight HTML 생성은
   `prompt_studio/highlight_core.js`가 소유한다.
-- `tools/check_frontend.ps1`은 전체 frontend JS 문법 검사, highlight semantic
-  smoke, 고정 버전 TypeScript 검사를 한 번에 실행한다.
+- overlay geometry, text metric 복사, autocomplete preview 조합은
+  `prompt_studio/highlight_overlay_core.js`가 소유한다.
+- `tools/check_frontend.ps1`은 전체 frontend JS 문법 검사, parser/renderer와
+  overlay semantic smoke, 고정 버전 TypeScript 검사를 한 번에 실행한다.
 - `noUnusedLocals`와 `noUnusedParameters`가 현재 typecheck 범위에 적용된다.
 - Vite/TypeScript build chain을 당장 도입하지 않고 raw ES module과 no-build
   typecheck를 유지하기로 결정했다.
 
 ### 정량 스냅샷
 
-`web/js`에는 JavaScript 52개, 총 28,825줄이 있다. `jsconfig.json`에 명시된
-include 대상은 Prompt Studio entry와 `prompt_studio/*.js` 40개, 8,386줄로
-전체 라인의 29.1%다. import를 따라 추가로 검사되는 dependency는 이 수치에
+`web/js`에는 JavaScript 53개, 총 28,782줄이 있다. `jsconfig.json`에 명시된
+include 대상은 Prompt Studio entry와 `prompt_studio/*.js` 41개, 8,485줄로
+전체 라인의 29.5%다. import를 따라 추가로 검사되는 dependency는 이 수치에
 포함하지 않았다.
 
 | 파일 | 줄 수 | 전체 비율 | 현재 판단 |
@@ -68,18 +72,18 @@ include 대상은 Prompt Studio entry와 `prompt_studio/*.js` 40개, 8,386줄로
 | `easyuse_anima_prompt_studio_regional.js` | 2,284 | 7.9% | Issue #14 종료 전에 분리할 대상 |
 | `easyuse_anima_autocomplete.js` | 2,067 | 7.2% | parser, popup, input runtime이 결합 |
 | `easyuse_anima_settings.js` | 1,935 | 6.7% | 설정 정의와 여러 editor 구현이 결합 |
-| `easyuse_anima_prompt_studio_common.js` | 1,561 | 5.4% | 현재 Regional만 import하는 legacy common layer |
+| `easyuse_anima_prompt_studio_common.js` | 1,419 | 4.9% | 현재 Regional만 import하는 legacy common layer |
 
-상위 6개 파일이 전체 frontend JS의 약 68.1%를 차지한다. 줄 수 자체를 목표로
+상위 6개 파일이 전체 frontend JS의 약 67.7%를 차지한다. 줄 수 자체를 목표로
 삼지는 않지만, 책임 경계와 검증 비용이 이 파일들에 집중돼 있다는 신호로
 사용한다.
 
 ### 남은 Prompt Studio 중복과 경계 문제
 
 - `easyuse_anima_prompt_studio_common.js`와
-  `prompt_studio/highlight.js`에는 동일 이름 함수가 19개 남아 있다.
-- 이 중 pixel 변환, scrollbar padding, overlay bounds, text metric 복사,
-  preview HTML, overlay 위치 동기화는 DOM overlay core 후보이다.
+  `prompt_studio/highlight.js`에 남은 동일 이름 함수는 9개다.
+- pixel 변환, scrollbar padding, overlay bounds, text metric 복사,
+  preview HTML, overlay 위치 동기화는 DOM overlay core로 공통화됐다.
 - 색상 설정, tooltip 문구, 설정 저장소, node별 highlight state와 listener
   lifecycle은 화면별 adapter에 남기는 편이 안전하다.
 - Regional entry는 constants, schema, serialization, mask geometry/editor,
@@ -164,7 +168,18 @@ Settings의 대형 분리는 별도 후속 이슈로 넘긴다.
 
 예상: 0.5-1일
 
-우선 후보:
+구현:
+
+- `prompt_studio/highlight_overlay_core.js`가 geometry, text metric,
+  autocomplete preview 조합을 소유한다.
+- Main/Advanced와 Regional adapter는 화면별 renderer와 escape 함수만
+  factory에 주입한다.
+- 설정, tooltip, node/field state, listener와 classification lifecycle은
+  기존 adapter에 유지한다.
+- `frontend_highlight_overlay_core_smoke.mjs`가 scrollbar padding, bounds,
+  metric 복사, scroll 동기화, preview와 stale-preview fallback을 검증한다.
+
+공통화 범위:
 
 - CSS pixel parsing과 scrollbar padding
 - input/textarea bounds 측정

--- a/tests/frontend_highlight_overlay_core_smoke.mjs
+++ b/tests/frontend_highlight_overlay_core_smoke.mjs
@@ -1,0 +1,122 @@
+import { readFileSync } from "node:fs";
+
+const coreSource = readFileSync(
+  new URL("../web/js/prompt_studio/highlight_overlay_core.js", import.meta.url),
+  "utf8",
+);
+const coreUrl = `data:text/javascript;base64,${Buffer.from(coreSource).toString("base64")}`;
+const {
+  HIGHLIGHT_TEXT_METRIC_PROPERTIES,
+  copyInputTextMetrics,
+  createHighlightOverlayRenderer,
+  overlayBounds,
+  overlayScrollbarPadding,
+  syncOverlayBounds,
+} = await import(coreUrl);
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const style = Object.fromEntries(
+  HIGHLIGHT_TEXT_METRIC_PROPERTIES.map((property) => [property, ""]),
+);
+Object.assign(style, {
+  borderLeftWidth: "1px",
+  borderRightWidth: "1px",
+  borderTopWidth: "2px",
+  borderBottomWidth: "2px",
+  paddingRight: "4px",
+  paddingBottom: "6px",
+  font: "12px sans-serif",
+  lineHeight: "18px",
+});
+
+const input = {
+  offsetLeft: 8,
+  offsetTop: 12,
+  offsetWidth: 120,
+  offsetHeight: 80,
+  clientWidth: 100,
+  clientHeight: 70,
+  scrollTop: 17,
+  scrollLeft: 5,
+};
+const overlay = {
+  style: {},
+  scrollTop: 0,
+  scrollLeft: 0,
+};
+
+const padding = overlayScrollbarPadding(input, style);
+assert(padding.right === "22px", "Vertical scrollbar padding changed");
+assert(padding.bottom === "12px", "Horizontal scrollbar padding changed");
+assert(
+  JSON.stringify(overlayBounds(input)) === JSON.stringify({
+    left: "8px",
+    top: "12px",
+    width: "120px",
+    height: "80px",
+  }),
+  "Overlay bounds changed",
+);
+
+copyInputTextMetrics(input, overlay, style);
+assert(overlay.style.font === "12px sans-serif", "Font metrics were not copied");
+assert(overlay.style.lineHeight === "18px", "Line height was not copied");
+assert(overlay.style.boxSizing === "border-box", "Overlay box sizing changed");
+assert(overlay.style.whiteSpace === "pre-wrap", "Overlay whitespace mode changed");
+assert(overlay.style.paddingRight === "22px", "Copied right padding changed");
+assert(overlay.style.paddingBottom === "12px", "Copied bottom padding changed");
+
+syncOverlayBounds(input, overlay, style);
+assert(overlay.style.left === "8px", "Overlay left position changed");
+assert(overlay.style.top === "12px", "Overlay top position changed");
+assert(overlay.style.width === "120px", "Overlay width changed");
+assert(overlay.style.height === "80px", "Overlay height changed");
+assert(overlay.scrollTop === 17, "Vertical scroll synchronization changed");
+assert(overlay.scrollLeft === 5, "Horizontal scroll synchronization changed");
+
+const escapeHtml = (value) => String(value ?? "")
+  .replaceAll("&", "&amp;")
+  .replaceAll("<", "&lt;")
+  .replaceAll(">", "&gt;");
+const renderHighlightedText = (text) => `<mark>${escapeHtml(text)}</mark>`;
+const highlightOverlayHtml = createHighlightOverlayRenderer({
+  escapeHtml,
+  renderHighlightedText,
+});
+
+assert(
+  highlightOverlayHtml("", [], "<prompt>") === '<span style="opacity: 0.45">&lt;prompt&gt;</span>',
+  "Empty prompt placeholder rendering changed",
+);
+assert(
+  highlightOverlayHtml("cat\n", []).endsWith("</mark> "),
+  "Trailing newline alignment spacer changed",
+);
+
+const previewInput = {
+  __easyuseAnimaAutocompletePreview: {
+    sourceValue: "cat",
+    value: "cathedral",
+    candidateStart: 0,
+    candidateEnd: 9,
+    ghostStart: 3,
+    ghostEnd: 9,
+    color: "#cbd5e1",
+  },
+};
+const previewHtml = highlightOverlayHtml("cat", [], "", previewInput);
+assert(previewHtml.includes('opacity: 0.95">cat</span>'), "Autocomplete typed segment changed");
+assert(previewHtml.includes('opacity: 0.52">hedral</span>'), "Autocomplete ghost segment changed");
+
+previewInput.__easyuseAnimaAutocompletePreview.sourceValue = "dog";
+assert(
+  highlightOverlayHtml("cat", [], "", previewInput) === "<mark>cat</mark>",
+  "Stale autocomplete preview fallback changed",
+);
+
+console.log("Highlight overlay core smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -16,6 +16,9 @@ PROMPT_STUDIO_COMMON_JS = WEB_JS / "easyuse_anima_prompt_studio_common.js"
 PROMPT_STUDIO_MODULES = WEB_JS / "prompt_studio"
 PROMPT_STUDIO_HIGHLIGHT_JS = PROMPT_STUDIO_MODULES / "highlight.js"
 PROMPT_STUDIO_HIGHLIGHT_CORE_JS = PROMPT_STUDIO_MODULES / "highlight_core.js"
+PROMPT_STUDIO_HIGHLIGHT_OVERLAY_CORE_JS = (
+    PROMPT_STUDIO_MODULES / "highlight_overlay_core.js"
+)
 STATIC_IMPORT_RE = re.compile(r"""from\s+["'](\./[^"']+\.js)["']""")
 
 
@@ -163,6 +166,58 @@ class FrontendModuleStructureTests(unittest.TestCase):
 
         for source in (modular_source, regional_source, constants_source):
             self.assertNotIn("WILDCARD_HIGHLIGHT_RE", source)
+
+    def test_prompt_highlight_overlay_core_is_shared(self):
+        core_source = PROMPT_STUDIO_HIGHLIGHT_OVERLAY_CORE_JS.read_text(
+            encoding="utf-8"
+        )
+        modular_source = PROMPT_STUDIO_HIGHLIGHT_JS.read_text(encoding="utf-8")
+        regional_source = PROMPT_STUDIO_COMMON_JS.read_text(encoding="utf-8")
+        constants_source = (PROMPT_STUDIO_MODULES / "constants.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('from "./highlight_overlay_core.js"', modular_source)
+        self.assertIn(
+            'from "./prompt_studio/highlight_overlay_core.js"', regional_source
+        )
+        for source in (modular_source, regional_source):
+            self.assertIn(
+                "const highlightOverlayHtml = createHighlightOverlayRenderer({",
+                source,
+            )
+
+        for name in (
+            "cssPixelNumber",
+            "cssPixel",
+            "overlayScrollbarPadding",
+            "applyOverlayScrollbarPadding",
+            "overlayBounds",
+            "autocompletePreviewSpanHtml",
+            "highlightOverlayPreviewHtml",
+            "highlightOverlayHtml",
+            "copyInputTextMetrics",
+            "syncOverlayBounds",
+        ):
+            with self.subTest(symbol=name):
+                self.assertIn(f"function {name}", core_source)
+                self.assertNotIn(f"function {name}", modular_source)
+                self.assertNotIn(f"function {name}", regional_source)
+
+        self.assertIn("const HIGHLIGHT_TEXT_METRIC_PROPERTIES", core_source)
+        for source in (modular_source, regional_source, constants_source):
+            self.assertNotIn("const HIGHLIGHT_TEXT_METRIC_PROPERTIES", source)
+
+        for name in (
+            "HIGHLIGHT_TEXT_METRIC_PROPERTIES",
+            "copyInputTextMetrics",
+            "createHighlightOverlayRenderer",
+            "overlayBounds",
+            "overlayScrollbarPadding",
+            "syncOverlayBounds",
+        ):
+            with self.subTest(export=name):
+                self.assertIn(f"  {name},", core_source)
 
     def test_prompt_studio_phase_2_modules_export_expected_symbols(self):
         advanced_controls_source = (
@@ -851,6 +906,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn('Get-ChildItem -File -Recurse -Path "web\\js"', source)
         self.assertIn("& node --check", source)
         self.assertIn(r'& node "tests\frontend_highlight_core_smoke.mjs"', source)
+        self.assertIn(
+            r'& node "tests\frontend_highlight_overlay_core_smoke.mjs"', source
+        )
         self.assertIn('"typescript@$TypeScriptVersion"', source)
         self.assertIn("tsc -p jsconfig.json", source)
 
@@ -902,6 +960,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "extend_slots.js",
             "fields.js",
             "highlight_core.js",
+            "highlight_overlay_core.js",
             "highlight_ui.js",
             "legend.js",
             "node_hooks.js",

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -34,6 +34,11 @@ try {
         throw "Frontend highlight core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_highlight_overlay_core_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend highlight overlay core smoke failed with exit code $LASTEXITCODE."
+    }
+
     & npx --yes --package "typescript@$TypeScriptVersion" -- tsc -p jsconfig.json
     if ($LASTEXITCODE -ne 0) {
         throw "TypeScript check failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_prompt_studio_common.js
+++ b/web/js/easyuse_anima_prompt_studio_common.js
@@ -1,6 +1,11 @@
 import { easyuseAnimaClassifyPrompt, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText } from "./easyuse_anima_i18n.js";
 import { createPromptHighlightRenderer } from "./prompt_studio/highlight_core.js";
+import {
+  copyInputTextMetrics,
+  createHighlightOverlayRenderer,
+  syncOverlayBounds,
+} from "./prompt_studio/highlight_overlay_core.js";
 
 export const PROMPT_STUDIO_VARIANT_FIELD_TYPES = ["quality", "artist", "trigger", "general"];
 export const PROMPT_STUDIO_VARIANT_FIELD_LABELS = {
@@ -242,37 +247,6 @@ let promptStudioCommonTagTooltip = null;
 let promptStudioCommonTagTooltipMoveFrame = 0;
 let promptStudioCommonTagTooltipPendingMove = null;
 let promptStudioCommonTagTooltipLastTarget = null;
-const HIGHLIGHT_TEXT_METRIC_PROPERTIES = [
-  "font",
-  "fontFamily",
-  "fontSize",
-  "fontSizeAdjust",
-  "fontStretch",
-  "fontWeight",
-  "fontStyle",
-  "fontVariant",
-  "fontKerning",
-  "fontOpticalSizing",
-  "fontFeatureSettings",
-  "fontVariationSettings",
-  "lineHeight",
-  "letterSpacing",
-  "wordSpacing",
-  "textIndent",
-  "padding",
-  "border",
-  "borderRadius",
-  "boxSizing",
-  "textAlign",
-  "textTransform",
-  "textRendering",
-  "direction",
-  "tabSize",
-  "whiteSpace",
-  "overflowWrap",
-  "wordBreak",
-];
-
 function commonText(key) {
   return easyuseAnimaText(PROMPT_STUDIO_COMMON_TEXT, key);
 }
@@ -1166,126 +1140,10 @@ const renderHighlightedText = createPromptHighlightRenderer({
   preferSyntaxBeforeToken: true,
 });
 
-function cssPixelNumber(value) {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function cssPixel(value) {
-  const rounded = Math.round(Number(value || 0) * 100) / 100;
-  return `${rounded}px`;
-}
-
-function overlayScrollbarPadding(input, style = getComputedStyle(input)) {
-  const verticalGutter = Math.max(
-    0,
-    (Number(input.offsetWidth) || 0)
-      - (Number(input.clientWidth) || 0)
-      - cssPixelNumber(style.borderLeftWidth)
-      - cssPixelNumber(style.borderRightWidth),
-  );
-  const horizontalGutter = Math.max(
-    0,
-    (Number(input.offsetHeight) || 0)
-      - (Number(input.clientHeight) || 0)
-      - cssPixelNumber(style.borderTopWidth)
-      - cssPixelNumber(style.borderBottomWidth),
-  );
-  return {
-    right: cssPixel(cssPixelNumber(style.paddingRight) + verticalGutter),
-    bottom: cssPixel(cssPixelNumber(style.paddingBottom) + horizontalGutter),
-  };
-}
-
-function applyOverlayScrollbarPadding(input, overlay, style = getComputedStyle(input)) {
-  const padding = overlayScrollbarPadding(input, style);
-  if (overlay.style.paddingRight !== padding.right) overlay.style.paddingRight = padding.right;
-  if (overlay.style.paddingBottom !== padding.bottom) overlay.style.paddingBottom = padding.bottom;
-}
-
-function overlayBounds(input) {
-  return {
-    left: `${input.offsetLeft}px`,
-    top: `${input.offsetTop}px`,
-    width: `${input.offsetWidth}px`,
-    height: `${input.offsetHeight}px`,
-  };
-}
-
-function autocompletePreviewSpanHtml(text, preview, opacity = 0.95) {
-  const color = String(preview?.color || "rgba(203, 213, 225, 0.86)");
-  return `<span style="font: inherit; line-height: inherit; letter-spacing: inherit; vertical-align: baseline; color: ${escapeHtml(color)}; opacity: ${opacity}">`
-    + escapeHtml(text)
-    + "</span>";
-}
-
-function highlightOverlayPreviewHtml(value, tokens, preview) {
-  if (!preview || String(preview.sourceValue || "") !== String(value || "")) {
-    return null;
-  }
-  const text = String(preview.value || "");
-  const candidateStart = Math.max(0, Math.min(Number(preview.candidateStart ?? preview.ghostStart) || 0, text.length));
-  const candidateEnd = Math.max(candidateStart, Math.min(Number(preview.candidateEnd ?? preview.ghostEnd) || 0, text.length));
-  const ghostStart = Math.max(0, Math.min(Number(preview.ghostStart) || 0, text.length));
-  const ghostEnd = Math.max(ghostStart, Math.min(Number(preview.ghostEnd) || 0, text.length));
-  if (!text || candidateEnd <= candidateStart || ghostEnd <= ghostStart) {
-    return null;
-  }
-  const safeGhostStart = Math.max(candidateStart, Math.min(ghostStart, candidateEnd));
-  const safeGhostEnd = Math.max(safeGhostStart, Math.min(ghostEnd, candidateEnd));
-  const html = [
-    renderHighlightedText(text.slice(0, candidateStart), tokens || []),
-    autocompletePreviewSpanHtml(text.slice(candidateStart, safeGhostStart), preview, 0.95),
-    autocompletePreviewSpanHtml(text.slice(safeGhostStart, safeGhostEnd), preview, 0.52),
-    autocompletePreviewSpanHtml(text.slice(safeGhostEnd, candidateEnd), preview, 0.95),
-    renderHighlightedText(text.slice(candidateEnd), tokens || []),
-  ].join("");
-  return text.endsWith("\n") ? `${html} ` : html;
-}
-
-function highlightOverlayHtml(value, tokens, placeholder = "", input = null) {
-  const text = String(value || "");
-  if (!text) {
-    return `<span style="opacity: 0.45">${escapeHtml(placeholder)}</span>`;
-  }
-  const previewHtml = highlightOverlayPreviewHtml(text, tokens, input?.__easyuseAnimaAutocompletePreview);
-  if (previewHtml != null) {
-    return previewHtml;
-  }
-  const html = renderHighlightedText(text, tokens);
-  return text.endsWith("\n") ? `${html} ` : html;
-}
-
-function copyInputTextMetrics(input, overlay, style = getComputedStyle(input)) {
-  for (const property of HIGHLIGHT_TEXT_METRIC_PROPERTIES) {
-    const val = style[property];
-    if (overlay.style[property] !== val) {
-      overlay.style[property] = val;
-    }
-  }
-  overlay.style.boxSizing = "border-box";
-  overlay.style.whiteSpace = "pre-wrap";
-  overlay.style.overflowWrap = "break-word";
-  overlay.style.wordWrap = "break-word";
-  overlay.style.wordBreak = "normal";
-  overlay.style.margin = "0";
-  applyOverlayScrollbarPadding(input, overlay, style);
-}
-
-function syncOverlayBounds(input, overlay) {
-  if (!overlay) return;
-  const style = getComputedStyle(input);
-  const { left, top, width, height } = overlayBounds(input);
-
-  if (overlay.style.left !== left) overlay.style.left = left;
-  if (overlay.style.top !== top) overlay.style.top = top;
-  if (overlay.style.width !== width) overlay.style.width = width;
-  if (overlay.style.height !== height) overlay.style.height = height;
-  applyOverlayScrollbarPadding(input, overlay, style);
-
-  if (overlay.scrollTop !== input.scrollTop) overlay.scrollTop = input.scrollTop;
-  if (overlay.scrollLeft !== input.scrollLeft) overlay.scrollLeft = input.scrollLeft;
-}
+const highlightOverlayHtml = createHighlightOverlayRenderer({
+  escapeHtml,
+  renderHighlightedText,
+});
 
 export function requestPromptStudioOverlaySync(input, forceCopyMetrics = false) {
   const overlay = input?.__easyuseAnimaHighlightOverlay;

--- a/web/js/prompt_studio/constants.js
+++ b/web/js/prompt_studio/constants.js
@@ -614,37 +614,6 @@ const PROMPT_STUDIO_FONT_SIZE_MIN = 8;
 const PROMPT_STUDIO_FONT_SIZE_MAX = 24;
 const PROMPT_STUDIO_FONT_FAMILY = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
 
-const HIGHLIGHT_TEXT_METRIC_PROPERTIES = [
-  "font",
-  "fontFamily",
-  "fontSize",
-  "fontSizeAdjust",
-  "fontStretch",
-  "fontWeight",
-  "fontStyle",
-  "fontVariant",
-  "fontKerning",
-  "fontOpticalSizing",
-  "fontFeatureSettings",
-  "fontVariationSettings",
-  "lineHeight",
-  "letterSpacing",
-  "wordSpacing",
-  "textIndent",
-  "padding",
-  "border",
-  "borderRadius",
-  "boxSizing",
-  "textAlign",
-  "textTransform",
-  "textRendering",
-  "direction",
-  "tabSize",
-  "whiteSpace",
-  "overflowWrap",
-  "wordBreak",
-];
-
 const AUTOCOMPLETE_TOOLTIP_SECTIONS = new Set([
   "quality",
   "safety",
@@ -951,7 +920,6 @@ export {
   PROMPT_STUDIO_FONT_SIZE_MIN,
   PROMPT_STUDIO_FONT_SIZE_MAX,
   PROMPT_STUDIO_FONT_FAMILY,
-  HIGHLIGHT_TEXT_METRIC_PROPERTIES,
   AUTOCOMPLETE_TOOLTIP_SECTIONS,
   ADVANCED_NATIVE_CONTROL_SELECTOR,
   ADVANCED_NATIVE_CONTROL_EVENTS,

--- a/web/js/prompt_studio/highlight.js
+++ b/web/js/prompt_studio/highlight.js
@@ -3,7 +3,6 @@
 import { easyuseAnimaClassifyPrompt } from "../easyuse_anima_api.js";
 import {
   SECTION_STYLES,
-  HIGHLIGHT_TEXT_METRIC_PROPERTIES,
   AUTOCOMPLETE_TOOLTIP_SECTIONS,
 } from "./constants.js";
 import {
@@ -18,6 +17,14 @@ import {
   createPromptHighlightRenderer,
   hasHighlightSyntax,
 } from "./highlight_core.js";
+import {
+  HIGHLIGHT_TEXT_METRIC_PROPERTIES,
+  copyInputTextMetrics,
+  createHighlightOverlayRenderer,
+  overlayBounds,
+  overlayScrollbarPadding,
+  syncOverlayBounds,
+} from "./highlight_overlay_core.js";
 
 /** @typedef {import("./types.js").PromptStudioWindow} PromptStudioWindow */
 
@@ -136,126 +143,10 @@ const renderHighlightedText = createPromptHighlightRenderer({
   preferSyntaxBeforeToken: false,
 });
 
-function cssPixelNumber(value) {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function cssPixel(value) {
-  const rounded = Math.round(Number(value || 0) * 100) / 100;
-  return `${rounded}px`;
-}
-
-function overlayScrollbarPadding(input, style = getComputedStyle(input)) {
-  const verticalGutter = Math.max(
-    0,
-    (Number(input.offsetWidth) || 0)
-      - (Number(input.clientWidth) || 0)
-      - cssPixelNumber(style.borderLeftWidth)
-      - cssPixelNumber(style.borderRightWidth),
-  );
-  const horizontalGutter = Math.max(
-    0,
-    (Number(input.offsetHeight) || 0)
-      - (Number(input.clientHeight) || 0)
-      - cssPixelNumber(style.borderTopWidth)
-      - cssPixelNumber(style.borderBottomWidth),
-  );
-  return {
-    right: cssPixel(cssPixelNumber(style.paddingRight) + verticalGutter),
-    bottom: cssPixel(cssPixelNumber(style.paddingBottom) + horizontalGutter),
-  };
-}
-
-function applyOverlayScrollbarPadding(input, overlay, style = getComputedStyle(input)) {
-  const padding = overlayScrollbarPadding(input, style);
-  if (overlay.style.paddingRight !== padding.right) overlay.style.paddingRight = padding.right;
-  if (overlay.style.paddingBottom !== padding.bottom) overlay.style.paddingBottom = padding.bottom;
-}
-
-function overlayBounds(input) {
-  return {
-    left: `${input.offsetLeft}px`,
-    top: `${input.offsetTop}px`,
-    width: `${input.offsetWidth}px`,
-    height: `${input.offsetHeight}px`,
-  };
-}
-
-function autocompletePreviewSpanHtml(text, preview, opacity = 0.95) {
-  const color = String(preview?.color || "rgba(203, 213, 225, 0.86)");
-  return `<span style="font: inherit; line-height: inherit; letter-spacing: inherit; vertical-align: baseline; color: ${escapeHtml(color)}; opacity: ${opacity}">`
-    + escapeHtml(text)
-    + "</span>";
-}
-
-function highlightOverlayPreviewHtml(value, tokens, preview) {
-  if (!preview || String(preview.sourceValue || "") !== String(value || "")) {
-    return null;
-  }
-  const text = String(preview.value || "");
-  const candidateStart = Math.max(0, Math.min(Number(preview.candidateStart ?? preview.ghostStart) || 0, text.length));
-  const candidateEnd = Math.max(candidateStart, Math.min(Number(preview.candidateEnd ?? preview.ghostEnd) || 0, text.length));
-  const ghostStart = Math.max(0, Math.min(Number(preview.ghostStart) || 0, text.length));
-  const ghostEnd = Math.max(ghostStart, Math.min(Number(preview.ghostEnd) || 0, text.length));
-  if (!text || candidateEnd <= candidateStart || ghostEnd <= ghostStart) {
-    return null;
-  }
-  const safeGhostStart = Math.max(candidateStart, Math.min(ghostStart, candidateEnd));
-  const safeGhostEnd = Math.max(safeGhostStart, Math.min(ghostEnd, candidateEnd));
-  const html = [
-    renderHighlightedText(text.slice(0, candidateStart), tokens || []),
-    autocompletePreviewSpanHtml(text.slice(candidateStart, safeGhostStart), preview, 0.95),
-    autocompletePreviewSpanHtml(text.slice(safeGhostStart, safeGhostEnd), preview, 0.52),
-    autocompletePreviewSpanHtml(text.slice(safeGhostEnd, candidateEnd), preview, 0.95),
-    renderHighlightedText(text.slice(candidateEnd), tokens || []),
-  ].join("");
-  return text.endsWith("\n") ? `${html} ` : html;
-}
-
-function highlightOverlayHtml(value, tokens, placeholder = "", input = null) {
-  const text = String(value || "");
-  if (!text) {
-    return `<span style="opacity: 0.45">${escapeHtml(placeholder)}</span>`;
-  }
-  const previewHtml = highlightOverlayPreviewHtml(text, tokens, input?.__easyuseAnimaAutocompletePreview);
-  if (previewHtml != null) {
-    return previewHtml;
-  }
-  const html = renderHighlightedText(text, tokens);
-  return text.endsWith("\n") ? `${html} ` : html;
-}
-
-function copyInputTextMetrics(input, overlay, style = getComputedStyle(input)) {
-  for (const property of HIGHLIGHT_TEXT_METRIC_PROPERTIES) {
-    const val = style[property];
-    if (overlay.style[property] !== val) {
-      overlay.style[property] = val;
-    }
-  }
-  overlay.style.boxSizing = "border-box";
-  overlay.style.whiteSpace = "pre-wrap";
-  overlay.style.overflowWrap = "break-word";
-  overlay.style.wordWrap = "break-word";
-  overlay.style.wordBreak = "normal";
-  overlay.style.margin = "0";
-  applyOverlayScrollbarPadding(input, overlay, style);
-}
-
-function syncOverlayBounds(input, overlay) {
-  if (!overlay) return;
-  const style = getComputedStyle(input);
-  const { left, top, width, height } = overlayBounds(input);
-
-  if (overlay.style.left !== left) overlay.style.left = left;
-  if (overlay.style.top !== top) overlay.style.top = top;
-  if (overlay.style.width !== width) overlay.style.width = width;
-  if (overlay.style.height !== height) overlay.style.height = height;
-  applyOverlayScrollbarPadding(input, overlay, style);
-
-  if (overlay.scrollTop !== input.scrollTop) overlay.scrollTop = input.scrollTop;
-  if (overlay.scrollLeft !== input.scrollLeft) overlay.scrollLeft = input.scrollLeft;
-}
+const highlightOverlayHtml = createHighlightOverlayRenderer({
+  escapeHtml,
+  renderHighlightedText,
+});
 
 function requestOverlaySync(input, forceCopyMetrics = false) {
   const overlay = input?.__easyuseAnimaHighlightOverlay;

--- a/web/js/prompt_studio/highlight_overlay_core.js
+++ b/web/js/prompt_studio/highlight_overlay_core.js
@@ -1,0 +1,240 @@
+// @ts-check
+
+/**
+ * @typedef {Object} HighlightAutocompletePreview
+ * @property {unknown} [sourceValue]
+ * @property {unknown} [value]
+ * @property {unknown} [color]
+ * @property {number} [candidateStart]
+ * @property {number} [candidateEnd]
+ * @property {number} [ghostStart]
+ * @property {number} [ghostEnd]
+ */
+
+/**
+ * @typedef {(HTMLTextAreaElement | HTMLInputElement) & {
+ *   __easyuseAnimaAutocompletePreview?: HighlightAutocompletePreview | null
+ * }} HighlightOverlayInput
+ */
+
+/**
+ * @callback HighlightTextRenderer
+ * @param {string} text
+ * @param {Array<any>} tokens
+ * @returns {string}
+ */
+
+const HIGHLIGHT_TEXT_METRIC_PROPERTIES = [
+  "font",
+  "fontFamily",
+  "fontSize",
+  "fontSizeAdjust",
+  "fontStretch",
+  "fontWeight",
+  "fontStyle",
+  "fontVariant",
+  "fontKerning",
+  "fontOpticalSizing",
+  "fontFeatureSettings",
+  "fontVariationSettings",
+  "lineHeight",
+  "letterSpacing",
+  "wordSpacing",
+  "textIndent",
+  "padding",
+  "border",
+  "borderRadius",
+  "boxSizing",
+  "textAlign",
+  "textTransform",
+  "textRendering",
+  "direction",
+  "tabSize",
+  "whiteSpace",
+  "overflowWrap",
+  "wordBreak",
+];
+
+/** @param {string} value */
+function cssPixelNumber(value) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** @param {number} value */
+function cssPixel(value) {
+  const rounded = Math.round(Number(value || 0) * 100) / 100;
+  return `${rounded}px`;
+}
+
+/**
+ * @param {HTMLTextAreaElement | HTMLInputElement} input
+ * @param {CSSStyleDeclaration} [style]
+ */
+function overlayScrollbarPadding(input, style = getComputedStyle(input)) {
+  const verticalGutter = Math.max(
+    0,
+    (Number(input.offsetWidth) || 0)
+      - (Number(input.clientWidth) || 0)
+      - cssPixelNumber(style.borderLeftWidth)
+      - cssPixelNumber(style.borderRightWidth),
+  );
+  const horizontalGutter = Math.max(
+    0,
+    (Number(input.offsetHeight) || 0)
+      - (Number(input.clientHeight) || 0)
+      - cssPixelNumber(style.borderTopWidth)
+      - cssPixelNumber(style.borderBottomWidth),
+  );
+  return {
+    right: cssPixel(cssPixelNumber(style.paddingRight) + verticalGutter),
+    bottom: cssPixel(cssPixelNumber(style.paddingBottom) + horizontalGutter),
+  };
+}
+
+/**
+ * @param {HTMLTextAreaElement | HTMLInputElement} input
+ * @param {HTMLElement} overlay
+ * @param {CSSStyleDeclaration} [style]
+ */
+function applyOverlayScrollbarPadding(input, overlay, style = getComputedStyle(input)) {
+  const padding = overlayScrollbarPadding(input, style);
+  if (overlay.style.paddingRight !== padding.right) overlay.style.paddingRight = padding.right;
+  if (overlay.style.paddingBottom !== padding.bottom) overlay.style.paddingBottom = padding.bottom;
+}
+
+/** @param {HTMLTextAreaElement | HTMLInputElement} input */
+function overlayBounds(input) {
+  return {
+    left: `${input.offsetLeft}px`,
+    top: `${input.offsetTop}px`,
+    width: `${input.offsetWidth}px`,
+    height: `${input.offsetHeight}px`,
+  };
+}
+
+/**
+ * @param {string} text
+ * @param {HighlightAutocompletePreview} preview
+ * @param {(value: unknown) => string} escapeHtml
+ * @param {number} [opacity]
+ */
+function autocompletePreviewSpanHtml(text, preview, escapeHtml, opacity = 0.95) {
+  const color = String(preview?.color || "rgba(203, 213, 225, 0.86)");
+  return `<span style="font: inherit; line-height: inherit; letter-spacing: inherit; vertical-align: baseline; color: ${escapeHtml(color)}; opacity: ${opacity}">`
+    + escapeHtml(text)
+    + "</span>";
+}
+
+/**
+ * @param {string} value
+ * @param {Array<any>} tokens
+ * @param {HighlightAutocompletePreview | null | undefined} preview
+ * @param {HighlightTextRenderer} renderHighlightedText
+ * @param {(value: unknown) => string} escapeHtml
+ */
+function highlightOverlayPreviewHtml(value, tokens, preview, renderHighlightedText, escapeHtml) {
+  if (!preview || String(preview.sourceValue || "") !== String(value || "")) {
+    return null;
+  }
+  const text = String(preview.value || "");
+  const candidateStart = Math.max(0, Math.min(Number(preview.candidateStart ?? preview.ghostStart) || 0, text.length));
+  const candidateEnd = Math.max(candidateStart, Math.min(Number(preview.candidateEnd ?? preview.ghostEnd) || 0, text.length));
+  const ghostStart = Math.max(0, Math.min(Number(preview.ghostStart) || 0, text.length));
+  const ghostEnd = Math.max(ghostStart, Math.min(Number(preview.ghostEnd) || 0, text.length));
+  if (!text || candidateEnd <= candidateStart || ghostEnd <= ghostStart) {
+    return null;
+  }
+  const safeGhostStart = Math.max(candidateStart, Math.min(ghostStart, candidateEnd));
+  const safeGhostEnd = Math.max(safeGhostStart, Math.min(ghostEnd, candidateEnd));
+  const html = [
+    renderHighlightedText(text.slice(0, candidateStart), tokens || []),
+    autocompletePreviewSpanHtml(text.slice(candidateStart, safeGhostStart), preview, escapeHtml, 0.95),
+    autocompletePreviewSpanHtml(text.slice(safeGhostStart, safeGhostEnd), preview, escapeHtml, 0.52),
+    autocompletePreviewSpanHtml(text.slice(safeGhostEnd, candidateEnd), preview, escapeHtml, 0.95),
+    renderHighlightedText(text.slice(candidateEnd), tokens || []),
+  ].join("");
+  return text.endsWith("\n") ? `${html} ` : html;
+}
+
+/**
+ * @param {Object} dependencies
+ * @param {HighlightTextRenderer} dependencies.renderHighlightedText
+ * @param {(value: unknown) => string} dependencies.escapeHtml
+ */
+function createHighlightOverlayRenderer({ renderHighlightedText, escapeHtml }) {
+  /**
+   * @param {unknown} value
+   * @param {Array<any>} tokens
+   * @param {unknown} [placeholder]
+   * @param {HighlightOverlayInput | null} [input]
+   */
+  return function highlightOverlayHtml(value, tokens, placeholder = "", input = null) {
+    const text = String(value || "");
+    if (!text) {
+      return `<span style="opacity: 0.45">${escapeHtml(placeholder)}</span>`;
+    }
+    const previewHtml = highlightOverlayPreviewHtml(
+      text,
+      tokens,
+      input?.__easyuseAnimaAutocompletePreview,
+      renderHighlightedText,
+      escapeHtml,
+    );
+    if (previewHtml != null) {
+      return previewHtml;
+    }
+    const html = renderHighlightedText(text, tokens);
+    return text.endsWith("\n") ? `${html} ` : html;
+  };
+}
+
+/**
+ * @param {HTMLTextAreaElement | HTMLInputElement} input
+ * @param {HTMLElement} overlay
+ * @param {CSSStyleDeclaration} [style]
+ */
+function copyInputTextMetrics(input, overlay, style = getComputedStyle(input)) {
+  for (const property of HIGHLIGHT_TEXT_METRIC_PROPERTIES) {
+    const val = style[property];
+    if (overlay.style[property] !== val) {
+      overlay.style[property] = val;
+    }
+  }
+  overlay.style.boxSizing = "border-box";
+  overlay.style.whiteSpace = "pre-wrap";
+  overlay.style.overflowWrap = "break-word";
+  overlay.style.wordWrap = "break-word";
+  overlay.style.wordBreak = "normal";
+  overlay.style.margin = "0";
+  applyOverlayScrollbarPadding(input, overlay, style);
+}
+
+/**
+ * @param {HTMLTextAreaElement | HTMLInputElement} input
+ * @param {HTMLElement | null | undefined} overlay
+ * @param {CSSStyleDeclaration} [style]
+ */
+function syncOverlayBounds(input, overlay, style) {
+  if (!overlay) return;
+  const currentStyle = style || getComputedStyle(input);
+  const { left, top, width, height } = overlayBounds(input);
+
+  if (overlay.style.left !== left) overlay.style.left = left;
+  if (overlay.style.top !== top) overlay.style.top = top;
+  if (overlay.style.width !== width) overlay.style.width = width;
+  if (overlay.style.height !== height) overlay.style.height = height;
+  applyOverlayScrollbarPadding(input, overlay, currentStyle);
+
+  if (overlay.scrollTop !== input.scrollTop) overlay.scrollTop = input.scrollTop;
+  if (overlay.scrollLeft !== input.scrollLeft) overlay.scrollLeft = input.scrollLeft;
+}
+
+export {
+  HIGHLIGHT_TEXT_METRIC_PROPERTIES,
+  copyInputTextMetrics,
+  createHighlightOverlayRenderer,
+  overlayBounds,
+  overlayScrollbarPadding,
+  syncOverlayBounds,
+};


### PR DESCRIPTION
## 변경 요약

- Main/Advanced와 Regional Prompt Studio에 중복돼 있던 overlay geometry, text metric 복사, scroll 동기화, autocomplete preview 조합을 `prompt_studio/highlight_overlay_core.js`로 통합했습니다.
- 화면별 renderer 우선순위, 색상, tooltip, settings, node/field state, listener 및 classification lifecycle은 기존 adapter에 유지했습니다.
- 독립 semantic smoke와 구조 회귀 테스트를 추가하고 공식 frontend 검사에 연결했습니다.
- 현재 `dev` 기준 수치와 R2 구현 상태를 frontend 유지보수 로드맵에 반영했습니다.

## 주요 파일

- `web/js/prompt_studio/highlight_overlay_core.js`: 공통 overlay geometry/preview core
- `web/js/prompt_studio/highlight.js`: Main/Advanced adapter 연결 및 기존 공개 export 유지
- `web/js/easyuse_anima_prompt_studio_common.js`: Regional adapter 연결
- `tests/frontend_highlight_overlay_core_smoke.mjs`: geometry, metric, scroll, preview, stale-preview semantic smoke
- `tests/test_frontend_modules.py`: 공통 소유권과 adapter 경계 회귀 검사
- `tools/check_frontend.ps1`: 새 smoke를 공식 frontend 검사에 포함

## 호환성

- node type, widget/socket 이름, workflow serialization, API route와 payload는 변경하지 않았습니다.
- adapter의 기존 호출 순서와 `highlight.js` 공개 export를 유지했습니다.
- 두 adapter 사이의 동일 이름 함수는 19개에서 9개로 줄었고, 남은 항목은 화면별 정책 또는 lifecycle 책임입니다.

## 검증

- `tools/check_project.ps1 -Profile full`: 320 tests OK
- Frontend syntax: 53 JavaScript files OK
- Highlight parser/renderer semantic smoke: passed
- Highlight overlay semantic smoke: passed
- TypeScript 6.0.3 no-build check: passed
- `git diff --check`: passed
- ComfyUI Codex test instance (0.27.0) / Node 2.0 browser smoke:
  - Advanced와 Regional 모두 input당 overlay 1개
  - input/overlay 위치와 크기 오차 0
  - padding 및 scroll 상태 일치
  - autocomplete ghost preview 표시
  - autocomplete popup 활성 중 trained-tag tooltip 비표시
  - EasyUse 관련 browser warning/error 없음

## 남은 위험

- legacy canvas surface는 이번 browser smoke에서 확인하지 않았습니다.
- listener 제거 정책과 Regional 대형 모듈 분리는 후속 R3-R5 범위로 유지합니다.

## 라벨 후보

저장소에 아래 라벨이 아직 없어 생성하지 않았습니다.

- `type: chore`
- `area: frontend`
- `status: ready`

Refs #14