### PR TITLE
[Maintenance] AiO Input Settings dialog 경계 분리

### DIFF
--- a/tests/frontend_aio_input_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_input_settings_dialog_smoke.mjs
@@ -1,0 +1,343 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertJsonEqual(actual, expected, message) {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function merge(defaults, current) {
+  if (Array.isArray(current)) {
+    return clone(current);
+  }
+  if (!current || typeof current !== "object") {
+    return current === undefined ? clone(defaults) : current;
+  }
+  const output = defaults && typeof defaults === "object" && !Array.isArray(defaults)
+    ? clone(defaults)
+    : {};
+  for (const [key, value] of Object.entries(current)) {
+    output[key] = merge(output[key], value);
+  }
+  return output;
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.className = "";
+    this.textContent = "";
+    this.value = "";
+    this.children = [];
+    this.parentElement = null;
+    this.listeners = new Map();
+  }
+
+  append(...children) {
+    for (const child of children) {
+      if (child && typeof child === "object") {
+        child.parentElement = this;
+      }
+      this.children.push(child);
+    }
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type) {
+    for (const listener of this.listeners.get(type) || []) {
+      listener({ target: this });
+    }
+  }
+}
+
+const inputSettingsDialogModule = await import(dataModule("../web/js/aio/input_settings_dialog.js"));
+assertJsonEqual(
+  Object.keys(inputSettingsDialogModule),
+  ["aioCreateInputSettingsDialog"],
+  "Input Settings dialog must expose only its factory contract",
+);
+
+const defaultInputSettings = {
+  resources: {
+    loader_mode: "split",
+    clip_loader: "single",
+    unet_weight_dtype: "default",
+    clip_device: "default",
+    default_only: "preserved",
+  },
+};
+
+let dependencyCalls = 0;
+let currentDialog = null;
+const dialogs = [];
+const findCalls = [];
+const parseCalls = [];
+const parsedValues = [];
+const mergeCalls = [];
+const writeAttempts = [];
+const writes = [];
+
+const fakeDocument = {
+  createElement(tagName) {
+    dependencyCalls += 1;
+    return new FakeElement(tagName);
+  },
+};
+
+function createDialog(title, subtitle) {
+  dependencyCalls += 1;
+  const dialog = {
+    title,
+    subtitle,
+    body: new FakeElement("div"),
+    actions: new FakeElement("div"),
+    controls: new Map(),
+    trace: [],
+  };
+  dialog.backdrop = new FakeElement("div");
+  dialog.backdrop.remove = () => dialog.trace.push("remove");
+  dialogs.push(dialog);
+  currentDialog = dialog;
+  return dialog;
+}
+
+function field(section, label, control) {
+  dependencyCalls += 1;
+  const wrapper = new FakeElement("div");
+  wrapper.append(control);
+  section.append(wrapper);
+  currentDialog.controls.set(label, control);
+  return control;
+}
+
+function selectInput(options, value) {
+  dependencyCalls += 1;
+  const control = new FakeElement("select");
+  control.options = clone(options);
+  control.value = String(value ?? "");
+  return control;
+}
+
+function staticText(value) {
+  dependencyCalls += 1;
+  return `static:${value}`;
+}
+
+function text(key) {
+  dependencyCalls += 1;
+  return `text:${key}`;
+}
+
+function findWidget(node, name) {
+  dependencyCalls += 1;
+  findCalls.push({ node, name });
+  return node.widgets?.find((widget) => widget.name === name);
+}
+
+function parseSettings(widget, defaults) {
+  dependencyCalls += 1;
+  parseCalls.push({ widget, defaults });
+  if (!widget) {
+    const parsed = clone(defaults);
+    parsedValues.push(parsed);
+    return parsed;
+  }
+  let current = widget.value || {};
+  if (typeof current === "string") {
+    try {
+      current = JSON.parse(current);
+    } catch (_error) {
+      current = {};
+    }
+  }
+  const parsed = merge(defaults, current);
+  parsedValues.push(parsed);
+  return parsed;
+}
+
+function mergeDefaults(defaults, current) {
+  dependencyCalls += 1;
+  currentDialog.trace.push("merge");
+  mergeCalls.push({ defaults, current });
+  return merge(defaults, current);
+}
+
+function writeSettings(node, widget, settings) {
+  dependencyCalls += 1;
+  currentDialog.trace.push(widget ? "write" : "write-noop");
+  const attempt = { node, widget, settings: clone(settings) };
+  writeAttempts.push(attempt);
+  if (!widget) {
+    return;
+  }
+  widget.value = JSON.stringify(settings);
+  writes.push(attempt);
+}
+
+const openInputSettings = inputSettingsDialogModule.aioCreateInputSettingsDialog({
+  document: fakeDocument,
+  createDialog,
+  field,
+  selectInput,
+  staticText,
+  text,
+  defaultInputSettings,
+  inputSettingsWidget: "input_settings",
+  findWidget,
+  parseSettings,
+  mergeDefaults,
+  writeSettings,
+});
+
+assert(typeof openInputSettings === "function", "Factory must return the Input Settings opener");
+assert(openInputSettings.name === "openInputSettings", "Returned opener must retain its controller name");
+assert(
+  dependencyCalls === 0 && dialogs.length === 0 && writeAttempts.length === 0,
+  "Factory creation must not touch DOM, settings, or lifecycle adapters",
+);
+
+function latestDialog() {
+  return dialogs[dialogs.length - 1];
+}
+
+function cancel(dialog) {
+  dialog.actions.children[0].dispatch("click");
+}
+
+function apply(dialog) {
+  dialog.actions.children[1].dispatch("click");
+}
+
+const inputNode = {
+  widgets: [{
+    name: "input_settings",
+    value: JSON.stringify({
+      resources: {
+        unet_weight_dtype: "fp8_e4m3fn",
+        clip_device: "cpu",
+        future_resource: "preserved",
+      },
+      schema_version: 7,
+      metadata: { future_owner: "preserved" },
+      future_root: { keep: true },
+    }),
+  }],
+};
+const defaultsBeforeInteractions = clone(defaultInputSettings);
+const beforeCancel = clone(inputNode.widgets[0].value);
+openInputSettings(inputNode);
+let dialog = latestDialog();
+assert(
+  findCalls[0].node === inputNode && findCalls[0].name === "input_settings",
+  "Opener must resolve the Input Settings widget by its injected name",
+);
+assert(
+  parseCalls[0].widget === inputNode.widgets[0] && parseCalls[0].defaults === defaultInputSettings,
+  "Opener must parse the resolved widget against the injected defaults",
+);
+assert(dialog.title === "Easy Use Anima Input Settings", "Dialog title must remain stable");
+assert(
+  dialog.subtitle === "Advanced resource options are saved internally with the workflow.",
+  "Dialog subtitle must remain stable",
+);
+assertJsonEqual(
+  dialog.controls.get("UNET weight dtype").options,
+  ["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],
+  "UNET dtype options must remain stable",
+);
+assertJsonEqual(
+  dialog.controls.get("CLIP device").options,
+  ["default", "cpu"],
+  "CLIP device options must remain stable",
+);
+assert(
+  dialog.controls.get("UNET weight dtype").value === "fp8_e4m3fn"
+    && dialog.controls.get("CLIP device").value === "cpu",
+  "Saved resource settings must hydrate their matching controls",
+);
+dialog.controls.get("UNET weight dtype").value = "fp8_e5m2";
+dialog.controls.get("CLIP device").value = "default";
+cancel(dialog);
+assertJsonEqual(dialog.trace, ["remove"], "Cancel must only close the dialog");
+assert(mergeCalls.length === 0, "Cancel must not merge an applied settings snapshot");
+assert(writeAttempts.length === 0, "Cancel must not attempt a settings write");
+assertJsonEqual(inputNode.widgets[0].value, beforeCancel, "Cancel must not mutate saved settings");
+
+openInputSettings(inputNode);
+dialog = latestDialog();
+dialog.controls.get("UNET weight dtype").value = "fp8_e5m2";
+dialog.controls.get("CLIP device").value = "";
+apply(dialog);
+assertJsonEqual(dialog.trace, ["merge", "write", "remove"], "Apply must merge, write, then close");
+assert(writeAttempts.length === 1 && writes.length === 1, "Apply must persist exactly one settings write");
+assert(writeAttempts[0].widget === inputNode.widgets[0], "Apply must target the hidden input settings widget");
+const written = writes[0].settings;
+assertJsonEqual(JSON.parse(inputNode.widgets[0].value), written, "Write adapter must serialize the applied settings");
+assert(
+  written.resources.loader_mode === "split"
+    && written.resources.clip_loader === "single"
+    && written.resources.unet_weight_dtype === "fp8_e5m2"
+    && written.resources.clip_device === "default",
+  "Apply must preserve forced loader values and selected resources",
+);
+assert(
+  written.resources.default_only === "preserved"
+    && written.resources.future_resource === "preserved"
+    && written.schema_version === 7
+    && written.metadata.future_owner === "preserved"
+    && written.future_root.keep === true,
+  "Apply must preserve schema metadata, defaults, and unknown future settings",
+);
+assertJsonEqual(defaultInputSettings, defaultsBeforeInteractions, "Apply must not mutate injected defaults");
+assert(
+  parsedValues[1].resources.unet_weight_dtype === "fp8_e4m3fn"
+    && parsedValues[1].resources.clip_device === "cpu",
+  "Apply must not mutate the parsed settings snapshot captured at open time",
+);
+
+const missingWidgetNode = { widgets: [], untouched: true };
+const beforeMissingApply = clone(missingWidgetNode);
+openInputSettings(missingWidgetNode);
+dialog = latestDialog();
+assert(
+  dialog.controls.get("UNET weight dtype").value === "default"
+    && dialog.controls.get("CLIP device").value === "default",
+  "Missing widgets must hydrate controls from defaults",
+);
+dialog.controls.get("UNET weight dtype").value = "";
+dialog.controls.get("CLIP device").value = "";
+apply(dialog);
+assertJsonEqual(
+  dialog.trace,
+  ["merge", "write-noop", "remove"],
+  "Missing-widget Apply must merge, attempt the no-op write, then close",
+);
+assert(writeAttempts.length === 2, "Missing-widget Apply must invoke the write adapter exactly once");
+assert(writeAttempts[1].widget === undefined, "Missing-widget Apply must pass the unresolved widget to the adapter");
+assert(writes.length === 1, "Missing-widget Apply must not report a persisted write");
+assert(
+  writeAttempts[1].settings.resources.unet_weight_dtype === "default"
+    && writeAttempts[1].settings.resources.clip_device === "default",
+  "Empty selections must normalize to default resource values",
+);
+assertJsonEqual(missingWidgetNode, beforeMissingApply, "Missing-widget Apply must not mutate the node directly");
+
+console.log("AiO Input Settings dialog smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -131,7 +131,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         preview_box_style = source[preview_box_start:preview_box_end]
         panel_registration_start = source.index("function ensureGeneratorPanel")
         panel_registration_end = source.index(
-            "\nfunction openInputSettings", panel_registration_start
+            "\nfunction openSamplerSettings", panel_registration_start
         )
         panel_registration = source[panel_registration_start:panel_registration_end]
 

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -23,6 +23,10 @@ AIO_DIALOG_PRIMITIVES_JS = AIO_MODULES / "dialog_primitives.js"
 AIO_DIALOG_PRIMITIVES_SMOKE = (
     ROOT / "tests" / "frontend_aio_dialog_primitives_smoke.mjs"
 )
+AIO_INPUT_SETTINGS_DIALOG_JS = AIO_MODULES / "input_settings_dialog.js"
+AIO_INPUT_SETTINGS_DIALOG_SMOKE = (
+    ROOT / "tests" / "frontend_aio_input_settings_dialog_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -513,6 +517,84 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_DIALOG_PRIMITIVES_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_dialog_primitives_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_input_settings_dialog_has_closed_controller_boundary(self):
+        source = AIO_INPUT_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreateInputSettingsDialog"],
+        )
+        self.assertLessEqual(len(source.splitlines()), 100)
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:app|api)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:window|globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+
+        self.assertIn(
+            'import { aioCreateInputSettingsDialog } from "./aio/input_settings_dialog.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+openInputSettings\s*=\s*aioCreateInputSettingsDialog"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().removesuffix(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "document",
+                "createDialog",
+                "field",
+                "selectInput",
+                "staticText: aioStaticText",
+                "text: aioText",
+                "defaultInputSettings: DEFAULT_INPUT_SETTINGS",
+                "inputSettingsWidget: INPUT_SETTINGS_WIDGET",
+                "findWidget",
+                "parseSettings",
+                "mergeDefaults",
+                "writeSettings",
+            },
+        )
+
+        self.assertNotRegex(entry_source, r"\bfunction\s+openInputSettings\(")
+        for entry_owned_dialog in ("openPostprocessSettings", "openPreviewSettings"):
+            with self.subTest(entry_owned_dialog=entry_owned_dialog):
+                self.assertRegex(
+                    entry_source,
+                    rf"\bfunction\s+{entry_owned_dialog}\(",
+                )
+
+        hook_start = entry_source.index("function hookInputNode")
+        hook_end = entry_source.index("\nfunction hookGeneratorNode", hook_start)
+        hook_body = entry_source[hook_start:hook_end]
+        self.assertIn(
+            'ensureButton(node, "easyuse_anima_input_settings", "Settings...", '
+            '() => openInputSettings(node));',
+            hook_body,
+        )
+        self.assertEqual(entry_source.count("openInputSettings(node)"), 1)
+
+        self.assertTrue(AIO_INPUT_SETTINGS_DIALOG_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_input_settings_dialog_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -69,6 +69,11 @@ try {
         throw "Frontend AiO dialog primitives smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_input_settings_dialog_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Input Settings dialog smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/input_settings_dialog.js
+++ b/web/js/aio/input_settings_dialog.js
@@ -1,0 +1,84 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioInputSettingsDialogDependencies
+ * @property {any} document
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(options: any[], value: any) => any} selectInput
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} text
+ * @property {any} defaultInputSettings
+ * @property {string} inputSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(widget: any, defaults: any) => any} parseSettings
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ */
+
+/**
+ * Build the Input Settings opener from shared DOM and settings adapters.
+ * Extension lifecycle and node registration remain owned by the entry module.
+ *
+ * @param {AioInputSettingsDialogDependencies} dependencies
+ * @returns {(node: any) => void}
+ */
+export function aioCreateInputSettingsDialog(dependencies) {
+  const {
+    document,
+    createDialog,
+    field,
+    selectInput,
+    staticText,
+    text,
+    defaultInputSettings,
+    inputSettingsWidget,
+    findWidget,
+    parseSettings,
+    mergeDefaults,
+    writeSettings,
+  } = dependencies;
+
+  return function openInputSettings(node) {
+    const widget = findWidget(node, inputSettingsWidget);
+    const settings = parseSettings(widget, defaultInputSettings);
+    const { backdrop, body, actions } = createDialog(
+      "Easy Use Anima Input Settings",
+      "Advanced resource options are saved internally with the workflow.",
+    );
+    const section = document.createElement("section");
+    section.className = "easyuse-anima-aio-section full";
+    section.append(Object.assign(document.createElement("h3"), { textContent: staticText("Loader Options") }));
+    const weightDtype = field(
+      section,
+      "UNET weight dtype",
+      selectInput(["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"], settings.resources.unet_weight_dtype),
+    );
+    const clipDevice = field(
+      section,
+      "CLIP device",
+      selectInput(["default", "cpu"], settings.resources.clip_device),
+    );
+    const loaderMode = document.createElement("p");
+    loaderMode.textContent = text("text.inputLoaderMode");
+    section.append(loaderMode);
+    body.append(section);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = text("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = text("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(defaultInputSettings, settings);
+      next.resources.loader_mode = "split";
+      next.resources.clip_loader = "single";
+      next.resources.unet_weight_dtype = weightDtype.value || "default";
+      next.resources.clip_device = clipDevice.value || "default";
+      writeSettings(node, widget, next);
+      backdrop.remove();
+    });
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -13,6 +13,7 @@ import {
   aioValueFromNodeInputControl as valueFromNodeInputControl,
 } from "./aio/dom_controls.js";
 import { aioCreateDialogPrimitives } from "./aio/dialog_primitives.js";
+import { aioCreateInputSettingsDialog } from "./aio/input_settings_dialog.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -5566,49 +5567,6 @@ function ensureGeneratorPanel(node) {
   markGeneratorNativeLivePreviewHidden(node);
 }
 
