### PR TITLE
Regional pure data 모듈 분리

### DIFF
--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -23,8 +23,8 @@
 
 ```text
 branch: dev
-HEAD: c7897a824b3bf28b41f826f557bb0330918e40a1
-origin/dev: c7897a824b3bf28b41f826f557bb0330918e40a1
+HEAD: 55a68ea0c49dc215fed05c39b896bea771b0b5b8
+origin/dev: 55a68ea0c49dc215fed05c39b896bea771b0b5b8
 working tree: clean
 ```
 
@@ -37,6 +37,7 @@ Issue #14는 열려 있다. 다음 변경은 `dev`에 병합됐다.
 | #47 | `2c818b6` | Main/Advanced와 Regional의 prompt highlight parser/renderer core 공통화 |
 | #48 | `781b4c4` | Issue #14 현재 로드맵과 종료 범위 정리 |
 | #49 | `c7897a8` | 저장소 소유 project/frontend/unittest 검증 명령 계약 통합 |
+| #50 | `55a68ea` | Prompt Studio DOM highlight overlay geometry/preview core 공통화 |
 
 ## 현재 상태
 
@@ -52,29 +53,33 @@ Issue #14는 열려 있다. 다음 변경은 `dev`에 병합됐다.
   `prompt_studio/highlight_core.js`가 소유한다.
 - overlay geometry, text metric 복사, autocomplete preview 조합은
   `prompt_studio/highlight_overlay_core.js`가 소유한다.
+- Regional의 상수, field/config schema와 migration, resolution 규칙,
+  serialization 정규화, mask geometry/hit-test는
+  `prompt_studio/regional/` 아래 DOM-free 모듈이 소유한다.
 - `tools/check_frontend.ps1`은 전체 frontend JS 문법 검사, parser/renderer와
-  overlay semantic smoke, 고정 버전 TypeScript 검사를 한 번에 실행한다.
+  overlay 및 Regional pure-data semantic smoke, 고정 버전 TypeScript 검사를
+  한 번에 실행한다.
 - `noUnusedLocals`와 `noUnusedParameters`가 현재 typecheck 범위에 적용된다.
 - Vite/TypeScript build chain을 당장 도입하지 않고 raw ES module과 no-build
   typecheck를 유지하기로 결정했다.
 
 ### 정량 스냅샷
 
-`web/js`에는 JavaScript 53개, 총 28,782줄이 있다. `jsconfig.json`에 명시된
+`web/js`에는 JavaScript 58개, 총 28,920줄이 있다. `jsconfig.json`에 명시된
 include 대상은 Prompt Studio entry와 `prompt_studio/*.js` 41개, 8,485줄로
-전체 라인의 29.5%다. import를 따라 추가로 검사되는 dependency는 이 수치에
+전체 라인의 29.3%다. import를 따라 추가로 검사되는 dependency는 이 수치에
 포함하지 않았다.
 
 | 파일 | 줄 수 | 전체 비율 | 현재 판단 |
 | --- | ---: | ---: | --- |
-| `easyuse_anima_aio.js` | 8,879 | 30.8% | 가장 큰 후속 hotspot |
+| `easyuse_anima_aio.js` | 8,879 | 30.7% | 가장 큰 후속 hotspot |
 | `easyuse_anima_lora_preset.js` | 2,907 | 10.1% | canvas/UI/API/state가 한 파일에 결합 |
-| `easyuse_anima_prompt_studio_regional.js` | 2,284 | 7.9% | Issue #14 종료 전에 분리할 대상 |
-| `easyuse_anima_autocomplete.js` | 2,067 | 7.2% | parser, popup, input runtime이 결합 |
+| `easyuse_anima_autocomplete.js` | 2,067 | 7.1% | parser, popup, input runtime이 결합 |
 | `easyuse_anima_settings.js` | 1,935 | 6.7% | 설정 정의와 여러 editor 구현이 결합 |
-| `easyuse_anima_prompt_studio_common.js` | 1,419 | 4.9% | 현재 Regional만 import하는 legacy common layer |
+| `easyuse_anima_prompt_studio_regional.js` | 1,828 | 6.3% | UI/editor/runtime 분리가 남은 Issue #14 대상 |
+| `easyuse_anima_prompt_studio_common.js` | 1,365 | 4.7% | 현재 Regional만 import하는 legacy common layer |
 
-상위 6개 파일이 전체 frontend JS의 약 67.7%를 차지한다. 줄 수 자체를 목표로
+상위 6개 파일이 전체 frontend JS의 약 65.6%를 차지한다. 줄 수 자체를 목표로
 삼지는 않지만, 책임 경계와 검증 비용이 이 파일들에 집중돼 있다는 신호로
 사용한다.
 
@@ -86,8 +91,9 @@ include 대상은 Prompt Studio entry와 `prompt_studio/*.js` 41개, 8,485줄로
   preview HTML, overlay 위치 동기화는 DOM overlay core로 공통화됐다.
 - 색상 설정, tooltip 문구, 설정 저장소, node별 highlight state와 listener
   lifecycle은 화면별 adapter에 남기는 편이 안전하다.
-- Regional entry는 constants, schema, serialization, mask geometry/editor,
-  DOM 생성, layout, hook 설치, extension 등록을 한 파일에서 담당한다.
+- Regional entry에서 constants, schema/migration, resolution, serialization,
+  mask geometry/hit-test가 분리됐다. DOM 생성, mask canvas draw/editor,
+  layout, hook 설치와 extension 등록은 R4 범위로 남아 있다.
 - `easyuse_anima_prompt_studio_common.js`는 Regional만 사용하므로 이름과 역할이
   현재 구조를 설명하지 못한다. Regional 분리 후 제거하거나 얇은 호환 adapter로
   축소해야 한다.
