### PR TITLE
[Maintenance] AiO DOM controls와 dialog primitives 분리

### DIFF
--- a/tests/frontend_aio_dialog_primitives_smoke.mjs
+++ b/tests/frontend_aio_dialog_primitives_smoke.mjs
@@ -1,0 +1,238 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertJsonEqual(actual, expected, message) {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+class FakeClassList {
+  constructor(owner) {
+    this.owner = owner;
+  }
+
+  add(...tokens) {
+    const classes = new Set(String(this.owner.className || "").split(/\s+/).filter(Boolean));
+    for (const token of tokens) {
+      classes.add(token);
+    }
+    this.owner.className = [...classes].join(" ");
+  }
+
+  contains(token) {
+    return String(this.owner.className || "").split(/\s+/).includes(token);
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.type = "";
+    this.className = "";
+    this.textContent = "";
+    this.title = "";
+    this.children = [];
+    this.listeners = new Map();
+    this.removed = false;
+    this.isConnected = true;
+    this.classList = new FakeClassList(this);
+  }
+
+  append(...children) {
+    this.children.push(...children);
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type, target = this) {
+    for (const listener of this.listeners.get(type) || []) {
+      listener({ target });
+    }
+  }
+
+  remove() {
+    this.removed = true;
+    this.isConnected = false;
+  }
+}
+
+const dialogModule = await import(dataModule("../web/js/aio/dialog_primitives.js"));
+assertJsonEqual(
+  Object.keys(dialogModule),
+  ["aioCreateDialogPrimitives"],
+  "AiO dialog primitives must expose only their factory contract",
+);
+
+const body = new FakeElement("body");
+const fakeDocument = {
+  body,
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  },
+};
+const tooltipCalls = [];
+const tooltipTextCalls = [];
+const presentationCalls = [];
+let ensureStyleCalls = 0;
+const primitives = dialogModule.aioCreateDialogPrimitives({
+  document: fakeDocument,
+  ensureStyle() {
+    ensureStyleCalls += 1;
+  },
+  staticText(value) {
+    return `static:${value}`;
+  },
+  text(key) {
+    return `text:${key}`;
+  },
+  resolveFieldPresentation(label, tooltipKey) {
+    presentationCalls.push([label, tooltipKey]);
+    const displayLabel = `label:${label}`;
+    const tooltipText = tooltipKey
+      ? `text:${tooltipKey}`
+      : label === "Mapped"
+        ? "text:tip.mapped"
+        : `format:tip.fieldGeneric:${displayLabel}`;
+    return { displayLabel, tooltipText };
+  },
+  applyTooltip(element, key) {
+    tooltipCalls.push([element, key]);
+  },
+  applyTooltipText(element, value) {
+    tooltipTextCalls.push([element, value]);
+  },
+});
+
+assertJsonEqual(
+  Object.keys(primitives),
+  ["createDialog", "createNodeField", "field"],
+  "AiO dialog primitive factory must expose only the three UI builders",
+);
+assert(Object.isFrozen(primitives), "AiO dialog primitive contract must be immutable");
+assert(ensureStyleCalls === 0, "Creating dialog primitives must not install styles eagerly");
+
+const textControl = new FakeElement("input");
+textControl.type = "text";
+const nodeField = primitives.createNodeField("Node label", textControl, "wide", "tip.node");
+assert(
+  nodeField.className === "easyuse-anima-aio-node-field wide",
+  "Node fields must retain their base and custom classes",
+);
+assert(
+  nodeField.children[0].tagName === "LABEL"
+    && nodeField.children[0].textContent === "Node label"
+    && nodeField.children[1] === textControl,
+  "Non-checkbox node fields must keep label/control order and text",
+);
+assertJsonEqual(
+  tooltipCalls.map(([, key]) => key),
+  ["tip.node", "tip.node", "tip.node"],
+  "Node fields must apply the tooltip key to wrapper, label, and control",
+);
+
+const checkboxControl = new FakeElement("input");
+checkboxControl.type = "checkbox";
+const checkboxNodeField = primitives.createNodeField("Enabled", checkboxControl);
+assert(
+  checkboxNodeField.classList.contains("checkbox")
+    && checkboxNodeField.children.length === 1,
+  "Checkbox node fields must retain their checkbox layout class and wrapper shape",
+);
+assert(
+  checkboxNodeField.children[0].children[0].textContent === "Enabled"
+    && checkboxNodeField.children[0].children[1] === checkboxControl,
+  "Checkbox node fields must keep text and native control inside the label",
+);
+
+const genericSection = new FakeElement("section");
+const genericControl = new FakeElement("input");
+const returnedGenericControl = primitives.field(genericSection, "Generic", genericControl);
+assert(returnedGenericControl === genericControl, "Dialog fields must return their control");
+assert(
+  genericSection.children[0].children[0].textContent === "label:Generic"
+    && genericSection.children[0].children[1] === genericControl,
+  "Dialog fields must append translated label/control rows to their section",
+);
+assertJsonEqual(
+  presentationCalls,
+  [["Generic", ""]],
+  "Dialog fields must delegate label and tooltip policy to the injected presentation resolver",
+);
+assertJsonEqual(
+  tooltipTextCalls.slice(-3).map(([, value]) => value),
+  [
+    "format:tip.fieldGeneric:label:Generic",
+    "format:tip.fieldGeneric:label:Generic",
+    "format:tip.fieldGeneric:label:Generic",
+  ],
+  "Dialog fields must apply generic tooltip text to row, label, and control",
+);
+
+const mappedSection = new FakeElement("section");
+const mappedControl = new FakeElement("input");
+mappedControl.type = "checkbox";
+primitives.field(mappedSection, "Mapped", mappedControl);
+assert(
+  mappedSection.children[0].classList.contains("checkbox")
+    && mappedSection.children[0].children[0].children[0].textContent === "label:Mapped"
+    && mappedSection.children[0].children[0].children[1] === mappedControl,
+  "Mapped checkbox fields must retain the checkbox row structure",
+);
+assertJsonEqual(
+  tooltipTextCalls.slice(-3).map(([, value]) => value),
+  ["text:tip.mapped", "text:tip.mapped", "text:tip.mapped"],
+  "Dialog fields must resolve mapped tooltip keys through the text adapter",
+);
+
+const explicitSection = new FakeElement("section");
+primitives.field(explicitSection, "Mapped", new FakeElement("input"), "tip.explicit");
+assertJsonEqual(
+  tooltipTextCalls.slice(-3).map(([, value]) => value),
+  ["text:tip.explicit", "text:tip.explicit", "text:tip.explicit"],
+  "An explicit dialog tooltip key must take precedence over the field mapping",
+);
+
+const firstDialog = primitives.createDialog("Title", "Subtitle");
+assert(ensureStyleCalls === 1, "Dialog creation must ensure the AiO stylesheet exactly once");
+assert(
+  firstDialog.backdrop.className === "easyuse-anima-aio-backdrop"
+    && firstDialog.body.className === "easyuse-anima-aio-body"
+    && firstDialog.actions.className === "easyuse-anima-aio-actions",
+  "Dialog creation must retain its public backdrop/body/actions classes",
+);
+assert(body.children[0] === firstDialog.backdrop, "Dialogs must append their backdrop to document.body");
+const firstDialogElement = firstDialog.backdrop.children[0];
+const firstHeader = firstDialogElement.children[0];
+const firstTitleBox = firstHeader.children[0];
+const firstClose = firstHeader.children[1];
+assert(
+  firstTitleBox.children[0].textContent === "static:Title"
+    && firstTitleBox.children[1].textContent === "static:Subtitle"
+    && firstClose.textContent === "text:button.close",
+  "Dialog title, subtitle, and close label must use their injected text adapters",
+);
+firstDialog.backdrop.dispatch("pointerdown", firstDialogElement);
+assert(!firstDialog.backdrop.removed, "Pointerdown inside a dialog must keep the backdrop connected");
+firstDialog.backdrop.dispatch("pointerdown");
+assert(firstDialog.backdrop.removed, "Pointerdown on the backdrop must close the dialog");
+
+const secondDialog = primitives.createDialog("Second", "Dialog");
+assert(ensureStyleCalls === 2, "Every dialog open must ensure the AiO stylesheet");
+const secondClose = secondDialog.backdrop.children[0].children[0].children[1];
+secondClose.dispatch("click");
+assert(secondDialog.backdrop.removed, "The dialog close button must remove its backdrop");
+
+console.log("AiO dialog primitives smoke passed.");