-function openInputSettings(node) {
-  const widget = findWidget(node, INPUT_SETTINGS_WIDGET);
-  const settings = parseSettings(widget, DEFAULT_INPUT_SETTINGS);
-  const { backdrop, body, actions } = createDialog(
-    "Easy Use Anima Input Settings",
-    "Advanced resource options are saved internally with the workflow."
-  );
-  const section = document.createElement("section");
-  section.className = "easyuse-anima-aio-section full";
-  section.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Loader Options") }));
-  const weightDtype = field(
-    section,
-    "UNET weight dtype",
-    selectInput(["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"], settings.resources.unet_weight_dtype)
-  );
-  const clipDevice = field(
-    section,
-    "CLIP device",
-    selectInput(["default", "cpu"], settings.resources.clip_device)
-  );
-  const loaderMode = document.createElement("p");
-  loaderMode.textContent = aioText("text.inputLoaderMode");
-  section.append(loaderMode);
-  body.append(section);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_INPUT_SETTINGS, settings);
-    next.resources.loader_mode = "split";
-    next.resources.clip_loader = "single";
-    next.resources.unet_weight_dtype = weightDtype.value || "default";
-    next.resources.clip_device = clipDevice.value || "default";
-    writeSettings(node, widget, next);
-    backdrop.remove();
-  });
-}
-
 function openSamplerSettings(node) {
   const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
   const settings = mergeVisibleGeneratorSettings(node, parseSettings(widget, DEFAULT_GENERATION_SETTINGS));
@@ -7566,6 +7524,21 @@ function ensureButton(node, key, label, callback) {
     widget.serialize = false;
   }
 }
