### PR TITLE
refactor: AiO 후보정 설정 대화상자 분리

### DIFF
--- a/tests/frontend_aio_postprocess_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_postprocess_settings_dialog_smoke.mjs
@@ -1,0 +1,465 @@
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertJsonEqual(actual, expected, message) {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function merge(defaults, current) {
+  if (Array.isArray(current)) {
+    return clone(current);
+  }
+  if (!current || typeof current !== "object") {
+    return current === undefined ? clone(defaults) : current;
+  }
+  const output = defaults && typeof defaults === "object" && !Array.isArray(defaults)
+    ? clone(defaults)
+    : {};
+  for (const [key, value] of Object.entries(current)) {
+    output[key] = merge(output[key], value);
+  }
+  return output;
+}
+
+class FakeClassList {
+  constructor() {
+    this.values = new Set();
+  }
+
+  add(...names) {
+    for (const name of names) {
+      this.values.add(name);
+    }
+  }
+
+  contains(name) {
+    return this.values.has(name);
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.className = "";
+    this.classList = new FakeClassList();
+    this.textContent = "";
+    this.value = "";
+    this.checked = false;
+    this.children = [];
+    this.parentElement = null;
+    this.style = {};
+    this.listeners = new Map();
+  }
+
+  append(...children) {
+    for (const child of children) {
+      if (child && typeof child === "object") {
+        child.parentElement = this;
+      }
+      this.children.push(child);
+    }
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type) {
+    for (const listener of this.listeners.get(type) || []) {
+      listener({ target: this });
+    }
+  }
+}
+
+const postprocessDialogModule = await import(dataModule("../web/js/aio/postprocess_settings_dialog.js"));
+assertJsonEqual(
+  Object.keys(postprocessDialogModule),
+  ["aioCreatePostprocessSettingsDialog"],
+  "Postprocess Settings dialog must expose only its factory contract",
+);
+
+const defaultGenerationSettings = {
+  schema_version: 4,
+  sampler: { seed: 0, default_sampler_field: "preserved" },
+  upscale: { enabled: false, default_upscale_field: "preserved" },
+  postprocess: {
+    enabled: false,
+    default_postprocess_field: "preserved",
+    fit: {
+      mode: "max_long_edge",
+      max_long_edge: 2048,
+      max_megapixels: 4,
+      method: "bicubic",
+      default_fit_field: "preserved",
+    },
+  },
+};
+
+let dependencyCalls = 0;
+let currentDialog = null;
+const dialogs = [];
+const findCalls = [];
+const settingsCalls = [];
+const settingsSnapshots = [];
+const mergeCalls = [];
+const clampCalls = [];
+const writeAttempts = [];
+const writes = [];
+const renderCalls = [];
+
+const fakeDocument = {
+  createElement(tagName) {
+    dependencyCalls += 1;
+    return new FakeElement(tagName);
+  },
+};
+
+function createDialog(title, subtitle) {
+  dependencyCalls += 1;
+  const dialog = {
+    title,
+    subtitle,
+    body: new FakeElement("div"),
+    actions: new FakeElement("div"),
+    controls: new Map(),
+    tooltips: new Map(),
+    trace: [],
+  };
+  dialog.backdrop = new FakeElement("div");
+  dialog.backdrop.remove = () => dialog.trace.push("remove");
+  dialogs.push(dialog);
+  currentDialog = dialog;
+  return dialog;
+}
+
+function field(section, label, control, tooltipKey = "") {
+  dependencyCalls += 1;
+  const wrapper = new FakeElement("div");
+  wrapper.append(control);
+  section.append(wrapper);
+  currentDialog.controls.set(label, control);
+  currentDialog.tooltips.set(label, tooltipKey);
+  return control;
+}
+
+function checkbox(value) {
+  dependencyCalls += 1;
+  const control = new FakeElement("input");
+  control.checked = !!value;
+  return control;
+}
+
+function selectInput(options, value) {
+  dependencyCalls += 1;
+  const control = new FakeElement("select");
+  control.options = clone(options);
+  control.value = String(value ?? "");
+  return control;
+}
+
+function numberInput(value, step = "1") {
+  dependencyCalls += 1;
+  const control = new FakeElement("input");
+  control.value = String(value ?? "");
+  control.step = step;
+  return control;
+}
+
+function staticText(value) {
+  dependencyCalls += 1;
+  return `static:${value}`;
+}
+
+function text(key) {
+  dependencyCalls += 1;
+  return `text:${key}`;
+}
+
+function findWidget(node, name) {
+  dependencyCalls += 1;
+  findCalls.push({ node, name });
+  return node.widgets?.find((widget) => widget.name === name);
+}
+
+function generatorSettings(node) {
+  dependencyCalls += 1;
+  settingsCalls.push(node);
+  const widget = node.widgets?.find((candidate) => candidate.name === "generation_settings");
+  let current = widget?.value || {};
+  if (typeof current === "string") {
+    try {
+      current = JSON.parse(current);
+    } catch (_error) {
+      current = {};
+    }
+  }
+  const snapshot = merge(defaultGenerationSettings, current);
+  settingsSnapshots.push(snapshot);
+  return snapshot;
+}
+
+function mergeDefaults(defaults, current) {
+  dependencyCalls += 1;
+  if (currentDialog) {
+    currentDialog.trace.push("merge");
+  }
+  mergeCalls.push({ defaults, current });
+  return merge(defaults, current);
+}
+
+function clampNumber(value, fallback, min, max) {
+  dependencyCalls += 1;
+  currentDialog.trace.push("clamp");
+  clampCalls.push({ value, fallback, min, max });
+  const parsed = Number(value);
+  const next = Number.isFinite(parsed) ? parsed : fallback;
+  return Math.max(min, Math.min(max, next));
+}
+
+function writeSettings(node, widget, settings) {
+  dependencyCalls += 1;
+  currentDialog.trace.push(widget ? "write" : "write-noop");
+  const attempt = { node, widget, settings: clone(settings) };
+  writeAttempts.push(attempt);
+  if (!widget) {
+    return;
+  }
+  widget.value = JSON.stringify(settings);
+  writes.push(attempt);
+}
+
+function renderGeneratorPanel(node) {
+  dependencyCalls += 1;
+  currentDialog.trace.push("render");
+  renderCalls.push(node);
+}
+
+const openPostprocessSettings = postprocessDialogModule.aioCreatePostprocessSettingsDialog({
+  document: fakeDocument,
+  createDialog,
+  field,
+  checkbox,
+  selectInput,
+  numberInput,
+  staticText,
+  text,
+  defaultGenerationSettings,
+  generatorSettingsWidget: "generation_settings",
+  findWidget,
+  generatorSettings,
+  mergeDefaults,
+  clampNumber,
+  writeSettings,
+  renderGeneratorPanel,
+});
+
+assert(typeof openPostprocessSettings === "function", "Factory must return the Postprocess Settings opener");
+assert(openPostprocessSettings.name === "openPostprocessSettings", "Returned opener must retain its controller name");
+assert(
+  dependencyCalls === 0 && dialogs.length === 0 && writeAttempts.length === 0 && renderCalls.length === 0,
+  "Factory creation must not touch DOM, settings, persistence, or lifecycle adapters",
+);
+
+function open(node) {
+  currentDialog = null;
+  openPostprocessSettings(node);
+  return dialogs[dialogs.length - 1];
+}
+
+function cancel(dialog) {
+  dialog.actions.children[0].dispatch("click");
+}
+
+function apply(dialog) {
+  dialog.actions.children[1].dispatch("click");
+}
+
+function display(dialog, label) {
+  return dialog.controls.get(label).parentElement.style.display;
+}
+
+const generatorNode = {
+  widgets: [{
+    name: "generation_settings",
+    value: JSON.stringify({
+      schema_version: 7,
+      sampler: { seed: 42, future_sampler_field: "preserved" },
+      upscale: {
+        enabled: true,
+        future_upscale_field: "preserved",
+        fit: { enabled: true, legacy_field: "removed" },
+      },
+      postprocess: {
+        enabled: true,
+        future_postprocess_field: "preserved",
+        fit: {
+          mode: "max_long_edge",
+          max_long_edge: 3072,
+          max_megapixels: 9.5,
+          method: "lanczos",
+          future_fit_field: "preserved",
+        },
+      },
+      future_root: { keep: true },
+    }),
+  }],
+};
+
+const defaultsBeforeInteractions = clone(defaultGenerationSettings);
+const serializedBeforeCancel = generatorNode.widgets[0].value;
+let dialog = open(generatorNode);
+const firstSettingsSnapshot = clone(settingsSnapshots[0]);
+assert(
+  findCalls[0].node === generatorNode && findCalls[0].name === "generation_settings",
+  "Opener must resolve the injected hidden generation settings widget once",
+);
+assert(settingsCalls.length === 1 && settingsCalls[0] === generatorNode, "Opener must read generator settings once");
+assert(dialog.title === "Postprocess Settings", "Dialog title must remain stable");
+assert(
+  dialog.subtitle === "Final size fit runs after Detailer and Upscale, before Save. Cap by long edge or megapixels.",
+  "Dialog subtitle must remain stable",
+);
+assert(dialog.body.classList.contains("easyuse-anima-aio-one-column"), "Dialog must retain one-column layout");
+assert(dialog.body.children[0].children[0].textContent === "static:Final Size Fit", "Section heading must use static text");
+assert(dialog.actions.children[0].textContent === "text:button.cancel", "Cancel label must use text adapter");
+assert(dialog.actions.children[1].textContent === "text:button.apply", "Apply label must use text adapter");
+assert(dialog.actions.children[1].className === "primary", "Apply button must remain primary");
+assertJsonEqual(
+  dialog.controls.get("Fit by").options,
+  [
+    { value: "max_long_edge", label: "Max long edge" },
+    { value: "megapixels", label: "Megapixels" },
+  ],
+  "Fit mode options must remain stable",
+);
+assertJsonEqual(
+  dialog.controls.get("Fit method").options,
+  ["bicubic", "lanczos", "area", "bilinear", "nearest-exact"],
+  "Fit method options must remain stable",
+);
+assert(dialog.controls.get("Enable postprocess").checked, "Saved enabled state must hydrate");
+assert(dialog.controls.get("Fit by").value === "max_long_edge", "Saved fit mode must hydrate");
+assert(dialog.controls.get("Max long edge").value === "3072", "Saved long edge must hydrate");
+assert(dialog.controls.get("Max megapixels").value === "9.5", "Saved megapixels must hydrate");
+assert(dialog.controls.get("Fit method").value === "lanczos", "Saved fit method must hydrate");
+assert(display(dialog, "Fit by") === "" && display(dialog, "Fit method") === "", "Enabled fit controls must show");
+assert(display(dialog, "Max long edge") === "", "Long-edge row must show in long-edge mode");
+assert(display(dialog, "Max megapixels") === "none", "Megapixels row must hide in long-edge mode");
+assert(dialog.tooltips.get("Enable postprocess") === "tip.postprocessEnabled", "Enable tooltip key must remain stable");
+for (const label of ["Fit by", "Max long edge", "Max megapixels", "Fit method"]) {
+  assert(dialog.tooltips.get(label) === "tip.finalFit", `${label} tooltip key must remain stable`);
+}
+
+dialog.controls.get("Fit by").value = "megapixels";
+dialog.controls.get("Fit by").dispatch("change");
+assert(display(dialog, "Max long edge") === "none", "Long-edge row must hide in megapixels mode");
+assert(display(dialog, "Max megapixels") === "", "Megapixels row must show in megapixels mode");
+dialog.controls.get("Enable postprocess").checked = false;
+dialog.controls.get("Enable postprocess").dispatch("change");
+for (const label of ["Fit by", "Max long edge", "Max megapixels", "Fit method"]) {
+  assert(display(dialog, label) === "none", `${label} must hide while postprocess is disabled`);
+}
+const mergeCountBeforeCancel = mergeCalls.length;
+cancel(dialog);
+assertJsonEqual(dialog.trace, ["remove"], "Cancel must only close the dialog");
+assert(mergeCalls.length === mergeCountBeforeCancel, "Cancel must not merge an applied settings snapshot");
+assert(writeAttempts.length === 0 && renderCalls.length === 0, "Cancel must not write or render");
+assert(generatorNode.widgets[0].value === serializedBeforeCancel, "Cancel must not mutate serialized settings");
+assertJsonEqual(settingsSnapshots[0], firstSettingsSnapshot, "Cancel must not mutate the open-time settings snapshot");
+
+dialog = open(generatorNode);
+const appliedSettingsSnapshot = clone(settingsSnapshots[1]);
+dialog.controls.get("Enable postprocess").checked = true;
+dialog.controls.get("Fit by").value = "";
+dialog.controls.get("Max long edge").value = "20000.8";
+dialog.controls.get("Max megapixels").value = "not-a-number";
+dialog.controls.get("Fit method").value = "";
+apply(dialog);
+assertJsonEqual(
+  dialog.trace,
+  ["merge", "clamp", "clamp", "write", "render", "remove"],
+  "Apply must merge, clamp, write, render, then close",
+);
+assert(writeAttempts.length === 1 && writes.length === 1, "Apply must persist exactly one settings write");
+assert(renderCalls.length === 1 && renderCalls[0] === generatorNode, "Apply must refresh the generator panel once");
+assert(writeAttempts[0].widget === generatorNode.widgets[0], "Apply must target the hidden generation settings widget");
+const written = writes[0].settings;
+assertJsonEqual(JSON.parse(generatorNode.widgets[0].value), written, "Write adapter must serialize applied settings");
+assert(
+  written.postprocess.enabled === true
+    && written.postprocess.fit.mode === "max_long_edge"
+    && written.postprocess.fit.max_long_edge === 16384
+    && written.postprocess.fit.max_megapixels === 4
+    && written.postprocess.fit.method === "bicubic",
+  "Apply must preserve fallbacks, clamps, and long-edge truncation",
+);
+assertJsonEqual(
+  clampCalls.slice(0, 2),
+  [
+    { value: "20000.8", fallback: 2048, min: 64, max: 16384 },
+    { value: "not-a-number", fallback: 4, min: 0.1, max: 256 },
+  ],
+  "Apply must retain exact numeric clamp contracts",
+);
+assert(
+  written.future_root.keep === true
+    && written.sampler.future_sampler_field === "preserved"
+    && written.upscale.future_upscale_field === "preserved"
+    && written.postprocess.future_postprocess_field === "preserved"
+    && written.postprocess.fit.future_fit_field === "preserved"
+    && written.postprocess.default_postprocess_field === "preserved"
+    && written.postprocess.fit.default_fit_field === "preserved",
+  "Apply must preserve root, stage, postprocess, fit, and default-compatible unknown fields",
+);
+assert(!Object.prototype.hasOwnProperty.call(written.upscale, "fit"), "Apply must remove legacy upscale.fit");
+assertJsonEqual(defaultGenerationSettings, defaultsBeforeInteractions, "Apply must not mutate injected defaults");
+assertJsonEqual(settingsSnapshots[1], appliedSettingsSnapshot, "Apply must not mutate the open-time settings snapshot");
+
+const missingWidgetNode = { widgets: [], untouched: true };
+const missingWidgetBeforeApply = clone(missingWidgetNode);
+dialog = open(missingWidgetNode);
+assert(!dialog.controls.get("Enable postprocess").checked, "Missing widgets must hydrate default enabled state");
+for (const label of ["Fit by", "Max long edge", "Max megapixels", "Fit method"]) {
+  assert(display(dialog, label) === "none", `${label} must start hidden for default disabled postprocess`);
+}
+dialog.controls.get("Enable postprocess").checked = true;
+dialog.controls.get("Fit by").value = "megapixels";
+dialog.controls.get("Max long edge").value = "";
+dialog.controls.get("Max megapixels").value = "";
+dialog.controls.get("Fit method").value = "area";
+apply(dialog);
+assertJsonEqual(
+  dialog.trace,
+  ["merge", "clamp", "clamp", "write-noop", "render", "remove"],
+  "Missing-widget Apply must still merge, clamp, attempt write, render, then close",
+);
+assert(writeAttempts.length === 2, "Missing-widget Apply must invoke the write adapter exactly once");
+assert(writeAttempts[1].widget === undefined, "Missing-widget Apply must pass the unresolved widget to the adapter");
+assert(writes.length === 1, "Missing-widget Apply must not report a persisted write");
+assert(renderCalls.length === 2 && renderCalls[1] === missingWidgetNode, "Missing-widget Apply must still refresh panel");
+assert(
+  writeAttempts[1].settings.postprocess.fit.mode === "megapixels"
+    && writeAttempts[1].settings.postprocess.fit.max_long_edge === 64
+    && writeAttempts[1].settings.postprocess.fit.max_megapixels === 0.1
+    && writeAttempts[1].settings.postprocess.fit.method === "area",
+  "Blank numeric controls must retain the existing minimum-clamp behavior",
+);
+assertJsonEqual(missingWidgetNode, missingWidgetBeforeApply, "Missing-widget Apply must not mutate the node directly");
+
+console.log("AiO Postprocess Settings dialog smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 AIO_JS = ROOT / "web" / "js" / "easyuse_anima_aio.js"
+AIO_POSTPROCESS_SETTINGS_DIALOG_JS = (
+    ROOT / "web" / "js" / "aio" / "postprocess_settings_dialog.js"
+)
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
@@ -260,7 +263,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
     def test_upscale_settings_offer_single_backend_and_usdu_helpers(self):
         source = AIO_JS.read_text(encoding="utf-8")
         start = source.index("function openUpscaleSettings")
-        end = source.index("\nfunction openPostprocessSettings", start)
+        end = source.index("\nfunction createDetailerTargetEditor", start)
         body = source[start:end]
 
         self.assertIn('selectInput(["usdu", "resshift"]', body)
@@ -285,21 +288,20 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("resshift:", body)
 
     def test_postprocess_settings_own_final_fit_controls(self):
-        source = AIO_JS.read_text(encoding="utf-8")
-        start = source.index("function openPostprocessSettings")
-        end = source.index("\nfunction createDetailerTargetEditor", start)
-        body = source[start:end]
+        body = AIO_POSTPROCESS_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
 
         self.assertIn('createDialog(', body)
         self.assertIn('"Postprocess Settings"', body)
-        self.assertIn('textContent: aioStaticText("Final Size Fit")', body)
+        self.assertIn('textContent: staticText("Final Size Fit")', body)
         self.assertIn('"Enable postprocess"', body)
         self.assertIn('"max_long_edge"', body)
         self.assertIn('"megapixels"', body)
         self.assertIn("next.postprocess = {", body)
         self.assertIn("fit: {", body)
         self.assertIn("max_long_edge: Math.trunc", body)
-        self.assertIn("max_megapixels: clampGeneratorNumber", body)
+        self.assertIn("max_megapixels: clampNumber", body)
+        self.assertIn("...postprocess", body)
+        self.assertIn("...fit", body)
         self.assertIn("delete next.upscale?.fit", body)
 
     def test_upscale_optional_dependency_sanitizer_disables_missing_backend(self):

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -27,6 +27,10 @@ AIO_INPUT_SETTINGS_DIALOG_JS = AIO_MODULES / "input_settings_dialog.js"
 AIO_INPUT_SETTINGS_DIALOG_SMOKE = (
     ROOT / "tests" / "frontend_aio_input_settings_dialog_smoke.mjs"
 )
+AIO_POSTPROCESS_SETTINGS_DIALOG_JS = AIO_MODULES / "postprocess_settings_dialog.js"
+AIO_POSTPROCESS_SETTINGS_DIALOG_SMOKE = (
+    ROOT / "tests" / "frontend_aio_postprocess_settings_dialog_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -575,7 +579,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
 
         self.assertNotRegex(entry_source, r"\bfunction\s+openInputSettings\(")
-        for entry_owned_dialog in ("openPostprocessSettings", "openPreviewSettings"):
+        for entry_owned_dialog in ("openPreviewSettings",):
             with self.subTest(entry_owned_dialog=entry_owned_dialog):
                 self.assertRegex(
                     entry_source,
@@ -595,6 +599,84 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_INPUT_SETTINGS_DIALOG_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_input_settings_dialog_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_postprocess_settings_dialog_has_closed_controller_boundary(self):
+        source = AIO_POSTPROCESS_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreatePostprocessSettingsDialog"],
+        )
+        self.assertLessEqual(len(source.splitlines()), 150)
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:app|api)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:window|globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+
+        self.assertIn(
+            'import { aioCreatePostprocessSettingsDialog } from '
+            '"./aio/postprocess_settings_dialog.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+openPostprocessSettings\s*=\s*"
+            r"aioCreatePostprocessSettingsDialog"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().removesuffix(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "document",
+                "createDialog",
+                "field",
+                "checkbox",
+                "selectInput",
+                "numberInput",
+                "staticText: aioStaticText",
+                "text: aioText",
+                "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS",
+                "generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET",
+                "findWidget",
+                "generatorSettings",
+                "mergeDefaults",
+                "clampNumber: clampGeneratorNumber",
+                "writeSettings",
+                "renderGeneratorPanel",
+            },
+        )
+
+        self.assertNotRegex(entry_source, r"\bfunction\s+openPostprocessSettings\(")
+        self.assertRegex(entry_source, r"\bfunction\s+openPreviewSettings\(")
+        self.assertIn("const openInputSettings = aioCreateInputSettingsDialog", entry_source)
+
+        render_start = entry_source.index("function renderGeneratorPanel")
+        render_end = entry_source.index("\nfunction ensureGeneratorPanel", render_start)
+        render_body = entry_source[render_start:render_end]
+        self.assertIn("openPostprocessSettings(node)", render_body)
+        self.assertEqual(entry_source.count("openPostprocessSettings(node)"), 1)
+
+        self.assertIn("...postprocess", source)
+        self.assertIn("...fit", source)
+        self.assertTrue(AIO_POSTPROCESS_SETTINGS_DIALOG_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_postprocess_settings_dialog_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -74,6 +74,11 @@ try {
         throw "Frontend AiO Input Settings dialog smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_postprocess_settings_dialog_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Postprocess Settings dialog smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/postprocess_settings_dialog.js
+++ b/web/js/aio/postprocess_settings_dialog.js
@@ -1,0 +1,130 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioPostprocessSettingsDialogDependencies
+ * @property {any} document
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(value: any) => any} checkbox
+ * @property {(options: any[], value: any) => any} selectInput
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} text
+ * @property {any} defaultGenerationSettings
+ * @property {string} generatorSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(node: any) => any} generatorSettings
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(value: any, fallback: number, min: number, max: number) => number} clampNumber
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ * @property {(node: any) => void} renderGeneratorPanel
+ */
+
+/**
+ * Build the Postprocess Settings opener from shared DOM and settings adapters.
+ * Extension lifecycle and generator panel ownership remain in the entry module.
+ *
+ * @param {AioPostprocessSettingsDialogDependencies} dependencies
+ * @returns {(node: any) => void}
+ */
+export function aioCreatePostprocessSettingsDialog(dependencies) {
+  const {
+    document,
+    createDialog,
+    field,
+    checkbox,
+    selectInput,
+    numberInput,
+    staticText,
+    text,
+    defaultGenerationSettings,
+    generatorSettingsWidget,
+    findWidget,
+    generatorSettings,
+    mergeDefaults,
+    clampNumber,
+    writeSettings,
+    renderGeneratorPanel,
+  } = dependencies;
+
+  return function openPostprocessSettings(node) {
+    const widget = findWidget(node, generatorSettingsWidget);
+    const settings = generatorSettings(node);
+    const postprocess = mergeDefaults(defaultGenerationSettings.postprocess, settings.postprocess || {});
+    const fit = mergeDefaults(defaultGenerationSettings.postprocess.fit, postprocess.fit || {});
+    const { backdrop, body, actions } = createDialog(
+      "Postprocess Settings",
+      "Final size fit runs after Detailer and Upscale, before Save. Cap by long edge or megapixels.",
+    );
+    body.classList.add("easyuse-anima-aio-one-column");
+
+    const fitSection = document.createElement("section");
+    fitSection.className = "easyuse-anima-aio-section";
+    fitSection.append(Object.assign(document.createElement("h3"), { textContent: staticText("Final Size Fit") }));
+    const enabled = field(fitSection, "Enable postprocess", checkbox(postprocess.enabled), "tip.postprocessEnabled");
+    const fitMode = field(
+      fitSection,
+      "Fit by",
+      selectInput([
+        { value: "max_long_edge", label: "Max long edge" },
+        { value: "megapixels", label: "Megapixels" },
+      ], fit.mode || "max_long_edge"),
+      "tip.finalFit",
+    );
+    const fitMaxLongEdge = field(fitSection, "Max long edge", numberInput(fit.max_long_edge, "64"), "tip.finalFit");
+    const fitMaxMegapixels = field(fitSection, "Max megapixels", numberInput(fit.max_megapixels, "0.1"), "tip.finalFit");
+    const fitMethod = field(
+      fitSection,
+      "Fit method",
+      selectInput(["bicubic", "lanczos", "area", "bilinear", "nearest-exact"], fit.method || "bicubic"),
+      "tip.finalFit",
+    );
+
+    const updateVisibility = () => {
+      const fitDisplay = enabled.checked ? "" : "none";
+      for (const control of [fitMode, fitMethod]) {
+        if (control?.parentElement) {
+          control.parentElement.style.display = fitDisplay;
+        }
+      }
+      const longEdgeDisplay = enabled.checked && fitMode.value === "max_long_edge" ? "" : "none";
+      const megapixelsDisplay = enabled.checked && fitMode.value === "megapixels" ? "" : "none";
+      if (fitMaxLongEdge?.parentElement) {
+        fitMaxLongEdge.parentElement.style.display = longEdgeDisplay;
+      }
+      if (fitMaxMegapixels?.parentElement) {
+        fitMaxMegapixels.parentElement.style.display = megapixelsDisplay;
+      }
+    };
+    enabled.addEventListener("change", updateVisibility);
+    fitMode.addEventListener("change", updateVisibility);
+    body.append(fitSection);
+    updateVisibility();
+
+    const cancel = document.createElement("button");
+    cancel.textContent = text("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = text("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(defaultGenerationSettings, settings);
+      next.postprocess = {
+        ...postprocess,
+        enabled: enabled.checked,
+        fit: {
+          ...fit,
+          mode: fitMode.value || "max_long_edge",
+          max_long_edge: Math.trunc(clampNumber(fitMaxLongEdge.value, 2048, 64, 16384)),
+          max_megapixels: clampNumber(fitMaxMegapixels.value, 4, 0.1, 256),
+          method: fitMethod.value || "bicubic",
+        },
+      };
+      delete next.upscale?.fit;
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -14,6 +14,7 @@ import {
 } from "./aio/dom_controls.js";
 import { aioCreateDialogPrimitives } from "./aio/dialog_primitives.js";
 import { aioCreateInputSettingsDialog } from "./aio/input_settings_dialog.js";
+import { aioCreatePostprocessSettingsDialog } from "./aio/postprocess_settings_dialog.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -6273,85 +6274,6 @@ function openUpscaleSettings(node) {
   });
 }
 
