### PR TITLE
[Maintenance] AiO optional dependency 판정 경계 분리

### DIFF
--- a/tests/frontend_aio_dependency_core_smoke.mjs
+++ b/tests/frontend_aio_dependency_core_smoke.mjs
@@ -1,0 +1,226 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const dependencies = await import(dataModule("../web/js/aio/dependencies.js"));
+const {
+  AIO_BACKEND_DEPENDENCIES,
+  AIO_OPTIONAL_DEPENDENCY_SPECS,
+  aioNodeInputMap,
+  aioNodeInputSpec,
+  aioNodeInputSupported,
+  aioNodeInputTooltip,
+  aioOptionalDependencyAvailable,
+  aioOptionalDependencyPack,
+  aioOptionalDependencyStatus,
+  aioQueryOptionalDependencies,
+  aioUpscaleBackendDependencyKeys,
+  aioUpscaleBackendMissingPacks,
+} = dependencies;
+
+assert(
+  AIO_BACKEND_DEPENDENCIES.spectrum_mod_guidance_advanced === "spectrumAdvanced",
+  "Spectrum Mod Guidance must keep its optional-dependency mapping",
+);
+assert(
+  AIO_OPTIONAL_DEPENDENCY_SPECS.imageSaver.nodeId === "Image Saver",
+  "The Image Saver object-info node id must remain stable",
+);
+
+const queriedSpecs = {
+  present: { nodeId: "PresentNode", pack: "Present Pack" },
+  absent: { nodeId: "AbsentNode", pack: "Absent Pack" },
+  broken: { nodeId: "BrokenNode", pack: "Broken Pack" },
+};
+const queriedSpecsSnapshot = JSON.stringify(queriedSpecs);
+const presentInfo = {
+  input: {
+    required: {
+      mode: [["fast", "quality"], { tooltip: "Required mode" }],
+      shared: ["INT", { tooltip: "Required shared" }],
+    },
+    optional: {
+      strength: ["FLOAT", { tooltip: "Optional strength" }],
+      shared: ["STRING", { tooltip: "Optional shared" }],
+    },
+  },
+};
+const queryCalls = [];
+let activeQueries = 0;
+let maxConcurrentQueries = 0;
+const queryResult = await aioQueryOptionalDependencies(
+  queriedSpecs,
+  async (spec, key) => {
+    queryCalls.push([key, spec.nodeId]);
+    activeQueries += 1;
+    maxConcurrentQueries = Math.max(maxConcurrentQueries, activeQueries);
+    await Promise.resolve();
+    activeQueries -= 1;
+    if (key === "present") {
+      return presentInfo;
+    }
+    if (key === "absent") {
+      return null;
+    }
+    throw new Error("object-info unavailable");
+  },
+);
+
+assert(queryCalls.length === 3, "Every optional dependency must be queried once");
+assert(maxConcurrentQueries === 1, "Optional dependencies must keep sequential object-info queries");
+assert(queryResult.status.present === "available", "Returned node info must be available");
+assert(queryResult.available.present === true, "Available results must set the boolean cache");
+assert(queryResult.nodeInfo.present === presentInfo, "Available node info must be preserved");
+assert(queryResult.status.absent === "missing", "Null node info must be missing");
+assert(queryResult.available.absent === false, "Missing results must set the boolean cache");
+assert(queryResult.nodeInfo.absent === null, "Missing node info must normalize to null");
+assert(queryResult.status.broken === "error", "Query failures must remain error states");
+assert(queryResult.nodeInfo.broken === null, "Failed node info must normalize to null");
+assert(
+  queryResult.errors.broken === "object-info unavailable",
+  "Query failure messages must be preserved",
+);
+assert(
+  !Object.prototype.hasOwnProperty.call(queryResult.available, "broken"),
+  "Query failures must not be cached as missing",
+);
+assert(
+  JSON.stringify(queriedSpecs) === queriedSpecsSnapshot,
+  "Dependency queries must not mutate their specs",
+);
+
+const capabilityState = {
+  loaded: true,
+  status: {
+    present: "available",
+    absent: "missing",
+    broken: "error",
+    ultimateSdUpscale: "missing",
+    upscaleModelLoader: "error",
+    resShiftLoader: "available",
+    resShiftUpscale: "missing",
+  },
+  nodeInfo: { present: presentInfo },
+};
+const capabilityStateSnapshot = JSON.stringify(capabilityState);
+
+assert(
+  aioOptionalDependencyStatus({ loaded: false, status: { present: "available" } }, "present")
+    === "unknown",
+  "Dependencies must remain unknown before the query cache is loaded",
+);
+assert(
+  aioOptionalDependencyStatus(capabilityState, "unregistered") === "unknown",
+  "Unregistered dependency keys must remain unknown",
+);
+assert(
+  aioOptionalDependencyAvailable(capabilityState, "present") === true,
+  "Available dependencies must remain enabled",
+);
+assert(
+  aioOptionalDependencyAvailable(capabilityState, "absent") === false,
+  "Only confirmed-missing dependencies may be disabled",
+);
+assert(
+  aioOptionalDependencyAvailable(capabilityState, "broken") === true,
+  "Query failures must not be treated as missing dependencies",
+);
+assert(
+  aioOptionalDependencyAvailable({ loaded: false, status: {} }, "present") === true,
+  "Unknown dependency state must keep settings available until queried",
+);
+
+assert(
+  aioOptionalDependencyPack("imageSaver") === "ComfyUI-Image-Saver",
+  "Known dependencies must expose their pack label",
+);
+assert(
+  aioOptionalDependencyPack("custom", queriedSpecs) === "custom",
+  "Unknown dependencies must fall back to their key",
+);
+assert(aioOptionalDependencyPack("") === "", "Empty dependency keys must stay empty");
+
+assert(
+  JSON.stringify(aioUpscaleBackendDependencyKeys("usdu"))
+    === JSON.stringify(["ultimateSdUpscale", "upscaleModelLoader"]),
+  "USDU must keep both runtime dependencies",
+);
+assert(
+  JSON.stringify(aioUpscaleBackendDependencyKeys("resshift"))
+    === JSON.stringify(["resShiftLoader", "resShiftUpscale"]),
+  "ResShift must keep both runtime dependencies",
+);
+assert(
+  aioUpscaleBackendDependencyKeys("unknown").length === 0,
+  "Unknown upscale backends must have no dependency keys",
+);
+assert(
+  JSON.stringify(aioUpscaleBackendMissingPacks(capabilityState, "usdu"))
+    === JSON.stringify(["ComfyUI_UltimateSDUpscale"]),
+  "USDU must report confirmed-missing packs without treating query errors as missing",
+);
+assert(
+  JSON.stringify(aioUpscaleBackendMissingPacks(capabilityState, "resshift"))
+    === JSON.stringify(["ComfyUI-Distilled-ResShift"]),
+  "ResShift must report the pack for its confirmed-missing node",
+);
+
+const inputMap = aioNodeInputMap(capabilityState, "present");
+assert(inputMap.mode === presentInfo.input.required.mode, "Required inputs must be exposed");
+assert(inputMap.strength === presentInfo.input.optional.strength, "Optional inputs must be exposed");
+assert(
+  inputMap.shared === presentInfo.input.optional.shared,
+  "Optional input metadata must retain the existing override order",
+);
+assert(
+  aioNodeInputSpec(capabilityState, "present", "mode") === presentInfo.input.required.mode,
+  "Known input specs must be returned unchanged",
+);
+assert(
+  aioNodeInputSpec(capabilityState, "present", "missing") === null,
+  "Unknown input specs must resolve to null",
+);
+assert(
+  aioNodeInputTooltip(capabilityState, "present", "mode") === "Required mode",
+  "Object-info tooltips must be exposed",
+);
+assert(
+  aioNodeInputTooltip(capabilityState, "present", "missing") === "",
+  "Inputs without metadata must have an empty tooltip",
+);
+assert(
+  aioNodeInputSupported(capabilityState, "present", "mode") === true,
+  "Available declared inputs must be supported",
+);
+assert(
+  aioNodeInputSupported(capabilityState, "present", "missing") === false,
+  "Available nodes must reject undeclared inputs",
+);
+assert(
+  aioNodeInputSupported(capabilityState, "absent", "mode") === false,
+  "Missing nodes must reject all inputs",
+);
+assert(
+  aioNodeInputSupported(capabilityState, "broken", "mode") === true,
+  "Query errors must preserve optimistic input support",
+);
+assert(
+  aioNodeInputSupported({ loaded: false, status: {}, nodeInfo: {} }, "present", "mode")
+    === true,
+  "Unknown nodes must preserve optimistic input support",
+);
+assert(
+  JSON.stringify(capabilityState) === capabilityStateSnapshot,
+  "Capability helpers must not mutate dependency state",
+);
+
+console.log("AiO dependency core smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -304,21 +304,28 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("upscaleBackendMissingPacks(next.upscale.backend).length", body)
         self.assertIn("next.upscale.enabled = false", body)
 
-    def test_optional_dependency_query_reports_results_without_treating_errors_as_missing(self):
+    def test_optional_dependency_query_adapter_updates_cache_and_reports_results(self):
         source = AIO_JS.read_text(encoding="utf-8")
         fetch_start = source.index("async function fetchGeneratorOptionalDependencies")
         fetch_end = source.index("\nfunction optionalDependencyResultLabel", fetch_start)
         fetch_body = source[fetch_start:fetch_end]
-        available_start = source.index("function optionalDependencyAvailable")
-        available_end = source.index("\nfunction backendDependencyMissing", available_start)
-        available_body = source[available_start:available_end]
         report_start = source.index("function reportGeneratorOptionalDependencyStatus")
         report_end = source.index("\nfunction loadGeneratorOptionalDependencies", report_start)
         report_body = source[report_start:report_end]
 
-        self.assertIn('nextStatus[key] = "error"', fetch_body)
-        self.assertNotIn("next[key] = false", fetch_body)
-        self.assertIn('optionalDependencyStatus(key) !== "missing"', available_body)
+        self.assertIn("aioQueryOptionalDependencies(", fetch_body)
+        self.assertIn("AIO_OPTIONAL_DEPENDENCY_SPECS", fetch_body)
+        self.assertIn(
+            "easyuseAnimaFetchComfyJson(api, `/object_info/${encodeURIComponent(spec.nodeId)}`)",
+            fetch_body,
+        )
+        self.assertIn("return data?.[spec.nodeId] || null", fetch_body)
+        for cache_name in ("available", "status", "nodeInfo", "errors"):
+            with self.subTest(cache_name=cache_name):
+                self.assertIn(
+                    f"generatorOptionalDependencyState.{cache_name} = next.{cache_name}",
+                    fetch_body,
+                )
         self.assertIn('console.info("[EasyUseAnima] AiO optional dependency query result", rows)', report_body)
         self.assertIn('severity: failed.length ? "warn" : "info"', report_body)
         self.assertIn("app.ui.dialog.show", report_body)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -13,6 +13,8 @@ WEB_JS = ROOT / "web" / "js"
 API_JS = WEB_JS / "easyuse_anima_api.js"
 AIO_JS = WEB_JS / "easyuse_anima_aio.js"
 AIO_MODULES = WEB_JS / "aio"
+AIO_DEPENDENCIES_JS = AIO_MODULES / "dependencies.js"
+AIO_DEPENDENCY_CORE_SMOKE = ROOT / "tests" / "frontend_aio_dependency_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
 AIO_PROFILE_CORE_SMOKE = ROOT / "tests" / "frontend_aio_profile_core_smoke.mjs"
 PROMPT_STUDIO_JS = WEB_JS / "easyuse_anima_prompt_studio.js"
@@ -84,6 +86,93 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_PROFILE_CORE_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_profile_core_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_dependency_core_module_owns_dom_free_capability_rules(self):
+        source = AIO_DEPENDENCIES_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+
+        expected_constants = {
+            "AIO_BACKEND_DEPENDENCIES",
+            "AIO_OPTIONAL_DEPENDENCY_SPECS",
+        }
+        exported_constants = set(
+            re.findall(r"export const ([A-Za-z0-9_]+)\s*=", source)
+        )
+        self.assertEqual(exported_constants, expected_constants)
+
+        expected_functions = {
+            "aioNodeInputMap",
+            "aioNodeInputSpec",
+            "aioNodeInputSupported",
+            "aioNodeInputTooltip",
+            "aioOptionalDependencyAvailable",
+            "aioOptionalDependencyPack",
+            "aioOptionalDependencyStatus",
+            "aioQueryOptionalDependencies",
+            "aioUpscaleBackendDependencyKeys",
+            "aioUpscaleBackendMissingPacks",
+        }
+        exported_functions = set(
+            re.findall(r"export (?:async )?function ([A-Za-z0-9_]+)\(", source)
+        )
+        self.assertEqual(exported_functions, expected_functions)
+
+        import_match = re.search(
+            r'import\s+\{(?P<names>[^}]*)\}\s+from\s+'
+            r'"\./aio/dependencies\.js";',
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip()
+            for name in import_match.group("names").split(",")
+            if name.strip()
+        }
+        self.assertEqual(
+            imported_names,
+            {
+                "AIO_BACKEND_DEPENDENCIES",
+                "AIO_OPTIONAL_DEPENDENCY_SPECS",
+                "aioNodeInputMap",
+                "aioNodeInputSpec",
+                "aioNodeInputSupported",
+                "aioNodeInputTooltip",
+                "aioOptionalDependencyAvailable",
+                "aioOptionalDependencyPack",
+                "aioOptionalDependencyStatus",
+                "aioQueryOptionalDependencies",
+                "aioUpscaleBackendMissingPacks",
+            },
+        )
+
+        self.assertNotRegex(source, r"\b(?:document|window|app)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("const GENERATOR_OPTIONAL_DEPENDENCY_SPECS", entry_source)
+        self.assertNotIn("const GENERATOR_BACKEND_DEPENDENCIES", entry_source)
+        self.assertNotIn("function upscaleBackendDependencyKeys", entry_source)
+
+        for delegation in (
+            "aioOptionalDependencyStatus(generatorOptionalDependencyState, key)",
+            "aioOptionalDependencyAvailable(generatorOptionalDependencyState, key)",
+            "aioUpscaleBackendMissingPacks(generatorOptionalDependencyState, backend)",
+            "aioNodeInputMap(generatorOptionalDependencyState, dependencyKey)",
+            "aioNodeInputSpec(generatorOptionalDependencyState, dependencyKey, inputName)",
+            "aioNodeInputTooltip(generatorOptionalDependencyState, dependencyKey, inputName)",
+            "aioNodeInputSupported(generatorOptionalDependencyState, dependencyKey, inputName)",
+        ):
+            with self.subTest(delegation=delegation):
+                self.assertIn(delegation, entry_source)
+
+        self.assertTrue(AIO_DEPENDENCY_CORE_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_dependency_core_smoke.mjs"',
             frontend_check_source,
         )
 
@@ -1167,6 +1256,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
         self.assertIn(
             r'& node "tests\frontend_aio_profile_core_smoke.mjs"', source
+        )
+        self.assertIn(
+            r'& node "tests\frontend_aio_dependency_core_smoke.mjs"', source
         )
         self.assertIn('"typescript@$TypeScriptVersion"', source)
         self.assertIn("tsc -p jsconfig.json", source)

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -44,6 +44,11 @@ try {
         throw "Frontend AiO profile core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_dependency_core_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/dependencies.js
+++ b/web/js/aio/dependencies.js
@@ -1,0 +1,161 @@
+// @ts-check
+
+export const AIO_OPTIONAL_DEPENDENCY_SPECS = {
+  spectrumAdvanced: {
+    nodeId: "SpectrumKSamplerAdvanced",
+    pack: "ComfyUI-Spectrum-KSampler",
+  },
+  spectrumSpd: {
+    nodeId: "SpectrumSPDKSampler",
+    pack: "ComfyUI-Spectrum-KSampler",
+  },
+  spectrumPatch: {
+    nodeId: "DiTSpectrumPatchAdvanced",
+    pack: "ComfyUI-Spectrum-KSampler",
+  },
+  spectrumCorrections: {
+    nodeId: "DiTCFGFSGPatch",
+    pack: "ComfyUI-Spectrum-KSampler",
+  },
+  dave: {
+    nodeId: "AnimaDAVE",
+    pack: "ComfyUI-Anima-DAVE",
+  },
+  safePag: {
+    nodeId: "AnimaSafePAG",
+    pack: "Anima Safe PAG",
+  },
+  imageSaver: {
+    nodeId: "Image Saver",
+    pack: "ComfyUI-Image-Saver",
+  },
+  upscaleModelLoader: {
+    nodeId: "UpscaleModelLoader",
+    pack: "ComfyUI built-in upscale model loader",
+  },
+  ultimateSdUpscale: {
+    nodeId: "UltimateSDUpscale",
+    pack: "ComfyUI_UltimateSDUpscale",
+  },
+  resShiftLoader: {
+    nodeId: "ResShiftLoader",
+    pack: "ComfyUI-Distilled-ResShift",
+  },
+  resShiftUpscale: {
+    nodeId: "ResShiftUpscale",
+    pack: "ComfyUI-Distilled-ResShift",
+  },
+  kjFp16: {
+    nodeId: "ModelPatchTorchSettings",
+    pack: "ComfyUI-KJNodes",
+  },
+  kjSage: {
+    nodeId: "PathchSageAttentionKJ",
+    pack: "ComfyUI-KJNodes",
+  },
+  kjTorchCompile: {
+    nodeId: "TorchCompileModelAdvanced",
+    pack: "ComfyUI-KJNodes",
+  },
+  impactDetailer: {
+    nodeId: "DetailerForEach",
+    pack: "ComfyUI-Impact-Pack",
+  },
+  impactMaskToSegs: {
+    nodeId: "MaskToSEGS",
+    pack: "ComfyUI-Impact-Pack",
+  },
+};
+
+export const AIO_BACKEND_DEPENDENCIES = {
+  spectrum_mod_guidance_advanced: "spectrumAdvanced",
+  spectrum_spd_speed: "spectrumSpd",
+};
+
+export async function aioQueryOptionalDependencies(specs, queryNodeInfo) {
+  const available = {};
+  const status = {};
+  const nodeInfo = {};
+  const errors = {};
+
+  for (const [key, spec] of Object.entries(specs || {})) {
+    try {
+      const info = await queryNodeInfo(spec, key);
+      available[key] = !!info;
+      status[key] = info ? "available" : "missing";
+      nodeInfo[key] = info || null;
+    } catch (error) {
+      status[key] = "error";
+      nodeInfo[key] = null;
+      errors[key] = error instanceof Error ? error.message : String(error || "Unknown error");
+    }
+  }
+
+  return { available, status, nodeInfo, errors };
+}
+
+export function aioOptionalDependencyStatus(state, key) {
+  if (!key || !state?.loaded) {
+    return "unknown";
+  }
+  return state.status?.[key] || "unknown";
+}
+
+export function aioOptionalDependencyAvailable(state, key) {
+  return aioOptionalDependencyStatus(state, key) !== "missing";
+}
+
+export function aioOptionalDependencyPack(key, specs = AIO_OPTIONAL_DEPENDENCY_SPECS) {
+  return specs?.[key]?.pack || key || "";
+}
+
+export function aioUpscaleBackendDependencyKeys(backend) {
+  if (backend === "usdu") {
+    return ["ultimateSdUpscale", "upscaleModelLoader"];
+  }
+  if (backend === "resshift") {
+    return ["resShiftLoader", "resShiftUpscale"];
+  }
+  return [];
+}
+
+export function aioUpscaleBackendMissingPacks(
+  state,
+  backend,
+  specs = AIO_OPTIONAL_DEPENDENCY_SPECS,
+) {
+  return aioUpscaleBackendDependencyKeys(backend)
+    .filter((key) => !aioOptionalDependencyAvailable(state, key))
+    .map((key) => aioOptionalDependencyPack(key, specs));
+}
+
+export function aioNodeInputMap(state, dependencyKey) {
+  const input = state?.nodeInfo?.[dependencyKey]?.input || {};
+  return {
+    ...(input.required || {}),
+    ...(input.optional || {}),
+  };
+}
+
+export function aioNodeInputSpec(state, dependencyKey, inputName) {
+  return aioNodeInputMap(state, dependencyKey)?.[inputName] || null;
+}
+
+export function aioNodeInputTooltip(state, dependencyKey, inputName) {
+  const spec = aioNodeInputSpec(state, dependencyKey, inputName);
+  const options = Array.isArray(spec) && spec[1] && typeof spec[1] === "object"
+    ? spec[1]
+    : null;
+  return options?.tooltip ? String(options.tooltip) : "";
+}
+
+export function aioNodeInputSupported(state, dependencyKey, inputName) {
+  const status = aioOptionalDependencyStatus(state, dependencyKey);
+  if (status === "unknown" || status === "error") {
+    return true;
+  }
+  if (status === "missing") {
+    return false;
+  }
+  return !!aioNodeInputSpec(state, dependencyKey, inputName);
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -2,6 +2,19 @@ import { app } from "../../../scripts/app.js";
 import { api } from "../../../scripts/api.js";
 import { easyuseAnimaFetchComfyJson, easyuseAnimaFetchText } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
+import {
+  AIO_BACKEND_DEPENDENCIES,
+  AIO_OPTIONAL_DEPENDENCY_SPECS,
+  aioNodeInputMap,
+  aioNodeInputSpec,
+  aioNodeInputSupported,
+  aioNodeInputTooltip,
+  aioOptionalDependencyAvailable,
+  aioOptionalDependencyPack,
+  aioOptionalDependencyStatus,
+  aioQueryOptionalDependencies,
+  aioUpscaleBackendMissingPacks,
+} from "./aio/dependencies.js";
 import { aioPanelFromWheelEvent, consumeAioPanelWheel } from "./aio/wheel.js";
 import {
   aioBuiltinProfileIdForSettings,
@@ -76,79 +89,6 @@ const GENERATOR_FALLBACK_SCHEDULER_NAMES = [
   "OSS FLUX",
   "OSS Wan",
   "OSS Chroma",
-];
-const GENERATOR_OPTIONAL_DEPENDENCY_SPECS = {
-  spectrumAdvanced: {
-    nodeId: "SpectrumKSamplerAdvanced",
-    pack: "ComfyUI-Spectrum-KSampler",
-  },
-  spectrumSpd: {
-    nodeId: "SpectrumSPDKSampler",
-    pack: "ComfyUI-Spectrum-KSampler",
-  },
-  spectrumPatch: {
-    nodeId: "DiTSpectrumPatchAdvanced",
-    pack: "ComfyUI-Spectrum-KSampler",
-  },
-  spectrumCorrections: {
-    nodeId: "DiTCFGFSGPatch",
-    pack: "ComfyUI-Spectrum-KSampler",
-  },
-  dave: {
-    nodeId: "AnimaDAVE",
-    pack: "ComfyUI-Anima-DAVE",
-  },
-  safePag: {
-    nodeId: "AnimaSafePAG",
-    pack: "Anima Safe PAG",
-  },
-  imageSaver: {
-    nodeId: "Image Saver",
-    pack: "ComfyUI-Image-Saver",
-  },
-  upscaleModelLoader: {
-    nodeId: "UpscaleModelLoader",
-    pack: "ComfyUI built-in upscale model loader",
-  },
-  ultimateSdUpscale: {
-    nodeId: "UltimateSDUpscale",
-    pack: "ComfyUI_UltimateSDUpscale",
-  },
-  resShiftLoader: {
-    nodeId: "ResShiftLoader",
-    pack: "ComfyUI-Distilled-ResShift",
-  },
-  resShiftUpscale: {
-    nodeId: "ResShiftUpscale",
-    pack: "ComfyUI-Distilled-ResShift",
-  },
-  kjFp16: {
-    nodeId: "ModelPatchTorchSettings",
-    pack: "ComfyUI-KJNodes",
-  },
-  kjSage: {
-    nodeId: "PathchSageAttentionKJ",
-    pack: "ComfyUI-KJNodes",
-  },
-  kjTorchCompile: {
-    nodeId: "TorchCompileModelAdvanced",
-    pack: "ComfyUI-KJNodes",
-  },
-  impactDetailer: {
-    nodeId: "DetailerForEach",
-    pack: "ComfyUI-Impact-Pack",
-  },
-  impactMaskToSegs: {
-    nodeId: "MaskToSEGS",
-    pack: "ComfyUI-Impact-Pack",
-  },
-};
-const GENERATOR_BACKEND_DEPENDENCIES = {
-  spectrum_mod_guidance_advanced: "spectrumAdvanced",
-  spectrum_spd_speed: "spectrumSpd",
-};
-const GENERATOR_HIGHRES_BACKENDS = [
-  "comfy_ksampler",
 ];
 const SPECTRUM_ADVANCED_KNOWN_INPUTS = new Set([
   "model",
@@ -2386,36 +2326,26 @@ function loadGeneratorSamplerOptions() {
 }
 
 async function fetchGeneratorOptionalDependencies() {
-  const next = {};
-  const nextStatus = {};
-  const nextInfo = {};
-  const nextErrors = {};
-  for (const [key, spec] of Object.entries(GENERATOR_OPTIONAL_DEPENDENCY_SPECS)) {
-    try {
+  const next = await aioQueryOptionalDependencies(
+    AIO_OPTIONAL_DEPENDENCY_SPECS,
+    async (spec) => {
       const data = await easyuseAnimaFetchComfyJson(api, `/object_info/${encodeURIComponent(spec.nodeId)}`);
-      const info = data?.[spec.nodeId] || null;
-      next[key] = !!info;
-      nextStatus[key] = info ? "available" : "missing";
-      nextInfo[key] = info;
-    } catch (error) {
-      nextStatus[key] = "error";
-      nextInfo[key] = null;
-      nextErrors[key] = error instanceof Error ? error.message : String(error || "Unknown error");
-    }
-  }
-  generatorOptionalDependencyState.available = next;
-  generatorOptionalDependencyState.status = nextStatus;
-  generatorOptionalDependencyState.nodeInfo = nextInfo;
-  generatorOptionalDependencyState.errors = nextErrors;
+      return data?.[spec.nodeId] || null;
+    },
+  );
+  generatorOptionalDependencyState.available = next.available;
+  generatorOptionalDependencyState.status = next.status;
+  generatorOptionalDependencyState.nodeInfo = next.nodeInfo;
+  generatorOptionalDependencyState.errors = next.errors;
 }
 
 function optionalDependencyResultLabel(key) {
-  const spec = GENERATOR_OPTIONAL_DEPENDENCY_SPECS[key];
+  const spec = AIO_OPTIONAL_DEPENDENCY_SPECS[key];
   return spec ? `${spec.nodeId} (${spec.pack})` : key;
 }
 
 function reportGeneratorOptionalDependencyStatus() {
-  const rows = Object.entries(GENERATOR_OPTIONAL_DEPENDENCY_SPECS).map(([key, spec]) => ({
+  const rows = Object.entries(AIO_OPTIONAL_DEPENDENCY_SPECS).map(([key, spec]) => ({
     key,
     node: spec.nodeId,
     pack: spec.pack,
@@ -2473,10 +2403,10 @@ function loadGeneratorOptionalDependencies({ retryErrors = false } = {}) {
         console.warn("[EasyUseAnima] Failed to load optional dependency status.", error);
         const message = error instanceof Error ? error.message : String(error || "Unknown error");
         generatorOptionalDependencyState.status = Object.fromEntries(
-          Object.keys(GENERATOR_OPTIONAL_DEPENDENCY_SPECS).map((key) => [key, "error"]),
+          Object.keys(AIO_OPTIONAL_DEPENDENCY_SPECS).map((key) => [key, "error"]),
         );
         generatorOptionalDependencyState.errors = Object.fromEntries(
-          Object.keys(GENERATOR_OPTIONAL_DEPENDENCY_SPECS).map((key) => [key, message]),
+          Object.keys(AIO_OPTIONAL_DEPENDENCY_SPECS).map((key) => [key, message]),
         );
       })
       .then(() => {
@@ -2492,61 +2422,31 @@ function loadGeneratorOptionalDependencies({ retryErrors = false } = {}) {
 }
 
 function optionalDependencyStatus(key) {
-  if (!key || !generatorOptionalDependencyState.loaded) {
-    return "unknown";
-  }
-  return generatorOptionalDependencyState.status[key] || "unknown";
+  return aioOptionalDependencyStatus(generatorOptionalDependencyState, key);
 }
 
 function optionalDependencyAvailable(key) {
-  return optionalDependencyStatus(key) !== "missing";
-}
-
-function backendDependencyMissing(backend) {
-  const dependencyKey = GENERATOR_BACKEND_DEPENDENCIES[backend];
-  return dependencyKey && !optionalDependencyAvailable(dependencyKey);
+  return aioOptionalDependencyAvailable(generatorOptionalDependencyState, key);
 }
 
 function optionalDependencyPack(key) {
-  return GENERATOR_OPTIONAL_DEPENDENCY_SPECS[key]?.pack || key || "";
-}
-
-function upscaleBackendDependencyKeys(backend) {
-  if (backend === "usdu") {
-    return ["ultimateSdUpscale", "upscaleModelLoader"];
-  }
-  if (backend === "resshift") {
-    return ["resShiftLoader", "resShiftUpscale"];
-  }
-  return [];
+  return aioOptionalDependencyPack(key);
 }
 
 function upscaleBackendMissingPacks(backend) {
-  return upscaleBackendDependencyKeys(backend)
-    .filter((key) => !optionalDependencyAvailable(key))
-    .map((key) => optionalDependencyPack(key));
-}
-
-function optionalDependencyNodeInfo(key) {
-  return generatorOptionalDependencyState.nodeInfo?.[key] || null;
+  return aioUpscaleBackendMissingPacks(generatorOptionalDependencyState, backend);
 }
 
 function nodeInputMap(dependencyKey) {
-  const input = optionalDependencyNodeInfo(dependencyKey)?.input || {};
-  return {
-    ...(input.required || {}),
-    ...(input.optional || {}),
-  };
+  return aioNodeInputMap(generatorOptionalDependencyState, dependencyKey);
 }
 
 function nodeInputSpec(dependencyKey, inputName) {
-  return nodeInputMap(dependencyKey)?.[inputName] || null;
+  return aioNodeInputSpec(generatorOptionalDependencyState, dependencyKey, inputName);
 }
 
 function nodeInputTooltip(dependencyKey, inputName) {
-  const spec = nodeInputSpec(dependencyKey, inputName);
-  const options = Array.isArray(spec) && spec[1] && typeof spec[1] === "object" ? spec[1] : null;
-  return options?.tooltip ? String(options.tooltip) : "";
+  return aioNodeInputTooltip(generatorOptionalDependencyState, dependencyKey, inputName);
 }
 
 function nodeInputChoiceOptions(dependencyKey, inputName, current, fallback = []) {
@@ -2555,14 +2455,7 @@ function nodeInputChoiceOptions(dependencyKey, inputName, current, fallback = []
 }
 
 function nodeInputSupported(dependencyKey, inputName) {
-  const status = optionalDependencyStatus(dependencyKey);
-  if (status === "unknown" || status === "error") {
-    return true;
-  }
-  if (status === "missing") {
-    return false;
-  }
-  return !!nodeInputSpec(dependencyKey, inputName);
+  return aioNodeInputSupported(generatorOptionalDependencyState, dependencyKey, inputName);
 }
 
 function applyNodeInputInfo(control, dependencyKey, inputName, fallbackTooltipKey = "") {
@@ -2702,7 +2595,7 @@ function disableGeneratorSpectrumOptions(target) {
 function sanitizeGeneratorSettingsForOptionalDependencies(settings) {
   const next = migrateGeneratorPostprocessSettings(mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings));
   delete next.sampler.dave;
-  const backendDependency = GENERATOR_BACKEND_DEPENDENCIES[next.sampler.backend];
+  const backendDependency = AIO_BACKEND_DEPENDENCIES[next.sampler.backend];
   if (backendDependency && !optionalDependencyAvailable(backendDependency)) {
     next.sampler.backend = "comfy_ksampler";
   }
@@ -6813,7 +6706,7 @@ function openSamplerSettings(node) {
   const refreshDependencyLocks = () => {
     const messages = [];
     for (const option of Array.from(backend.options)) {
-      const dependencyKey = GENERATOR_BACKEND_DEPENDENCIES[option.value];
+      const dependencyKey = AIO_BACKEND_DEPENDENCIES[option.value];
       const pack = optionalDependencyPack(dependencyKey);
       const missing = !!dependencyKey && !optionalDependencyAvailable(dependencyKey);
       option.disabled = missing;


### PR DESCRIPTION
## 변경 요약

- AiO 선택 의존성 카탈로그, 상태 판정, 백엔드 매핑, 입력 메타데이터 판정을 `web/js/aio/dependencies.js`로 분리했습니다.
- fetch/cache/toast/DOM/queue hook은 기존 엔트리에 남기고 pure helper만 호출하도록 연결했습니다.
- 16개 `/object_info/{nodeId}` 순차 조회, 개별 오류 격리, `unknown/error` fail-open 및 확정 `missing` fail-closed 의미를 유지했습니다.
- 더 이상 사용되지 않던 highres backend 상수와 dependency wrapper를 제거했습니다.
- 실제 ESM smoke와 Python 구조 검사를 공식 프런트엔드 검증에 포함했습니다.

## 주요 파일

- `web/js/aio/dependencies.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_dependency_core_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- 저장소 공식 full validation: 327 tests, OK
- 프런트엔드 검사: 66 JavaScript files, TypeScript 6.0.3, 통과
- AiO dependency semantic smoke: 통과
  - available/missing/error/unknown 상태
  - error fail-open 및 missing fail-closed
  - 순차 조회(max concurrency 1)
  - required/optional 입력 병합 우선순위
  - backend별 누락 pack 판정 및 입력 capability
- `git diff --check`: 통과
- ComfyUI v0.27.0 Codex test instance
  - legacy canvas: AiO DOM 및 의존성 대화상자 확인
  - Node 2.0: AiO DOM 및 의존성 대화상자 확인
  - 두 표면 모두 누락 Spectrum 옵션 비활성화 및 EasyUseAnima 관련 콘솔 오류 없음
- ComfyUI v0.27.0 user instance: manual browser check not run

## 남은 위험과 후속 작업

- legacy `DiTSpectrumPatch` 별칭 지원과 `spectrumPatch`/`spectrumCorrections` 독립 판정은 동작 수정이므로 이번 구조 분리에서 제외했습니다.
- 선택 의존성 API 조회 오류를 일시적 미설치로 확정하지 않는 기존 fail-open 정책을 유지합니다.

Refs #54