+
+const openInputSettings = aioCreateInputSettingsDialog({
+  document,
+  createDialog,
+  field,
+  selectInput,
+  staticText: aioStaticText,
+  text: aioText,
+  defaultInputSettings: DEFAULT_INPUT_SETTINGS,
+  inputSettingsWidget: INPUT_SETTINGS_WIDGET,
+  findWidget,
+  parseSettings,
+  mergeDefaults,
+  writeSettings,
+});
 
 function hookInputNode(node) {
   node.serialize_widgets = true;


### PR DESCRIPTION
## 변경 요약

Issue #54의 DOM primitive 분리 후속으로, Input 노드의 Settings dialog controller만 작은 reviewable slice로 분리합니다.

- `web/js/aio/input_settings_dialog.js`에 dependency-injected factory 추가
- entry에는 extension lifecycle, node hook, 번역/DOM/settings adapter 조립 책임 유지
- 기존 widget 이름, 저장 schema, 옵션, Apply/Cancel 순서와 fallback 유지
- factory 경계와 직렬화 의미를 semantic smoke 및 source-boundary 검사로 고정

## 변경 이유

Input Settings의 상태 hydrate, control 생성, Apply/Cancel persistence가 큰 AiO entry 안에 남아 있어 다음 dialog 및 runtime 경계 작업의 회귀 범위가 넓었습니다. 이번 조각은 lifecycle과 node registration을 옮기지 않고 controller 하나만 분리해 의존 방향을 명시합니다.

## 주요 파일

- `web/js/aio/input_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_input_settings_dialog_smoke.mjs`
- `tests/test_frontend_modules.py`
- `tests/test_aio_frontend.py`
- `tools/check_frontend.ps1`

## 유지되는 동작

- `EasyUseAnimaInput` node type과 `input_settings` hidden widget 계약
- UNET dtype / CLIP device 옵션과 기본값
- Apply 시 `loader_mode=split`, `clip_loader=single` 강제
- unknown schema/metadata 보존
- Cancel은 저장값을 변경하지 않음
- workflow load/save 및 queue payload 계약

## 검증

- Focused checks
  - 신규/entry JS syntax 검사 통과
  - Input Settings semantic smoke 통과
  - `tests.test_frontend_modules` + `tests.test_aio_frontend`: 59 passed
  - `git diff --check` 통과
- Official full runner
  - `tools/check_custom_node.ps1 -Project <PR worktree> -Profile full`
  - Python unittest: 332 passed
  - Frontend: 71 JavaScript files, TypeScript 6.0.3
  - 모든 semantic smoke 및 diff 검사 통과
- ComfyUI 0.27.0 Codex test instance
  - Legacy canvas: saved-state hydrate, Cancel, Apply, reopen, close, backdrop, 재로드 자동 복원 후 적용값 유지, minimal queue success
  - Node 2.0: 동일 시나리오, legacy에서 적용한 상태의 mode reload 복원, minimal queue success
  - 두 queue 모두 server history에서 `success` / `completed=true`
  - 최초 legacy queue 1회는 browser automation의 Preview Image 연결 누락으로 validation 실패; 테스트 그래프 연결을 수정한 뒤 두 모드에서 재실행해 성공 (제품 코드 변경 없음)
  - EasyUseAnima 신규 404/SyntaxError/ReferenceError 없음
  - 종료 시 legacy canvas 설정으로 복원
- 사용자 v0.27.0 인스턴스
  - Issue #54–57 전체 유지보수 완료 뒤 한 번 반영해 수동 확인 예정

## 범위 밖 / 다음 단계

Postprocess/Preview dialog와 queue/runtime/extension entry 경계는 이번 PR에서 이동하지 않습니다. 다음 Issue #54 조각에서 같은 방식으로 진행합니다.

저장소에 아직 없는 라벨 후보: `type: chore`, `area: frontend`, `status: ready`

Refs #54