### PR TITLE
[Maintenance] AiO 프로필 판정 pure-data 경계 분리

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -13,6 +13,7 @@
     "strict": false
   },
   "include": [
+    "web/js/aio/**/*.js",
     "web/js/easyuse_anima_prompt_studio.js",
     "web/js/easyuse_anima_prompt_studio_regional.js",
     "web/js/prompt_studio/**/*.js"

--- a/tests/frontend_aio_profile_core_smoke.mjs
+++ b/tests/frontend_aio_profile_core_smoke.mjs
@@ -1,0 +1,170 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const presets = await import(dataModule("../web/js/aio/presets.js"));
+const {
+  aioBuiltinProfileSettings,
+  aioFindUserProfileByName,
+  aioProfileSettingsFingerprint,
+  aioResolvedProfileValue,
+} = presets;
+
+const profiles = [
+  { name: "Portrait", settings: { sampler: { steps: 32 } } },
+  { name: "Landscape", settings: { sampler: { steps: 24 } } },
+];
+assert(
+  aioFindUserProfileByName(profiles, "pOrTrAiT") === profiles[0],
+  "User-profile lookup must remain case-insensitive",
+);
+assert(
+  aioFindUserProfileByName(profiles, "missing") === null,
+  "Unknown user profiles must resolve to null",
+);
+assert(
+  aioFindUserProfileByName(null, "Portrait") === null,
+  "Invalid profile collections must resolve to null",
+);
+
+const orderedSettings = {
+  sampler: { steps: 24, scheduler: "simple" },
+  nested: { enabled: true, values: [{ alpha: 1, beta: 2 }] },
+};
+const reorderedSettings = {
+  nested: { values: [{ beta: 2, alpha: 1 }], enabled: true },
+  sampler: { scheduler: "simple", steps: 24 },
+};
+assert(
+  aioProfileSettingsFingerprint(orderedSettings)
+    === aioProfileSettingsFingerprint(reorderedSettings),
+  "Profile fingerprints must be stable across object key order",
+);
+
+const disabledCorrections = {
+  enabled: false,
+  dcw_mode: "off",
+  smc_cfg: false,
+  cfgpp: false,
+  fsg: false,
+  replace_existing_cfg: false,
+};
+const defaultSettings = {
+  sampler: {
+    steps: 28,
+    cfg: 4,
+    sampler_name: "euler",
+    scheduler: "normal",
+    spectrum: { enabled: false },
+    dit_corrections: { ...disabledCorrections },
+  },
+  highres: {
+    spectrum: { enabled: false },
+    dit_corrections: { ...disabledCorrections },
+  },
+  upscale: {
+    spectrum: { enabled: false },
+    dit_corrections: { ...disabledCorrections },
+  },
+  detailer: {
+    enabled: true,
+    order: ["face"],
+    sam3: {},
+    face: {
+      spectrum: { enabled: false },
+      dit_corrections: { ...disabledCorrections },
+    },
+  },
+  model_patches: {
+    kj: {
+      fp16_accumulation: false,
+      sage_attention: "disabled",
+      sage_allow_compile: false,
+      torch_compile: { enabled: false },
+    },
+    dave: { enabled: false },
+    safe_pag: { enabled: false },
+  },
+};
+const defaultSnapshot = JSON.stringify(defaultSettings);
+const normalSettings = aioBuiltinProfileSettings("normal", defaultSettings);
+assert(
+  JSON.stringify(defaultSettings) === defaultSnapshot,
+  "Building a built-in profile must not mutate default settings",
+);
+
+const normalSnapshot = JSON.stringify(normalSettings);
+const builtinValue = aioResolvedProfileValue({
+  settings: normalSettings,
+  defaultSettings,
+  selectedValue: "user:Portrait",
+  selectedFingerprint: aioProfileSettingsFingerprint(normalSettings),
+  profiles,
+  customValue: "sentinel-custom",
+});
+assert(builtinValue === "builtin:normal", "Built-in profile identity must take priority");
+assert(
+  JSON.stringify(normalSettings) === normalSnapshot
+    && JSON.stringify(defaultSettings) === defaultSnapshot,
+  "Built-in profile resolution must not mutate its settings inputs",
+);
+
+const customSettings = {
+  ...normalSettings,
+  sampler: { ...normalSettings.sampler, steps: normalSettings.sampler.steps + 1 },
+};
+const customFingerprint = aioProfileSettingsFingerprint(customSettings);
+assert(
+  aioResolvedProfileValue({
+    settings: customSettings,
+    defaultSettings,
+    selectedValue: "user:pOrTrAiT",
+    selectedFingerprint: customFingerprint,
+    profiles,
+    customValue: "sentinel-custom",
+  }) === "user:pOrTrAiT",
+  "Existing user profiles with an exact fingerprint must preserve the selected value",
+);
+assert(
+  aioResolvedProfileValue({
+    settings: customSettings,
+    defaultSettings,
+    selectedValue: "user:Portrait",
+    selectedFingerprint: "stale-fingerprint",
+    profiles,
+    customValue: "sentinel-custom",
+  }) === "sentinel-custom",
+  "Changed user-profile settings must resolve to Custom",
+);
+assert(
+  aioResolvedProfileValue({
+    settings: customSettings,
+    defaultSettings,
+    selectedValue: "user:Deleted",
+    selectedFingerprint: customFingerprint,
+    profiles,
+    customValue: "sentinel-custom",
+  }) === "sentinel-custom",
+  "Missing user profiles must resolve to Custom",
+);
+assert(
+  aioResolvedProfileValue({
+    settings: customSettings,
+    defaultSettings,
+    selectedValue: "custom",
+    selectedFingerprint: customFingerprint,
+    profiles,
+  }) === "custom",
+  "Non-profile selections must use the default Custom value",
+);
+
+console.log("AiO profile core smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -31,6 +31,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         apply_start = source.index("function applyGeneratorProfileSettings")
         apply_end = source.index("\nasync function applyGeneratorProfile", apply_start)
         apply_body = source[apply_start:apply_end]
+        lookup_start = source.index("function generatorUserProfileByName")
+        lookup_end = source.index("\nasync function loadGeneratorUserProfiles", lookup_start)
+        lookup_body = source[lookup_start:lookup_end]
         resolve_start = source.index("function resolvedGeneratorProfileValue")
         resolve_end = source.index("\nfunction generatorProfileDisplayLabel", resolve_start)
         resolve_body = source[resolve_start:resolve_end]
@@ -44,6 +47,10 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('from "./aio/presets.js"', source)
         self.assertIn("aioBuiltinProfileIdForSettings", source)
         self.assertIn("aioProfileSettingsFingerprint", source)
+        for helper in ("aioFindUserProfileByName", "aioResolvedProfileValue"):
+            with self.subTest(profile_core_helper=helper):
+                self.assertIn(f"export function {helper}(", presets_source)
+                self.assertIn(helper, source)
         self.assertIn('"profile.custom": "Custom"', source)
         self.assertIn('"normal", "turbo", "optimized"', presets_source)
         self.assertIn('settings.sampler.steps = 10', presets_source)
@@ -54,8 +61,21 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("applyVisibleGeneratorSettings(node, next)", apply_body)
         self.assertIn("writeGeneratorSettingsFromState(node, next, true)", apply_body)
         self.assertIn("aioProfileSettingsFingerprint", apply_body)
-        self.assertIn("aioBuiltinProfileIdForSettings(settings, DEFAULT_GENERATION_SETTINGS)", resolve_body)
-        self.assertIn("return GENERATOR_PROFILE_CUSTOM_VALUE", resolve_body)
+        self.assertIn(
+            "aioFindUserProfileByName(generatorProfileState.profiles, name)",
+            lookup_body,
+        )
+        self.assertIn("return aioResolvedProfileValue({", resolve_body)
+        self.assertIn("settings,", resolve_body)
+        for option in (
+            "defaultSettings",
+            "selectedValue",
+            "selectedFingerprint",
+            "profiles",
+            "customValue",
+        ):
+            with self.subTest(profile_resolution_option=option):
+                self.assertIn(f"{option}:", resolve_body)
         self.assertIn("syncGeneratorProfileValue(node, settings)", render_body)
         self.assertIn('profileButton.setAttribute("data-aio-profile-button", "")', render_body)
         self.assertIn('panel.querySelector("[data-aio-profile-button]")', summary_body)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -11,6 +11,10 @@ JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 WEB_JS = ROOT / "web" / "js"
 API_JS = WEB_JS / "easyuse_anima_api.js"
+AIO_JS = WEB_JS / "easyuse_anima_aio.js"
+AIO_MODULES = WEB_JS / "aio"
+AIO_PRESETS_JS = AIO_MODULES / "presets.js"
+AIO_PROFILE_CORE_SMOKE = ROOT / "tests" / "frontend_aio_profile_core_smoke.mjs"
 PROMPT_STUDIO_JS = WEB_JS / "easyuse_anima_prompt_studio.js"
 PROMPT_STUDIO_COMMON_JS = WEB_JS / "easyuse_anima_prompt_studio_common.js"
 PROMPT_STUDIO_MODULES = WEB_JS / "prompt_studio"
@@ -64,6 +68,24 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(filename=filename):
                 source = (WEB_JS / filename).read_text(encoding="utf-8")
                 self.assertIn(import_path, source)
+
+    def test_aio_profile_core_module_owns_dom_free_resolution_rules(self):
+        source = AIO_PRESETS_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        for helper in ("aioFindUserProfileByName", "aioResolvedProfileValue"):
+            with self.subTest(helper=helper):
+                self.assertIn(f"export function {helper}(", source)
+                self.assertIn(helper, entry_source)
+
+        self.assertNotRegex(source, r"\b(?:document|window|app)\b")
+        self.assertNotIn("fetch(", source)
+        self.assertTrue(AIO_PROFILE_CORE_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_profile_core_smoke.mjs"',
+            frontend_check_source,
+        )
 
     def test_legacy_regional_common_is_thin_compatibility_adapter(self):
         common_source = PROMPT_STUDIO_COMMON_JS.read_text(encoding="utf-8")
@@ -1126,6 +1148,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(config["compilerOptions"]["noUnusedParameters"])
 
         for path in (
+            "web/js/aio/**/*.js",
             "web/js/easyuse_anima_prompt_studio.js",
             "web/js/easyuse_anima_prompt_studio_regional.js",
             "web/js/prompt_studio/**/*.js",
@@ -1141,6 +1164,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn(r'& node "tests\frontend_highlight_core_smoke.mjs"', source)
         self.assertIn(
             r'& node "tests\frontend_highlight_overlay_core_smoke.mjs"', source
+        )
+        self.assertIn(
+            r'& node "tests\frontend_aio_profile_core_smoke.mjs"', source
         )
         self.assertIn('"typescript@$TypeScriptVersion"', source)
         self.assertIn("tsc -p jsconfig.json", source)

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -39,6 +39,11 @@ try {
         throw "Frontend highlight overlay core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_profile_core_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO profile core smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/presets.js
+++ b/web/js/aio/presets.js
@@ -141,3 +141,36 @@ export function aioUserProfileName(value) {
   const text = String(value || "");
   return text.startsWith("user:") ? text.slice(5) : "";
 }
+
+export function aioFindUserProfileByName(profiles, name) {
+  const expected = String(name || "").toLowerCase();
+  return (Array.isArray(profiles) ? profiles : []).find(
+    (profile) => String(profile?.name || "").toLowerCase() === expected,
+  ) || null;
+}
+
+export function aioResolvedProfileValue({
+  settings,
+  defaultSettings,
+  selectedValue,
+  selectedFingerprint,
+  profiles,
+  customValue = "custom",
+}) {
+  const builtinId = aioBuiltinProfileIdForSettings(settings, defaultSettings);
+  if (builtinId) {
+    return `builtin:${builtinId}`;
+  }
+
+  const textValue = String(selectedValue || "");
+  const userName = aioUserProfileName(textValue);
+  const fingerprint = aioProfileSettingsFingerprint(settings);
+  if (
+    userName
+    && aioFindUserProfileByName(profiles, userName)
+    && selectedFingerprint === fingerprint
+  ) {
+    return textValue;
+  }
+  return customValue;
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -7,7 +7,9 @@ import {
   aioBuiltinProfileIdForSettings,
   aioBuiltinProfileIds,
   aioBuiltinProfileSettings,
+  aioFindUserProfileByName,
   aioProfileSettingsFingerprint,
+  aioResolvedProfileValue,
   aioUserProfileName,
   aioUserProfileValue,
 } from "./aio/presets.js";
@@ -2767,10 +2769,7 @@ function generatorProfileErrorMessage(error) {
 }
 
 function generatorUserProfileByName(name) {
-  const expected = String(name || "").toLowerCase();
-  return generatorProfileState.profiles.find(
-    (profile) => String(profile?.name || "").toLowerCase() === expected,
-  ) || null;
+  return aioFindUserProfileByName(generatorProfileState.profiles, name);
 }
 
 async function loadGeneratorUserProfiles({ force = false } = {}) {
@@ -2919,21 +2918,14 @@ async function deleteGeneratorUserProfile(node, selectedValue = node.__easyuseAn
 }
 
 function resolvedGeneratorProfileValue(node, settings = generatorSettings(node)) {
-  const builtinId = aioBuiltinProfileIdForSettings(settings, DEFAULT_GENERATION_SETTINGS);
-  if (builtinId) {
-    return `builtin:${builtinId}`;
-  }
-  const textValue = String(node?.__easyuseAnimaGeneratorProfileValue || "");
-  const userName = aioUserProfileName(textValue);
-  const fingerprint = aioProfileSettingsFingerprint(settings);
-  if (
-    userName
-    && generatorUserProfileByName(userName)
-    && node?.__easyuseAnimaGeneratorProfileFingerprint === fingerprint
-  ) {
-    return textValue;
-  }
-  return GENERATOR_PROFILE_CUSTOM_VALUE;
+  return aioResolvedProfileValue({
+    settings,
+    defaultSettings: DEFAULT_GENERATION_SETTINGS,
+    selectedValue: node?.__easyuseAnimaGeneratorProfileValue,
+    selectedFingerprint: node?.__easyuseAnimaGeneratorProfileFingerprint,
+    profiles: generatorProfileState.profiles,
+    customValue: GENERATOR_PROFILE_CUSTOM_VALUE,
+  });
 }
 
 function syncGeneratorProfileValue(node, settings = generatorSettings(node)) {


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 사용자 프로필 검색과 현재 프로필 판정을 `aio/presets.js`의 DOM 비의존 pure-data helper로 분리했습니다.
- `easyuse_anima_aio.js`에는 현재 노드 상태를 전달하는 얇은 어댑터만 남겨 API, DOM, 직렬화 흐름을 유지했습니다.
- AiO helper 전체를 TypeScript `checkJs` 범위에 포함하고 실제 의미 동작을 실행하는 Node smoke를 추가했습니다.

## 주요 파일

- `web/js/aio/presets.js`: `aioFindUserProfileByName`, `aioResolvedProfileValue`
- `web/js/easyuse_anima_aio.js`: pure helper 위임
- `tests/frontend_aio_profile_core_smoke.mjs`: built-in 우선순위, 대소문자 무시 검색, fingerprint 일치/불일치, 삭제된 프로필, 입력 비변경 회귀 검사
- `tests/test_aio_frontend.py`, `tests/test_frontend_modules.py`: 모듈 경계와 위임 계약
- `jsconfig.json`, `tools/check_frontend.ps1`: AiO helper typecheck 및 smoke 연결

## 유지되는 동작

- built-in 프로필 판정이 사용자 선택보다 우선합니다.
- 사용자 프로필 이름 검색은 대소문자를 구분하지 않습니다.
- 프로필이 존재하고 전체 설정 fingerprint가 일치할 때만 기존 사용자 선택값을 유지합니다.
- 설정 변경, fingerprint 불일치, 삭제된 프로필은 Custom으로 판정합니다.
- 프로필 선택 상태의 workflow 직렬화 정책과 프로필 CRUD API 흐름은 변경하지 않았습니다.

## 검증

- `python -m unittest tests.test_aio_frontend tests.test_frontend_modules tests.test_aio_profiles`: 58 tests 통과
- `tools/check_project.ps1 -Profile quick`: 통과
- `tools/check_custom_node.ps1 -Project <target-worktree> -Profile full`: 326 tests 통과
- frontend: 65 JavaScript files 문법 검사, Node semantic smoke, TypeScript 6.0.3 통과
- ComfyUI Codex test instance 0.27.0: legacy canvas와 Node 2.0에서 built-in 적용 및 설정 변경 시 Custom 전환 확인
- ComfyUI v0.27.0 user instance: manual browser check 미실행

## 남은 범위

- 이 PR은 이슈 #54의 첫 incremental slice입니다.
- settings/schema 기본값·병합·마이그레이션, 의존성 해석, preview, DOM/runtime 경계 분리는 후속 PR에서 진행합니다.
- 사용자 프로필 생성·이름 변경·삭제 API는 변경하지 않았으며 이번 브라우저 smoke의 직접 대상이 아닙니다.

## 라벨 후보

- 기존 라벨: `enhancement`
- 저장소에 아직 없는 후보: `type: chore`, `area: frontend`, `status: draft`

Refs #54