--- a/tests/frontend_aio_dom_controls_core_smoke.mjs
+++ b/tests/frontend_aio_dom_controls_core_smoke.mjs
@@ -1,0 +1,246 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertJsonEqual(actual, expected, message) {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.type = "";
+    this.step = "";
+    this.checked = false;
+    this.disabled = false;
+    this.selected = false;
+    this.title = "";
+    this.textContent = "";
+    this.children = [];
+    this._value = "";
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(value) {
+    this._value = String(value);
+  }
+
+  append(...children) {
+    this.children.push(...children);
+  }
+}
+
+const previousDocument = globalThis.document;
+const hadDocument = Object.prototype.hasOwnProperty.call(globalThis, "document");
+delete globalThis.document;
+
+const controlsModule = await import(dataModule("../web/js/aio/dom_controls.js"));
+const expectedExports = [
+  "aioCreateCheckboxInput",
+  "aioCreateNumberInput",
+  "aioCreateSelectInput",
+  "aioCreateTextInput",
+  "aioCreateTextareaInput",
+  "aioNodeInputControlForSpec",
+  "aioNodeInputDefault",
+  "aioValueFromNodeInputControl",
+];
+assertJsonEqual(
+  Object.keys(controlsModule).sort(),
+  expectedExports,
+  "AiO DOM controls core must expose only its public helper contract",
+);
+
+globalThis.document = {
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  },
+};
+
+try {
+  const {
+    aioCreateCheckboxInput,
+    aioCreateNumberInput,
+    aioCreateSelectInput,
+    aioCreateTextInput,
+    aioCreateTextareaInput,
+    aioNodeInputControlForSpec,
+    aioNodeInputDefault,
+    aioValueFromNodeInputControl,
+  } = controlsModule;
+
+  const number = aioCreateNumberInput(12);
+  assert(
+    number.tagName === "INPUT"
+      && number.type === "number"
+      && number.step === "1"
+      && number.value === "12",
+    "Number controls must keep the native input type, default step, and value",
+  );
+  const preciseNumber = aioCreateNumberInput("1.25", "0.05");
+  assert(
+    preciseNumber.step === "0.05" && preciseNumber.value === "1.25",
+    "Number controls must preserve an explicit step and value",
+  );
+
+  const text = aioCreateTextInput(null);
+  const textarea = aioCreateTextareaInput(undefined);
+  assert(
+    text.tagName === "INPUT" && text.type === "text" && text.value === "",
+    "Text controls must normalize nullish values to an empty native input",
+  );
+  assert(
+    textarea.tagName === "TEXTAREA" && textarea.value === "",
+    "Textarea controls must normalize nullish values to an empty textarea",
+  );
+
+  const unchecked = aioCreateCheckboxInput(0);
+  const checked = aioCreateCheckboxInput("enabled");
+  assert(
+    unchecked.tagName === "INPUT"
+      && unchecked.type === "checkbox"
+      && unchecked.checked === false
+      && checked.checked === true,
+    "Checkbox controls must preserve their native type and boolean coercion",
+  );
+
+  const select = aioCreateSelectInput([
+    "alpha",
+    {
+      value: "beta",
+      label: "Beta label",
+      disabled: true,
+      title: "Beta title",
+    },
+    { value: 3 },
+  ], "beta");
+  assert(select.tagName === "SELECT", "Choice controls must create a native select");
+  assertJsonEqual(
+    select.children.map((option) => option.value),
+    ["alpha", "beta", "3"],
+    "Choice controls must retain option order and normalize values to strings",
+  );
+  assertJsonEqual(
+    select.children.map((option) => option.textContent),
+    ["alpha", "Beta label", "3"],
+    "Choice controls must use structured labels and value fallbacks",
+  );
+  assert(
+    select.children[1].selected === true
+      && select.children[1].disabled === true
+      && select.children[1].title === "Beta title",
+    "Structured choice metadata and the matching selected option must be preserved",
+  );
+  assert(
+    select.children[0].selected === false
+      && select.children[0].disabled === false
+      && select.children[0].title === "",
+    "Plain choice options must retain their native defaults",
+  );
+  const strictSelect = aioCreateSelectInput([1], 1);
+  assert(
+    strictSelect.children[0].value === "1" && strictSelect.children[0].selected === false,
+    "Choice selection must retain the existing strict string comparison contract",
+  );
+  const stringSelect = aioCreateSelectInput([1], "1");
+  assert(
+    stringSelect.children[0].selected === true,
+    "A string choice value must select the matching normalized option",
+  );
+
+  assert(
+    aioNodeInputDefault(["INT", { default: 0 }], 99) === 0,
+    "Node input defaults must preserve an own default property, including zero",
+  );
+  const inheritedOptions = Object.create({ default: "inherited" });
+  assert(
+    aioNodeInputDefault(["STRING", inheritedOptions], "fallback") === "fallback",
+    "Node input defaults must ignore inherited default properties",
+  );
+  assert(
+    aioNodeInputDefault(null, "fallback") === "fallback",
+    "Invalid node specs must use the supplied fallback",
+  );
+
+  const choiceControl = aioNodeInputControlForSpec([
+    ["first", "second"],
+    { default: "second" },
+  ], null);
+  assert(
+    choiceControl.tagName === "SELECT"
+      && choiceControl.children[1].selected === true,
+    "Choice node specs must build a select using their default value",
+  );
+  const booleanControl = aioNodeInputControlForSpec(["BOOLEAN", { default: true }]);
+  assert(
+    booleanControl.type === "checkbox" && booleanControl.checked === true,
+    "BOOLEAN node specs must build checkbox controls",
+  );
+  const intControl = aioNodeInputControlForSpec(["int", { default: 7 }], 0);
+  assert(
+    intControl.type === "number" && intControl.step === "1" && intControl.value === "0",
+    "INT node specs must build integer controls and preserve an explicit zero",
+  );
+  const floatControl = aioNodeInputControlForSpec(["FLOAT", { default: 1.5 }]);
+  assert(
+    floatControl.type === "number"
+      && floatControl.step === "0.01"
+      && floatControl.value === "1.5",
+    "FLOAT node specs must build decimal controls",
+  );
+  const stringControl = aioNodeInputControlForSpec(["STRING", { default: "fallback" }], "");
+  assert(
+    stringControl.type === "text" && stringControl.value === "",
+    "STRING node specs must build text controls and preserve an explicit empty string",
+  );
+  assert(
+    aioNodeInputControlForSpec(["IMAGE"], "value") === null
+      && aioNodeInputControlForSpec(null, "value") === null,
+    "Unsupported and invalid node specs must not create controls",
+  );
+
+  assert(
+    aioValueFromNodeInputControl(null) === null,
+    "Missing controls must extract as null",
+  );
+  checked.checked = true;
+  assert(
+    aioValueFromNodeInputControl(checked) === true,
+    "Checkbox controls must extract boolean values",
+  );
+  preciseNumber.value = "12.5";
+  assert(
+    aioValueFromNodeInputControl(preciseNumber) === 12.5,
+    "Number controls must extract numeric values",
+  );
+  preciseNumber.value = "";
+  assert(
+    aioValueFromNodeInputControl(preciseNumber) === 0,
+    "Empty number controls must retain the existing zero fallback",
+  );
+  text.value = "plain text";
+  assert(
+    aioValueFromNodeInputControl(text) === "plain text",
+    "Text controls must extract their string value",
+  );
+} finally {
+  if (hadDocument) {
+    globalThis.document = previousDocument;
+  } else {
+    delete globalThis.document;
+  }
+}
+
+console.log("AiO DOM controls core smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -130,7 +130,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         preview_box_end = source.index("\n    .easyuse-anima-aio-node-preview-box img {", preview_box_start)
         preview_box_style = source[preview_box_start:preview_box_end]
         panel_registration_start = source.index("function ensureGeneratorPanel")
-        panel_registration_end = source.index("\nfunction field", panel_registration_start)
+        panel_registration_end = source.index(
+            "\nfunction openInputSettings", panel_registration_start
+        )
         panel_registration = source[panel_registration_start:panel_registration_end]
 
         self.assertIn("getMinHeight: () => GENERATOR_PANEL_MIN_HEIGHT", panel_registration)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -19,6 +19,10 @@ AIO_DOM_CONTROLS_JS = AIO_MODULES / "dom_controls.js"
 AIO_DOM_CONTROLS_CORE_SMOKE = (
     ROOT / "tests" / "frontend_aio_dom_controls_core_smoke.mjs"
 )
+AIO_DIALOG_PRIMITIVES_JS = AIO_MODULES / "dialog_primitives.js"
+AIO_DIALOG_PRIMITIVES_SMOKE = (
+    ROOT / "tests" / "frontend_aio_dialog_primitives_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -442,6 +446,73 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_DOM_CONTROLS_CORE_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_dom_controls_core_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_dialog_primitives_module_owns_shared_dom_shells(self):
+        source = AIO_DIALOG_PRIMITIVES_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreateDialogPrimitives"],
+        )
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:app|api)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:window|globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+
+        self.assertIn(
+            'import { aioCreateDialogPrimitives } from "./aio/dialog_primitives.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+\{\s*createDialog,\s*createNodeField,\s*field,\s*\}\s*="
+            r"\s*aioCreateDialogPrimitives\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        for dependency in (
+            "document",
+            "ensureStyle",
+            "staticText: aioStaticText",
+            "text: aioText",
+            "resolveFieldPresentation: aioFieldPresentation",
+            "applyTooltip",
+            "applyTooltipText",
+        ):
+            with self.subTest(dependency=dependency):
+                self.assertIn(dependency, factory_match.group("dependencies"))
+
+        presentation_start = entry_source.index("function aioFieldPresentation")
+        presentation_end = entry_source.index(
+            "\nfunction applyTooltip", presentation_start
+        )
+        presentation_body = entry_source[presentation_start:presentation_end]
+        self.assertIn("aioFieldLabel(label)", presentation_body)
+        self.assertIn(
+            "tooltipKey || AIO_FIELD_TOOLTIP_KEYS[label]",
+            presentation_body,
+        )
+        self.assertIn('aioFormat("tip.fieldGeneric"', presentation_body)
+
+        for local_function in ("createDialog", "createNodeField", "field"):
+            with self.subTest(local_function=local_function):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\bfunction\s+{local_function}\(",
+                )
+
+        self.assertTrue(AIO_DIALOG_PRIMITIVES_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_dialog_primitives_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -15,6 +15,10 @@ AIO_JS = WEB_JS / "easyuse_anima_aio.js"
 AIO_MODULES = WEB_JS / "aio"
 AIO_DEPENDENCIES_JS = AIO_MODULES / "dependencies.js"
 AIO_DEPENDENCY_CORE_SMOKE = ROOT / "tests" / "frontend_aio_dependency_core_smoke.mjs"
+AIO_DOM_CONTROLS_JS = AIO_MODULES / "dom_controls.js"
+AIO_DOM_CONTROLS_CORE_SMOKE = (
+    ROOT / "tests" / "frontend_aio_dom_controls_core_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -370,6 +374,74 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_SETTINGS_CORE_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_settings_core_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_dom_controls_core_module_owns_native_control_construction(self):
+        source = AIO_DOM_CONTROLS_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+
+        expected_functions = {
+            "aioCreateCheckboxInput",
+            "aioCreateNumberInput",
+            "aioCreateSelectInput",
+            "aioCreateTextInput",
+            "aioCreateTextareaInput",
+            "aioNodeInputControlForSpec",
+            "aioNodeInputDefault",
+            "aioValueFromNodeInputControl",
+        }
+        exported_functions = set(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source)
+        )
+        self.assertEqual(exported_functions, expected_functions)
+        self.assertNotRegex(source, r"export const [A-Za-z0-9_]+\s*=")
+
+        import_match = re.search(
+            r'import\s+\{(?P<names>[^}]*)\}\s+from\s+'
+            r'"\./aio/dom_controls\.js";',
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(import_match)
+        imported_exports = {
+            name.strip().split(" as ", 1)[0].strip()
+            for name in import_match.group("names").split(",")
+            if name.strip()
+        }
+        self.assertEqual(imported_exports, expected_functions)
+
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:app|api)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:window|globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+
+        for local_function in (
+            "checkbox",
+            "nodeInputControlForSpec",
+            "nodeInputDefault",
+            "numberInput",
+            "selectInput",
+            "textInput",
+            "textareaInput",
+            "valueFromNodeInputControl",
+        ):
+            with self.subTest(local_function=local_function):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\bfunction\s+{local_function}\(",
+                )
+
+        self.assertTrue(AIO_DOM_CONTROLS_CORE_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_dom_controls_core_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -59,6 +59,11 @@ try {
         throw "Frontend AiO settings core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_dom_controls_core_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO DOM controls core smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -64,6 +64,11 @@ try {
         throw "Frontend AiO DOM controls core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_dialog_primitives_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO dialog primitives smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/dialog_primitives.js
+++ b/web/js/aio/dialog_primitives.js
@@ -1,0 +1,129 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioDialogPrimitiveDependencies
+ * @property {any} document
+ * @property {() => void} ensureStyle
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} text
+ * @property {(label: any, tooltipKey: string) => {displayLabel: string, tooltipText: string}} resolveFieldPresentation
+ * @property {(element: any, key: string) => void} applyTooltip
+ * @property {(element: any, text: string) => void} applyTooltipText
+ */
+
+/**
+ * Build the DOM-only primitives shared by the AiO node panel and settings
+ * dialogs. Translation, tooltip, and style ownership stay with the entry and
+ * are injected explicitly so this module remains import-safe and lifecycle
+ * neutral.
+ *
+ * @param {AioDialogPrimitiveDependencies} dependencies
+ */
+export function aioCreateDialogPrimitives(dependencies) {
+  const {
+    document,
+    ensureStyle,
+    staticText,
+    text,
+    resolveFieldPresentation,
+    applyTooltip,
+    applyTooltipText,
+  } = dependencies;
+
+  /**
+   * @param {any} label
+   * @param {any} control
+   * @param {string} [className]
+   * @param {string} [tooltipKey]
+   */
+  function createNodeField(label, control, className = "", tooltipKey = "") {
+    const wrapper = document.createElement("div");
+    wrapper.className = `easyuse-anima-aio-node-field ${className}`.trim();
+    const labelEl = document.createElement("label");
+    applyTooltip(wrapper, tooltipKey);
+    applyTooltip(labelEl, tooltipKey);
+    applyTooltip(control, tooltipKey);
+    if (control?.type === "checkbox") {
+      wrapper.classList.add("checkbox");
+      const labelText = document.createElement("span");
+      labelText.textContent = label;
+      labelEl.append(labelText, control);
+      wrapper.append(labelEl);
+    } else {
+      labelEl.textContent = label;
+      wrapper.append(labelEl, control);
+    }
+    return wrapper;
+  }
+
+  /**
+   * @param {any} section
+   * @param {any} label
+   * @param {any} control
+   * @param {string} [tooltipKey]
+   */
+  function field(section, label, control, tooltipKey = "") {
+    const row = document.createElement("div");
+    row.className = "easyuse-anima-aio-field";
+    const labelEl = document.createElement("label");
+    const { displayLabel, tooltipText } = resolveFieldPresentation(label, tooltipKey);
+    applyTooltipText(row, tooltipText);
+    applyTooltipText(labelEl, tooltipText);
+    applyTooltipText(control, tooltipText);
+    if (control?.type === "checkbox") {
+      row.classList.add("checkbox");
+      const labelText = document.createElement("span");
+      labelText.textContent = displayLabel;
+      labelEl.append(labelText, control);
+      row.append(labelEl);
+    } else {
+      labelEl.textContent = displayLabel;
+      row.append(labelEl, control);
+    }
+    section.append(row);
+    return control;
+  }
+
+  /**
+   * @param {any} title
+   * @param {any} subtitle
+   */
+  function createDialog(title, subtitle) {
+    ensureStyle();
+    const backdrop = document.createElement("div");
+    backdrop.className = "easyuse-anima-aio-backdrop";
+    const dialog = document.createElement("div");
+    dialog.className = "easyuse-anima-aio-dialog";
+    const header = document.createElement("header");
+    const titleBox = document.createElement("div");
+    const heading = document.createElement("h2");
+    heading.textContent = staticText(title);
+    const description = document.createElement("p");
+    description.textContent = staticText(subtitle);
+    titleBox.append(heading, description);
+    const close = document.createElement("button");
+    close.className = "easyuse-anima-aio-close";
+    close.textContent = text("button.close");
+    header.append(titleBox, close);
+    const body = document.createElement("div");
+    body.className = "easyuse-anima-aio-body";
+    const actions = document.createElement("div");
+    actions.className = "easyuse-anima-aio-actions";
+    dialog.append(header, body, actions);
+    backdrop.append(dialog);
+    close.addEventListener("click", () => backdrop.remove());
+    backdrop.addEventListener("pointerdown", (event) => {
+      if (event.target === backdrop) {
+        backdrop.remove();
+      }
+    });
+    document.body.append(backdrop);
+    return { backdrop, body, actions };
+  }
+
+  return Object.freeze({
+    createDialog,
+    createNodeField,
+    field,
+  });
+}

--- a/web/js/aio/dom_controls.js
+++ b/web/js/aio/dom_controls.js
@@ -1,0 +1,135 @@
+// @ts-check
+
+/**
+ * @param {any} value
+ * @param {string} [step]
+ * @returns {HTMLInputElement}
+ */
+export function aioCreateNumberInput(value, step = "1") {
+  const input = document.createElement("input");
+  input.type = "number";
+  input.step = step;
+  input.value = value;
+  return input;
+}
+
+/**
+ * @param {any} value
+ * @returns {HTMLInputElement}
+ */
+export function aioCreateTextInput(value) {
+  const input = document.createElement("input");
+  input.type = "text";
+  input.value = value ?? "";
+  return input;
+}
+
+/**
+ * @param {any} value
+ * @returns {HTMLTextAreaElement}
+ */
+export function aioCreateTextareaInput(value) {
+  const textarea = document.createElement("textarea");
+  textarea.value = value ?? "";
+  return textarea;
+}
+
+/**
+ * @param {any} value
+ * @returns {HTMLInputElement}
+ */
+export function aioCreateCheckboxInput(value) {
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.checked = !!value;
+  return input;
+}
+
+/**
+ * @param {any[]} options
+ * @param {any} value
+ * @returns {HTMLSelectElement}
+ */
+export function aioCreateSelectInput(options, value) {
+  const select = document.createElement("select");
+  for (const optionSpec of options) {
+    const optionValue = typeof optionSpec === "object" && optionSpec
+      ? String(optionSpec.value ?? "")
+      : String(optionSpec ?? "");
+    const option = document.createElement("option");
+    option.value = optionValue;
+    option.textContent = typeof optionSpec === "object" && optionSpec
+      ? String(optionSpec.label ?? optionValue)
+      : optionValue;
+    option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
+    if (typeof optionSpec === "object" && optionSpec?.title) {
+      option.title = String(optionSpec.title);
+    }
+    if (optionValue === value) {
+      option.selected = true;
+    }
+    select.append(option);
+  }
+  return select;
+}
+
+/**
+ * @param {any} spec
+ * @param {any} [fallback]
+ * @returns {any}
+ */
+export function aioNodeInputDefault(spec, fallback = "") {
+  const options = Array.isArray(spec) && spec[1] && typeof spec[1] === "object" ? spec[1] : null;
+  if (options && Object.prototype.hasOwnProperty.call(options, "default")) {
+    return options.default;
+  }
+  return fallback;
+}
+
+/**
+ * @param {any} spec
+ * @param {any} [value]
+ * @returns {HTMLInputElement | HTMLSelectElement | null}
+ */
+export function aioNodeInputControlForSpec(spec, value) {
+  if (!Array.isArray(spec)) {
+    return null;
+  }
+  const type = spec[0];
+  if (Array.isArray(type)) {
+    return aioCreateSelectInput(type, value ?? aioNodeInputDefault(spec, type[0] ?? ""));
+  }
+  const normalizedType = String(type || "").toUpperCase();
+  if (normalizedType === "BOOLEAN") {
+    return aioCreateCheckboxInput(value ?? aioNodeInputDefault(spec, false));
+  }
+  if (normalizedType === "INT") {
+    const input = aioCreateNumberInput(value ?? aioNodeInputDefault(spec, 0), "1");
+    input.step = "1";
+    return input;
+  }
+  if (normalizedType === "FLOAT") {
+    return aioCreateNumberInput(value ?? aioNodeInputDefault(spec, 0), "0.01");
+  }
+  if (normalizedType === "STRING") {
+    return aioCreateTextInput(value ?? aioNodeInputDefault(spec, ""));
+  }
+  return null;
+}
+
+/**
+ * @param {any} control
+ * @returns {any}
+ */
+export function aioValueFromNodeInputControl(control) {
+  if (!control) {
+    return null;
+  }
+  if (control.type === "checkbox") {
+    return !!control.checked;
+  }
+  if (control.type === "number") {
+    return Number(control.value || 0);
+  }
+  return control.value;
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -3,6 +3,16 @@ import { api } from "../../../scripts/api.js";
 import { easyuseAnimaFetchComfyJson, easyuseAnimaFetchText } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
 import {
+  aioCreateCheckboxInput as checkbox,
+  aioCreateNumberInput as numberInput,
+  aioCreateSelectInput as selectInput,
+  aioCreateTextareaInput as textareaInput,
+  aioCreateTextInput as textInput,
+  aioNodeInputControlForSpec as nodeInputControlForSpec,
+  aioNodeInputDefault as nodeInputDefault,
+  aioValueFromNodeInputControl as valueFromNodeInputControl,
+} from "./aio/dom_controls.js";
+import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
   aioNodeInputMap,
@@ -2075,53 +2085,6 @@ function applyNodeInputInfo(control, dependencyKey, inputName, fallbackTooltipKe
   return control;
 }
 
-function nodeInputDefault(spec, fallback = "") {
-  const options = Array.isArray(spec) && spec[1] && typeof spec[1] === "object" ? spec[1] : null;
-  if (options && Object.prototype.hasOwnProperty.call(options, "default")) {
-    return options.default;
-  }
-  return fallback;
-}
-
-function nodeInputControlForSpec(spec, value) {
-  if (!Array.isArray(spec)) {
-    return null;
-  }
-  const type = spec[0];
-  if (Array.isArray(type)) {
-    return selectInput(type, value ?? nodeInputDefault(spec, type[0] ?? ""));
-  }
-  const normalizedType = String(type || "").toUpperCase();
-  if (normalizedType === "BOOLEAN") {
-    return checkbox(value ?? nodeInputDefault(spec, false));
-  }
-  if (normalizedType === "INT") {
-    const input = numberInput(value ?? nodeInputDefault(spec, 0), "1");
-    input.step = "1";
-    return input;
-  }
-  if (normalizedType === "FLOAT") {
-    return numberInput(value ?? nodeInputDefault(spec, 0), "0.01");
-  }
-  if (normalizedType === "STRING") {
-    return textInput(value ?? nodeInputDefault(spec, ""));
-  }
-  return null;
-}
-
-function valueFromNodeInputControl(control) {
-  if (!control) {
-    return null;
-  }
-  if (control.type === "checkbox") {
-    return !!control.checked;
-  }
-  if (control.type === "number") {
-    return Number(control.value || 0);
-  }
-  return control.value;
-}
-
 function createDynamicNodeInputEditor(title, dependencyKey, knownInputs, values = {}) {
   const section = document.createElement("div");
   section.className = "easyuse-anima-aio-subsection";
@@ -3535,57 +3498,6 @@ function ensureStyle() {
     }
   `;
   document.head.append(style);
-}
-
-function numberInput(value, step = "1") {
-  const input = document.createElement("input");
-  input.type = "number";
-  input.step = step;
-  input.value = value;
-  return input;
-}
-
-function textInput(value) {
-  const input = document.createElement("input");
-  input.type = "text";
-  input.value = value ?? "";
-  return input;
-}
-
-function textareaInput(value) {
-  const textarea = document.createElement("textarea");
-  textarea.value = value ?? "";
-  return textarea;
-}
-
-function checkbox(value) {
-  const input = document.createElement("input");
-  input.type = "checkbox";
-  input.checked = !!value;
-  return input;
-}
-
-function selectInput(options, value) {
-  const select = document.createElement("select");
-  for (const optionSpec of options) {
-    const optionValue = typeof optionSpec === "object" && optionSpec
-      ? String(optionSpec.value ?? "")
-      : String(optionSpec ?? "");
-    const option = document.createElement("option");
-    option.value = optionValue;
-    option.textContent = typeof optionSpec === "object" && optionSpec
-      ? String(optionSpec.label ?? optionValue)
-      : optionValue;
-    option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
-    if (typeof optionSpec === "object" && optionSpec?.title) {
-      option.title = String(optionSpec.title);
-    }
-    if (optionValue === value) {
-      option.selected = true;
-    }
-    select.append(option);
-  }
-  return select;
 }
 
 function widgetValue(node, name, fallback) {

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -12,6 +12,7 @@ import {
   aioNodeInputDefault as nodeInputDefault,
   aioValueFromNodeInputControl as valueFromNodeInputControl,
 } from "./aio/dom_controls.js";
+import { aioCreateDialogPrimitives } from "./aio/dialog_primitives.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -1826,6 +1827,15 @@ function aioFormat(key, values = {}) {
   return text;
 }
 
+function aioFieldPresentation(label, tooltipKey = "") {
+  const displayLabel = aioFieldLabel(label);
+  const resolvedTooltipKey = tooltipKey || AIO_FIELD_TOOLTIP_KEYS[label] || "";
+  const tooltipText = resolvedTooltipKey
+    ? aioText(resolvedTooltipKey)
+    : aioFormat("tip.fieldGeneric", { label: displayLabel });
+  return { displayLabel, tooltipText };
+}
+
 function applyTooltip(element, key) {
   if (!element || !key) {
     return element;
@@ -3500,6 +3510,20 @@ function ensureStyle() {
   document.head.append(style);
 }
 
+const {
+  createDialog,
+  createNodeField,
+  field,
+} = aioCreateDialogPrimitives({
+  document,
+  ensureStyle,
+  staticText: aioStaticText,
+  text: aioText,
+  resolveFieldPresentation: aioFieldPresentation,
+  applyTooltip,
+  applyTooltipText,
+});
+
 function widgetValue(node, name, fallback) {
   if (Object.prototype.hasOwnProperty.call(node?.__easyuseAnimaGeneratorUiValues || {}, name)) {
     return node.__easyuseAnimaGeneratorUiValues[name];
@@ -4610,26 +4634,6 @@ function scheduleGeneratorDefaultPreviewSuppression(node, options = {}) {
   }, 360);
 }
 
-function createNodeField(label, control, className = "", tooltipKey = "") {
-  const wrapper = document.createElement("div");
-  wrapper.className = `easyuse-anima-aio-node-field ${className}`.trim();
-  const labelEl = document.createElement("label");
-  applyTooltip(wrapper, tooltipKey);
-  applyTooltip(labelEl, tooltipKey);
-  applyTooltip(control, tooltipKey);
-  if (control?.type === "checkbox") {
-    wrapper.classList.add("checkbox");
-    const text = document.createElement("span");
-    text.textContent = label;
-    labelEl.append(text, control);
-    wrapper.append(labelEl);
-  } else {
-    labelEl.textContent = label;
-    wrapper.append(labelEl, control);
-  }
-  return wrapper;
-}
-
 function createDomNumberControl(node, name, value, step = "1") {
   const input = numberInput(value, step);
   input.addEventListener("input", () => {
@@ -5560,65 +5564,6 @@ function ensureGeneratorPanel(node) {
   markGeneratorNativeLivePreviewHidden(node);
   renderGeneratorPanel(node);
   markGeneratorNativeLivePreviewHidden(node);
-}
-
-function field(section, label, control, tooltipKey = "") {
-  const row = document.createElement("div");
-  row.className = "easyuse-anima-aio-field";
-  const labelEl = document.createElement("label");
-  const displayLabel = aioFieldLabel(label);
-  const resolvedTooltipKey = tooltipKey || AIO_FIELD_TOOLTIP_KEYS[label] || "";
-  const tooltipText = resolvedTooltipKey
-    ? aioText(resolvedTooltipKey)
-    : aioFormat("tip.fieldGeneric", { label: displayLabel });
-  applyTooltipText(row, tooltipText);
-  applyTooltipText(labelEl, tooltipText);
-  applyTooltipText(control, tooltipText);
-  if (control?.type === "checkbox") {
-    row.classList.add("checkbox");
-    const text = document.createElement("span");
-    text.textContent = displayLabel;
-    labelEl.append(text, control);
-    row.append(labelEl);
-  } else {
-    labelEl.textContent = displayLabel;
-    row.append(labelEl, control);
-  }
-  section.append(row);
-  return control;
-}
-
-function createDialog(title, subtitle) {
-  ensureStyle();
-  const backdrop = document.createElement("div");
-  backdrop.className = "easyuse-anima-aio-backdrop";
-  const dialog = document.createElement("div");
-  dialog.className = "easyuse-anima-aio-dialog";
-  const header = document.createElement("header");
-  const titleBox = document.createElement("div");
-  const heading = document.createElement("h2");
-  heading.textContent = aioStaticText(title);
-  const desc = document.createElement("p");
-  desc.textContent = aioStaticText(subtitle);
-  titleBox.append(heading, desc);
-  const close = document.createElement("button");
-  close.className = "easyuse-anima-aio-close";
-  close.textContent = aioText("button.close");
-  header.append(titleBox, close);
-  const body = document.createElement("div");
-  body.className = "easyuse-anima-aio-body";
-  const actions = document.createElement("div");
-  actions.className = "easyuse-anima-aio-actions";
-  dialog.append(header, body, actions);
-  backdrop.append(dialog);
-  close.addEventListener("click", () => backdrop.remove());
-  backdrop.addEventListener("pointerdown", (event) => {
-    if (event.target === backdrop) {
-      backdrop.remove();
-    }
-  });
-  document.body.append(backdrop);
-  return { backdrop, body, actions };
 }
 
 function openInputSettings(node) {


### PR DESCRIPTION
## 변경 요약

Issue #54의 AiO 프론트엔드 유지보수 단계 중 DOM 경계를 작은 reviewable slice로 분리합니다.

- 반복되는 native DOM control 생성기를 `web/js/aio/dom_controls.js`로 분리
- node field, settings field, dialog shell을 `web/js/aio/dialog_primitives.js`의 dependency-injected factory로 분리
- 번역, tooltip 정책, stylesheet 수명주기는 entry에 유지하고 명시적으로 주입
- import-safe leaf module과 semantic smoke, source-boundary 검사를 공식 frontend runner에 연결

## 변경 이유

AiO entry가 제어 생성, dialog DOM shell, 번역/tooltip 정책, 런타임 orchestration을 한 파일에서 함께 소유해 다음 settings dialog 분리 시 회귀 범위가 컸습니다. 이번 변경은 DOM 생성 책임만 먼저 떼어내고 기존 클래스, append 순서, Apply/Cancel 동작, close/backdrop 이벤트를 그대로 유지합니다.

## 주요 파일

- `web/js/aio/dom_controls.js`
- `web/js/aio/dialog_primitives.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_dom_controls_core_smoke.mjs`
- `tests/frontend_aio_dialog_primitives_smoke.mjs`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- Official full runner
  - `workspace tools/check_custom_node.ps1 -Project <PR worktree> -Profile full`
  - Python unittest: 331 passed
  - Frontend: 70 JavaScript files, TypeScript 6.0.3
  - 모든 semantic smoke 및 `git diff --check` 통과
- ComfyUI 0.27.0 Codex test instance
  - Legacy canvas: Save Options open, controls, Cancel, Apply, reopen, close, backdrop, queue success
  - Node 2.0: 동일 시나리오 및 queue success
  - 두 queue 모두 server history에서 `success` / `completed=true`
  - 새 EasyUseAnima syntax/reference/404 오류 없음
- 사용자 인스턴스 수동 확인
  - Issue #54–57 전체 유지보수 완료 뒤 v0.27.0에 한 번 반영해 진행

## 범위 밖 / 다음 단계

실제 settings dialog controller와 queue/runtime hook은 아직 entry에 남아 있습니다. 다음 Issue #54 slice에서 dialog별 상태·Apply/Cancel 순서를 유지하며 점진적으로 이동합니다.

Refs #54