-function openPostprocessSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = generatorSettings(node);
-  const postprocess = mergeDefaults(DEFAULT_GENERATION_SETTINGS.postprocess, settings.postprocess || {});
-  const fit = mergeDefaults(DEFAULT_GENERATION_SETTINGS.postprocess.fit, postprocess.fit || {});
-  const { backdrop, body, actions } = createDialog(
-    "Postprocess Settings",
-    "Final size fit runs after Detailer and Upscale, before Save. Cap by long edge or megapixels."
-  );
-  body.classList.add("easyuse-anima-aio-one-column");
-
-  const fitSection = document.createElement("section");
-  fitSection.className = "easyuse-anima-aio-section";
-  fitSection.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Final Size Fit") }));
-  const enabled = field(fitSection, "Enable postprocess", checkbox(postprocess.enabled), "tip.postprocessEnabled");
-  const fitMode = field(
-    fitSection,
-    "Fit by",
-    selectInput([
-      { value: "max_long_edge", label: "Max long edge" },
-      { value: "megapixels", label: "Megapixels" },
-    ], fit.mode || "max_long_edge"),
-    "tip.finalFit",
-  );
-  const fitMaxLongEdge = field(fitSection, "Max long edge", numberInput(fit.max_long_edge, "64"), "tip.finalFit");
-  const fitMaxMegapixels = field(fitSection, "Max megapixels", numberInput(fit.max_megapixels, "0.1"), "tip.finalFit");
-  const fitMethod = field(
-    fitSection,
-    "Fit method",
-    selectInput(["bicubic", "lanczos", "area", "bilinear", "nearest-exact"], fit.method || "bicubic"),
-    "tip.finalFit",
-  );
-
-  const updateVisibility = () => {
-    const fitDisplay = enabled.checked ? "" : "none";
-    for (const control of [fitMode, fitMethod]) {
-      if (control?.parentElement) {
-        control.parentElement.style.display = fitDisplay;
-      }
-    }
-    const longEdgeDisplay = enabled.checked && fitMode.value === "max_long_edge" ? "" : "none";
-    const megapixelsDisplay = enabled.checked && fitMode.value === "megapixels" ? "" : "none";
-    if (fitMaxLongEdge?.parentElement) {
-      fitMaxLongEdge.parentElement.style.display = longEdgeDisplay;
-    }
-    if (fitMaxMegapixels?.parentElement) {
-      fitMaxMegapixels.parentElement.style.display = megapixelsDisplay;
-    }
-  };
-  enabled.addEventListener("change", updateVisibility);
-  fitMode.addEventListener("change", updateVisibility);
-  body.append(fitSection);
-  updateVisibility();
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    next.postprocess = {
-      enabled: enabled.checked,
-      fit: {
-        mode: fitMode.value || "max_long_edge",
-        max_long_edge: Math.trunc(clampGeneratorNumber(fitMaxLongEdge.value, 2048, 64, 16384)),
-        max_megapixels: clampGeneratorNumber(fitMaxMegapixels.value, 4, 0.1, 256),
-        method: fitMethod.value || "bicubic",
-      },
-    };
-    delete next.upscale?.fit;
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
-
 function createDetailerTargetEditor(node, title, values, defaults, onLabelChange = null) {
   const target = mergeDefaults(defaults, values || {});
   const section = document.createElement("section");
@@ -7538,6 +7460,25 @@ const openInputSettings = aioCreateInputSettingsDialog({
   parseSettings,
   mergeDefaults,
   writeSettings,
+});
+
+const openPostprocessSettings = aioCreatePostprocessSettingsDialog({
+  document,
+  createDialog,
+  field,
+  checkbox,
+  selectInput,
+  numberInput,
+  staticText: aioStaticText,
+  text: aioText,
+  defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+  generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+  findWidget,
+  generatorSettings,
+  mergeDefaults,
+  clampNumber: clampGeneratorNumber,
+  writeSettings,
+  renderGeneratorPanel,
 });
 
 function hookInputNode(node) {


### PR DESCRIPTION
## 변경 요약

- AiO 후보정(Postprocess) 설정 대화상자를 `web/js/aio/postprocess_settings_dialog.js`로 분리했습니다.
- 메인 엔트리는 확장 lifecycle과 후보정 톱니바퀴 연결만 유지하고, 대화상자의 hydration·visibility·Cancel·Apply·정규화 책임은 새 모듈로 이동했습니다.
- 적용 시 알려진 후보정 값은 기존과 동일하게 덮어쓰되, 향후 추가될 수 있는 알 수 없는 `postprocess`/`fit` 필드는 보존하도록 호환성을 개선했습니다.
- 전용 semantic smoke와 Python 경계 검사를 공식 frontend runner에 연결했습니다.

## 주요 파일

- `web/js/aio/postprocess_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_postprocess_settings_dialog_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- Focused frontend semantic smoke: 통과
- Focused Python frontend boundary tests: 60 passed
- Official full profile: Python unittest 333 passed
- Official frontend profile: 72 JavaScript files, TypeScript 6.0.3, 전체 semantic smoke 통과
- `git diff --check`: 통과
- ComfyUI legacy canvas:
  - 후보정 열기, 활성화/표시 전환, Cancel, Apply, 재열기 값 보존, 닫기, backdrop 닫기 확인
  - 테스트용 AiO를 bypass한 최소 Empty Image → Preview Image 그래프 queue success 확인
- ComfyUI Node 2.0:
  - legacy에서 저장한 값 반영 확인
  - Cancel 후 기존 값 유지, Apply 후 `Max long edge=1536`/`area` 재열기 보존 확인
  - 같은 최소 그래프 queue success 확인
- 최초 legacy queue 시도는 스모크 구성에서 필수 입력이 없는 AiO를 우회하지 않아 입력 검증 단계에서 중단됐습니다. 테스트용 AiO를 bypass한 뒤 양 캔버스에서 재실행해 success 이력을 확인했습니다.
- 브라우저 로그에는 기존 ComfyUI baseline 경고와 초기화 시점 `ComfyApp graph accessed before initialization`만 있었고, 새 모듈의 404/SyntaxError/ReferenceError는 없었습니다.

## 남은 확인

- 사용자 v0.27.0 인스턴스 수동 확인은 Issue #54–#57 전체 작업이 끝난 뒤 한 번만 진행합니다.
- 이 PR은 Issue #54의 작은 유지보수 조각이며, Preview/profile/stage/runtime thin-entry 분리는 후속 PR로 계속 진행합니다.

Refs #54

라벨 후보: `type: chore`, `area: frontend`, `status: draft` (저장소에 해당 라벨이 없으면 생성하지 않음)