@@ -218,6 +224,13 @@ web/js/prompt_studio/regional/
   mask_geometry.js
 ```
 
+현재 구현:
+
+- 위 5개 모듈이 `web/js/prompt_studio/regional/`에 분리돼 있다.
+- `frontend_regional_pure_data_smoke.mjs`가 field/config migration,
+  resolution, mask geometry, save/reload 정규화를 DOM 없이 검증한다.
+- legacy common은 기존 Regional 상수 export를 호환 re-export로 유지한다.
+
 완료 기준:
 
 - field/config normalization과 migration이 DOM 없이 테스트된다.
@@ -283,16 +296,13 @@ web/js/prompt_studio/regional/
 
 ## Issue #14 예상 잔여 시간
 
-R1-R6은 약 4-7 작업일로 본다. 가장 큰 변수는 Regional mask/editor의 browser
-smoke와 workflow compatibility 확인이다. 한 PR로 묶지 않고 다음 정도로
-나누는 것이 적절하다.
+R4-R6은 약 2.5-4.5 작업일로 본다. 가장 큰 변수는 Regional mask/editor의
+browser smoke와 workflow compatibility 확인이다. 남은 작업은 한 PR로 묶지
+않고 다음 순서로 진행한다.
 
-1. validation contract
-2. overlay core
-3. Regional pure data
-4. Regional UI/runtime
-5. common retirement와 typecheck
-6. closure validation과 Issue update
+1. Regional UI/runtime
+2. common retirement와 typecheck
+3. closure validation과 Issue update
 
 ## Issue #14 이후 후속 트랙
 

--- a/tests/frontend_regional_pure_data_smoke.mjs
+++ b/tests/frontend_regional_pure_data_smoke.mjs
@@ -1,0 +1,138 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [specifier, replacement] of Object.entries(replacements)) {
+    source = source.replaceAll(`"${specifier}"`, `"${replacement}"`);
+  }
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const constantsUrl = dataModule("../web/js/prompt_studio/regional/constants.js");
+const maskGeometryUrl = dataModule("../web/js/prompt_studio/regional/mask_geometry.js");
+const resolutionUrl = dataModule("../web/js/prompt_studio/regional/resolution.js", {
+  "./constants.js": constantsUrl,
+});
+const schemaUrl = dataModule("../web/js/prompt_studio/regional/schema.js", {
+  "./constants.js": constantsUrl,
+  "./mask_geometry.js": maskGeometryUrl,
+  "./resolution.js": resolutionUrl,
+});
+const serializationUrl = dataModule("../web/js/prompt_studio/regional/serialization.js", {
+  "./constants.js": constantsUrl,
+  "./schema.js": schemaUrl,
+});
+
+const constants = await import(constantsUrl);
+const geometry = await import(maskGeometryUrl);
+const resolution = await import(resolutionUrl);
+const schema = await import(schemaUrl);
+const serialization = await import(serializationUrl);
+
+assert(constants.REGIONAL_WIDGET_INDEX.regional_config === 1, "Regional widget order changed");
+assert(constants.PROMPT_STUDIO_VARIANT_FIELD_TYPES.join(",") === "quality,artist,trigger,general", "Regional field type order changed");
+
+assert(resolution.ratioLabel(1024, 1536) === "2:3", "Resolution ratio label changed");
+assert(resolution.resolutionOptions("1024").includes("896 * 1152 (7:9)"), "1024 resolution options changed");
+assert(resolution.normalizeResolutionBucket("unknown") === "1024", "Resolution bucket fallback changed");
+assert(resolution.normalizeResolutionSize("1024", "896 * 1152 (7:9)") === "896 * 1152 (7:9)", "Resolution size normalization changed");
+assert(resolution.snapResolution32(1000) === 992, "32-pixel resolution snapping changed");
+assert(
+  JSON.stringify(resolution.readRegionalResolutionValues({
+    bucket: "1024",
+    size: "896 * 1152 (7:9)",
+    customWidth: 1024,
+    customHeight: 1024,
+  })) === JSON.stringify({ width: 896, height: 1152 }),
+  "Bucket resolution reading changed",
+);
+assert(
+  JSON.stringify(resolution.readRegionalResolutionValues({
+    bucket: "Custom",
+    size: "896 * 1152 (7:9)",
+    customWidth: 1000,
+    customHeight: 777,
+  })) === JSON.stringify({ width: 1000, height: 777 }),
+  "Custom resolution reading changed",
+);
+
+assert(
+  JSON.stringify(schema.normalizeRegionalConditioningWidgetValues(["default", "0.35"]))
+    === JSON.stringify([0.35, "default"]),
+  "Regional conditioning widget migration changed",
+);
+assert(schema.createDefaultRegionalFields().length === 5, "Default Regional fields changed");
+const positiveField = schema.normalizeRegionalField({
+  pane: "positive",
+  type: "unknown",
+  height: 12,
+  enabled: "false",
+  mask_ids: "2, 2; -1 3",
+});
+assert(positiveField.type === "general", "Unknown Regional field type fallback changed");
+assert(positiveField.height === 36, "Regional field minimum height changed");
+assert(positiveField.enabled === false, "Regional field boolean normalization changed");
+assert(JSON.stringify(positiveField.mask_ids) === JSON.stringify([2, 3]), "Regional mask id normalization changed");
+const negativeField = schema.normalizeRegionalField({ pane: "negative", type: "trigger", mask_ids: [1] });
+assert(negativeField.type === "general", "Negative trigger migration changed");
+assert(negativeField.mask_ids.length === 0, "Negative mask assignment filtering changed");
+
+const migratedConfig = schema.normalizeRegionalConfig({
+  regions: [
+    { id: 2, color: "#abcdef", geometry: { type: "ellipse", x: 0.9, y: -1, width: 0.5, height: 2 } },
+    { id: 2, geometry: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 } },
+    { id: 0 },
+  ],
+  mask_authoring: { preview_enabled: false },
+  artist_mix: { mode: "hybrid" },
+}, { width: 640, height: 480 });
+assert(migratedConfig.canvas.width === 640 && migratedConfig.canvas.height === 480, "Regional canvas resolution changed");
+assert(migratedConfig.canvas.aspect_ratio === "4:3", "Regional canvas aspect ratio changed");
+assert(migratedConfig.masks.length === 1 && migratedConfig.masks[0].mask_id === 2, "Region-to-mask migration changed");
+assert(migratedConfig.masks[0].geometry.width === 0.1, "Mask geometry boundary clamp changed");
+assert(migratedConfig.next_mask_id === 3, "Next mask id migration changed");
+assert(migratedConfig.mask_authoring.preview_enabled === false, "Mask authoring settings migration changed");
+assert(migratedConfig.mask_authoring.storage_space === "normalized_canvas", "Mask authoring defaults changed");
+
+const normalizedRect = geometry.normalizeGeometry({ type: "rect", x: -1, y: 0.2, width: 0.25, height: 0.3 });
+assert(normalizedRect.x === 0 && normalizedRect.width === 0.25, "Rectangle normalization changed");
+const ellipse = geometry.normalizeGeometry({ type: "ellipse", x: 0.2, y: 0.2, width: 0.4, height: 0.4 });
+assert(geometry.maskContainsPoint(ellipse, { x: 0.4, y: 0.4 }), "Ellipse center hit-test changed");
+assert(!geometry.maskContainsPoint(ellipse, { x: 0.2, y: 0.2 }), "Ellipse corner hit-test changed");
+assert(geometry.hitTestMaskHandle(ellipse, { x: 0.2, y: 0.2 }) === "nw", "Mask handle hit-test changed");
+const moved = geometry.moveGeometry({ type: "rect", x: 0.2, y: 0.2, width: 0.3, height: 0.3 }, 1, 1);
+assert(moved.x === 0.7 && moved.y === 0.7, "Mask movement boundary changed");
+const resized = geometry.resizeGeometry({ type: "rect", x: 0.2, y: 0.2, width: 0.3, height: 0.3 }, "nw", 1, 1);
+assert(resized.width >= 0.01 && resized.height >= 0.01, "Mask resize minimum changed");
+
+const propertyFields = JSON.stringify([{ id: "property", pane: "positive", type: "general" }]);
+const widgetFields = JSON.stringify([{ id: "widget", pane: "positive", type: "general" }]);
+const selectedFields = serialization.serializedRegionalValue({
+  properties: { easyuse_anima_regional_fields: propertyFields },
+  widgets_values: [widgetFields],
+}, "regional_fields");
+assert(JSON.parse(selectedFields)[0].id === "property", "Serialized Regional property precedence changed");
+const selectedConfig = serialization.serializedRegionalValue({
+  properties: { easyuse_anima_regional_config: JSON.stringify({ regions: [{ id: 4 }] }) },
+  widgets_values: [],
+}, "regional_config", { width: 800, height: 600 });
+assert(JSON.parse(selectedConfig).canvas.aspect_ratio === "4:3", "Serialized Regional config normalization changed");
+assert(JSON.parse(selectedConfig).masks[0].mask_id === 4, "Serialized Regional config migration changed");
+assert(
+  serialization.normalizeRegionalFieldsString(selectedFields)
+    === selectedFields,
+  "Regional field save/reload normalization changed",
+);
+assert(
+  serialization.normalizeRegionalConfigString(selectedConfig, { width: 800, height: 600 })
+    === selectedConfig,
+  "Regional config save/reload normalization changed",
+);
+
+console.log("Regional pure data smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -19,6 +19,11 @@ PROMPT_STUDIO_HIGHLIGHT_CORE_JS = PROMPT_STUDIO_MODULES / "highlight_core.js"
 PROMPT_STUDIO_HIGHLIGHT_OVERLAY_CORE_JS = (
     PROMPT_STUDIO_MODULES / "highlight_overlay_core.js"
 )
+PROMPT_STUDIO_REGIONAL_JS = WEB_JS / "easyuse_anima_prompt_studio_regional.js"
+PROMPT_STUDIO_REGIONAL_MODULES = PROMPT_STUDIO_MODULES / "regional"
+PROMPT_STUDIO_REGIONAL_PURE_DATA_SMOKE = (
+    ROOT / "tests" / "frontend_regional_pure_data_smoke.mjs"
+)
 STATIC_IMPORT_RE = re.compile(r"""from\s+["'](\./[^"']+\.js)["']""")
 
 
@@ -218,6 +223,104 @@ class FrontendModuleStructureTests(unittest.TestCase):
         ):
             with self.subTest(export=name):
                 self.assertIn(f"  {name},", core_source)
+
+    def test_regional_pure_data_modules_own_dom_free_rules(self):
+        entry_source = PROMPT_STUDIO_REGIONAL_JS.read_text(encoding="utf-8")
+        common_source = PROMPT_STUDIO_COMMON_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+        expected_modules = {
+            "constants.js": (
+                "REGIONAL_WIDGET_INDEX",
+                "PROMPT_STUDIO_RESOLUTION_BUCKETS",
+                "PROMPT_STUDIO_VARIANT_FIELD_TYPES",
+            ),
+            "resolution.js": (
+                "ratioLabel",
+                "normalizeResolutionBucket",
+                "readRegionalResolutionValues",
+            ),
+            "schema.js": (
+                "createDefaultRegionalFields",
+                "normalizeRegionalField",
+                "normalizeRegionalConfig",
+            ),
+            "serialization.js": (
+                "normalizeRegionalFieldsString",
+                "normalizeRegionalConfigString",
+                "serializedRegionalValue",
+            ),
+            "mask_geometry.js": (
+                "normalizeGeometry",
+                "findMaskAt",
+                "moveGeometry",
+                "resizeGeometry",
+            ),
+        }
+
+        for filename, symbols in expected_modules.items():
+            with self.subTest(module=filename):
+                path = PROMPT_STUDIO_REGIONAL_MODULES / filename
+                self.assertTrue(path.is_file())
+                source = path.read_text(encoding="utf-8")
+                self.assertTrue(source.startswith("// @ts-check"))
+                self.assertNotRegex(source, r"\b(?:document|window|app)\b")
+                for symbol in symbols:
+                    self.assertRegex(
+                        source,
+                        rf"export (?:const|function) {symbol}\b",
+                    )
+                self.assertIn(
+                    f'./prompt_studio/regional/{filename}"',
+                    entry_source,
+                )
+
+        for name in (
+            "ratioLabel",
+            "resolutionLabel",
+            "resolutionOptions",
+            "normalizeResolutionBucket",
+            "normalizeResolutionSize",
+            "snapResolution32",
+            "defaultFields",
+            "normalizeMaskIds",
+            "normalizeField",
+            "normalizeFieldsValue",
+            "normalizeGeometry",
+            "geometryToCanvasRect",
+            "maskHandlePoints",
+            "findMaskHandleAt",
+            "findMaskAt",
+            "moveGeometry",
+            "resizeGeometry",
+        ):
+            with self.subTest(extracted=name):
+                self.assertNotIn(f"function {name}", entry_source)
+
+        self.assertIn(
+            'from "./prompt_studio/regional/constants.js"',
+            common_source,
+        )
+        self.assertNotIn(
+            "export const PROMPT_STUDIO_RESOLUTION_BUCKETS",
+            common_source,
+        )
+        self.assertTrue(PROMPT_STUDIO_REGIONAL_PURE_DATA_SMOKE.is_file())
+        self.assertIn(
+            'node "tests\\frontend_regional_pure_data_smoke.mjs"',
+            frontend_check_source,
+        )
+
+        write_fields_source = entry_source[
+            entry_source.index("function writeRegionalFields"):
+            entry_source.index("function writeRegionalConfig")
+        ]
+        write_config_source = entry_source[
+            entry_source.index("function writeRegionalConfig"):
+            entry_source.index("function updateRegionalConfigCanvas")
+        ]
+        self.assertIn("if (syncInputs)", write_fields_source)
+        self.assertIn("syncRegionalFieldInputs(node, normalized)", write_fields_source)
+        self.assertNotIn("syncRegionalFieldInputs", write_config_source)
 
     def test_prompt_studio_phase_2_modules_export_expected_symbols(self):
         advanced_controls_source = (

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -39,6 +39,11 @@ try {
         throw "Frontend highlight overlay core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_regional_pure_data_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."
+    }
+
     & npx --yes --package "typescript@$TypeScriptVersion" -- tsc -p jsconfig.json
     if ($LASTEXITCODE -ne 0) {
         throw "TypeScript check failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_prompt_studio_common.js
+++ b/web/js/easyuse_anima_prompt_studio_common.js
@@ -6,73 +6,19 @@ import {
   createHighlightOverlayRenderer,
   syncOverlayBounds,
 } from "./prompt_studio/highlight_overlay_core.js";
+import { PROMPT_STUDIO_VARIANT_FIELD_LABELS } from "./prompt_studio/regional/constants.js";
 
-export const PROMPT_STUDIO_VARIANT_FIELD_TYPES = ["quality", "artist", "trigger", "general"];
-export const PROMPT_STUDIO_VARIANT_FIELD_LABELS = {
-  quality: "Quality Tags",
-  artist: "Artist Tags",
-  trigger: "Trigger Words",
-  general: "General Tags",
-};
-export const PROMPT_STUDIO_WILDCARD_MODES = ["일반 채우기", "고정", "순차", "재현"];
-export const PROMPT_STUDIO_WILDCARD_SEED_CONTROLS = ["fixed", "randomize", "increment", "decrement"];
-export const PROMPT_STUDIO_WILDCARD_DEFAULT_MODE = "고정";
-export const PROMPT_STUDIO_RESOLUTION_BUCKETS = {
-  "512": [
-    [256, 1024], [1024, 256],
-    [288, 896], [896, 288],
-    [384, 672], [672, 384],
-    [512, 512],
-    [448, 576], [576, 448],
-  ],
-  "768": [
-    [384, 1440], [1440, 384],
-    [480, 1152], [1152, 480],
-    [576, 960], [960, 576],
-    [640, 864], [864, 640],
-    [768, 768],
-  ],
-  "896": [
-    [448, 1728], [1728, 448],
-    [480, 1600], [1600, 480],
-    [576, 1344], [1344, 576],
-    [672, 1152], [1152, 672],
-    [800, 960], [960, 800],
-    [896, 896],
-  ],
-  "1024": [
-    [512, 2016], [2016, 512],
-    [576, 1792], [1792, 576],
-    [672, 1536], [1536, 672],
-    [672, 1600], [1600, 672],
-    [768, 1344], [1344, 768],
-    [800, 1344], [1344, 800],
-    [896, 1152], [1152, 896],
-    [960, 1120], [1120, 960],
-    [1024, 1024],
-  ],
-  "1280": [
-    [672, 2400], [2400, 672],
-    [800, 2016], [2016, 800],
-    [1024, 1536], [1536, 1024],
-    [1024, 1600], [1600, 1024],
-    [1120, 1440], [1440, 1120],
-    [1280, 1280],
-  ],
-  "1536": [
-    [1440, 1536], [1536, 1440],
-    [1280, 1728], [1728, 1280],
-    [1152, 1920], [1920, 1152],
-    [1024, 2176], [2176, 1024],
-    [960, 2304], [2304, 960],
-    [864, 2560], [2560, 864],
-    [768, 2880], [2880, 768],
-    [1536, 1536],
-  ],
-};
-export const PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET = "Custom";
-export const PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET = "1024";
-export const PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE = "1024 * 1024 (1:1)";
+export {
+  PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET,
+  PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET,
+  PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE,
+  PROMPT_STUDIO_RESOLUTION_BUCKETS,
+  PROMPT_STUDIO_VARIANT_FIELD_LABELS,
+  PROMPT_STUDIO_VARIANT_FIELD_TYPES,
+  PROMPT_STUDIO_WILDCARD_DEFAULT_MODE,
+  PROMPT_STUDIO_WILDCARD_MODES,
+  PROMPT_STUDIO_WILDCARD_SEED_CONTROLS,
+} from "./prompt_studio/regional/constants.js";
 
 const PROMPT_STUDIO_COMMON_TEXT = {
   en: {

--- a/web/js/easyuse_anima_prompt_studio_regional.js
+++ b/web/js/easyuse_anima_prompt_studio_regional.js
@@ -1,14 +1,5 @@
 import { app } from "../../../scripts/app.js";
 import {
-  PROMPT_STUDIO_VARIANT_FIELD_LABELS,
-  PROMPT_STUDIO_VARIANT_FIELD_TYPES,
-  PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET,
-  PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET,
-  PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE,
-  PROMPT_STUDIO_RESOLUTION_BUCKETS,
-  PROMPT_STUDIO_WILDCARD_DEFAULT_MODE,
-  PROMPT_STUDIO_WILDCARD_MODES,
-  PROMPT_STUDIO_WILDCARD_SEED_CONTROLS,
   createPromptStudioActionButton,
   ensurePromptStudioVariantStyle,
   promptStudioFieldIndexLabel,
@@ -20,32 +11,62 @@ import {
   schedulePromptStudioFieldHighlight,
   updatePromptStudioFieldHighlight,
 } from "./easyuse_anima_prompt_studio_common.js";
+import {
+  PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET,
+  PROMPT_STUDIO_RESOLUTION_BUCKETS,
+  PROMPT_STUDIO_VARIANT_FIELD_LABELS as REGIONAL_FIELD_LABELS,
+  PROMPT_STUDIO_VARIANT_FIELD_TYPES as REGIONAL_FIELD_TYPES,
+  PROMPT_STUDIO_WILDCARD_DEFAULT_MODE,
+  PROMPT_STUDIO_WILDCARD_MODES,
+  PROMPT_STUDIO_WILDCARD_SEED_CONTROLS,
+  REGIONAL_CONDITIONING_NODE_TYPE,
+  REGIONAL_CONFIG_PROPERTY,
+  REGIONAL_FIELDS_PROPERTY,
+  REGIONAL_INTERNAL_WIDGET_NAMES,
+  REGIONAL_NODE_TYPE,
+  REGIONAL_WIDGET_INDEX,
+} from "./prompt_studio/regional/constants.js";
+import {
+  clampRegionalValue as clamp,
+  findMaskAt,
+  findMaskHandleAt,
+  geometryToCanvasRect,
+  maskHandlePoints,
+  moveGeometry,
+  normalizeGeometry,
+  resizeGeometry,
+} from "./prompt_studio/regional/mask_geometry.js";
+import {
+  normalizeResolutionBucket,
+  normalizeResolutionSize,
+  ratioLabel,
+  readRegionalResolutionValues,
+  resolutionLabel,
+  resolutionOptions,
+  snapResolution32,
+} from "./prompt_studio/regional/resolution.js";
+import {
+  createDefaultRegionalConfig,
+  createDefaultRegionalFields as defaultFields,
+  firstRegionalValue as firstValue,
+  isRegionalConditioningAreaMode,
+  normalizeRegionalConditioningWidgetValues,
+  normalizeRegionalConfig,
+  normalizeRegionalField as normalizeField,
+  normalizeRegionalFields as normalizeFieldsValue,
+  normalizeRegionalMaskIds as normalizeMaskIds,
+  toRegionalInteger as asInt,
+} from "./prompt_studio/regional/schema.js";
+import {
+  normalizeRegionalConfigString,
+  normalizeRegionalFieldsString as normalizedFieldsString,
+  serializedRegionalValue as readSerializedRegionalValue,
+} from "./prompt_studio/regional/serialization.js";
 
-const REGIONAL_NODE_TYPE = "EasyUseAnimaPromptStudioRegional";
-const REGIONAL_CONDITIONING_NODE_TYPE = "EasyUseAnimaRegionalConditioning";
-const REGIONAL_FIELDS_PROPERTY = "easyuse_anima_regional_fields";
-const REGIONAL_CONFIG_PROPERTY = "easyuse_anima_regional_config";
-const REGIONAL_WIDGET_INDEX = {
-  regional_fields: 0,
-  regional_config: 1,
-  resolution_bucket: 2,
-  resolution_size: 3,
-  resolution_custom_width: 4,
-  resolution_custom_height: 5,
-  wildcard_mode: 6,
-  wildcard_seed: 7,
-  wildcard_seed_after_generate: 8,
-};
-const REGIONAL_INTERNAL_WIDGET_NAMES = new Set(Object.keys(REGIONAL_WIDGET_INDEX));
-const REGIONAL_FIELD_TYPES = PROMPT_STUDIO_VARIANT_FIELD_TYPES;
-const REGIONAL_FIELD_LABELS = PROMPT_STUDIO_VARIANT_FIELD_LABELS;
 const REGIONAL_NODE_MIN_WIDTH = 560;
 const REGIONAL_NODE_DEFAULT_WIDTH = 620;
 const REGIONAL_EDITOR_MIN_VIEWPORT_HEIGHT = 360;
 const REGIONAL_EDITOR_MAX_AUTO_VIEWPORT_HEIGHT = 640;
-const MASK_MIN_SIZE = 0.01;
-const MASK_HANDLE_RADIUS = 0.018;
-const MASK_HANDLE_NAMES = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];
 const REGIONAL_LAYOUT_REASON_PRIORITY = {
   layout: 0,
   render: 1,
@@ -54,41 +75,10 @@ const REGIONAL_LAYOUT_REASON_PRIORITY = {
   settings: 1,
   resize: 3,
 };
-const REGIONAL_CONDITIONING_AREA_MODES = new Set(["mask bounds", "default"]);
 let activeMaskPopover = null;
-
-function deepClone(value) {
-  return JSON.parse(JSON.stringify(value));
-}
 
 function findWidget(node, name) {
   return node?.widgets?.find((widget) => widget.name === name) || null;
-}
-
-function isRegionalConditioningAreaMode(value) {
-  return REGIONAL_CONDITIONING_AREA_MODES.has(String(value || ""));
-}
-
-function normalizeRegionalConditioningWidgetValues(values) {
-  const raw = Array.isArray(values) ? values : [];
-  let maskStrength = null;
-  let setCondArea = null;
-  for (const value of raw) {
-    if (maskStrength == null && value != null && value !== "") {
-      const number = Number(value);
-      if (Number.isFinite(number) && !isRegionalConditioningAreaMode(value)) {
-        maskStrength = number;
-        continue;
-      }
-    }
-    if (setCondArea == null && isRegionalConditioningAreaMode(value)) {
-      setCondArea = String(value);
-    }
-  }
-  return [
-    maskStrength == null ? 1.0 : maskStrength,
-    setCondArea || "mask bounds",
-  ];
 }
 
 function repairRegionalConditioningWidgets(node, serialized = null) {
@@ -140,92 +130,6 @@ function wrapRegionalConditioningNode(nodeType) {
   };
 }
 
-function firstValue(value, fallback = null) {
-  return Array.isArray(value) ? (value.length ? value[0] : fallback) : (value ?? fallback);
-}
-
-function asBool(value, fallback = false) {
-  if (value == null) {
-    return fallback;
-  }
-  if (typeof value === "string") {
-    return ["true", "1", "yes", "on", "enabled"].includes(value.trim().toLowerCase());
-  }
-  return !!value;
-}
-
-function asInt(value, fallback = 0) {
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-function clamp(value, min, max) {
-  return Math.max(min, Math.min(max, value));
-}
-
-function ratioLabel(width, height) {
-  const gcd = (a, b) => (b ? gcd(b, a % b) : a);
-  const divisor = gcd(Math.max(1, width), Math.max(1, height));
-  return `${Math.floor(width / divisor)}:${Math.floor(height / divisor)}`;
-}
-
-function resolutionLabel(width, height) {
-  return `${width} * ${height} (${ratioLabel(width, height)})`;
-}
-
-function resolutionOptions(bucket) {
-  const values = PROMPT_STUDIO_RESOLUTION_BUCKETS[bucket]
-    || PROMPT_STUDIO_RESOLUTION_BUCKETS[PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET];
-  return [...values]
-    .sort((a, b) => (a[0] / a[1]) - (b[0] / b[1]) || a[0] - b[0] || a[1] - b[1])
-    .map(([width, height]) => resolutionLabel(width, height));
-}
-
-function normalizeResolutionBucket(value) {
-  const bucket = String(value || "").trim();
-  if (bucket === PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET) {
-    return bucket;
-  }
-  return Object.prototype.hasOwnProperty.call(PROMPT_STUDIO_RESOLUTION_BUCKETS, bucket)
-    ? bucket
-    : PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET;
-}
-
-function resolutionRatioFromLabel(value) {
-  const match = String(value || "").match(/(\d+)\s*(?:\*|x|×)\s*(\d+)/i);
-  if (!match) {
-    return "";
-  }
-  return ratioLabel(Number(match[1]), Number(match[2]));
-}
-
-function normalizeResolutionSize(bucket, value) {
-  if (bucket === PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET) {
-    return String(value || PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE);
-  }
-  const options = resolutionOptions(bucket);
-  const raw = String(value || "").trim();
-  if (options.includes(raw)) {
-    return raw;
-  }
-  const sameRatio = resolutionRatioFromLabel(raw);
-  if (sameRatio) {
-    const matched = options.find((option) => resolutionRatioFromLabel(option) === sameRatio);
-    if (matched) {
-      return matched;
-    }
-  }
-  return options.includes(PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE)
-    ? PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE
-    : options[0];
-}
-
-function snapResolution32(value, fallback = 1024) {
-  const raw = Number.parseInt(value, 10);
-  const base = Number.isFinite(raw) && raw > 0 ? raw : fallback;
-  return Math.max(32, Math.round(base / 32) * 32);
-}
-
 function customResolution(node) {
   return {
     width: snapResolution32(findWidget(node, "resolution_custom_width")?.value, 1024),
@@ -257,227 +161,20 @@ function setCustomResolution(node, width, height, { normalize = false } = {}) {
 }
 
 function readResolution(node) {
-  const width = Math.max(32, asInt(findWidget(node, "resolution_custom_width")?.value, 1024));
-  const height = Math.max(32, asInt(findWidget(node, "resolution_custom_height")?.value, 1024));
-  const size = String(findWidget(node, "resolution_size")?.value || "");
-  const match = size.match(/(\d+)\s*(?:\*|x|×)\s*(\d+)/i);
-  if (normalizeResolutionBucket(findWidget(node, "resolution_bucket")?.value) !== PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET && match) {
-    return {
-      width: Math.max(32, asInt(match[1], width)),
-      height: Math.max(32, asInt(match[2], height)),
-    };
-  }
-  return { width, height };
-}
-
-function defaultFields() {
-  return [
-    {
-      id: "positive_quality",
-      pane: "positive",
-      type: "quality",
-      label: "Quality Tags",
-      text: "newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic",
-      height: 72,
-      enabled: true,
-      pin: false,
-      collapsed: false,
-      mask_ids: [],
-    },
-    {
-      id: "positive_artist",
-      pane: "positive",
-      type: "artist",
-      label: "Artist Tags",
-      text: "",
-      height: 72,
-      enabled: true,
-      pin: false,
-      collapsed: false,
-      mask_ids: [],
-    },
-    {
-      id: "positive_trigger",
-      pane: "positive",
-      type: "trigger",
-      label: "Trigger Words",
-      text: "",
-      height: 72,
-      enabled: true,
-      pin: true,
-      collapsed: false,
-      mask_ids: [],
-    },
-    {
-      id: "positive_general",
-      pane: "positive",
-      type: "general",
-      label: "General Tags",
-      text: "",
-      height: 150,
-      enabled: true,
-      pin: false,
-      collapsed: false,
-      mask_ids: [],
-    },
-    {
-      id: "negative_general",
-      pane: "negative",
-      type: "general",
-      label: "Negative Prompt",
-      text: "",
-      height: 120,
-      enabled: true,
-      pin: false,
-      collapsed: false,
-      mask_ids: [],
-    },
-  ];
+  return readRegionalResolutionValues({
+    bucket: findWidget(node, "resolution_bucket")?.value,
+    size: findWidget(node, "resolution_size")?.value,
+    customWidth: findWidget(node, "resolution_custom_width")?.value,
+    customHeight: findWidget(node, "resolution_custom_height")?.value,
+  });
 }
 
 function defaultConfig(node = null) {
-  const { width, height } = node ? readResolution(node) : { width: 1024, height: 1024 };
-  return {
-    version: 1,
-    canvas: {
-      width,
-      height,
-      aspect_ratio: ratioLabel(width, height),
-      source: "resolution_fields",
-    },
-    mask_authoring: {
-      render_space: "image_pixels",
-      storage_space: "normalized_canvas",
-      preview_enabled: true,
-    },
-    global_prompt: "",
-    negative_prompt: "",
-    next_mask_id: 1,
-    masks: [],
-    regional_enabled: false,
-    mask_prompts: [],
-    assignments: [],
-    artist_mix: {},
-    conditioning_settings: {},
-    regional_settings: {},
-  };
-}
-
-function parseJson(value, fallback) {
-  if (value == null || value === "") {
-    return deepClone(fallback);
-  }
-  try {
-    const parsed = typeof value === "string" ? JSON.parse(value) : value;
-    return parsed == null ? deepClone(fallback) : parsed;
-  } catch {
-    return deepClone(fallback);
-  }
-}
-
-function normalizeMaskIds(value) {
-  const values = Array.isArray(value) ? value : String(value ?? "").split(/[,\s;]+/);
-  const result = [];
-  for (const raw of values) {
-    const id = asInt(raw, 0);
-    if (id > 0 && !result.includes(id)) {
-      result.push(id);
-    }
-  }
-  return result;
-}
-
-function normalizeField(field, index = 0) {
-  const pane = field?.pane === "negative" ? "negative" : "positive";
-  let type = String(field?.type || "general").toLowerCase();
-  if (!REGIONAL_FIELD_TYPES.includes(type)) {
-    type = "general";
-  }
-  if (pane === "negative" && type === "trigger") {
-    type = "general";
-  }
-  const label = String(field?.label || REGIONAL_FIELD_LABELS[type] || "Prompt").trim();
-  const id = String(field?.id || `${pane}_${type}_${index + 1}`).trim() || `${pane}_${type}_${index + 1}`;
-  return {
-    id,
-    pane,
-    type,
-    label,
-    text: String(field?.text || ""),
-    height: Math.max(36, asInt(field?.height, 72)),
-    enabled: asBool(field?.enabled, true),
-    pin: asBool(field?.pin, type === "trigger"),
-    collapsed: asBool(field?.collapsed, false),
-    mask_ids: pane === "positive" ? normalizeMaskIds(field?.mask_ids) : [],
-  };
-}
-
-function normalizeFieldsValue(value) {
-  const parsed = parseJson(value, []);
-  const raw = Array.isArray(parsed) && parsed.length ? parsed : defaultFields();
-  const fields = raw.map((field, index) => normalizeField(field, index));
-  return fields.length ? fields : defaultFields();
-}
-
-function normalizeGeometry(geometry) {
-  const raw = geometry && typeof geometry === "object" ? geometry : {};
-  const shape = String(raw.type || "rect").toLowerCase() === "ellipse" ? "ellipse" : "rect";
-  const x = clamp(Number(raw.x ?? 0.1), 0, 1);
-  const y = clamp(Number(raw.y ?? 0.1), 0, 1);
-  const width = clamp(Number(raw.width ?? 0.35), 0.01, 1);
-  const height = clamp(Number(raw.height ?? 0.35), 0.01, 1);
-  return {
-    type: shape,
-    x: Number(clamp(x, 0, 0.99).toFixed(6)),
-    y: Number(clamp(y, 0, 0.99).toFixed(6)),
-    width: Number(clamp(width, 0.01, 1 - x).toFixed(6)),
-    height: Number(clamp(height, 0.01, 1 - y).toFixed(6)),
-  };
-}
-
-function normalizeMask(mask, index) {
-  const maskId = asInt(mask?.mask_id ?? mask?.id, index + 1);
-  const label = String(mask?.label || mask?.name || `Mask ${maskId}`);
-  const color = /^#[0-9A-Fa-f]{6}$/.test(String(mask?.color || "")) ? String(mask.color) : "#3b82f6";
-  return {
-    mask_id: maskId,
-    label,
-    name: String(mask?.name || ""),
-    color,
-    enabled: asBool(mask?.enabled, true),
-    geometry: normalizeGeometry(mask?.geometry),
-    strokes: Array.isArray(mask?.strokes) ? mask.strokes : undefined,
-    shapes: Array.isArray(mask?.shapes) ? mask.shapes : undefined,
-  };
+  return createDefaultRegionalConfig(node ? readResolution(node) : null);
 }
 
 function normalizeConfigValue(node, value) {
-  const parsed = parseJson(value, {});
-  const base = defaultConfig(node);
-  const rawMasks = Array.isArray(parsed.masks) ? parsed.masks : (Array.isArray(parsed.regions) ? parsed.regions : []);
-  const used = new Set();
-  const masks = [];
-  for (const [index, raw] of rawMasks.entries()) {
-    const mask = normalizeMask(raw, index);
-    if (mask.mask_id <= 0 || used.has(mask.mask_id)) {
-      continue;
-    }
-    used.add(mask.mask_id);
-    masks.push(mask);
-  }
-  const maxMaskId = masks.reduce((max, mask) => Math.max(max, mask.mask_id), 0);
-  return {
-    ...base,
-    artist_mix: parsed.artist_mix && typeof parsed.artist_mix === "object" ? parsed.artist_mix : {},
-    conditioning_settings: parsed.conditioning_settings && typeof parsed.conditioning_settings === "object" ? parsed.conditioning_settings : {},
-    regional_settings: parsed.regional_settings && typeof parsed.regional_settings === "object" ? parsed.regional_settings : {},
-    mask_authoring: {
-      ...base.mask_authoring,
-      ...(parsed.mask_authoring && typeof parsed.mask_authoring === "object" ? parsed.mask_authoring : {}),
-    },
-    next_mask_id: Math.max(1, asInt(parsed.next_mask_id, 1), maxMaskId + 1),
-    masks,
-  };
+  return normalizeRegionalConfig(value, node ? readResolution(node) : null);
 }
 
 function regionalFieldsWidget(node) {
@@ -504,25 +201,12 @@ function configBackup(node) {
   return typeof value === "string" && value.trim() ? value : "";
 }
 
-function normalizedFieldsString(value) {
-  return JSON.stringify(normalizeFieldsValue(value));
-}
-
 function normalizedConfigString(node, value) {
-  return JSON.stringify(normalizeConfigValue(node, value));
+  return normalizeRegionalConfigString(value, node ? readResolution(node) : null);
 }
 
 function serializedRegionalValue(node, serialized, name) {
-  const propertyName = name === "regional_fields" ? REGIONAL_FIELDS_PROPERTY : REGIONAL_CONFIG_PROPERTY;
-  const propertyValue = serialized?.properties?.[propertyName];
-  if (propertyValue != null && String(propertyValue).trim()) {
-    return name === "regional_fields" ? normalizedFieldsString(propertyValue) : normalizedConfigString(node, propertyValue);
-  }
-  const widgetValue = serialized?.widgets_values?.[REGIONAL_WIDGET_INDEX[name]];
-  if (widgetValue != null && String(widgetValue).trim()) {
-    return name === "regional_fields" ? normalizedFieldsString(widgetValue) : normalizedConfigString(node, widgetValue);
-  }
-  return "";
+  return readSerializedRegionalValue(serialized, name, node ? readResolution(node) : null);
 }
 
 function captureRegionalConfigure(node, serialized) {
@@ -1401,15 +1085,6 @@ function drawMaskCanvas(canvas, config, activeMaskId = 0) {
   }
 }
 
-function geometryToCanvasRect(geometry, width, height) {
-  return {
-    x: geometry.x * width,
-    y: geometry.y * height,
-    width: geometry.width * width,
-    height: geometry.height * height,
-  };
-}
-
 function drawMaskShape(ctx, geometry, rect, fill = true) {
   ctx.beginPath();
   if (geometry.type === "ellipse") {
@@ -1429,25 +1104,6 @@ function drawMaskShape(ctx, geometry, rect, fill = true) {
     ctx.fill();
   }
   ctx.stroke();
-}
-
-function maskHandlePoints(geometry) {
-  const left = geometry.x;
-  const top = geometry.y;
-  const right = geometry.x + geometry.width;
-  const bottom = geometry.y + geometry.height;
-  const midX = geometry.x + geometry.width / 2;
-  const midY = geometry.y + geometry.height / 2;
-  return {
-    nw: { x: left, y: top },
-    n: { x: midX, y: top },
-    ne: { x: right, y: top },
-    e: { x: right, y: midY },
-    se: { x: right, y: bottom },
-    s: { x: midX, y: bottom },
-    sw: { x: left, y: bottom },
-    w: { x: left, y: midY },
-  };
 }
 
 function drawMaskHandles(ctx, geometry, width, height) {
@@ -1473,118 +1129,6 @@ function canvasPoint(canvas, event) {
     x: clamp((event.clientX - rect.left) / rect.width, 0, 1),
     y: clamp((event.clientY - rect.top) / rect.height, 0, 1),
   };
-}
-
-function hitTestMaskHandle(geometry, point) {
-  const points = maskHandlePoints(geometry);
-  for (const name of MASK_HANDLE_NAMES) {
-    const handle = points[name];
-    if (Math.abs(point.x - handle.x) <= MASK_HANDLE_RADIUS && Math.abs(point.y - handle.y) <= MASK_HANDLE_RADIUS) {
-      return name;
-    }
-  }
-  return "";
-}
-
-function maskContainsPoint(geometry, point) {
-  if (
-    point.x < geometry.x
-    || point.x > geometry.x + geometry.width
-    || point.y < geometry.y
-    || point.y > geometry.y + geometry.height
-  ) {
-    return false;
-  }
-  if (geometry.type !== "ellipse") {
-    return true;
-  }
-  const rx = Math.max(MASK_MIN_SIZE / 2, geometry.width / 2);
-  const ry = Math.max(MASK_MIN_SIZE / 2, geometry.height / 2);
-  const cx = geometry.x + geometry.width / 2;
-  const cy = geometry.y + geometry.height / 2;
-  return (((point.x - cx) / rx) ** 2 + ((point.y - cy) / ry) ** 2) <= 1;
-}
-
-function findMaskHandleAt(config, point, activeMaskId = 0) {
-  const masks = Array.isArray(config.masks) ? config.masks : [];
-  const active = masks.find((mask) => mask.mask_id === activeMaskId);
-  if (!active) {
-    return null;
-  }
-  const geometry = normalizeGeometry(active.geometry);
-  const handle = hitTestMaskHandle(geometry, point);
-  return handle ? { mask: active, geometry, handle } : null;
-}
-
-function findMaskAt(config, point) {
-  const masks = Array.isArray(config.masks) ? [...config.masks].reverse() : [];
-  for (const mask of masks) {
-    const geometry = normalizeGeometry(mask.geometry);
-    if (maskContainsPoint(geometry, point)) {
-      return mask;
-    }
-  }
-  return null;
-}
-
-function moveGeometry(geometry, dx, dy) {
-  const width = clamp(geometry.width, MASK_MIN_SIZE, 1);
-  const height = clamp(geometry.height, MASK_MIN_SIZE, 1);
-  return normalizeGeometry({
-    ...geometry,
-    x: clamp(geometry.x + dx, 0, Math.max(0, 1 - width)),
-    y: clamp(geometry.y + dy, 0, Math.max(0, 1 - height)),
-    width,
-    height,
-  });
-}
-
-function resizeGeometry(geometry, handle, dx, dy) {
-  let left = geometry.x;
-  let top = geometry.y;
-  let right = geometry.x + geometry.width;
-  let bottom = geometry.y + geometry.height;
-
-  if (handle.includes("w")) {
-    left += dx;
-  }
-  if (handle.includes("e")) {
-    right += dx;
-  }
-  if (handle.includes("n")) {
-    top += dy;
-  }
-  if (handle.includes("s")) {
-    bottom += dy;
-  }
-
-  left = clamp(left, 0, 1 - MASK_MIN_SIZE);
-  top = clamp(top, 0, 1 - MASK_MIN_SIZE);
-  right = clamp(right, MASK_MIN_SIZE, 1);
-  bottom = clamp(bottom, MASK_MIN_SIZE, 1);
-
-  if (right - left < MASK_MIN_SIZE) {
-    if (handle.includes("w")) {
-      left = right - MASK_MIN_SIZE;
-    } else {
-      right = left + MASK_MIN_SIZE;
-    }
-  }
-  if (bottom - top < MASK_MIN_SIZE) {
-    if (handle.includes("n")) {
-      top = bottom - MASK_MIN_SIZE;
-    } else {
-      bottom = top + MASK_MIN_SIZE;
-    }
-  }
-
-  return normalizeGeometry({
-    type: geometry.type,
-    x: left,
-    y: top,
-    width: right - left,
-    height: bottom - top,
-  });
 }
 
 function openMaskEditor(node) {

--- a/web/js/prompt_studio/regional/constants.js
+++ b/web/js/prompt_studio/regional/constants.js
@@ -1,0 +1,91 @@
+// @ts-check
+
+export const REGIONAL_NODE_TYPE = "EasyUseAnimaPromptStudioRegional";
+export const REGIONAL_CONDITIONING_NODE_TYPE = "EasyUseAnimaRegionalConditioning";
+export const REGIONAL_FIELDS_PROPERTY = "easyuse_anima_regional_fields";
+export const REGIONAL_CONFIG_PROPERTY = "easyuse_anima_regional_config";
+
+export const REGIONAL_WIDGET_INDEX = {
+  regional_fields: 0,
+  regional_config: 1,
+  resolution_bucket: 2,
+  resolution_size: 3,
+  resolution_custom_width: 4,
+  resolution_custom_height: 5,
+  wildcard_mode: 6,
+  wildcard_seed: 7,
+  wildcard_seed_after_generate: 8,
+};
+
+export const REGIONAL_INTERNAL_WIDGET_NAMES = new Set(Object.keys(REGIONAL_WIDGET_INDEX));
+export const REGIONAL_CONDITIONING_AREA_MODES = new Set(["mask bounds", "default"]);
+
+export const PROMPT_STUDIO_VARIANT_FIELD_TYPES = ["quality", "artist", "trigger", "general"];
+export const PROMPT_STUDIO_VARIANT_FIELD_LABELS = {
+  quality: "Quality Tags",
+  artist: "Artist Tags",
+  trigger: "Trigger Words",
+  general: "General Tags",
+};
+
+export const PROMPT_STUDIO_WILDCARD_MODES = ["일반 채우기", "고정", "순차", "재현"];
+export const PROMPT_STUDIO_WILDCARD_SEED_CONTROLS = ["fixed", "randomize", "increment", "decrement"];
+export const PROMPT_STUDIO_WILDCARD_DEFAULT_MODE = "고정";
+
+export const PROMPT_STUDIO_RESOLUTION_BUCKETS = {
+  "512": [
+    [256, 1024], [1024, 256],
+    [288, 896], [896, 288],
+    [384, 672], [672, 384],
+    [512, 512],
+    [448, 576], [576, 448],
+  ],
+  "768": [
+    [384, 1440], [1440, 384],
+    [480, 1152], [1152, 480],
+    [576, 960], [960, 576],
+    [640, 864], [864, 640],
+    [768, 768],
+  ],
+  "896": [
+    [448, 1728], [1728, 448],
+    [480, 1600], [1600, 480],
+    [576, 1344], [1344, 576],
+    [672, 1152], [1152, 672],
+    [800, 960], [960, 800],
+    [896, 896],
+  ],
+  "1024": [
+    [512, 2016], [2016, 512],
+    [576, 1792], [1792, 576],
+    [672, 1536], [1536, 672],
+    [672, 1600], [1600, 672],
+    [768, 1344], [1344, 768],
+    [800, 1344], [1344, 800],
+    [896, 1152], [1152, 896],
+    [960, 1120], [1120, 960],
+    [1024, 1024],
+  ],
+  "1280": [
+    [672, 2400], [2400, 672],
+    [800, 2016], [2016, 800],
+    [1024, 1536], [1536, 1024],
+    [1024, 1600], [1600, 1024],
+    [1120, 1440], [1440, 1120],
+    [1280, 1280],
+  ],
+  "1536": [
+    [1440, 1536], [1536, 1440],
+    [1280, 1728], [1728, 1280],
+    [1152, 1920], [1920, 1152],
+    [1024, 2176], [2176, 1024],
+    [960, 2304], [2304, 960],
+    [864, 2560], [2560, 864],
+    [768, 2880], [2880, 768],
+    [1536, 1536],
+  ],
+};
+
+export const PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET = "Custom";
+export const PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET = "1024";
+export const PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE = "1024 * 1024 (1:1)";

--- a/web/js/prompt_studio/regional/mask_geometry.js
+++ b/web/js/prompt_studio/regional/mask_geometry.js
@@ -1,0 +1,168 @@
+// @ts-check
+
+const MASK_MIN_SIZE = 0.01;
+const MASK_HANDLE_RADIUS = 0.018;
+const MASK_HANDLE_NAMES = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];
+
+export function clampRegionalValue(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function normalizeGeometry(geometry) {
+  const raw = geometry && typeof geometry === "object" ? geometry : {};
+  const shape = String(raw.type || "rect").toLowerCase() === "ellipse" ? "ellipse" : "rect";
+  const x = clampRegionalValue(Number(raw.x ?? 0.1), 0, 1);
+  const y = clampRegionalValue(Number(raw.y ?? 0.1), 0, 1);
+  const width = clampRegionalValue(Number(raw.width ?? 0.35), MASK_MIN_SIZE, 1);
+  const height = clampRegionalValue(Number(raw.height ?? 0.35), MASK_MIN_SIZE, 1);
+  return {
+    type: shape,
+    x: Number(clampRegionalValue(x, 0, 0.99).toFixed(6)),
+    y: Number(clampRegionalValue(y, 0, 0.99).toFixed(6)),
+    width: Number(clampRegionalValue(width, MASK_MIN_SIZE, 1 - x).toFixed(6)),
+    height: Number(clampRegionalValue(height, MASK_MIN_SIZE, 1 - y).toFixed(6)),
+  };
+}
+
+export function geometryToCanvasRect(geometry, width, height) {
+  return {
+    x: geometry.x * width,
+    y: geometry.y * height,
+    width: geometry.width * width,
+    height: geometry.height * height,
+  };
+}
+
+export function maskHandlePoints(geometry) {
+  const left = geometry.x;
+  const top = geometry.y;
+  const right = geometry.x + geometry.width;
+  const bottom = geometry.y + geometry.height;
+  const midX = geometry.x + geometry.width / 2;
+  const midY = geometry.y + geometry.height / 2;
+  return {
+    nw: { x: left, y: top },
+    n: { x: midX, y: top },
+    ne: { x: right, y: top },
+    e: { x: right, y: midY },
+    se: { x: right, y: bottom },
+    s: { x: midX, y: bottom },
+    sw: { x: left, y: bottom },
+    w: { x: left, y: midY },
+  };
+}
+
+export function hitTestMaskHandle(geometry, point) {
+  const points = maskHandlePoints(geometry);
+  for (const name of MASK_HANDLE_NAMES) {
+    const handle = points[name];
+    if (
+      Math.abs(point.x - handle.x) <= MASK_HANDLE_RADIUS
+      && Math.abs(point.y - handle.y) <= MASK_HANDLE_RADIUS
+    ) {
+      return name;
+    }
+  }
+  return "";
+}
+
+export function maskContainsPoint(geometry, point) {
+  if (
+    point.x < geometry.x
+    || point.x > geometry.x + geometry.width
+    || point.y < geometry.y
+    || point.y > geometry.y + geometry.height
+  ) {
+    return false;
+  }
+  if (geometry.type !== "ellipse") {
+    return true;
+  }
+  const rx = Math.max(MASK_MIN_SIZE / 2, geometry.width / 2);
+  const ry = Math.max(MASK_MIN_SIZE / 2, geometry.height / 2);
+  const cx = geometry.x + geometry.width / 2;
+  const cy = geometry.y + geometry.height / 2;
+  return (((point.x - cx) / rx) ** 2 + ((point.y - cy) / ry) ** 2) <= 1;
+}
+
+export function findMaskHandleAt(config, point, activeMaskId = 0) {
+  const masks = Array.isArray(config.masks) ? config.masks : [];
+  const active = masks.find((mask) => mask.mask_id === activeMaskId);
+  if (!active) {
+    return null;
+  }
+  const geometry = normalizeGeometry(active.geometry);
+  const handle = hitTestMaskHandle(geometry, point);
+  return handle ? { mask: active, geometry, handle } : null;
+}
+
+export function findMaskAt(config, point) {
+  const masks = Array.isArray(config.masks) ? [...config.masks].reverse() : [];
+  for (const mask of masks) {
+    const geometry = normalizeGeometry(mask.geometry);
+    if (maskContainsPoint(geometry, point)) {
+      return mask;
+    }
+  }
+  return null;
+}
+
+export function moveGeometry(geometry, dx, dy) {
+  const width = clampRegionalValue(geometry.width, MASK_MIN_SIZE, 1);
+  const height = clampRegionalValue(geometry.height, MASK_MIN_SIZE, 1);
+  return normalizeGeometry({
+    ...geometry,
+    x: clampRegionalValue(geometry.x + dx, 0, Math.max(0, 1 - width)),
+    y: clampRegionalValue(geometry.y + dy, 0, Math.max(0, 1 - height)),
+    width,
+    height,
+  });
+}
+
+export function resizeGeometry(geometry, handle, dx, dy) {
+  let left = geometry.x;
+  let top = geometry.y;
+  let right = geometry.x + geometry.width;
+  let bottom = geometry.y + geometry.height;
+
+  if (handle.includes("w")) {
+    left += dx;
+  }
+  if (handle.includes("e")) {
+    right += dx;
+  }
+  if (handle.includes("n")) {
+    top += dy;
+  }
+  if (handle.includes("s")) {
+    bottom += dy;
+  }
+
+  left = clampRegionalValue(left, 0, 1 - MASK_MIN_SIZE);
+  top = clampRegionalValue(top, 0, 1 - MASK_MIN_SIZE);
+  right = clampRegionalValue(right, MASK_MIN_SIZE, 1);
+  bottom = clampRegionalValue(bottom, MASK_MIN_SIZE, 1);
+
+  if (right - left < MASK_MIN_SIZE) {
+    if (handle.includes("w")) {
+      left = right - MASK_MIN_SIZE;
+    } else {
+      right = left + MASK_MIN_SIZE;
+    }
+  }
+  if (bottom - top < MASK_MIN_SIZE) {
+    if (handle.includes("n")) {
+      top = bottom - MASK_MIN_SIZE;
+    } else {
+      bottom = top + MASK_MIN_SIZE;
+    }
+  }
+
+  return normalizeGeometry({
+    type: geometry.type,
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+  });
+}

--- a/web/js/prompt_studio/regional/resolution.js
+++ b/web/js/prompt_studio/regional/resolution.js
@@ -1,0 +1,94 @@
+// @ts-check
+
+import {
+  PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET,
+  PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET,
+  PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE,
+  PROMPT_STUDIO_RESOLUTION_BUCKETS,
+} from "./constants.js";
+
+function toInteger(value, fallback = 0) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function ratioLabel(width, height) {
+  const gcd = (a, b) => (b ? gcd(b, a % b) : a);
+  const divisor = gcd(Math.max(1, width), Math.max(1, height));
+  return `${Math.floor(width / divisor)}:${Math.floor(height / divisor)}`;
+}
+
+export function resolutionLabel(width, height) {
+  return `${width} * ${height} (${ratioLabel(width, height)})`;
+}
+
+export function resolutionOptions(bucket) {
+  const values = PROMPT_STUDIO_RESOLUTION_BUCKETS[bucket]
+    || PROMPT_STUDIO_RESOLUTION_BUCKETS[PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET];
+  return [...values]
+    .sort((a, b) => (a[0] / a[1]) - (b[0] / b[1]) || a[0] - b[0] || a[1] - b[1])
+    .map(([width, height]) => resolutionLabel(width, height));
+}
+
+export function normalizeResolutionBucket(value) {
+  const bucket = String(value || "").trim();
+  if (bucket === PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET) {
+    return bucket;
+  }
+  return Object.prototype.hasOwnProperty.call(PROMPT_STUDIO_RESOLUTION_BUCKETS, bucket)
+    ? bucket
+    : PROMPT_STUDIO_DEFAULT_RESOLUTION_BUCKET;
+}
+
+export function resolutionRatioFromLabel(value) {
+  const match = String(value || "").match(/(\d+)\s*(?:\*|x|×)\s*(\d+)/i);
+  if (!match) {
+    return "";
+  }
+  return ratioLabel(Number(match[1]), Number(match[2]));
+}
+
+export function normalizeResolutionSize(bucket, value) {
+  if (bucket === PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET) {
+    return String(value || PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE);
+  }
+  const options = resolutionOptions(bucket);
+  const raw = String(value || "").trim();
+  if (options.includes(raw)) {
+    return raw;
+  }
+  const sameRatio = resolutionRatioFromLabel(raw);
+  if (sameRatio) {
+    const matched = options.find((option) => resolutionRatioFromLabel(option) === sameRatio);
+    if (matched) {
+      return matched;
+    }
+  }
+  return options.includes(PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE)
+    ? PROMPT_STUDIO_DEFAULT_RESOLUTION_SIZE
+    : options[0];
+}
+
+export function snapResolution32(value, fallback = 1024) {
+  const raw = Number.parseInt(value, 10);
+  const base = Number.isFinite(raw) && raw > 0 ? raw : fallback;
+  return Math.max(32, Math.round(base / 32) * 32);
+}
+
+export function readRegionalResolutionValues({
+  bucket,
+  size,
+  customWidth,
+  customHeight,
+} = {}) {
+  const width = Math.max(32, toInteger(customWidth, 1024));
+  const height = Math.max(32, toInteger(customHeight, 1024));
+  const match = String(size || "").match(/(\d+)\s*(?:\*|x|×)\s*(\d+)/i);
+  if (normalizeResolutionBucket(bucket) !== PROMPT_STUDIO_CUSTOM_RESOLUTION_BUCKET && match) {
+    return {
+      width: Math.max(32, toInteger(match[1], width)),
+      height: Math.max(32, toInteger(match[2], height)),
+    };
+  }
+  return { width, height };
+}

--- a/web/js/prompt_studio/regional/schema.js
+++ b/web/js/prompt_studio/regional/schema.js
@@ -1,0 +1,259 @@
+// @ts-check
+
+import {
+  PROMPT_STUDIO_VARIANT_FIELD_LABELS,
+  PROMPT_STUDIO_VARIANT_FIELD_TYPES,
+  REGIONAL_CONDITIONING_AREA_MODES,
+} from "./constants.js";
+import { normalizeGeometry } from "./mask_geometry.js";
+import { ratioLabel } from "./resolution.js";
+
+function deepClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function asBool(value, fallback = false) {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value === "string") {
+    return ["true", "1", "yes", "on", "enabled"].includes(value.trim().toLowerCase());
+  }
+  return !!value;
+}
+
+export function toRegionalInteger(value, fallback = 0) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function firstRegionalValue(value, fallback = null) {
+  return Array.isArray(value) ? (value.length ? value[0] : fallback) : (value ?? fallback);
+}
+
+export function isRegionalConditioningAreaMode(value) {
+  return REGIONAL_CONDITIONING_AREA_MODES.has(String(value || ""));
+}
+
+export function normalizeRegionalConditioningWidgetValues(values) {
+  const raw = Array.isArray(values) ? values : [];
+  let maskStrength = null;
+  let setCondArea = null;
+  for (const value of raw) {
+    if (maskStrength == null && value != null && value !== "") {
+      const number = Number(value);
+      if (Number.isFinite(number) && !isRegionalConditioningAreaMode(value)) {
+        maskStrength = number;
+        continue;
+      }
+    }
+    if (setCondArea == null && isRegionalConditioningAreaMode(value)) {
+      setCondArea = String(value);
+    }
+  }
+  return [
+    maskStrength == null ? 1.0 : maskStrength,
+    setCondArea || "mask bounds",
+  ];
+}
+
+export function createDefaultRegionalFields() {
+  return [
+    {
+      id: "positive_quality",
+      pane: "positive",
+      type: "quality",
+      label: "Quality Tags",
+      text: "newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic",
+      height: 72,
+      enabled: true,
+      pin: false,
+      collapsed: false,
+      mask_ids: [],
+    },
+    {
+      id: "positive_artist",
+      pane: "positive",
+      type: "artist",
+      label: "Artist Tags",
+      text: "",
+      height: 72,
+      enabled: true,
+      pin: false,
+      collapsed: false,
+      mask_ids: [],
+    },
+    {
+      id: "positive_trigger",
+      pane: "positive",
+      type: "trigger",
+      label: "Trigger Words",
+      text: "",
+      height: 72,
+      enabled: true,
+      pin: true,
+      collapsed: false,
+      mask_ids: [],
+    },
+    {
+      id: "positive_general",
+      pane: "positive",
+      type: "general",
+      label: "General Tags",
+      text: "",
+      height: 150,
+      enabled: true,
+      pin: false,
+      collapsed: false,
+      mask_ids: [],
+    },
+    {
+      id: "negative_general",
+      pane: "negative",
+      type: "general",
+      label: "Negative Prompt",
+      text: "",
+      height: 120,
+      enabled: true,
+      pin: false,
+      collapsed: false,
+      mask_ids: [],
+    },
+  ];
+}
+
+export function createDefaultRegionalConfig(resolution = null) {
+  const width = Math.max(32, toRegionalInteger(resolution?.width, 1024));
+  const height = Math.max(32, toRegionalInteger(resolution?.height, 1024));
+  return {
+    version: 1,
+    canvas: {
+      width,
+      height,
+      aspect_ratio: ratioLabel(width, height),
+      source: "resolution_fields",
+    },
+    mask_authoring: {
+      render_space: "image_pixels",
+      storage_space: "normalized_canvas",
+      preview_enabled: true,
+    },
+    global_prompt: "",
+    negative_prompt: "",
+    next_mask_id: 1,
+    masks: [],
+    regional_enabled: false,
+    mask_prompts: [],
+    assignments: [],
+    artist_mix: {},
+    conditioning_settings: {},
+    regional_settings: {},
+  };
+}
+
+function parseJson(value, fallback) {
+  if (value == null || value === "") {
+    return deepClone(fallback);
+  }
+  try {
+    const parsed = typeof value === "string" ? JSON.parse(value) : value;
+    return parsed == null ? deepClone(fallback) : parsed;
+  } catch {
+    return deepClone(fallback);
+  }
+}
+
+export function normalizeRegionalMaskIds(value) {
+  const values = Array.isArray(value) ? value : String(value ?? "").split(/[,\s;]+/);
+  const result = [];
+  for (const raw of values) {
+    const id = toRegionalInteger(raw, 0);
+    if (id > 0 && !result.includes(id)) {
+      result.push(id);
+    }
+  }
+  return result;
+}
+
+export function normalizeRegionalField(field, index = 0) {
+  const pane = field?.pane === "negative" ? "negative" : "positive";
+  let type = String(field?.type || "general").toLowerCase();
+  if (!PROMPT_STUDIO_VARIANT_FIELD_TYPES.includes(type)) {
+    type = "general";
+  }
+  if (pane === "negative" && type === "trigger") {
+    type = "general";
+  }
+  const label = String(field?.label || PROMPT_STUDIO_VARIANT_FIELD_LABELS[type] || "Prompt").trim();
+  const id = String(field?.id || `${pane}_${type}_${index + 1}`).trim() || `${pane}_${type}_${index + 1}`;
+  return {
+    id,
+    pane,
+    type,
+    label,
+    text: String(field?.text || ""),
+    height: Math.max(36, toRegionalInteger(field?.height, 72)),
+    enabled: asBool(field?.enabled, true),
+    pin: asBool(field?.pin, type === "trigger"),
+    collapsed: asBool(field?.collapsed, false),
+    mask_ids: pane === "positive" ? normalizeRegionalMaskIds(field?.mask_ids) : [],
+  };
+}
+
+export function normalizeRegionalFields(value) {
+  const parsed = parseJson(value, []);
+  const raw = Array.isArray(parsed) && parsed.length ? parsed : createDefaultRegionalFields();
+  const fields = raw.map((field, index) => normalizeRegionalField(field, index));
+  return fields.length ? fields : createDefaultRegionalFields();
+}
+
+export function normalizeRegionalMask(mask, index) {
+  const maskId = toRegionalInteger(mask?.mask_id ?? mask?.id, index + 1);
+  const label = String(mask?.label || mask?.name || `Mask ${maskId}`);
+  const color = /^#[0-9A-Fa-f]{6}$/.test(String(mask?.color || "")) ? String(mask.color) : "#3b82f6";
+  return {
+    mask_id: maskId,
+    label,
+    name: String(mask?.name || ""),
+    color,
+    enabled: asBool(mask?.enabled, true),
+    geometry: normalizeGeometry(mask?.geometry),
+    strokes: Array.isArray(mask?.strokes) ? mask.strokes : undefined,
+    shapes: Array.isArray(mask?.shapes) ? mask.shapes : undefined,
+  };
+}
+
+export function normalizeRegionalConfig(value, resolution = null) {
+  const parsed = parseJson(value, {});
+  const base = createDefaultRegionalConfig(resolution);
+  const rawMasks = Array.isArray(parsed.masks)
+    ? parsed.masks
+    : (Array.isArray(parsed.regions) ? parsed.regions : []);
+  const used = new Set();
+  const masks = [];
+  for (const [index, raw] of rawMasks.entries()) {
+    const mask = normalizeRegionalMask(raw, index);
+    if (mask.mask_id <= 0 || used.has(mask.mask_id)) {
+      continue;
+    }
+    used.add(mask.mask_id);
+    masks.push(mask);
+  }
+  const maxMaskId = masks.reduce((max, mask) => Math.max(max, mask.mask_id), 0);
+  return {
+    ...base,
+    artist_mix: parsed.artist_mix && typeof parsed.artist_mix === "object" ? parsed.artist_mix : {},
+    conditioning_settings: parsed.conditioning_settings && typeof parsed.conditioning_settings === "object"
+      ? parsed.conditioning_settings
+      : {},
+    regional_settings: parsed.regional_settings && typeof parsed.regional_settings === "object"
+      ? parsed.regional_settings
+      : {},
+    mask_authoring: {
+      ...base.mask_authoring,
+      ...(parsed.mask_authoring && typeof parsed.mask_authoring === "object" ? parsed.mask_authoring : {}),
+    },
+    next_mask_id: Math.max(1, toRegionalInteger(parsed.next_mask_id, 1), maxMaskId + 1),
+    masks,
+  };
+}

--- a/web/js/prompt_studio/regional/serialization.js
+++ b/web/js/prompt_studio/regional/serialization.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+import {
+  REGIONAL_CONFIG_PROPERTY,
+  REGIONAL_FIELDS_PROPERTY,
+  REGIONAL_WIDGET_INDEX,
+} from "./constants.js";
+import {
+  normalizeRegionalConfig,
+  normalizeRegionalFields,
+} from "./schema.js";
+
+export function normalizeRegionalFieldsString(value) {
+  return JSON.stringify(normalizeRegionalFields(value));
+}
+
+export function normalizeRegionalConfigString(value, resolution = null) {
+  return JSON.stringify(normalizeRegionalConfig(value, resolution));
+}
+
+export function serializedRegionalValue(serialized, name, resolution = null) {
+  const propertyName = name === "regional_fields" ? REGIONAL_FIELDS_PROPERTY : REGIONAL_CONFIG_PROPERTY;
+  const propertyValue = serialized?.properties?.[propertyName];
+  if (propertyValue != null && String(propertyValue).trim()) {
+    return name === "regional_fields"
+      ? normalizeRegionalFieldsString(propertyValue)
+      : normalizeRegionalConfigString(propertyValue, resolution);
+  }
+  const widgetValue = serialized?.widgets_values?.[REGIONAL_WIDGET_INDEX[name]];
+  if (widgetValue != null && String(widgetValue).trim()) {
+    return name === "regional_fields"
+      ? normalizeRegionalFieldsString(widgetValue)
+      : normalizeRegionalConfigString(widgetValue, resolution);
+  }
+  return "";
+}


### PR DESCRIPTION
## 변경 요약

- Issue #14 로드맵의 R3 범위로 Regional Prompt Studio의 상수, field/config schema와 migration, resolution 규칙, serialization 정규화, mask geometry/hit-test를 `prompt_studio/regional/` 아래 DOM-free 모듈로 분리했습니다.
- 기존 Regional entry에는 widget/DOM/canvas/runtime 연결 책임만 남기고 node type, widget/socket 이름, `widgets_values` 순서와 API payload는 유지했습니다.
- legacy common의 Regional 상수 export는 호환 re-export로 유지했습니다.
- 독립 Regional pure-data semantic smoke와 구조 회귀 검사를 공식 frontend runner에 연결하고 현재 유지보수 로드맵을 갱신했습니다.

## 주요 파일

- `web/js/prompt_studio/regional/constants.js`: node/property/widget 순서, field/wildcard/resolution 상수
- `web/js/prompt_studio/regional/resolution.js`: bucket/size normalization과 resolution parsing
- `web/js/prompt_studio/regional/schema.js`: field/config/mask normalization과 legacy regions migration
- `web/js/prompt_studio/regional/serialization.js`: property/widget precedence와 정규화된 JSON 직렬화
- `web/js/prompt_studio/regional/mask_geometry.js`: normalized geometry, hit-test, move/resize
- `web/js/easyuse_anima_prompt_studio_regional.js`: pure-data 구현을 새 모듈 호출로 교체
- `tests/frontend_regional_pure_data_smoke.mjs`: migration, resolution, geometry, save/reload normalization smoke
- `tests/test_frontend_modules.py`: DOM-free 경계와 socket sync 회귀 검사
- `tools/check_frontend.ps1`: 새 smoke를 공식 frontend 검사에 포함

## 호환성

- 기존 field id, label, value, mask id/geometry와 기본 resolution 규칙을 유지합니다.
- value-only field 변경은 기존 socket 순서를 다시 만들지 않습니다.
- Regional Conditioning의 과거 widget 순서 복구 규칙을 pure schema 모듈로 이동했지만 wrapper 호출 순서는 유지합니다.
- Python node, API route, workflow schema와 backend 실행 코드는 변경하지 않았습니다.

## 검증

- `tools/check_project.ps1 -Profile full`: 321 tests OK
- Frontend syntax: 58 JavaScript files OK
- Regional pure data semantic smoke: passed
- Highlight parser/renderer 및 overlay semantic smoke: passed
- TypeScript 6.0.3 no-build check: passed
- `git diff --check`: passed
- ComfyUI Codex test instance (0.27.0) browser smoke:
  - Node 2.0: Regional editor 정상 생성, textarea 5개, field socket 5개, 1024 해상도, 원시 JSON 미노출 확인
  - legacy canvas: Regional editor 정상 생성, textarea 5개, field socket 5개, 1024 해상도, 원시 JSON 미노출 확인
  - Node 2.0에서 편집한 field 값이 legacy canvas 전환 후 유지됨
  - legacy canvas에서도 field 편집과 socket 순서 유지 확인
  - 새 runtime module 요청 200 및 EasyUse/Regional 관련 module 404, SyntaxError, ReferenceError 없음

## 남은 위험

- 브라우저에서 명시적인 workflow 저장 후 재로드는 실행하지 않았습니다. JSON normalization round-trip은 semantic smoke로 검증했습니다.
- 사용자 ComfyUI 0.27.0 인스턴스의 수동 브라우저 확인은 회신 대기 상태입니다.
- ComfyUI 자체 `dialogService`의 초기화 시점 오류 로그 1건이 있었지만 EasyUseAnima/Regional 모듈 오류는 아니었습니다.
- mask canvas/editor DOM lifecycle과 extension/runtime 분리는 후속 R4 범위입니다.
- 새 Regional 하위 모듈의 명시적 `jsconfig.json` include 확장은 R5에서 진행합니다.

## 라벨 후보

저장소에 아래 라벨이 아직 없어 생성하지 않았습니다.

- `type: chore`
- `area: frontend`
- `status: ready`

Refs #14