### PR TITLE
[Maintenance] AiO settings schema 경계 분리

### DIFF
--- a/tests/frontend_aio_settings_core_smoke.mjs
+++ b/tests/frontend_aio_settings_core_smoke.mjs
@@ -1,0 +1,374 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertJsonEqual(actual, expected, message) {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+const {
+  AIO_DEFAULT_GENERATION_SETTINGS,
+  AIO_DEFAULT_INPUT_SETTINGS,
+  AIO_GENERATOR_MAX_SEED,
+  AIO_GENERATOR_SEED_CONTROLS,
+  AIO_GENERATOR_SPECIAL_SEED_DECREMENT,
+  AIO_GENERATOR_SPECIAL_SEED_INCREMENT,
+  AIO_GENERATOR_SPECIAL_SEED_RANDOM,
+  aioAsBool,
+  aioCloneJson,
+  aioMergeDefaults,
+  aioMigrateGeneratorPostprocessSettings,
+  aioNormalizeGeneratorPreviewSettings,
+  aioNormalizeSeedControl,
+  aioNormalizeSeedValue,
+  aioParseSettingsValue,
+  aioSettingsToCompactJson,
+} = settingsModule;
+
+assert(
+  AIO_DEFAULT_INPUT_SETTINGS.schema === "easy_use_anima_input"
+    && AIO_DEFAULT_INPUT_SETTINGS.version === 1,
+  "AiO input settings must keep their versioned schema",
+);
+assertJsonEqual(
+  AIO_DEFAULT_INPUT_SETTINGS.resources,
+  {
+    loader_mode: "split",
+    clip_loader: "single",
+    unet_weight_dtype: "default",
+    clip_device: "default",
+  },
+  "AiO input resource defaults must remain stable",
+);
+assert(
+  AIO_DEFAULT_GENERATION_SETTINGS.schema === "easyuse_anima_aio_generation_settings"
+    && AIO_DEFAULT_GENERATION_SETTINGS.version === 1
+    && AIO_DEFAULT_GENERATION_SETTINGS.mode === "txt2img",
+  "AiO generation settings must keep their versioned schema",
+);
+assert(
+  AIO_DEFAULT_GENERATION_SETTINGS.sampler.seed === AIO_GENERATOR_SPECIAL_SEED_RANDOM
+    && AIO_DEFAULT_GENERATION_SETTINGS.sampler.steps === 32
+    && AIO_DEFAULT_GENERATION_SETTINGS.sampler.cfg === 5
+    && AIO_DEFAULT_GENERATION_SETTINGS.preview.feed_count === 12,
+  "AiO generation defaults must retain their serialized baseline",
+);
+
+const cloneSource = {
+  nested: { value: 1 },
+  rows: [{ name: "first" }],
+};
+const cloned = aioCloneJson(cloneSource);
+assertJsonEqual(cloned, cloneSource, "JSON cloning must preserve serializable data");
+cloned.nested.value = 2;
+cloned.rows[0].name = "changed";
+assert(
+  cloneSource.nested.value === 1 && cloneSource.rows[0].name === "first",
+  "JSON cloning must detach nested objects and arrays",
+);
+
+const mergeDefaults = {
+  enabled: false,
+  nested: {
+    alpha: 1,
+    beta: 2,
+  },
+  rows: ["default-a", "default-b"],
+};
+const mergeValue = {
+  nested: {
+    beta: 9,
+    future_nested: "kept",
+  },
+  rows: ["replacement"],
+  future_root: {
+    value: 42,
+  },
+};
+const mergeDefaultsSnapshot = JSON.stringify(mergeDefaults);
+const mergeValueSnapshot = JSON.stringify(mergeValue);
+const merged = aioMergeDefaults(mergeDefaults, mergeValue);
+assertJsonEqual(
+  merged,
+  {
+    enabled: false,
+    nested: {
+      alpha: 1,
+      beta: 9,
+      future_nested: "kept",
+    },
+    rows: ["replacement"],
+    future_root: {
+      value: 42,
+    },
+  },
+  "Default merging must deep-merge objects, replace arrays, and preserve future keys",
+);
+assert(
+  JSON.stringify(mergeDefaults) === mergeDefaultsSnapshot
+    && JSON.stringify(mergeValue) === mergeValueSnapshot,
+  "Default merging must not mutate either input while merging",
+);
+assertJsonEqual(
+  aioMergeDefaults(mergeDefaults, null),
+  mergeDefaults,
+  "Invalid merge values must fall back to a cloned default object",
+);
+assertJsonEqual(
+  aioMergeDefaults(mergeDefaults, ["invalid"]),
+  mergeDefaults,
+  "Root arrays must not replace a settings object",
+);
+
+const partialInput = aioParseSettingsValue(JSON.stringify({
+  resources: {
+    future_loader_mode: "external",
+  },
+  future_root: {
+    enabled: true,
+  },
+}), AIO_DEFAULT_INPUT_SETTINGS);
+assert(
+  partialInput.resources.loader_mode === "split"
+    && partialInput.resources.future_loader_mode === "external"
+    && partialInput.future_root.enabled === true,
+  "Input settings parsing must merge defaults and preserve unknown future keys",
+);
+const invalidGeneration = aioParseSettingsValue("{", AIO_DEFAULT_GENERATION_SETTINGS);
+assertJsonEqual(
+  invalidGeneration,
+  AIO_DEFAULT_GENERATION_SETTINGS,
+  "Invalid generation JSON must fall back to versioned defaults",
+);
+invalidGeneration.sampler.steps = 1;
+assert(
+  AIO_DEFAULT_GENERATION_SETTINGS.sampler.steps === 32,
+  "Invalid JSON fallback must return a fresh settings clone",
+);
+assertJsonEqual(
+  aioParseSettingsValue("[]", AIO_DEFAULT_GENERATION_SETTINGS),
+  AIO_DEFAULT_GENERATION_SETTINGS,
+  "A root JSON array must fall back to generation defaults",
+);
+const parsedLegacyGeneration = aioParseSettingsValue(JSON.stringify({
+  upscale: {
+    fit: {
+      enabled: true,
+      mode: "megapixels",
+      max_megapixels: 9,
+    },
+  },
+}), AIO_DEFAULT_GENERATION_SETTINGS);
+assert(
+  !Object.prototype.hasOwnProperty.call(parsedLegacyGeneration.upscale, "fit")
+    && parsedLegacyGeneration.postprocess.enabled === true
+    && parsedLegacyGeneration.postprocess.fit.mode === "megapixels"
+    && parsedLegacyGeneration.postprocess.fit.max_megapixels === 9,
+  "Parsing with the canonical generation defaults must run legacy fit migration",
+);
+
+const legacySettings = aioMergeDefaults(AIO_DEFAULT_GENERATION_SETTINGS, {
+  upscale: {
+    fit: {
+      enabled: "true",
+      mode: "megapixels",
+      max_long_edge: 1536,
+      max_megapixels: 8,
+      method: "lanczos",
+    },
+  },
+});
+const migratedIdentity = aioMigrateGeneratorPostprocessSettings(legacySettings);
+assert(
+  migratedIdentity === legacySettings,
+  "Legacy postprocess migration must retain its current in-place mutation contract",
+);
+assert(
+  !Object.prototype.hasOwnProperty.call(legacySettings.upscale, "fit")
+    && legacySettings.postprocess.enabled === true,
+  "Legacy upscale.fit must be removed and enable the postprocess stage",
+);
+assertJsonEqual(
+  legacySettings.postprocess.fit,
+  {
+    mode: "megapixels",
+    max_long_edge: 1536,
+    max_megapixels: 8,
+    method: "lanczos",
+  },
+  "Legacy final-fit fields must migrate into postprocess.fit",
+);
+const migratedSnapshot = JSON.stringify(legacySettings);
+aioMigrateGeneratorPostprocessSettings(legacySettings);
+assert(
+  JSON.stringify(legacySettings) === migratedSnapshot,
+  "Legacy postprocess migration must be idempotent",
+);
+
+const precedenceSettings = aioMergeDefaults(AIO_DEFAULT_GENERATION_SETTINGS, {
+  upscale: {
+    fit: {
+      enabled: true,
+      mode: "max_long_edge",
+      max_long_edge: 1024,
+      max_megapixels: 2,
+      method: "bicubic",
+    },
+  },
+  postprocess: {
+    enabled: false,
+    fit: {
+      mode: "megapixels",
+      max_long_edge: 3072,
+      max_megapixels: 12,
+      method: "lanczos",
+    },
+  },
+});
+aioMigrateGeneratorPostprocessSettings(precedenceSettings);
+assertJsonEqual(
+  precedenceSettings.postprocess.fit,
+  {
+    mode: "megapixels",
+    max_long_edge: 3072,
+    max_megapixels: 12,
+    method: "lanczos",
+  },
+  "Explicit non-default postprocess values must win over legacy upscale.fit values",
+);
+assert(
+  precedenceSettings.postprocess.enabled === true,
+  "The legacy enabled flag must keep enabling postprocess during migration",
+);
+
+for (const value of [true, "true", "1", "yes", "on", " TRUE "]) {
+  assert(aioAsBool(value, false) === true, `Boolean value ${String(value)} must normalize true`);
+}
+for (const value of [false, "false", "0", "no", "off", " FALSE "]) {
+  assert(aioAsBool(value, true) === false, `Boolean value ${String(value)} must normalize false`);
+}
+assert(aioAsBool(null, true) === true, "Null booleans must use their fallback");
+assert(aioAsBool(undefined, false) === false, "Missing booleans must use their fallback");
+
+assertJsonEqual(
+  AIO_GENERATOR_SEED_CONTROLS,
+  ["fixed", "randomize", "increment", "decrement"],
+  "AiO seed control modes must remain stable",
+);
+assert(
+  AIO_GENERATOR_SPECIAL_SEED_RANDOM === -1
+    && AIO_GENERATOR_SPECIAL_SEED_INCREMENT === -2
+    && AIO_GENERATOR_SPECIAL_SEED_DECREMENT === -3,
+  "rgthree-compatible special seed values must remain stable",
+);
+assert(
+  aioNormalizeSeedControl(" increment ") === "increment"
+    && aioNormalizeSeedControl("invalid") === "fixed",
+  "Seed controls must trim valid values and fall back to fixed",
+);
+assert(aioNormalizeSeedValue("12.9") === 12, "Seed values must truncate finite numbers");
+assert(
+  aioNormalizeSeedValue("invalid", 77) === 77,
+  "Invalid seed values must use the supplied fallback",
+);
+assert(
+  aioNormalizeSeedValue(-999) === AIO_GENERATOR_SPECIAL_SEED_DECREMENT,
+  "Seeds below the rgthree decrement sentinel must clamp to -3",
+);
+assert(
+  aioNormalizeSeedValue(AIO_GENERATOR_MAX_SEED + 100) === AIO_GENERATOR_MAX_SEED,
+  "Seeds above ComfyUI's supported range must clamp to the maximum",
+);
+
+const previewSettings = {
+  save: {
+    image_saver: {
+      show_preview: true,
+      future_save_key: "kept",
+    },
+  },
+  preview: {
+    intermediate_images: "yes",
+    compare_previous: "0",
+    image_feed: "off",
+    feed_count: 999,
+    future_preview_key: "kept",
+  },
+};
+const normalizedPreview = aioNormalizeGeneratorPreviewSettings(previewSettings);
+assert(
+  normalizedPreview === previewSettings.preview,
+  "Preview normalization must return the preview object stored on the settings input",
+);
+assert(
+  normalizedPreview.intermediate_images === true
+    && normalizedPreview.compare_previous === false
+    && normalizedPreview.image_feed === false
+    && normalizedPreview.feed_count === 100,
+  "Preview booleans and feed count must normalize to their UI contract",
+);
+assert(
+  normalizedPreview.future_preview_key === "kept"
+    && previewSettings.save.image_saver.future_save_key === "kept"
+    && !Object.prototype.hasOwnProperty.call(previewSettings.save.image_saver, "show_preview"),
+  "Preview normalization must preserve future keys and remove legacy show_preview",
+);
+const minimumPreviewSettings = { preview: { feed_count: 0 } };
+aioNormalizeGeneratorPreviewSettings(minimumPreviewSettings);
+assert(minimumPreviewSettings.preview.feed_count === 1, "Preview feed count must clamp to one");
+const fallbackPreviewSettings = { preview: { feed_count: "invalid" } };
+aioNormalizeGeneratorPreviewSettings(fallbackPreviewSettings);
+assert(fallbackPreviewSettings.preview.feed_count === 12, "Invalid preview feed counts must use defaults");
+
+const compactSource = {
+  sampler: {
+    steps: 24,
+  },
+  save: {
+    filename_prefix: "legacy/prefix",
+    image_saver: {
+      show_preview: true,
+    },
+  },
+  preview: {
+    feed_count: 0,
+  },
+  future_section: {
+    value: 42,
+  },
+};
+const compactSourceSnapshot = JSON.stringify(compactSource);
+const compactJson = aioSettingsToCompactJson(compactSource);
+assert(!compactJson.includes("\n"), "Serialized generation settings must remain compact JSON");
+const compactSettings = JSON.parse(compactJson);
+assert(
+  compactSettings.schema === "easyuse_anima_aio_generation_settings"
+    && compactSettings.sampler.steps === 24
+    && compactSettings.preview.feed_count === 1,
+  "Compact generation settings must merge defaults and normalize preview values",
+);
+assert(
+  !Object.prototype.hasOwnProperty.call(compactSettings.save, "filename_prefix")
+    && !Object.prototype.hasOwnProperty.call(compactSettings.save.image_saver, "show_preview"),
+  "Compact generation settings must remove obsolete save and preview storage keys",
+);
+assert(
+  compactSettings.future_section.value === 42,
+  "Compact generation settings must preserve future sections",
+);
+assert(
+  JSON.stringify(compactSource) === compactSourceSnapshot,
+  "Compact generation serialization must not mutate the caller's settings object",
+);
+
+console.log("AiO settings core smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 AIO_JS = ROOT / "web" / "js" / "easyuse_anima_aio.js"
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
+AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
 AIO_PRESETS_JS = ROOT / "web" / "js" / "aio" / "presets.js"
 AUTOCOMPLETE_JS = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
@@ -386,14 +387,12 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_save_settings_expose_prompt_metadata_toggle(self):
         source = AIO_JS.read_text(encoding="utf-8")
-        defaults_start = source.index("const DEFAULT_GENERATION_SETTINGS")
-        defaults_end = source.index("\nconst AIO_TEXT", defaults_start)
-        defaults_body = source[defaults_start:defaults_end]
+        settings_source = AIO_SETTINGS_JS.read_text(encoding="utf-8")
         start = source.index("function openSaveSettings")
         end = source.index("\nfunction openAdvancedSettings", start)
         body = source[start:end]
 
-        self.assertIn("save_prompt_metadata: true", defaults_body)
+        self.assertIn("save_prompt_metadata: true", settings_source)
         self.assertIn('field(metadata, "Save prompt metadata"', body)
         self.assertIn("checkbox(imageSaver.save_prompt_metadata)", body)
         self.assertIn("save_prompt_metadata: savePromptMetadata.checked", body)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -19,6 +19,8 @@ AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
 AIO_PROFILE_CORE_SMOKE = ROOT / "tests" / "frontend_aio_profile_core_smoke.mjs"
+AIO_SETTINGS_JS = AIO_MODULES / "settings.js"
+AIO_SETTINGS_CORE_SMOKE = ROOT / "tests" / "frontend_aio_settings_core_smoke.mjs"
 PROMPT_STUDIO_JS = WEB_JS / "easyuse_anima_prompt_studio.js"
 PROMPT_STUDIO_COMMON_JS = WEB_JS / "easyuse_anima_prompt_studio_common.js"
 PROMPT_STUDIO_MODULES = WEB_JS / "prompt_studio"
@@ -270,6 +272,104 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_PREVIEW_CORE_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_preview_core_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_settings_core_module_owns_dom_free_storage_rules(self):
+        source = AIO_SETTINGS_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+
+        expected_constants = {
+            "AIO_DEFAULT_GENERATION_SETTINGS",
+            "AIO_DEFAULT_INPUT_SETTINGS",
+            "AIO_GENERATOR_MAX_SEED",
+            "AIO_GENERATOR_SEED_CONTROLS",
+            "AIO_GENERATOR_SPECIAL_SEED_DECREMENT",
+            "AIO_GENERATOR_SPECIAL_SEED_INCREMENT",
+            "AIO_GENERATOR_SPECIAL_SEED_RANDOM",
+        }
+        exported_constants = set(
+            re.findall(r"export const ([A-Za-z0-9_]+)\s*=", source)
+        )
+        self.assertEqual(exported_constants, expected_constants)
+
+        expected_functions = {
+            "aioAsBool",
+            "aioCloneJson",
+            "aioMergeDefaults",
+            "aioMigrateGeneratorPostprocessSettings",
+            "aioNormalizeGeneratorPreviewSettings",
+            "aioNormalizeSeedControl",
+            "aioNormalizeSeedValue",
+            "aioParseSettingsValue",
+            "aioSettingsToCompactJson",
+        }
+        exported_functions = set(
+            re.findall(r"export (?:async )?function ([A-Za-z0-9_]+)\(", source)
+        )
+        self.assertEqual(exported_functions, expected_functions)
+
+        import_match = re.search(
+            r'import\s+\{(?P<names>[^}]*)\}\s+from\s+'
+            r'"\./aio/settings\.js";',
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(import_match)
+        imported_exports = {
+            name.strip().split(" as ", 1)[0].strip()
+            for name in import_match.group("names").split(",")
+            if name.strip()
+        }
+        self.assertEqual(imported_exports, expected_constants | expected_functions)
+
+        self.assertNotRegex(source, r"\b(?:document|window|app|api)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        for ui_dependency in (
+            "findWidget",
+            "widgetValue",
+            "setWidgetValue",
+            "setDirtyCanvas",
+        ):
+            with self.subTest(ui_dependency=ui_dependency):
+                self.assertNotIn(ui_dependency, source)
+
+        for local_constant in (
+            "DEFAULT_GENERATION_SETTINGS",
+            "DEFAULT_INPUT_SETTINGS",
+            "GENERATOR_MAX_SEED",
+            "GENERATOR_SEED_CONTROLS",
+            "GENERATOR_SPECIAL_SEED_RANDOM",
+            "GENERATOR_SPECIAL_SEED_INCREMENT",
+            "GENERATOR_SPECIAL_SEED_DECREMENT",
+        ):
+            with self.subTest(local_constant=local_constant):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"const\s+{local_constant}\s*=",
+                )
+
+        for local_function in (
+            "asBool",
+            "clone",
+            "mergeDefaults",
+            "migrateGeneratorPostprocessSettings",
+            "normalizeGeneratorPreviewSettings",
+            "normalizeSeedControl",
+            "normalizeSeedValue",
+            "settingsToCompactJson",
+        ):
+            with self.subTest(local_function=local_function):
+                self.assertNotIn(f"function {local_function}(", entry_source)
+
+        self.assertNotIn("JSON.parse(widget.value ||", entry_source)
+        self.assertTrue(AIO_SETTINGS_CORE_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_settings_core_smoke.mjs"',
             frontend_check_source,
         )
 
@@ -1359,6 +1459,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
         self.assertIn(
             r'& node "tests\frontend_aio_preview_core_smoke.mjs"', source
+        )
+        self.assertIn(
+            r'& node "tests\frontend_aio_settings_core_smoke.mjs"', source
         )
         self.assertIn('"typescript@$TypeScriptVersion"', source)
         self.assertIn("tsc -p jsconfig.json", source)

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -54,6 +54,11 @@ try {
         throw "Frontend AiO preview core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_settings_core_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO settings core smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/settings.js
+++ b/web/js/aio/settings.js
@@ -1,0 +1,574 @@
+// @ts-check
+
+export const AIO_GENERATOR_SEED_CONTROLS = ["fixed", "randomize", "increment", "decrement"];
+export const AIO_GENERATOR_SPECIAL_SEED_RANDOM = -1;
+export const AIO_GENERATOR_SPECIAL_SEED_INCREMENT = -2;
+export const AIO_GENERATOR_SPECIAL_SEED_DECREMENT = -3;
+export const AIO_GENERATOR_MAX_SEED = 1125899906842624;
+
+export const AIO_DEFAULT_GENERATION_SETTINGS = {
+  schema: "easyuse_anima_aio_generation_settings",
+  version: 1,
+  mode: "txt2img",
+  sampler: {
+    backend: "comfy_ksampler",
+    seed: AIO_GENERATOR_SPECIAL_SEED_RANDOM,
+    seed_after_generate: "fixed",
+    steps: 32,
+    cfg: 5.0,
+    sampler_name: "er_sde",
+    scheduler: "simple",
+    denoise: 1.0,
+    spectrum: {
+      enabled: false,
+      window_size: 2.0,
+      flex_window: 0.25,
+      warmup_steps: 6,
+      tail_actual_steps: 3,
+      blend_w: 0.3,
+      cheby_degree: 3,
+      ridge_lambda: 0.1,
+      history_size: 100,
+      one_sampler_only: false,
+      verbose: false,
+      compat_policy: "conservative",
+    },
+    spd: {
+      split_mode: "single",
+      scale: 0.5,
+      sigma: 0.7,
+      adaptive_smc_alpha: 0.0,
+    },
+    spectrum_extra: {},
+    spd_extra: {},
+    dit_corrections: {
+      enabled: false,
+      dcw_mode: "off",
+      dcw_lambda: 0.01,
+      dcw_band_mask: "LL",
+      dcw_calibrator: "(auto-download default)",
+      smc_cfg: false,
+      adaptive_smc_alpha: 0.0,
+      smc_cfg_lambda: 6.0,
+      cfgpp: false,
+      cfgpp_lambda: 0.0,
+      fsg: false,
+      fsg_band_lo: 0.59,
+      fsg_band_hi: 0.75,
+      fsg_k: 3,
+      fsg_d_sigma: 0.1,
+      fsg_gamma: 0.0,
+      replace_existing_cfg: false,
+    },
+  },
+  model_patches: {
+    aura_flow: {
+      shift: 3.0,
+    },
+    dave: {
+      enabled: false,
+      mask: "dave_alpha.npz",
+      strength: 0.30,
+      tau: 0.10,
+    },
+    safe_pag: {
+      enabled: false,
+      scale: 4.0,
+      block_indices: "18",
+      perturbation_strength: 0.75,
+      head_indices: "",
+      start_percent: 0.0,
+      end_percent: 0.7,
+      rescale: 0.2,
+      rescale_mode: "full",
+    },
+    kj: {
+      fp16_accumulation: false,
+      sage_attention: "disabled",
+      sage_allow_compile: false,
+      torch_compile: {
+        enabled: false,
+        backend: "inductor",
+        fullgraph: false,
+        mode: "max-autotune-no-cudagraphs",
+        dynamic: "false",
+        compile_transformer_blocks_only: true,
+        dynamo_cache_size_limit: 64,
+        debug_compile_keys: false,
+        disable_dynamic_vram: true,
+      },
+    },
+  },
+  mod_guidance: {
+    mode: "prompt_data",
+    profile: "step_i8_skip27",
+    advanced: {
+      adapter: "(auto-download default)",
+      quality_tags: "highres, best quality, score_7",
+      quality_neg: "score_1, score_2, score_3, worst quality, lowres, old, bad hands, bad anatomy",
+      mod_w: 3.0,
+      mod_start_layer: 8,
+      mod_end_layer: 27,
+      mod_taper: 0,
+      mod_taper_scale: 0.25,
+      mod_final_w: 0.0,
+    },
+  },
+  artist_mix: {
+    mode: "prompt_data",
+    start_percent: 0.5,
+    strength_scale: 1.0,
+    style_gain: 1.35,
+    rms_scale_cap: 2.0,
+    exact_top_k: 4,
+    cluster_count: 4,
+    dominant_isolation: true,
+    dominant_threshold: 0.25,
+  },
+  highres: {
+    enabled: false,
+    scale_by: 1.5,
+    upscale_method: "bicubic",
+    multiple: "32",
+    max_long_edge: 2560,
+    steps: 20,
+    inherit_sampler_settings: true,
+    cfg: 8.0,
+    sampler_name: "euler",
+    scheduler: "simple",
+    denoise: 0.25,
+    spectrum: {
+      enabled: false,
+      window_size: 2.0,
+      flex_window: 0.2,
+      warmup_steps: 7,
+      tail_actual_steps: 4,
+      blend_w: 0.3,
+      cheby_degree: 3,
+      ridge_lambda: 0.1,
+      history_size: 100,
+      one_sampler_only: false,
+      verbose: false,
+      compat_policy: "conservative",
+    },
+    dit_corrections: {
+      enabled: false,
+      dcw_mode: "off",
+      dcw_lambda: 0.02,
+      dcw_band_mask: "LL",
+      dcw_calibrator: "(auto-download default)",
+      smc_cfg: false,
+      adaptive_smc_alpha: 0.0,
+      smc_cfg_lambda: 6.0,
+      cfgpp: false,
+      cfgpp_lambda: 0.0,
+      fsg: false,
+      fsg_band_lo: 0.59,
+      fsg_band_hi: 0.75,
+      fsg_k: 3,
+      fsg_d_sigma: 0.1,
+      fsg_gamma: 0.0,
+      replace_existing_cfg: false,
+    },
+  },
+  upscale: {
+    enabled: false,
+    backend: "usdu",
+    scale_by: 2.0,
+    steps: 20,
+    inherit_sampler_settings: true,
+    cfg: 8.0,
+    sampler_name: "euler",
+    scheduler: "simple",
+    denoise: 0.2,
+    spectrum: {
+      enabled: false,
+      window_size: 2.0,
+      flex_window: 0.2,
+      warmup_steps: 7,
+      tail_actual_steps: 4,
+      blend_w: 0.3,
+      cheby_degree: 3,
+      ridge_lambda: 0.1,
+      history_size: 100,
+      one_sampler_only: false,
+      verbose: false,
+      compat_policy: "conservative",
+    },
+    dit_corrections: {
+      enabled: false,
+      dcw_mode: "off",
+      dcw_lambda: 0.02,
+      dcw_band_mask: "LL",
+      dcw_calibrator: "(auto-download default)",
+      smc_cfg: false,
+      adaptive_smc_alpha: 0.0,
+      smc_cfg_lambda: 6.0,
+      cfgpp: false,
+      cfgpp_lambda: 0.0,
+      fsg: false,
+      fsg_band_lo: 0.59,
+      fsg_band_hi: 0.75,
+      fsg_k: 3,
+      fsg_d_sigma: 0.1,
+      fsg_gamma: 0.0,
+      replace_existing_cfg: false,
+    },
+    usdu: {
+      upscale_model_name: "2x-AnimeSharpV4_Fast_RCAN_PU.safetensors",
+      auto_tile_size: true,
+      prompt_mode: "full",
+      mode_type: "Linear",
+      auto_tile_target: 1024,
+      auto_tile_min: 512,
+      auto_tile_max: 2048,
+      tile_width: 512,
+      tile_height: 512,
+      mask_blur: 8,
+      tile_padding: 32,
+      seam_fix_mode: "None",
+      seam_fix_denoise: 1.0,
+      seam_fix_width: 64,
+      seam_fix_mask_blur: 8,
+      seam_fix_padding: 16,
+      force_uniform_tiles: true,
+      tiled_decode: false,
+      batch_size: 1,
+    },
+    resshift: {
+      scale: "x2",
+      student_name: "(auto-download)",
+      dtype: "bf16",
+      chop: 512,
+      overlap: 64,
+      tile_batch: 4,
+    },
+  },
+  postprocess: {
+    enabled: false,
+    fit: {
+      mode: "max_long_edge",
+      max_long_edge: 2048,
+      max_megapixels: 4.0,
+      method: "bicubic",
+    },
+  },
+  detailer: {
+    enabled: false,
+    order: ["face", "eye"],
+    sam3: {
+      context: "load_checkpoint",
+      checkpoint: "sam3.1_multiplex_fp16.safetensors",
+    },
+    face: {
+      label: "Face Detailer",
+      enabled: false,
+      detect_prompt: "face",
+      detect_count: 1,
+      threshold: 0.52,
+      refine_iterations: 2,
+      individual_masks: true,
+      combined: false,
+      crop_factor: 4.0,
+      bbox_fill: false,
+      drop_size: 100,
+      contour_fill: true,
+      guide_size: 1024,
+      guide_size_for: false,
+      max_size: 2048,
+      steps: 20,
+      inherit_sampler_settings: true,
+      cfg: 8.0,
+      sampler_name: "euler",
+      scheduler: "sgm_uniform",
+      denoise: 0.33,
+      feather: 5,
+      noise_mask: true,
+      force_inpaint: true,
+      wildcard: "",
+      cycle: 1,
+      alignment: "32",
+      inpaint_model: false,
+      noise_mask_feather: 10,
+      tiled_encode: false,
+      tiled_decode: false,
+      spectrum: {
+        enabled: true,
+        window_size: 2.0,
+        flex_window: 0.15,
+        warmup_steps: 6,
+        tail_actual_steps: 3,
+        blend_w: 0.3,
+        cheby_degree: 3,
+        ridge_lambda: 0.1,
+        history_size: 100,
+        one_sampler_only: false,
+        verbose: false,
+        compat_policy: "conservative",
+      },
+      dit_corrections: {
+        enabled: false,
+        dcw_mode: "off",
+        dcw_lambda: 0.02,
+        dcw_band_mask: "LL",
+        dcw_calibrator: "(auto-download default)",
+        smc_cfg: false,
+        adaptive_smc_alpha: 0.0,
+        smc_cfg_lambda: 6.0,
+        cfgpp: false,
+        cfgpp_lambda: 0.0,
+        fsg: false,
+        fsg_band_lo: 0.59,
+        fsg_band_hi: 0.75,
+        fsg_k: 3,
+        fsg_d_sigma: 0.1,
+        fsg_gamma: 0.0,
+        replace_existing_cfg: false,
+      },
+    },
+    eye: {
+      label: "Eye Detailer",
+      enabled: false,
+      detect_prompt: "eyes",
+      detect_count: 1,
+      threshold: 0.5,
+      refine_iterations: 2,
+      individual_masks: true,
+      combined: false,
+      crop_factor: 6.0,
+      bbox_fill: false,
+      drop_size: 40,
+      contour_fill: true,
+      guide_size: 1024,
+      guide_size_for: false,
+      max_size: 2048,
+      steps: 20,
+      inherit_sampler_settings: true,
+      cfg: 8.0,
+      sampler_name: "euler",
+      scheduler: "sgm_uniform",
+      denoise: 0.29,
+      feather: 6,
+      noise_mask: true,
+      force_inpaint: true,
+      wildcard: "",
+      cycle: 1,
+      alignment: "32",
+      inpaint_model: false,
+      noise_mask_feather: 20,
+      tiled_encode: false,
+      tiled_decode: false,
+      spectrum: {
+        enabled: true,
+        window_size: 2.0,
+        flex_window: 0.15,
+        warmup_steps: 6,
+        tail_actual_steps: 3,
+        blend_w: 0.3,
+        cheby_degree: 3,
+        ridge_lambda: 0.1,
+        history_size: 100,
+        one_sampler_only: false,
+        verbose: false,
+        compat_policy: "conservative",
+      },
+      dit_corrections: {
+        enabled: false,
+        dcw_mode: "off",
+        dcw_lambda: 0.02,
+        dcw_band_mask: "LL",
+        dcw_calibrator: "(auto-download default)",
+        smc_cfg: false,
+        adaptive_smc_alpha: 0.0,
+        smc_cfg_lambda: 6.0,
+        cfgpp: false,
+        cfgpp_lambda: 0.0,
+        fsg: false,
+        fsg_band_lo: 0.59,
+        fsg_band_hi: 0.75,
+        fsg_k: 3,
+        fsg_d_sigma: 0.1,
+        fsg_gamma: 0.0,
+        replace_existing_cfg: false,
+      },
+    },
+  },
+  save: {
+    enabled: true,
+    backend: "image_saver",
+    image_saver: {
+      filename: "%time_%basemodelname",
+      path: "EasyUseAnima/AiO",
+      extension: "webp",
+      lossless_webp: false,
+      quality_jpeg_or_webp: 97,
+      optimize_png: true,
+      counter: 0,
+      clip_skip: 0,
+      time_format: "%Y-%m-%d-%H%M%S",
+      save_workflow_as_json: false,
+      embed_workflow: true,
+      save_prompt_metadata: true,
+      additional_hashes: "",
+      additional_hash_bundles: [],
+      civitai_hash_fetchers: [],
+      download_civitai_data: true,
+      easy_remix: true,
+      custom: "",
+    },
+  },
+  preview: {
+    intermediate_images: false,
+    compare_previous: false,
+    image_feed: true,
+    feed_count: 12,
+  },
+};
+
+export const AIO_DEFAULT_INPUT_SETTINGS = {
+  schema: "easy_use_anima_input",
+  version: 1,
+  resources: {
+    loader_mode: "split",
+    clip_loader: "single",
+    unet_weight_dtype: "default",
+    clip_device: "default",
+  },
+  metadata: {},
+};
+
+export function aioCloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function aioMergeDefaults(defaults, value) {
+  const output = aioCloneJson(defaults);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return output;
+  }
+  const merge = (base, incoming) => {
+    for (const [key, incomingValue] of Object.entries(incoming)) {
+      if (
+        base[key]
+        && typeof base[key] === "object"
+        && !Array.isArray(base[key])
+        && incomingValue
+        && typeof incomingValue === "object"
+        && !Array.isArray(incomingValue)
+      ) {
+        merge(base[key], incomingValue);
+      } else {
+        base[key] = incomingValue;
+      }
+    }
+    return base;
+  };
+  return merge(output, value);
+}
+
+export function aioAsBool(value, fallback = false) {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) {
+      return true;
+    }
+    if (["false", "0", "no", "off"].includes(normalized)) {
+      return false;
+    }
+  }
+  return value == null ? fallback : !!value;
+}
+
+export function aioMigrateGeneratorPostprocessSettings(settings) {
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+    return settings;
+  }
+  const legacyFit = settings.upscale?.fit;
+  if (legacyFit && typeof legacyFit === "object" && !Array.isArray(legacyFit)) {
+    const defaults = AIO_DEFAULT_GENERATION_SETTINGS.postprocess;
+    const defaultFit = defaults.fit;
+    settings.postprocess = aioMergeDefaults(defaults, settings.postprocess || {});
+    settings.postprocess.fit = aioMergeDefaults(defaultFit, settings.postprocess.fit || {});
+    if (aioAsBool(legacyFit.enabled, false)) {
+      settings.postprocess.enabled = true;
+    }
+    for (const key of ["mode", "max_long_edge", "max_megapixels", "method"]) {
+      if (
+        Object.prototype.hasOwnProperty.call(legacyFit, key)
+        && settings.postprocess.fit[key] === defaultFit[key]
+      ) {
+        settings.postprocess.fit[key] = legacyFit[key];
+      }
+    }
+  }
+  if (settings.upscale && typeof settings.upscale === "object" && !Array.isArray(settings.upscale)) {
+    delete settings.upscale.fit;
+  }
+  return settings;
+}
+
+export function aioParseSettingsValue(rawValue, defaults) {
+  try {
+    const parsed = aioMergeDefaults(defaults, JSON.parse(rawValue || "{}"));
+    return defaults === AIO_DEFAULT_GENERATION_SETTINGS
+      ? aioMigrateGeneratorPostprocessSettings(parsed)
+      : parsed;
+  } catch {
+    return aioCloneJson(defaults);
+  }
+}
+
+export function aioNormalizeSeedControl(value) {
+  const normalized = String(value || "").trim();
+  return AIO_GENERATOR_SEED_CONTROLS.includes(normalized) ? normalized : "fixed";
+}
+
+export function aioNormalizeSeedValue(value, fallback = AIO_GENERATOR_SPECIAL_SEED_RANDOM) {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return fallback;
+  }
+  return Math.max(AIO_GENERATOR_SPECIAL_SEED_DECREMENT, Math.min(AIO_GENERATOR_MAX_SEED, Math.trunc(numberValue)));
+}
+
+function clampNumber(value, fallback, min, max) {
+  const parsed = Number(value);
+  const next = Number.isFinite(parsed) ? parsed : fallback;
+  return Math.max(min, Math.min(max, next));
+}
+
+export function aioNormalizeGeneratorPreviewSettings(settings) {
+  settings.preview = aioMergeDefaults(AIO_DEFAULT_GENERATION_SETTINGS.preview, settings.preview || {});
+  settings.preview.intermediate_images = aioAsBool(
+    settings.preview.intermediate_images,
+    AIO_DEFAULT_GENERATION_SETTINGS.preview.intermediate_images,
+  );
+  settings.preview.compare_previous = aioAsBool(
+    settings.preview.compare_previous,
+    AIO_DEFAULT_GENERATION_SETTINGS.preview.compare_previous,
+  );
+  settings.preview.image_feed = aioAsBool(
+    settings.preview.image_feed,
+    AIO_DEFAULT_GENERATION_SETTINGS.preview.image_feed,
+  );
+  settings.preview.feed_count = Math.trunc(clampNumber(
+    settings.preview.feed_count,
+    AIO_DEFAULT_GENERATION_SETTINGS.preview.feed_count,
+    1,
+    100,
+  ));
+  if (settings.save?.image_saver) {
+    delete settings.save.image_saver.show_preview;
+  }
+  return settings.preview;
+}
+
+export function aioSettingsToCompactJson(settings) {
+  const next = aioMergeDefaults(AIO_DEFAULT_GENERATION_SETTINGS, settings);
+  delete next.save?.filename_prefix;
+  aioNormalizeGeneratorPreviewSettings(next);
+  return JSON.stringify(next);
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -46,6 +46,24 @@ import {
   aioUserProfileName,
   aioUserProfileValue,
 } from "./aio/presets.js";
+import {
+  AIO_DEFAULT_GENERATION_SETTINGS as DEFAULT_GENERATION_SETTINGS,
+  AIO_DEFAULT_INPUT_SETTINGS as DEFAULT_INPUT_SETTINGS,
+  AIO_GENERATOR_MAX_SEED as GENERATOR_MAX_SEED,
+  AIO_GENERATOR_SEED_CONTROLS as GENERATOR_SEED_CONTROLS,
+  AIO_GENERATOR_SPECIAL_SEED_DECREMENT as GENERATOR_SPECIAL_SEED_DECREMENT,
+  AIO_GENERATOR_SPECIAL_SEED_INCREMENT as GENERATOR_SPECIAL_SEED_INCREMENT,
+  AIO_GENERATOR_SPECIAL_SEED_RANDOM as GENERATOR_SPECIAL_SEED_RANDOM,
+  aioAsBool as asBool,
+  aioCloneJson as clone,
+  aioMergeDefaults as mergeDefaults,
+  aioMigrateGeneratorPostprocessSettings as migrateGeneratorPostprocessSettings,
+  aioNormalizeGeneratorPreviewSettings as normalizeGeneratorPreviewSettings,
+  aioNormalizeSeedControl as normalizeSeedControl,
+  aioNormalizeSeedValue as normalizeSeedValue,
+  aioParseSettingsValue,
+  aioSettingsToCompactJson as settingsToCompactJson,
+} from "./aio/settings.js";
 
 const INPUT_NODE_TYPE = "EasyUseAnimaInput";
 const GENERATOR_NODE_TYPE = "EasyUseAnimaAIOGenerator";
@@ -54,16 +72,11 @@ const GENERATOR_SETTINGS_WIDGET = "generation_settings";
 const GENERATOR_PROFILE_CUSTOM_VALUE = "custom";
 const GENERATOR_DOM_WIDGET = "easyuse_anima_generator_panel";
 const GENERATOR_PREVIEW_EVENT = "easyuse-anima-aio-preview";
-const GENERATOR_SEED_CONTROLS = ["fixed", "randomize", "increment", "decrement"];
-const GENERATOR_SPECIAL_SEED_RANDOM = -1;
-const GENERATOR_SPECIAL_SEED_INCREMENT = -2;
-const GENERATOR_SPECIAL_SEED_DECREMENT = -3;
 const GENERATOR_SPECIAL_SEEDS = [
   GENERATOR_SPECIAL_SEED_RANDOM,
   GENERATOR_SPECIAL_SEED_INCREMENT,
   GENERATOR_SPECIAL_SEED_DECREMENT,
 ];
-const GENERATOR_MAX_SEED = 1125899906842624;
 const GENERATOR_NODE_MIN_WIDTH = 560;
 const GENERATOR_NODE_DEFAULT_WIDTH = 620;
 const GENERATOR_PANEL_MIN_HEIGHT = 430;
@@ -157,424 +170,6 @@ const SPECTRUM_SPD_KNOWN_INPUTS = new Set([
   "adaptive_smc_alpha",
 ]);
 
-const DEFAULT_GENERATION_SETTINGS = {
-  schema: "easyuse_anima_aio_generation_settings",
-  version: 1,
-  mode: "txt2img",
-  sampler: {
-    backend: "comfy_ksampler",
-    seed: GENERATOR_SPECIAL_SEED_RANDOM,
-    seed_after_generate: "fixed",
-    steps: 32,
-    cfg: 5.0,
-    sampler_name: "er_sde",
-    scheduler: "simple",
-    denoise: 1.0,
-    spectrum: {
-      enabled: false,
-      window_size: 2.0,
-      flex_window: 0.25,
-      warmup_steps: 6,
-      tail_actual_steps: 3,
-      blend_w: 0.3,
-      cheby_degree: 3,
-      ridge_lambda: 0.1,
-      history_size: 100,
-      one_sampler_only: false,
-      verbose: false,
-      compat_policy: "conservative",
-    },
-    spd: {
-      split_mode: "single",
-      scale: 0.5,
-      sigma: 0.7,
-      adaptive_smc_alpha: 0.0,
-    },
-    spectrum_extra: {},
-    spd_extra: {},
-    dit_corrections: {
-      enabled: false,
-      dcw_mode: "off",
-      dcw_lambda: 0.01,
-      dcw_band_mask: "LL",
-      dcw_calibrator: "(auto-download default)",
-      smc_cfg: false,
-      adaptive_smc_alpha: 0.0,
-      smc_cfg_lambda: 6.0,
-      cfgpp: false,
-      cfgpp_lambda: 0.0,
-      fsg: false,
-      fsg_band_lo: 0.59,
-      fsg_band_hi: 0.75,
-      fsg_k: 3,
-      fsg_d_sigma: 0.1,
-      fsg_gamma: 0.0,
-      replace_existing_cfg: false,
-    },
-  },
-  model_patches: {
-    aura_flow: {
-      shift: 3.0,
-    },
-    dave: {
-      enabled: false,
-      mask: "dave_alpha.npz",
-      strength: 0.30,
-      tau: 0.10,
-    },
-    safe_pag: {
-      enabled: false,
-      scale: 4.0,
-      block_indices: "18",
-      perturbation_strength: 0.75,
-      head_indices: "",
-      start_percent: 0.0,
-      end_percent: 0.7,
-      rescale: 0.2,
-      rescale_mode: "full",
-    },
-    kj: {
-      fp16_accumulation: false,
-      sage_attention: "disabled",
-      sage_allow_compile: false,
-      torch_compile: {
-        enabled: false,
-        backend: "inductor",
-        fullgraph: false,
-        mode: "max-autotune-no-cudagraphs",
-        dynamic: "false",
-        compile_transformer_blocks_only: true,
-        dynamo_cache_size_limit: 64,
-        debug_compile_keys: false,
-        disable_dynamic_vram: true,
-      },
-    },
-  },
-  mod_guidance: {
-    mode: "prompt_data",
-    profile: "step_i8_skip27",
-    advanced: {
-      adapter: "(auto-download default)",
-      quality_tags: "highres, best quality, score_7",
-      quality_neg: "score_1, score_2, score_3, worst quality, lowres, old, bad hands, bad anatomy",
-      mod_w: 3.0,
-      mod_start_layer: 8,
-      mod_end_layer: 27,
-      mod_taper: 0,
-      mod_taper_scale: 0.25,
-      mod_final_w: 0.0,
-    },
-  },
-  artist_mix: {
-    mode: "prompt_data",
-    start_percent: 0.5,
-    strength_scale: 1.0,
-    style_gain: 1.35,
-    rms_scale_cap: 2.0,
-    exact_top_k: 4,
-    cluster_count: 4,
-    dominant_isolation: true,
-    dominant_threshold: 0.25,
-  },
-  highres: {
-    enabled: false,
-    scale_by: 1.5,
-    upscale_method: "bicubic",
-    multiple: "32",
-    max_long_edge: 2560,
-    steps: 20,
-    inherit_sampler_settings: true,
-    cfg: 8.0,
-    sampler_name: "euler",
-    scheduler: "simple",
-    denoise: 0.25,
-    spectrum: {
-      enabled: false,
-      window_size: 2.0,
-      flex_window: 0.2,
-      warmup_steps: 7,
-      tail_actual_steps: 4,
-      blend_w: 0.3,
-      cheby_degree: 3,
-      ridge_lambda: 0.1,
-      history_size: 100,
-      one_sampler_only: false,
-      verbose: false,
-      compat_policy: "conservative",
-    },
-    dit_corrections: {
-      enabled: false,
-      dcw_mode: "off",
-      dcw_lambda: 0.02,
-      dcw_band_mask: "LL",
-      dcw_calibrator: "(auto-download default)",
-      smc_cfg: false,
-      adaptive_smc_alpha: 0.0,
-      smc_cfg_lambda: 6.0,
-      cfgpp: false,
-      cfgpp_lambda: 0.0,
-      fsg: false,
-      fsg_band_lo: 0.59,
-      fsg_band_hi: 0.75,
-      fsg_k: 3,
-      fsg_d_sigma: 0.1,
-      fsg_gamma: 0.0,
-      replace_existing_cfg: false,
-    },
-  },
-  upscale: {
-    enabled: false,
-    backend: "usdu",
-    scale_by: 2.0,
-    steps: 20,
-    inherit_sampler_settings: true,
-    cfg: 8.0,
-    sampler_name: "euler",
-    scheduler: "simple",
-    denoise: 0.2,
-    spectrum: {
-      enabled: false,
-      window_size: 2.0,
-      flex_window: 0.2,
-      warmup_steps: 7,
-      tail_actual_steps: 4,
-      blend_w: 0.3,
-      cheby_degree: 3,
-      ridge_lambda: 0.1,
-      history_size: 100,
-      one_sampler_only: false,
-      verbose: false,
-      compat_policy: "conservative",
-    },
-    dit_corrections: {
-      enabled: false,
-      dcw_mode: "off",
-      dcw_lambda: 0.02,
-      dcw_band_mask: "LL",
-      dcw_calibrator: "(auto-download default)",
-      smc_cfg: false,
-      adaptive_smc_alpha: 0.0,
-      smc_cfg_lambda: 6.0,
-      cfgpp: false,
-      cfgpp_lambda: 0.0,
-      fsg: false,
-      fsg_band_lo: 0.59,
-      fsg_band_hi: 0.75,
-      fsg_k: 3,
-      fsg_d_sigma: 0.1,
-      fsg_gamma: 0.0,
-      replace_existing_cfg: false,
-    },
-    usdu: {
-      upscale_model_name: "2x-AnimeSharpV4_Fast_RCAN_PU.safetensors",
-      auto_tile_size: true,
-      prompt_mode: "full",
-      mode_type: "Linear",
-      auto_tile_target: 1024,
-      auto_tile_min: 512,
-      auto_tile_max: 2048,
-      tile_width: 512,
-      tile_height: 512,
-      mask_blur: 8,
-      tile_padding: 32,
-      seam_fix_mode: "None",
-      seam_fix_denoise: 1.0,
-      seam_fix_width: 64,
-      seam_fix_mask_blur: 8,
-      seam_fix_padding: 16,
-      force_uniform_tiles: true,
-      tiled_decode: false,
-      batch_size: 1,
-    },
-    resshift: {
-      scale: "x2",
-      student_name: "(auto-download)",
-      dtype: "bf16",
-      chop: 512,
-      overlap: 64,
-      tile_batch: 4,
-    },
-  },
-  postprocess: {
-    enabled: false,
-    fit: {
-      mode: "max_long_edge",
-      max_long_edge: 2048,
-      max_megapixels: 4.0,
-      method: "bicubic",
-    },
-  },
-  detailer: {
-    enabled: false,
-    order: ["face", "eye"],
-    sam3: {
-      context: "load_checkpoint",
-      checkpoint: "sam3.1_multiplex_fp16.safetensors",
-    },
-    face: {
-      label: "Face Detailer",
-      enabled: false,
-      detect_prompt: "face",
-      detect_count: 1,
-      threshold: 0.52,
-      refine_iterations: 2,
-      individual_masks: true,
-      combined: false,
-      crop_factor: 4.0,
-      bbox_fill: false,
-      drop_size: 100,
-      contour_fill: true,
-      guide_size: 1024,
-      guide_size_for: false,
-      max_size: 2048,
-      steps: 20,
-      inherit_sampler_settings: true,
-      cfg: 8.0,
-      sampler_name: "euler",
-      scheduler: "sgm_uniform",
-      denoise: 0.33,
-      feather: 5,
-      noise_mask: true,
-      force_inpaint: true,
-      wildcard: "",
-      cycle: 1,
-      alignment: "32",
-      inpaint_model: false,
-      noise_mask_feather: 10,
-      tiled_encode: false,
-      tiled_decode: false,
-      spectrum: {
-        enabled: true,
-        window_size: 2.0,
-        flex_window: 0.15,
-        warmup_steps: 6,
-        tail_actual_steps: 3,
-        blend_w: 0.3,
-        cheby_degree: 3,
-        ridge_lambda: 0.1,
-        history_size: 100,
-        one_sampler_only: false,
-        verbose: false,
-        compat_policy: "conservative",
-      },
-      dit_corrections: {
-        enabled: false,
-        dcw_mode: "off",
-        dcw_lambda: 0.02,
-        dcw_band_mask: "LL",
-        dcw_calibrator: "(auto-download default)",
-        smc_cfg: false,
-        adaptive_smc_alpha: 0.0,
-        smc_cfg_lambda: 6.0,
-        cfgpp: false,
-        cfgpp_lambda: 0.0,
-        fsg: false,
-        fsg_band_lo: 0.59,
-        fsg_band_hi: 0.75,
-        fsg_k: 3,
-        fsg_d_sigma: 0.1,
-        fsg_gamma: 0.0,
-        replace_existing_cfg: false,
-      },
-    },
-    eye: {
-      label: "Eye Detailer",
-      enabled: false,
-      detect_prompt: "eyes",
-      detect_count: 1,
-      threshold: 0.5,
-      refine_iterations: 2,
-      individual_masks: true,
-      combined: false,
-      crop_factor: 6.0,
-      bbox_fill: false,
-      drop_size: 40,
-      contour_fill: true,
-      guide_size: 1024,
-      guide_size_for: false,
-      max_size: 2048,
-      steps: 20,
-      inherit_sampler_settings: true,
-      cfg: 8.0,
-      sampler_name: "euler",
-      scheduler: "sgm_uniform",
-      denoise: 0.29,
-      feather: 6,
-      noise_mask: true,
-      force_inpaint: true,
-      wildcard: "",
-      cycle: 1,
-      alignment: "32",
-      inpaint_model: false,
-      noise_mask_feather: 20,
-      tiled_encode: false,
-      tiled_decode: false,
-      spectrum: {
-        enabled: true,
-        window_size: 2.0,
-        flex_window: 0.15,
-        warmup_steps: 6,
-        tail_actual_steps: 3,
-        blend_w: 0.3,
-        cheby_degree: 3,
-        ridge_lambda: 0.1,
-        history_size: 100,
-        one_sampler_only: false,
-        verbose: false,
-        compat_policy: "conservative",
-      },
-      dit_corrections: {
-        enabled: false,
-        dcw_mode: "off",
-        dcw_lambda: 0.02,
-        dcw_band_mask: "LL",
-        dcw_calibrator: "(auto-download default)",
-        smc_cfg: false,
-        adaptive_smc_alpha: 0.0,
-        smc_cfg_lambda: 6.0,
-        cfgpp: false,
-        cfgpp_lambda: 0.0,
-        fsg: false,
-        fsg_band_lo: 0.59,
-        fsg_band_hi: 0.75,
-        fsg_k: 3,
-        fsg_d_sigma: 0.1,
-        fsg_gamma: 0.0,
-        replace_existing_cfg: false,
-      },
-    },
-  },
-  save: {
-    enabled: true,
-    backend: "image_saver",
-    image_saver: {
-      filename: "%time_%basemodelname",
-      path: "EasyUseAnima/AiO",
-      extension: "webp",
-      lossless_webp: false,
-      quality_jpeg_or_webp: 97,
-      optimize_png: true,
-      counter: 0,
-      clip_skip: 0,
-      time_format: "%Y-%m-%d-%H%M%S",
-      save_workflow_as_json: false,
-      embed_workflow: true,
-      save_prompt_metadata: true,
-      additional_hashes: "",
-      additional_hash_bundles: [],
-      civitai_hash_fetchers: [],
-      download_civitai_data: true,
-      easy_remix: true,
-      custom: "",
-    },
-  },
-  preview: {
-    intermediate_images: false,
-    compare_previous: false,
-    image_feed: true,
-    feed_count: 12,
-  },
-};
 
 const AIO_TEXT = {
   en: {
@@ -2240,17 +1835,6 @@ function applyTooltipText(element, text) {
   return element;
 }
 
-const DEFAULT_INPUT_SETTINGS = {
-  schema: "easy_use_anima_input",
-  version: 1,
-  resources: {
-    loader_mode: "split",
-    clip_loader: "single",
-    unet_weight_dtype: "default",
-    clip_device: "default",
-  },
-  metadata: {},
-};
 
 const generatorSamplerOptionState = {
   loaded: false,
@@ -2988,75 +2572,11 @@ function hideWidget(widget) {
   }
 }
 
-function clone(value) {
-  return JSON.parse(JSON.stringify(value));
-}
-
-function mergeDefaults(defaults, value) {
-  const output = clone(defaults);
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return output;
-  }
-  const merge = (base, incoming) => {
-    for (const [key, incomingValue] of Object.entries(incoming)) {
-      if (
-        base[key]
-        && typeof base[key] === "object"
-        && !Array.isArray(base[key])
-        && incomingValue
-        && typeof incomingValue === "object"
-        && !Array.isArray(incomingValue)
-      ) {
-        merge(base[key], incomingValue);
-      } else {
-        base[key] = incomingValue;
-      }
-    }
-    return base;
-  };
-  return merge(output, value);
-}
-
-function migrateGeneratorPostprocessSettings(settings) {
-  if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
-    return settings;
-  }
-  const legacyFit = settings.upscale?.fit;
-  if (legacyFit && typeof legacyFit === "object" && !Array.isArray(legacyFit)) {
-    const defaults = DEFAULT_GENERATION_SETTINGS.postprocess;
-    const defaultFit = defaults.fit;
-    settings.postprocess = mergeDefaults(defaults, settings.postprocess || {});
-    settings.postprocess.fit = mergeDefaults(defaultFit, settings.postprocess.fit || {});
-    if (asBool(legacyFit.enabled, false)) {
-      settings.postprocess.enabled = true;
-    }
-    for (const key of ["mode", "max_long_edge", "max_megapixels", "method"]) {
-      if (
-        Object.prototype.hasOwnProperty.call(legacyFit, key)
-        && settings.postprocess.fit[key] === defaultFit[key]
-      ) {
-        settings.postprocess.fit[key] = legacyFit[key];
-      }
-    }
-  }
-  if (settings.upscale && typeof settings.upscale === "object" && !Array.isArray(settings.upscale)) {
-    delete settings.upscale.fit;
-  }
-  return settings;
-}
-
 function parseSettings(widget, defaults) {
   if (!widget) {
     return clone(defaults);
   }
-  try {
-    const parsed = mergeDefaults(defaults, JSON.parse(widget.value || "{}"));
-    return defaults === DEFAULT_GENERATION_SETTINGS
-      ? migrateGeneratorPostprocessSettings(parsed)
-      : parsed;
-  } catch {
-    return clone(defaults);
-  }
+  return aioParseSettingsValue(widget.value, defaults);
 }
 
 function writeSettings(node, widget, value, markDirty = true) {
@@ -4086,22 +3606,6 @@ function setWidgetValue(node, name, value) {
   node.__easyuseAnimaGeneratorUiValues[name] = value;
 }
 
-function asBool(value, fallback = false) {
-  if (typeof value === "boolean") {
-    return value;
-  }
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (["true", "1", "yes", "on"].includes(normalized)) {
-      return true;
-    }
-    if (["false", "0", "no", "off"].includes(normalized)) {
-      return false;
-    }
-  }
-  return value == null ? fallback : !!value;
-}
-
 function firstValue(value, fallback = "") {
   if (Array.isArray(value)) {
     return value.length > 0 ? value[0] : fallback;
@@ -4184,21 +3688,8 @@ function generatorImageUrl(image) {
   return typeof api?.apiURL === "function" ? api.apiURL(path) : path;
 }
 
-function normalizeSeedControl(value) {
-  const normalized = String(value || "").trim();
-  return GENERATOR_SEED_CONTROLS.includes(normalized) ? normalized : "fixed";
-}
-
 function isSpecialSeed(value) {
   return GENERATOR_SPECIAL_SEEDS.includes(Number(value));
-}
-
-function normalizeSeedValue(value, fallback = GENERATOR_SPECIAL_SEED_RANDOM) {
-  const numberValue = Number(value);
-  if (!Number.isFinite(numberValue)) {
-    return fallback;
-  }
-  return Math.max(GENERATOR_SPECIAL_SEED_DECREMENT, Math.min(GENERATOR_MAX_SEED, Math.trunc(numberValue)));
 }
 
 function clampGeneratorNumber(value, fallback, min, max) {
@@ -4307,32 +3798,6 @@ function nextDetailerTargetName(order, detailer = null) {
   return `custom_${Date.now()}`;
 }
 
-function normalizeGeneratorPreviewSettings(settings) {
-  settings.preview = mergeDefaults(DEFAULT_GENERATION_SETTINGS.preview, settings.preview || {});
-  settings.preview.intermediate_images = asBool(
-    settings.preview.intermediate_images,
-    DEFAULT_GENERATION_SETTINGS.preview.intermediate_images,
-  );
-  settings.preview.compare_previous = asBool(
-    settings.preview.compare_previous,
-    DEFAULT_GENERATION_SETTINGS.preview.compare_previous,
-  );
-  settings.preview.image_feed = asBool(
-    settings.preview.image_feed,
-    DEFAULT_GENERATION_SETTINGS.preview.image_feed,
-  );
-  settings.preview.feed_count = Math.trunc(clampGeneratorNumber(
-    settings.preview.feed_count,
-    DEFAULT_GENERATION_SETTINGS.preview.feed_count,
-    1,
-    100,
-  ));
-  if (settings.save?.image_saver) {
-    delete settings.save.image_saver.show_preview;
-  }
-  return settings.preview;
-}
-
 function normalizeGeneratorInputValues(node, settings = DEFAULT_GENERATION_SETTINGS) {
   const merged = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
   return {
@@ -4436,13 +3901,6 @@ function setWorkflowWidgetValue(node, workflowNode, name, value) {
     workflowNode.widgets_values.push(null);
   }
   workflowNode.widgets_values[index] = value;
-}
-
-function settingsToCompactJson(settings) {
-  const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-  delete next.save?.filename_prefix;
-  normalizeGeneratorPreviewSettings(next);
-  return JSON.stringify(next);
 }
 
 function syncGeneratorSerializedWidgets(node, serialized = null) {


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 generation/input 기본 설정과 JSON storage 규칙을 `web/js/aio/settings.js`로 분리했습니다.
- deep merge, legacy `upscale.fit` migration, boolean/seed/preview normalization, compact serialization을 DOM 없는 core module이 소유하도록 정리했습니다.
- 기존 entry는 alias import와 얇은 widget parser wrapper만 유지해 기존 호출 흐름과 직렬화 계약을 보존했습니다.
- schema/default/migration 동작을 고정하는 semantic smoke와 module ownership 회귀 검사를 추가했습니다.

## 주요 파일

- `web/js/aio/settings.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_settings_core_smoke.mjs`
- `tests/test_frontend_modules.py`
- `tests/test_aio_frontend.py`
- `tools/check_frontend.ps1`

## 호환성

- default literal의 key 순서와 singleton identity를 유지합니다.
- unknown key 보존, nested object merge, array 전체 교체 동작을 유지합니다.
- generation default를 사용한 parse에서만 legacy postprocess migration이 적용되는 identity 계약을 유지합니다.
- legacy migration의 in-place mutation/delete 동작과 compact JSON 처리 순서를 변경하지 않습니다.
- Python API와 workflow schema는 변경하지 않습니다.

## 검증

- `node tests\frontend_aio_settings_core_smoke.mjs`: PASS
- focused frontend unittest: 56/56 PASS
- `tools/check_project.ps1 -Profile quick`: PASS
- 공식 full validation: PASS
  - Python unittest 329개
  - Python compile
  - JavaScript syntax 68개
  - TypeScript 6.0.3
  - semantic smoke 전체
  - `git diff --check`
- ComfyUI Codex test instance: module/frontend smoke
- ComfyUI v0.27.0 user instance: manual browser check pending
- Live ComfyUI browser smoke: not run

이번 변경은 DOM, runtime hook, API, workflow schema를 건드리지 않는 pure-data extraction이므로 별도 browser matrix는 생략했습니다. legacy canvas와 Node 2.0 browser regression은 다음 주요 Issue #54 checkpoint에서 각각 다시 확인합니다.

## 남은 위험 / 후속 작업

- AiO entry의 DOM control builder와 settings dialog 분리는 후속 PR 범위입니다.
- queue/runtime hook과 extension entry 분리는 이후 checkpoint에서 진행합니다.

Refs #54