### PR TITLE
[Maintenance] AiO preview 상태 경계 분리

### DIFF
--- a/tests/frontend_aio_preview_core_smoke.mjs
+++ b/tests/frontend_aio_preview_core_smoke.mjs
@@ -1,0 +1,345 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertJsonEqual(actual, expected, message) {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+const preview = await import(dataModule("../web/js/aio/preview.js"));
+const {
+  aioAppendPreviewFeed,
+  aioCreatePreviewProgressTracker,
+  aioDefaultPreviewIndex,
+  aioDeletePreviewStoreEntry,
+  aioMainPreviewImage,
+  aioMergePreviewImages,
+  aioPreviewEventDetail,
+  aioPreviewFileSize,
+  aioPreviewImageLabel,
+  aioPreviewImageName,
+  aioPreviewImages,
+  aioPreviewNodeIdsFromDetail,
+  aioPreviewResolution,
+  aioPreviewRunId,
+  aioRemovePreviewRun,
+  aioSelectedPreviewIndex,
+  aioSuppressDefaultPreview,
+  aioTagPreviewRun,
+} = preview;
+
+assertJsonEqual(
+  aioPreviewNodeIdsFromDetail({
+    displayNodeId: " 7:42 ",
+    nodeId: 42,
+    real_node_id: "42",
+    node: "",
+  }),
+  ["7:42", "42"],
+  "Preview node ids must preserve alias order while trimming and deduplicating values",
+);
+
+const progress = aioCreatePreviewProgressTracker();
+progress.remember({ nodeId: "42", value: "3", max: "10", prompt_id: "job-a" });
+assertJsonEqual(
+  {
+    value: progress.find({ node_id: "42", prompt_id: "job-a" })?.value,
+    max: progress.find({ node_id: "42", prompt_id: "job-a" })?.max,
+    promptId: progress.find({ node_id: "42", prompt_id: "job-a" })?.promptId,
+  },
+  { value: 3, max: 10, promptId: "job-a" },
+  "Progress lookup must normalize numeric fields and node id aliases",
+);
+assert(
+  progress.find({ nodeId: "42", prompt_id: "job-b" }) === null,
+  "Progress from another prompt must not leak into the active preview",
+);
+progress.rememberState({
+  prompt_id: "job-b",
+  nodes: {
+    first: { display_node_id: "43", value: 5, max: 8 },
+    second: { realNodeId: "44", value: "invalid", max: 9, prompt_id: "job-c" },
+  },
+});
+assert(
+  progress.find({ nodeId: "43", prompt_id: "job-b" })?.value === 5,
+  "Progress-state snapshots must inherit their parent prompt id",
+);
+assert(
+  progress.find({ nodeId: "44", prompt_id: "job-c" })?.value === 0,
+  "Invalid progress values must keep the existing zero fallback",
+);
+progress.remember({ nodeId: "42", value: 7, max: 10, prompt_id: "job-b" });
+assert(
+  progress.find({ nodeId: "42", prompt_id: "job-a" }) === null
+    && progress.find({ nodeId: "42", prompt_id: "job-b" })?.value === 7,
+  "The latest prompt for a node must replace stale progress without cross-prompt matches",
+);
+progress.clear();
+assert(
+  progress.find({ nodeId: "42", prompt_id: "job-b" }) === null,
+  "Clearing progress must remove every cached node entry",
+);
+
+const firstImage = { stage: "first_pass", filename: "first.webp", type: "temp" };
+const finalImage = { stage: "final", filename: "final.webp", type: "output" };
+assertJsonEqual(
+  aioPreviewImages({
+    easyuse_anima_preview: [firstImage, [finalImage, null], "invalid", null, []],
+  }),
+  [firstImage, finalImage],
+  "Preview payloads must flatten one nested image array and filter invalid entries",
+);
+assertJsonEqual(aioPreviewImages({}), [], "Missing preview payloads must normalize to an empty list");
+assert(
+  aioPreviewRunId({ easyuse_anima_run_id: ["run-primary"], run_id: "run-fallback" })
+    === "run-primary",
+  "The EasyUseAnima run id must retain precedence and first-value normalization",
+);
+assert(
+  aioPreviewRunId({ run_id: 17 }) === "17",
+  "Fallback run ids must normalize to strings",
+);
+
+const imagesToTag = [
+  { filename: "a.webp" },
+  { filename: "b.webp", __aio_run_id: "kept", __aio_run_index: 9 },
+];
+const imagesToTagSnapshot = JSON.stringify(imagesToTag);
+const tagged = aioTagPreviewRun(imagesToTag, "run-tagged", 4);
+assertJsonEqual(
+  tagged.map((image) => [image.__aio_run_id, image.__aio_run_index]),
+  [["run-tagged", 4], ["kept", 9]],
+  "Run tagging must add stable ids and indexes without replacing existing tags",
+);
+assert(
+  JSON.stringify(imagesToTag) === imagesToTagSnapshot,
+  "Run tagging must not mutate its input images",
+);
+
+const existingImages = [
+  {
+    stage: "first_pass",
+    filename: "first.webp",
+    type: "temp",
+    subfolder: "",
+    width: 512,
+    __aio_run_id: "run-old",
+    __aio_run_index: 0,
+  },
+  { stage: "highres", filename: "high.webp", type: "temp", subfolder: "" },
+];
+const nextImages = [
+  {
+    stage: "first_pass",
+    filename: "first.webp",
+    type: "temp",
+    subfolder: "",
+    width: 768,
+    bytes: 2048,
+  },
+  { stage: "final", filename: "final.webp", type: "output", subfolder: "" },
+];
+const existingSnapshot = JSON.stringify(existingImages);
+const nextSnapshot = JSON.stringify(nextImages);
+const merged = aioMergePreviewImages(existingImages, nextImages, "run-new");
+assert(merged.length === 3, "Duplicate preview identities must merge instead of appending");
+assert(
+  merged[0].width === 768 && merged[0].bytes === 2048,
+  "New preview metadata must update an existing matching image",
+);
+assert(
+  merged[2].stage === "final",
+  "New unique preview images must retain their append order",
+);
+assert(
+  JSON.stringify(existingImages) === existingSnapshot && JSON.stringify(nextImages) === nextSnapshot,
+  "Preview merging must not mutate either input list",
+);
+assertJsonEqual(
+  aioMergePreviewImages([], [{ filename: "1" }, { filename: "2" }, { filename: "3" }], "run", 2)
+    .map((image) => image.filename),
+  ["2", "3"],
+  "Limited preview merges must retain the most recent images",
+);
+assert(
+  aioMergePreviewImages([], [{}, {}], "run").length === 2,
+  "Images without an identity must not collapse into one entry",
+);
+assertJsonEqual(
+  aioAppendPreviewFeed(
+    [],
+    [{ filename: "1" }, { filename: "2" }, { filename: "3" }],
+    { preview: { feed_count: 2 } },
+    "run",
+    9,
+  ).map((image) => image.filename),
+  ["2", "3"],
+  "Preview feeds must honor the configured history limit",
+);
+
+const multipleRuns = [
+  { filename: "old.webp", __aio_run_id: "old" },
+  { filename: "current.webp", __aio_run_id: "current" },
+];
+assertJsonEqual(
+  aioRemovePreviewRun(multipleRuns, "old"),
+  [multipleRuns[1]],
+  "Removing a preview run must preserve images from every other run",
+);
+const replacedCurrentRunFeed = aioAppendPreviewFeed(
+  aioRemovePreviewRun(
+    [
+      { filename: "old-run.webp", __aio_run_id: "old" },
+      { filename: "stale-current.webp", __aio_run_id: "current" },
+    ],
+    "current",
+  ),
+  [{ filename: "fresh-current.webp", stage: "final" }],
+  { preview: { feed_count: 4 } },
+  "current",
+);
+assertJsonEqual(
+  replacedCurrentRunFeed.map((image) => image.filename),
+  ["old-run.webp", "fresh-current.webp"],
+  "Replacing one run must preserve prior feed history while removing stale images from that run",
+);
+
+const selectableImages = [
+  { stage: "final", filename: "old-final.webp" },
+  { stage: "highres", filename: "high.webp" },
+  { stage: "final", filename: "new-final.webp" },
+];
+assert(
+  aioDefaultPreviewIndex(selectableImages) === 2,
+  "The newest final image must be the default preview",
+);
+assert(
+  aioDefaultPreviewIndex([{ stage: "first" }, { stage: "highres" }]) === 1
+    && aioDefaultPreviewIndex([]) === -1,
+  "Preview selection must fall back to the last image or -1 for an empty list",
+);
+assert(
+  aioSelectedPreviewIndex({ __easyuseAnimaSelectedPreviewIndex: 1 }, selectableImages) === 1,
+  "A valid explicit preview selection must take precedence",
+);
+assert(
+  aioSelectedPreviewIndex({ __easyuseAnimaSelectedPreviewIndex: 99 }, selectableImages) === 2,
+  "An invalid explicit selection must fall back to the default final image",
+);
+assert(
+  aioMainPreviewImage({ __easyuseAnimaSelectedPreviewIndex: 1 }, selectableImages)
+    === selectableImages[1]
+    && aioMainPreviewImage({}, []) === null,
+  "Main preview lookup must return the selected image or null",
+);
+
+const wrappedDetail = { node: "42", images: [finalImage] };
+assert(
+  aioPreviewEventDetail({ detail: { data: wrappedDetail } }) === wrappedDetail,
+  "Wrapped event payloads must expose their nested data object",
+);
+assertJsonEqual(
+  aioPreviewEventDetail({ detail: { node: "42" } }),
+  { node: "42" },
+  "Plain event details must pass through unchanged",
+);
+assert(aioPreviewImageLabel({ label: "Result", stage: "final" }) === "Result", "Explicit labels must win");
+assert(aioPreviewImageLabel({ stage: "final" }) === "final", "Stages must remain label fallbacks");
+assert(aioPreviewImageName({ name: "named.webp" }) === "named.webp", "Image names must remain supported");
+assert(
+  aioPreviewResolution({ width: 1024.9, height: 1536.7 }) === "1024 x 1536"
+    && aioPreviewResolution({ width: 0, height: 1536 }) === "-",
+  "Preview resolution formatting must truncate valid dimensions and reject incomplete sizes",
+);
+assert(
+  aioPreviewFileSize({ bytes: 1536 }) === "1.5 KB"
+    && aioPreviewFileSize({ size: 12 * 1024 }) === "12 KB"
+    && aioPreviewFileSize({ bytes: 0 }) === "-",
+  "Preview file sizes must retain binary-unit formatting and empty fallbacks",
+);
+
+const mapStore = new Map([["map-node", true]]);
+aioDeletePreviewStoreEntry(mapStore, "map-node");
+assert(!mapStore.has("map-node"), "Preview store deletion must support Map containers");
+const refMapStore = { value: new Map([["ref-map-node", true]]) };
+aioDeletePreviewStoreEntry(refMapStore, "ref-map-node");
+assert(!refMapStore.value.has("ref-map-node"), "Preview store deletion must support ref-wrapped Maps");
+const objectStore = { "object-node": true };
+aioDeletePreviewStoreEntry(objectStore, "object-node");
+assert(!Object.hasOwn(objectStore, "object-node"), "Preview store deletion must support plain objects");
+const refObjectStore = { value: { "ref-object-node": true } };
+aioDeletePreviewStoreEntry(refObjectStore, "ref-object-node");
+assert(
+  !Object.hasOwn(refObjectStore.value, "ref-object-node"),
+  "Preview store deletion must support ref-wrapped objects",
+);
+
+const dirtyNodes = [];
+const legacyNode = {
+  imgs: [{ src: "native" }],
+  images: [{ src: "native" }],
+  imageRects: [{ x: 0 }],
+  imageIndex: 2,
+  overIndex: 1,
+  previewMediaType: "image",
+};
+const changed = aioSuppressDefaultPreview(legacyNode, {
+  markNodeDirty(node) {
+    dirtyNodes.push(node);
+  },
+});
+assert(changed === true, "The first native preview suppression must report a state change");
+assert(legacyNode.hideOutputImages === true, "Native output images must remain hidden");
+assert(
+  legacyNode.imgs.length === 0
+    && legacyNode.images.length === 0
+    && legacyNode.imageRects.length === 0,
+  "Every native preview image collection must be empty",
+);
+assert(
+  legacyNode.imageIndex === null
+    && legacyNode.overIndex === null
+    && legacyNode.previewMediaType === undefined,
+  "Native preview selection and media state must be cleared",
+);
+assert(dirtyNodes.length === 1 && dirtyNodes[0] === legacyNode, "Changed nodes must be marked dirty once");
+legacyNode.imgs = [{ src: "late-native" }];
+assert(
+  legacyNode.imgs.length === 0,
+  "The legacy canvas lock must reject ComfyUI's later node.imgs assignment",
+);
+const imgsDescriptor = Object.getOwnPropertyDescriptor(legacyNode, "imgs");
+assert(
+  imgsDescriptor?.configurable === true && imgsDescriptor?.enumerable === false,
+  "The legacy imgs lock must retain its configurable non-enumerable descriptor",
+);
+assert(
+  aioSuppressDefaultPreview(legacyNode, { markNodeDirty: () => dirtyNodes.push(legacyNode) }) === false
+    && dirtyNodes.length === 1,
+  "Repeated suppression must be idempotent and avoid redundant dirty updates",
+);
+let disabledDirtyCalls = 0;
+const quietNode = {};
+assert(
+  aioSuppressDefaultPreview(quietNode, {
+    markDirty: false,
+    markNodeDirty() {
+      disabledDirtyCalls += 1;
+    },
+  }) === true
+    && disabledDirtyCalls === 0,
+  "markDirty false must preserve setup-time suppression without canvas invalidation",
+);
+assert(aioSuppressDefaultPreview(null) === false, "Missing nodes must be a safe no-op");
+
+console.log("AiO preview core smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 AIO_JS = ROOT / "web" / "js" / "easyuse_anima_aio.js"
+AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
 AIO_PRESETS_JS = ROOT / "web" / "js" / "aio" / "presets.js"
 AUTOCOMPLETE_JS = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
@@ -195,6 +196,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_generator_keeps_native_output_preview_suppressed_after_execution(self):
         source = AIO_JS.read_text(encoding="utf-8")
+        preview_source = AIO_PREVIEW_JS.read_text(encoding="utf-8")
         registration_start = source.index("async beforeRegisterNodeDef")
         generator_block = source[source.index("if (nodeData.name === GENERATOR_NODE_TYPE)", registration_start):]
         start = generator_block.index("nodeType.prototype.onExecuted = function")
@@ -204,8 +206,11 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("nodeType.prototype.hideOutputImages = true", source)
         self.assertIn("module?.useNodeOutputStore || module?.cn || module?.L", source)
         self.assertIn("outputStore.revokePreviewsByLocatorId?.(locator);", source)
-        self.assertIn('Object.defineProperty(node, "imgs"', source)
-        self.assertIn("lockGeneratorLegacyCanvasPreview(node);", source)
+        self.assertIn("aioDeletePreviewStoreEntry(app.nodePreviewImages, id);", source)
+        self.assertIn("aioDeletePreviewStoreEntry(outputStore.nodePreviewImages, locator);", source)
+        self.assertIn('Object.defineProperty(node, "imgs"', preview_source)
+        self.assertIn("lockLegacyCanvasPreview(node);", preview_source)
+        self.assertIn("aioSuppressDefaultPreview", source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .text-node-component-header-text", source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground", source)
         self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)
@@ -221,9 +226,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         meta_end = body.index("].filter", meta_start)
         meta_parts = body[meta_start:meta_end]
 
-        self.assertIn("generatorPreviewImageName(currentImage)", meta_parts)
-        self.assertIn("generatorPreviewResolution(currentImage)", meta_parts)
-        self.assertIn("generatorPreviewFileSize(currentImage)", meta_parts)
+        self.assertIn("aioPreviewImageName(currentImage)", meta_parts)
+        self.assertIn("aioPreviewResolution(currentImage)", meta_parts)
+        self.assertIn("aioPreviewFileSize(currentImage)", meta_parts)
 
     def test_detailer_target_editor_builds_optimization_before_visibility_refresh(self):
         source = AIO_JS.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -15,6 +15,8 @@ AIO_JS = WEB_JS / "easyuse_anima_aio.js"
 AIO_MODULES = WEB_JS / "aio"
 AIO_DEPENDENCIES_JS = AIO_MODULES / "dependencies.js"
 AIO_DEPENDENCY_CORE_SMOKE = ROOT / "tests" / "frontend_aio_dependency_core_smoke.mjs"
+AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
+AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
 AIO_PROFILE_CORE_SMOKE = ROOT / "tests" / "frontend_aio_profile_core_smoke.mjs"
 PROMPT_STUDIO_JS = WEB_JS / "easyuse_anima_prompt_studio.js"
@@ -173,6 +175,101 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_DEPENDENCY_CORE_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_dependency_core_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_preview_core_module_owns_dom_free_preview_rules(self):
+        source = AIO_PREVIEW_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+
+        expected_functions = {
+            "aioAppendPreviewFeed",
+            "aioCreatePreviewProgressTracker",
+            "aioDefaultPreviewIndex",
+            "aioDeletePreviewStoreEntry",
+            "aioMainPreviewImage",
+            "aioMergePreviewImages",
+            "aioPreviewEventDetail",
+            "aioPreviewFileSize",
+            "aioPreviewImageLabel",
+            "aioPreviewImageName",
+            "aioPreviewImages",
+            "aioPreviewNodeIdsFromDetail",
+            "aioPreviewResolution",
+            "aioPreviewRunId",
+            "aioRemovePreviewRun",
+            "aioSelectedPreviewIndex",
+            "aioSuppressDefaultPreview",
+            "aioTagPreviewRun",
+        }
+        exported_functions = set(
+            re.findall(r"export (?:async )?function ([A-Za-z0-9_]+)\(", source)
+        )
+        self.assertEqual(exported_functions, expected_functions)
+        self.assertNotRegex(source, r"export const [A-Za-z0-9_]+\s*=")
+
+        import_match = re.search(
+            r'import\s+\{(?P<names>[^}]*)\}\s+from\s+'
+            r'"\./aio/preview\.js";',
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip()
+            for name in import_match.group("names").split(",")
+            if name.strip()
+        }
+        self.assertEqual(imported_names, expected_functions)
+
+        self.assertNotRegex(source, r"\b(?:document|window|app)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("const GENERATOR_PROGRESS_BY_NODE", entry_source)
+        self.assertIn("aioCreatePreviewProgressTracker();", entry_source)
+        for local_function in (
+            "appendGeneratorPreviewFeed",
+            "deleteGeneratorPreviewStoreEntry",
+            "generatorDefaultPreviewIndex",
+            "generatorMainPreviewImage",
+            "generatorNodeIdsFromDetail",
+            "generatorPreviewEventDetail",
+            "generatorPreviewFeedLimit",
+            "generatorPreviewFileSize",
+            "generatorPreviewIdentity",
+            "generatorPreviewImageLabel",
+            "generatorPreviewImageName",
+            "generatorPreviewImages",
+            "generatorPreviewResolution",
+            "generatorPreviewRunId",
+            "generatorSelectedPreviewIndex",
+            "lockGeneratorLegacyCanvasPreview",
+            "mergeGeneratorPreviewImages",
+            "normalizeGeneratorNodeId",
+            "removeGeneratorPreviewRun",
+            "tagGeneratorPreviewRun",
+        ):
+            with self.subTest(local_function=local_function):
+                self.assertNotIn(f"function {local_function}(", entry_source)
+
+        suppress_start = entry_source.index(
+            "function suppressGeneratorDefaultPreview(node, options = {})"
+        )
+        suppress_end = entry_source.index(
+            "\nfunction scheduleGeneratorDefaultPreviewSuppression", suppress_start
+        )
+        suppress_body = entry_source[suppress_start:suppress_end]
+        self.assertIn("return aioSuppressDefaultPreview(node, {", suppress_body)
+        self.assertIn("markDirty: options.markDirty", suppress_body)
+        self.assertIn("markNodeDirty,", suppress_body)
+        self.assertNotIn('Object.defineProperty(node, "imgs"', suppress_body)
+
+        self.assertTrue(AIO_PREVIEW_CORE_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_preview_core_smoke.mjs"',
             frontend_check_source,
         )
 
@@ -1259,6 +1356,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
         self.assertIn(
             r'& node "tests\frontend_aio_dependency_core_smoke.mjs"', source
+        )
+        self.assertIn(
+            r'& node "tests\frontend_aio_preview_core_smoke.mjs"', source
         )
         self.assertIn('"typescript@$TypeScriptVersion"', source)
         self.assertIn("tsc -p jsconfig.json", source)

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -49,6 +49,11 @@ try {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_preview_core_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO preview core smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/preview.js
+++ b/web/js/aio/preview.js
@@ -1,0 +1,315 @@
+// @ts-check
+
+const PREVIEW_NODE_ID_KEYS = [
+  "displayNodeId",
+  "nodeId",
+  "realNodeId",
+  "parentNodeId",
+  "display_node_id",
+  "node_id",
+  "real_node_id",
+  "parent_node_id",
+  "node",
+];
+
+function firstValue(value, fallback = "") {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value[0] : fallback;
+  }
+  return value ?? fallback;
+}
+
+function normalizeNodeId(value) {
+  return value == null ? "" : String(value).trim();
+}
+
+function previewIdentity(image) {
+  return [
+    image?.stage || "",
+    image?.type || "",
+    image?.subfolder || "",
+    image?.filename || image?.name || "",
+  ].map((part) => String(part)).join("\u0001");
+}
+
+function previewFeedLimit(settings, fallback = 12) {
+  const parsed = Number(settings?.preview?.feed_count);
+  const fallbackValue = Number(fallback);
+  const next = Number.isFinite(parsed)
+    ? parsed
+    : (Number.isFinite(fallbackValue) ? fallbackValue : 12);
+  return Math.trunc(Math.max(1, Math.min(100, next)));
+}
+
+function lockLegacyCanvasPreview(node) {
+  if (!node || node.__easyuseAnimaLegacyCanvasPreviewLocked) {
+    return;
+  }
+  node.__easyuseAnimaLegacyCanvasPreviewLocked = true;
+  try {
+    Object.defineProperty(node, "imgs", {
+      configurable: true,
+      enumerable: false,
+      get() {
+        return [];
+      },
+      set() {
+        // Comfy syncs ui.images into node.imgs for legacy canvas previews.
+        // AiO keeps queue/history images but renders its own in-node preview.
+      },
+    });
+  } catch {
+    node.imgs = [];
+  }
+}
+
+export function aioPreviewNodeIdsFromDetail(detail) {
+  const ids = [];
+  for (const key of PREVIEW_NODE_ID_KEYS) {
+    const id = normalizeNodeId(detail?.[key]);
+    if (id && !ids.includes(id)) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+export function aioCreatePreviewProgressTracker() {
+  const progressByNode = new Map();
+
+  const remember = (detail) => {
+    const ids = aioPreviewNodeIdsFromDetail(detail);
+    if (!ids.length) {
+      return;
+    }
+    const value = Number(detail?.value);
+    const max = Number(detail?.max);
+    const promptId = normalizeNodeId(detail?.prompt_id ?? detail?.jobId ?? detail?.job_id);
+    const entry = {
+      value: Number.isFinite(value) ? value : 0,
+      max: Number.isFinite(max) ? max : 0,
+      promptId,
+      updatedAt: Date.now(),
+    };
+    for (const id of ids) {
+      progressByNode.set(id, entry);
+    }
+  };
+
+  const rememberState = (detail) => {
+    const nodes = detail?.nodes;
+    if (!nodes || typeof nodes !== "object") {
+      return;
+    }
+    for (const state of Object.values(nodes)) {
+      remember({
+        ...state,
+        prompt_id: state?.prompt_id || detail?.prompt_id,
+      });
+    }
+  };
+
+  const find = (detail) => {
+    const promptId = normalizeNodeId(detail?.prompt_id ?? detail?.jobId ?? detail?.job_id);
+    for (const id of aioPreviewNodeIdsFromDetail(detail)) {
+      const progress = progressByNode.get(id);
+      if (!progress) {
+        continue;
+      }
+      if (promptId && progress.promptId && promptId !== progress.promptId) {
+        continue;
+      }
+      return progress;
+    }
+    return null;
+  };
+
+  return {
+    remember,
+    rememberState,
+    find,
+    clear: () => progressByNode.clear(),
+  };
+}
+
+export function aioPreviewImages(message) {
+  const value = message?.easyuse_anima_preview;
+  const raw = Array.isArray(value) ? value : [firstValue(value, null)];
+  const images = [];
+  for (const item of raw) {
+    if (Array.isArray(item)) {
+      images.push(...item);
+    } else if (item) {
+      images.push(item);
+    }
+  }
+  return images.filter((item) => item && typeof item === "object" && !Array.isArray(item));
+}
+
+export function aioPreviewRunId(message) {
+  return String(firstValue(message?.easyuse_anima_run_id ?? message?.run_id, "") || "");
+}
+
+export function aioTagPreviewRun(images, runId = "", startIndex = 0) {
+  const normalizedRunId = runId || `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return images.map((image, index) => ({
+    ...image,
+    __aio_run_id: image.__aio_run_id || normalizedRunId,
+    __aio_run_index: Number.isInteger(image.__aio_run_index) ? image.__aio_run_index : startIndex + index,
+  }));
+}
+
+export function aioMergePreviewImages(existingImages, nextImages, runId = "", limit = 0) {
+  const existing = Array.isArray(existingImages)
+    ? existingImages.filter((item) => item && typeof item === "object" && !Array.isArray(item))
+    : [];
+  const tagged = aioTagPreviewRun(nextImages, runId, existing.length);
+  const merged = [];
+  const indexByKey = new Map();
+  for (const item of [...existing, ...tagged]) {
+    const key = previewIdentity(item);
+    if (!key.replace(/\u0001/g, "")) {
+      merged.push(item);
+      continue;
+    }
+    if (indexByKey.has(key)) {
+      const index = indexByKey.get(key);
+      merged[index] = { ...merged[index], ...item };
+    } else {
+      indexByKey.set(key, merged.length);
+      merged.push(item);
+    }
+  }
+  return limit > 0 ? merged.slice(Math.max(0, merged.length - limit)) : merged;
+}
+
+export function aioAppendPreviewFeed(existingImages, nextImages, settings, runId = "", fallbackLimit = 12) {
+  return aioMergePreviewImages(
+    existingImages,
+    nextImages,
+    runId,
+    previewFeedLimit(settings, fallbackLimit),
+  );
+}
+
+export function aioRemovePreviewRun(images, runId = "") {
+  const normalizedRunId = String(runId || "");
+  if (!normalizedRunId || !Array.isArray(images)) {
+    return Array.isArray(images) ? images : [];
+  }
+  return images.filter((item) => String(item?.__aio_run_id || "") !== normalizedRunId);
+}
+
+export function aioPreviewEventDetail(event) {
+  const detail = event?.detail || {};
+  if (detail?.data && typeof detail.data === "object") {
+    return detail.data;
+  }
+  return detail;
+}
+
+export function aioPreviewImageLabel(image) {
+  return String(image?.label || image?.stage || "Preview");
+}
+
+export function aioPreviewImageName(image) {
+  return String(image?.filename || image?.name || aioPreviewImageLabel(image) || "-");
+}
+
+export function aioPreviewResolution(image) {
+  const width = Number(image?.width || 0);
+  const height = Number(image?.height || 0);
+  return width > 0 && height > 0 ? `${Math.trunc(width)} x ${Math.trunc(height)}` : "-";
+}
+
+export function aioPreviewFileSize(image) {
+  const bytes = Number(image?.bytes || image?.size || 0);
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "-";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const decimals = unit === 0 || value >= 10 ? 0 : 1;
+  return `${value.toFixed(decimals)} ${units[unit]}`;
+}
+
+export function aioDefaultPreviewIndex(images) {
+  if (!Array.isArray(images) || !images.length) {
+    return -1;
+  }
+  for (let index = images.length - 1; index >= 0; index -= 1) {
+    if (String(images[index]?.stage || "") === "final") {
+      return index;
+    }
+  }
+  return images.length - 1;
+}
+
+export function aioSelectedPreviewIndex(node, images) {
+  const selected = Number(node?.__easyuseAnimaSelectedPreviewIndex);
+  if (Number.isInteger(selected) && selected >= 0 && selected < images.length) {
+    return selected;
+  }
+  return aioDefaultPreviewIndex(images);
+}
+
+export function aioMainPreviewImage(node, images) {
+  const index = aioSelectedPreviewIndex(node, images);
+  return index >= 0 ? images[index] : null;
+}
+
+export function aioDeletePreviewStoreEntry(container, locator) {
+  if (!container || !locator) {
+    return;
+  }
+  try {
+    const target = container.value && typeof container.value === "object"
+      ? container.value
+      : container;
+    if (target instanceof Map) {
+      target.delete(locator);
+    } else if (typeof target === "object") {
+      delete target[locator];
+    }
+  } catch {
+    // Store shapes differ across ComfyUI frontend builds.
+  }
+}
+
+export function aioSuppressDefaultPreview(node, options = {}) {
+  if (!node) {
+    return false;
+  }
+  lockLegacyCanvasPreview(node);
+  const shouldMarkDirty = options.markDirty !== false;
+  let changed = false;
+  if (node.hideOutputImages !== true) {
+    node.hideOutputImages = true;
+    changed = true;
+  }
+  for (const key of ["imgs", "images", "imageRects"]) {
+    if (!Array.isArray(node[key]) || node[key].length) {
+      node[key] = [];
+      changed = true;
+    }
+  }
+  for (const key of ["imageIndex", "overIndex"]) {
+    if (node[key] !== null) {
+      node[key] = null;
+      changed = true;
+    }
+  }
+  if (node.previewMediaType !== undefined) {
+    node.previewMediaType = undefined;
+    changed = true;
+  }
+  if (changed && shouldMarkDirty) {
+    options.markNodeDirty?.(node);
+  }
+  return changed;
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -15,6 +15,26 @@ import {
   aioQueryOptionalDependencies,
   aioUpscaleBackendMissingPacks,
 } from "./aio/dependencies.js";
+import {
+  aioAppendPreviewFeed,
+  aioCreatePreviewProgressTracker,
+  aioDefaultPreviewIndex,
+  aioDeletePreviewStoreEntry,
+  aioMainPreviewImage,
+  aioMergePreviewImages,
+  aioPreviewEventDetail,
+  aioPreviewFileSize,
+  aioPreviewImageLabel,
+  aioPreviewImageName,
+  aioPreviewImages,
+  aioPreviewNodeIdsFromDetail,
+  aioPreviewResolution,
+  aioPreviewRunId,
+  aioRemovePreviewRun,
+  aioSelectedPreviewIndex,
+  aioSuppressDefaultPreview,
+  aioTagPreviewRun,
+} from "./aio/preview.js";
 import { aioPanelFromWheelEvent, consumeAioPanelWheel } from "./aio/wheel.js";
 import {
   aioBuiltinProfileIdForSettings,
@@ -34,17 +54,6 @@ const GENERATOR_SETTINGS_WIDGET = "generation_settings";
 const GENERATOR_PROFILE_CUSTOM_VALUE = "custom";
 const GENERATOR_DOM_WIDGET = "easyuse_anima_generator_panel";
 const GENERATOR_PREVIEW_EVENT = "easyuse-anima-aio-preview";
-const GENERATOR_DENOISE_PREVIEW_NODE_KEYS = [
-  "displayNodeId",
-  "nodeId",
-  "realNodeId",
-  "parentNodeId",
-  "display_node_id",
-  "node_id",
-  "real_node_id",
-  "parent_node_id",
-  "node",
-];
 const GENERATOR_SEED_CONTROLS = ["fixed", "randomize", "increment", "decrement"];
 const GENERATOR_SPECIAL_SEED_RANDOM = -1;
 const GENERATOR_SPECIAL_SEED_INCREMENT = -2;
@@ -4100,69 +4109,12 @@ function firstValue(value, fallback = "") {
   return value ?? fallback;
 }
 
-const GENERATOR_PROGRESS_BY_NODE = new Map();
-
-function normalizeGeneratorNodeId(value) {
-  return value == null ? "" : String(value).trim();
-}
-
-function generatorNodeIdsFromDetail(detail) {
-  const ids = [];
-  for (const key of GENERATOR_DENOISE_PREVIEW_NODE_KEYS) {
-    const id = normalizeGeneratorNodeId(detail?.[key]);
-    if (id && !ids.includes(id)) {
-      ids.push(id);
-    }
-  }
-  return ids;
-}
-
-function rememberGeneratorProgress(detail) {
-  const ids = generatorNodeIdsFromDetail(detail);
-  if (!ids.length) {
-    return;
-  }
-  const value = Number(detail?.value);
-  const max = Number(detail?.max);
-  const promptId = normalizeGeneratorNodeId(detail?.prompt_id ?? detail?.jobId ?? detail?.job_id);
-  const entry = {
-    value: Number.isFinite(value) ? value : 0,
-    max: Number.isFinite(max) ? max : 0,
-    promptId,
-    updatedAt: Date.now(),
-  };
-  for (const id of ids) {
-    GENERATOR_PROGRESS_BY_NODE.set(id, entry);
-  }
-}
-
-function rememberGeneratorProgressState(detail) {
-  const nodes = detail?.nodes;
-  if (!nodes || typeof nodes !== "object") {
-    return;
-  }
-  for (const state of Object.values(nodes)) {
-    rememberGeneratorProgress({
-      ...state,
-      prompt_id: state?.prompt_id || detail?.prompt_id,
-    });
-  }
-}
-
-function generatorProgressForPreviewDetail(detail) {
-  const promptId = normalizeGeneratorNodeId(detail?.prompt_id ?? detail?.jobId ?? detail?.job_id);
-  for (const id of generatorNodeIdsFromDetail(detail)) {
-    const progress = GENERATOR_PROGRESS_BY_NODE.get(id);
-    if (!progress) {
-      continue;
-    }
-    if (promptId && progress.promptId && promptId !== progress.promptId) {
-      continue;
-    }
-    return progress;
-  }
-  return null;
-}
+const {
+  remember: rememberGeneratorProgress,
+  rememberState: rememberGeneratorProgressState,
+  find: generatorProgressForPreviewDetail,
+  clear: clearGeneratorPreviewProgress,
+} = aioCreatePreviewProgressTracker();
 
 function generatorDenoisePreviewLabel(preview) {
   const base = aioText("text.previewDenoise");
@@ -4214,100 +4166,6 @@ function setGeneratorDenoisePreview(node, blob, detail = {}) {
   markNodeDirty(node);
 }
 
-function generatorPreviewImages(message) {
-  const value = message?.easyuse_anima_preview;
-  const raw = Array.isArray(value) ? value : [firstValue(value, null)];
-  const images = [];
-  for (const item of raw) {
-    if (Array.isArray(item)) {
-      images.push(...item);
-    } else if (item) {
-      images.push(item);
-    }
-  }
-  return images.filter((item) => item && typeof item === "object" && !Array.isArray(item));
-}
-
-function generatorPreviewRunId(message) {
-  return String(firstValue(message?.easyuse_anima_run_id ?? message?.run_id, "") || "");
-}
-
-function generatorPreviewFeedLimit(settings) {
-  return Math.trunc(clampGeneratorNumber(
-    settings?.preview?.feed_count,
-    DEFAULT_GENERATION_SETTINGS.preview.feed_count,
-    1,
-    100,
-  ));
-}
-
-function generatorPreviewIdentity(image) {
-  return [
-    image?.stage || "",
-    image?.type || "",
-    image?.subfolder || "",
-    image?.filename || image?.name || "",
-  ].map((part) => String(part)).join("\u0001");
-}
-
-function tagGeneratorPreviewRun(images, runId = "", startIndex = 0) {
-  const normalizedRunId = runId || `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  return images.map((image, index) => ({
-    ...image,
-    __aio_run_id: image.__aio_run_id || normalizedRunId,
-    __aio_run_index: Number.isInteger(image.__aio_run_index) ? image.__aio_run_index : startIndex + index,
-  }));
-}
-
-function mergeGeneratorPreviewImages(existingImages, nextImages, runId = "", limit = 0) {
-  const existing = Array.isArray(existingImages)
-    ? existingImages.filter((item) => item && typeof item === "object" && !Array.isArray(item))
-    : [];
-  const tagged = tagGeneratorPreviewRun(nextImages, runId, existing.length);
-  const merged = [];
-  const indexByKey = new Map();
-  for (const item of [...existing, ...tagged]) {
-    const key = generatorPreviewIdentity(item);
-    if (!key.replace(/\u0001/g, "")) {
-      merged.push(item);
-      continue;
-    }
-    if (indexByKey.has(key)) {
-      const index = indexByKey.get(key);
-      merged[index] = { ...merged[index], ...item };
-    } else {
-      indexByKey.set(key, merged.length);
-      merged.push(item);
-    }
-  }
-  return limit > 0 ? merged.slice(Math.max(0, merged.length - limit)) : merged;
-}
-
-function appendGeneratorPreviewFeed(existingImages, nextImages, settings, runId = "") {
-  return mergeGeneratorPreviewImages(
-    existingImages,
-    nextImages,
-    runId,
-    generatorPreviewFeedLimit(settings),
-  );
-}
-
-function removeGeneratorPreviewRun(images, runId = "") {
-  const normalizedRunId = String(runId || "");
-  if (!normalizedRunId || !Array.isArray(images)) {
-    return Array.isArray(images) ? images : [];
-  }
-  return images.filter((item) => String(item?.__aio_run_id || "") !== normalizedRunId);
-}
-
-function generatorPreviewEventDetail(event) {
-  const detail = event?.detail || {};
-  if (detail?.data && typeof detail.data === "object") {
-    return detail.data;
-  }
-  return detail;
-}
-
 function generatorImageUrl(image) {
   if (!image || typeof image !== "object") {
     return "";
@@ -4324,61 +4182,6 @@ function generatorImageUrl(image) {
   params.set("preview", "webp;90");
   const path = `/view?${params.toString()}`;
   return typeof api?.apiURL === "function" ? api.apiURL(path) : path;
-}
-
-function generatorPreviewImageLabel(image) {
-  return String(image?.label || image?.stage || "Preview");
-}
-
-function generatorPreviewImageName(image) {
-  return String(image?.filename || image?.name || generatorPreviewImageLabel(image) || "-");
-}
-
-function generatorPreviewResolution(image) {
-  const width = Number(image?.width || 0);
-  const height = Number(image?.height || 0);
-  return width > 0 && height > 0 ? `${Math.trunc(width)} x ${Math.trunc(height)}` : "-";
-}
-
-function generatorPreviewFileSize(image) {
-  const bytes = Number(image?.bytes || image?.size || 0);
-  if (!Number.isFinite(bytes) || bytes <= 0) {
-    return "-";
-  }
-  const units = ["B", "KB", "MB", "GB"];
-  let value = bytes;
-  let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  const decimals = unit === 0 || value >= 10 ? 0 : 1;
-  return `${value.toFixed(decimals)} ${units[unit]}`;
-}
-
-function generatorDefaultPreviewIndex(images) {
-  if (!Array.isArray(images) || !images.length) {
-    return -1;
-  }
-  for (let index = images.length - 1; index >= 0; index -= 1) {
-    if (String(images[index]?.stage || "") === "final") {
-      return index;
-    }
-  }
-  return images.length - 1;
-}
-
-function generatorSelectedPreviewIndex(node, images) {
-  const selected = Number(node?.__easyuseAnimaSelectedPreviewIndex);
-  if (Number.isInteger(selected) && selected >= 0 && selected < images.length) {
-    return selected;
-  }
-  return generatorDefaultPreviewIndex(images);
-}
-
-function generatorMainPreviewImage(node, images) {
-  const index = generatorSelectedPreviewIndex(node, images);
-  return index >= 0 ? images[index] : null;
 }
 
 function normalizeSeedControl(value) {
@@ -4881,13 +4684,13 @@ function renderGeneratorPreviewFeed(node, panel, images, settings, selectedIndex
       thumb.classList.add("active");
       selectedThumb = thumb;
     }
-    thumb.title = generatorPreviewImageLabel(image);
+    thumb.title = aioPreviewImageLabel(image);
     const thumbImage = document.createElement("img");
     thumbImage.src = thumbUrl;
     thumbImage.alt = "";
     thumbImage.loading = "lazy";
     const label = document.createElement("span");
-    label.textContent = generatorPreviewImageLabel(image);
+    label.textContent = aioPreviewImageLabel(image);
     thumb.append(thumbImage, label);
     thumb.addEventListener("click", () => {
       node.__easyuseAnimaSelectedPreviewIndex = index;
@@ -4941,7 +4744,7 @@ function updateGeneratorDomPreview(node) {
       panel,
       feedImages,
       settings,
-      generatorSelectedPreviewIndex(node, feedImages),
+      aioSelectedPreviewIndex(node, feedImages),
       { showPending: true },
     );
     const metaEl = panel.querySelector("[data-aio-preview-meta]");
@@ -4967,18 +4770,18 @@ function updateGeneratorDomPreview(node) {
     }
     return;
   }
-  const currentImage = generatorMainPreviewImage(node, images);
+  const currentImage = aioMainPreviewImage(node, images);
   const imageUrl = generatorImageUrl(currentImage);
   if (!currentImage || !imageUrl) {
     return;
   }
-  const selectedIndex = generatorSelectedPreviewIndex(node, images);
+  const selectedIndex = aioSelectedPreviewIndex(node, images);
   const metaEl = panel.querySelector("[data-aio-preview-meta]");
   if (metaEl) {
     const parts = [
-      generatorPreviewImageName(currentImage),
-      generatorPreviewResolution(currentImage),
-      generatorPreviewFileSize(currentImage),
+      aioPreviewImageName(currentImage),
+      aioPreviewResolution(currentImage),
+      aioPreviewFileSize(currentImage),
     ].filter((part) => part && part !== "-");
     const metaText = parts.length ? parts.join(" · ") : "-";
     metaEl.textContent = metaText;
@@ -5030,8 +4833,8 @@ function updateGeneratorDomPreview(node) {
     const labels = document.createElement("div");
     labels.className = "easyuse-anima-aio-node-preview-compare-labels";
     labels.append(
-      makeCompareLabel("current", `${aioText("text.previewCurrent")} · ${generatorPreviewImageLabel(currentImage)}`),
-      makeCompareLabel("previous", `${aioText("text.previewPrevious")} · ${generatorPreviewImageLabel(previousImage)}`),
+      makeCompareLabel("current", `${aioText("text.previewCurrent")} · ${aioPreviewImageLabel(currentImage)}`),
+      makeCompareLabel("previous", `${aioText("text.previewPrevious")} · ${aioPreviewImageLabel(previousImage)}`),
     );
     compare.append(
       makeLayer("before", currentImage),
@@ -5141,10 +4944,8 @@ function generatorPreviewLocatorCandidates(node, detail = null) {
   if (node?.id != null) {
     addGeneratorPreviewLocatorCandidate(ids, node.id);
   }
-  for (const key of GENERATOR_DENOISE_PREVIEW_NODE_KEYS) {
-    if (detail?.[key] != null) {
-      addGeneratorPreviewLocatorCandidate(ids, detail[key]);
-    }
+  for (const id of aioPreviewNodeIdsFromDetail(detail)) {
+    addGeneratorPreviewLocatorCandidate(ids, id);
   }
   for (const root of generatorVueNodeRoots(node)) {
     addGeneratorPreviewLocatorCandidate(ids, root.getAttribute?.("data-node-id"));
@@ -5297,24 +5098,6 @@ async function generatorNativePreviewStores() {
   return generatorNativePreviewStoresPromise;
 }
 
-function deleteGeneratorPreviewStoreEntry(container, locator) {
-  if (!container || !locator) {
-    return;
-  }
-  try {
-    const target = container.value && typeof container.value === "object"
-      ? container.value
-      : container;
-    if (target instanceof Map) {
-      target.delete(locator);
-    } else if (typeof target === "object") {
-      delete target[locator];
-    }
-  } catch {
-    // Store shape differs across ComfyUI frontend builds; DOM fallback still runs.
-  }
-}
-
 async function purgeGeneratorNativeLivePreviewStore(node, detail = null) {
   try {
     if (!node) {
@@ -5326,7 +5109,7 @@ async function purgeGeneratorNativeLivePreviewStore(node, detail = null) {
     }
     if (app.nodePreviewImages && typeof app.nodePreviewImages === "object") {
       for (const id of ids) {
-        deleteGeneratorPreviewStoreEntry(app.nodePreviewImages, id);
+        aioDeletePreviewStoreEntry(app.nodePreviewImages, id);
       }
     }
 
@@ -5350,7 +5133,7 @@ async function purgeGeneratorNativeLivePreviewStore(node, detail = null) {
     }
     for (const locator of locators) {
       outputStore.revokePreviewsByLocatorId?.(locator);
-      deleteGeneratorPreviewStoreEntry(outputStore.nodePreviewImages, locator);
+      aioDeletePreviewStoreEntry(outputStore.nodePreviewImages, locator);
     }
   } catch {
     // Native preview store access is version-dependent; CSS/DOM fallback remains scoped to this node.
@@ -5424,57 +5207,10 @@ function scheduleGeneratorNativeLivePreviewHidden(node) {
 }
 
 function suppressGeneratorDefaultPreview(node, options = {}) {
-  if (!node) {
-    return;
-  }
-  lockGeneratorLegacyCanvasPreview(node);
-  const shouldMarkDirty = options.markDirty !== false;
-  let changed = false;
-  if (node.hideOutputImages !== true) {
-    node.hideOutputImages = true;
-    changed = true;
-  }
-  for (const key of ["imgs", "images", "imageRects"]) {
-    if (!Array.isArray(node[key]) || node[key].length) {
-      node[key] = [];
-      changed = true;
-    }
-  }
-  for (const key of ["imageIndex", "overIndex"]) {
-    if (node[key] !== null) {
-      node[key] = null;
-      changed = true;
-    }
-  }
-  if (node.previewMediaType !== undefined) {
-    node.previewMediaType = undefined;
-    changed = true;
-  }
-  if (changed && shouldMarkDirty) {
-    markNodeDirty(node);
-  }
-}
-
-function lockGeneratorLegacyCanvasPreview(node) {
-  if (!node || node.__easyuseAnimaLegacyCanvasPreviewLocked) {
-    return;
-  }
-  node.__easyuseAnimaLegacyCanvasPreviewLocked = true;
-  try {
-    Object.defineProperty(node, "imgs", {
-      configurable: true,
-      enumerable: false,
-      get() {
-        return [];
-      },
-      set() {
-        // Comfy syncs ui.images into node.imgs for legacy canvas previews.
-        // AiO keeps queue/history images but renders its own in-node preview.
-      },
-    });
-  } catch {
-    node.imgs = [];
-  }
+  return aioSuppressDefaultPreview(node, {
+    markDirty: options.markDirty,
+    markNodeDirty,
+  });
 }
 
 function scheduleGeneratorDefaultPreviewSuppression(node, options = {}) {
@@ -7942,7 +7678,7 @@ function openPreviewSettings(node) {
     node.__easyuseAnimaGeneratorPreviewImages = next.preview.image_feed
       ? (node.__easyuseAnimaGeneratorPreviewFeedImages || [])
       : (node.__easyuseAnimaGeneratorCurrentRunImages || []);
-    node.__easyuseAnimaSelectedPreviewIndex = generatorDefaultPreviewIndex(node.__easyuseAnimaGeneratorPreviewImages);
+    node.__easyuseAnimaSelectedPreviewIndex = aioDefaultPreviewIndex(node.__easyuseAnimaGeneratorPreviewImages);
     applyVisibleGeneratorSettings(node, next);
     writeSettings(node, widget, next);
     renderGeneratorPanel(node);
@@ -8583,23 +8319,24 @@ function addGeneratorPreviewImagesToNode(node, nextImages, runId = "", options =
   const currentBase = replaceCurrentRun || (runId && currentRunId && currentRunId !== runId)
     ? []
     : currentImages;
-  const taggedNextImages = tagGeneratorPreviewRun(nextImages, runId, currentBase.length);
-  node.__easyuseAnimaGeneratorCurrentRunImages = mergeGeneratorPreviewImages(currentBase, taggedNextImages, runId);
+  const taggedNextImages = aioTagPreviewRun(nextImages, runId, currentBase.length);
+  node.__easyuseAnimaGeneratorCurrentRunImages = aioMergePreviewImages(currentBase, taggedNextImages, runId);
   if (settings.preview.image_feed) {
     const feedBase = replaceCurrentRun
-      ? removeGeneratorPreviewRun(node.__easyuseAnimaGeneratorPreviewFeedImages, runId)
+      ? aioRemovePreviewRun(node.__easyuseAnimaGeneratorPreviewFeedImages, runId)
       : node.__easyuseAnimaGeneratorPreviewFeedImages;
-    node.__easyuseAnimaGeneratorPreviewFeedImages = appendGeneratorPreviewFeed(
+    node.__easyuseAnimaGeneratorPreviewFeedImages = aioAppendPreviewFeed(
       feedBase,
       taggedNextImages,
       settings,
       runId,
+      DEFAULT_GENERATION_SETTINGS.preview.feed_count,
     );
     node.__easyuseAnimaGeneratorPreviewImages = node.__easyuseAnimaGeneratorPreviewFeedImages;
   } else {
     node.__easyuseAnimaGeneratorPreviewImages = node.__easyuseAnimaGeneratorCurrentRunImages;
   }
-  node.__easyuseAnimaSelectedPreviewIndex = generatorDefaultPreviewIndex(node.__easyuseAnimaGeneratorPreviewImages);
+  node.__easyuseAnimaSelectedPreviewIndex = aioDefaultPreviewIndex(node.__easyuseAnimaGeneratorPreviewImages);
   updateGeneratorDomSummary(node);
   requestAnimationFrame(() => updateGeneratorDomSummary(node));
   scheduleGeneratorLayout(node);
@@ -8610,8 +8347,8 @@ function updateGeneratorExecutedStatus(node, message) {
   if (!node) {
     return;
   }
-  const nextImages = generatorPreviewImages(message);
-  const runId = generatorPreviewRunId(message);
+  const nextImages = aioPreviewImages(message);
+  const runId = aioPreviewRunId(message);
   addGeneratorPreviewImagesToNode(node, nextImages, runId, { replaceCurrentRun: true });
   node.__easyuseAnimaGeneratorStatus = {
     status: String(firstValue(message?.status, "generated") || "generated"),
@@ -8624,19 +8361,19 @@ function updateGeneratorExecutedStatus(node, message) {
 }
 
 function handleGeneratorPreviewEvent(event) {
-  const detail = generatorPreviewEventDetail(event);
+  const detail = aioPreviewEventDetail(event);
   const node = findGeneratorNodeByQualifiedId(app.graph, detail.node);
   if (!node || node.type !== GENERATOR_NODE_TYPE) {
     return;
   }
   scheduleGeneratorNativeLivePreviewPurge(node, detail);
-  const images = generatorPreviewImages({ easyuse_anima_preview: detail.images });
+  const images = aioPreviewImages({ easyuse_anima_preview: detail.images });
   scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
   addGeneratorPreviewImagesToNode(node, images, String(detail.run_id || ""));
 }
 
 function findGeneratorNodeForDenoisePreview(detail) {
-  for (const id of generatorNodeIdsFromDetail(detail)) {
+  for (const id of aioPreviewNodeIdsFromDetail(detail)) {
     const node = findGeneratorNodeByQualifiedId(app.graph, id);
     if (node?.type === GENERATOR_NODE_TYPE) {
       return node;
@@ -8646,15 +8383,15 @@ function findGeneratorNodeForDenoisePreview(detail) {
 }
 
 function handleGeneratorProgressEvent(event) {
-  rememberGeneratorProgress(generatorPreviewEventDetail(event));
+  rememberGeneratorProgress(aioPreviewEventDetail(event));
 }
 
 function handleGeneratorProgressStateEvent(event) {
-  rememberGeneratorProgressState(generatorPreviewEventDetail(event));
+  rememberGeneratorProgressState(aioPreviewEventDetail(event));
 }
 
 function handleGeneratorDenoisePreviewEvent(event) {
-  const detail = generatorPreviewEventDetail(event);
+  const detail = aioPreviewEventDetail(event);
   const node = findGeneratorNodeForDenoisePreview(detail);
   const blob = detail?.blob;
   if (!node || !blob) {
@@ -8667,7 +8404,7 @@ function handleGeneratorDenoisePreviewEvent(event) {
 }
 
 function handleGeneratorExecutingEvent(event) {
-  const nodeId = generatorPreviewEventDetail(event);
+  const nodeId = aioPreviewEventDetail(event);
   const node = findGeneratorNodeByQualifiedId(app.graph, nodeId);
   if (node?.type === GENERATOR_NODE_TYPE) {
     clearGeneratorDenoisePreview(node, true);
@@ -8676,7 +8413,7 @@ function handleGeneratorExecutingEvent(event) {
 }
 
 function clearGeneratorDenoisePreviews() {
-  GENERATOR_PROGRESS_BY_NODE.clear();
+  clearGeneratorPreviewProgress();
   for (const node of generatorGraphNodes()) {
     if (node?.type === GENERATOR_NODE_TYPE) {
       clearGeneratorDenoisePreview(node, true);


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 프리뷰 상태 처리, 실행별 이미지 병합·선택, progress 추적, native preview 억제 primitive를 DOM-free `web/js/aio/preview.js` 모듈로 분리했습니다.
- `easyuse_anima_aio.js`는 DOM 렌더링, ComfyUI store 연결, 이벤트·observer·timer, extension 등록만 조정하는 entry 역할을 유지합니다.
- 기존 widget/socket/API/workflow 직렬화와 raw ES module 로딩 계약은 변경하지 않았습니다.

## 주요 파일

- `web/js/aio/preview.js`
  - node ID alias 정규화
  - prompt별 preview progress 추적
  - payload 정규화, run tagging, feed 병합·제한·선택
  - Map/ref/plain-object preview store 삭제
  - legacy `imgs` lock과 native preview 상태 억제
- `web/js/easyuse_anima_aio.js`
  - 위 pure primitive를 import하고 DOM/store orchestration만 유지
- `tests/frontend_aio_preview_core_smoke.mjs`
  - preview 상태·병합·선택·store·suppression 의미 검증
- `tests/test_frontend_modules.py`, `tests/test_aio_frontend.py`, `tools/check_frontend.ps1`
  - 모듈 경계와 runner 회귀 검사 추가

## 검증

- `tools/check_project.ps1 -Profile full`
  - Python unittest: **328 passed**
  - Frontend: **67 JavaScript files**, TypeScript **6.0.3**
  - highlight/profile/dependency/preview/regional semantic smoke: **PASS**
  - `git diff --check`: **PASS**
- ComfyUI **0.27.0**, legacy canvas
  - 실제 1-step queue 완료
  - AiO 커스텀 main/feed preview 표시
  - 패널 밖 native preview 이미지 없음
- ComfyUI **0.27.0**, Node 2.0
  - 실제 1-step queue 완료
  - AiO 커스텀 main/feed preview 표시
  - native preview 이미지와 native main-image 후보 없음
- 두 표면 모두 EasyUseAnima frontend console error 없음

## 호환성과 남은 범위

- 프리뷰 동작 변경이 아닌 모듈 경계 분리가 목적입니다.
- DOM dialog, dynamic store import, MutationObserver/timer, queue/runtime hook은 후속 maintenance slice에서 계속 분리할 수 있도록 entry에 남겼습니다.
- 실사용 환경의 수동 브라우저 확인은 별도 확인 항목입니다.

Refs #54
