### PR TITLE
refactor: LoRA Preset 프로필 데이터 경계 분리

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -14,6 +14,7 @@
   },
   "include": [
     "web/js/aio/**/*.js",
+    "web/js/lora_preset/**/*.js",
     "web/js/easyuse_anima_prompt_studio.js",
     "web/js/easyuse_anima_prompt_studio_regional.js",
     "web/js/prompt_studio/**/*.js"

--- a/tests/frontend_lora_preset_profile_data_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_data_smoke.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const profileData = await import(dataModule("../web/js/lora_preset/profile_data.js"));
+
+assert.deepEqual(Object.keys(profileData).sort(), [
+  "INTERNAL_WIDGET_DEFAULTS",
+  "MAX_PROFILES",
+  "WIDGET_INDEX",
+  "emptyProfile",
+  "isMeaningfulProfile",
+  "normalizeLoraEntry",
+  "normalizeProfileDataValue",
+  "normalizeSerializedWidgets",
+  "profileContent",
+  "profileKey",
+  "profileSavedName",
+  "profileSnapshot",
+  "withSavedMeta",
+  "wrapProfileIndex",
+].sort());
+
+const {
+  INTERNAL_WIDGET_DEFAULTS,
+  MAX_PROFILES,
+  WIDGET_INDEX,
+  emptyProfile,
+  isMeaningfulProfile,
+  normalizeLoraEntry,
+  normalizeProfileDataValue,
+  normalizeSerializedWidgets,
+  profileContent,
+  profileKey,
+  profileSavedName,
+  profileSnapshot,
+  withSavedMeta,
+  wrapProfileIndex,
+} = profileData;
+
+assert.equal(MAX_PROFILES, 16);
+assert.deepEqual(WIDGET_INDEX, {
+  stylePrompt: 0,
+  profileIndex: 1,
+  profileCount: 2,
+  loraName: 3,
+  loras: 4,
+  profileData: 5,
+});
+assert.deepEqual(INTERNAL_WIDGET_DEFAULTS, {
+  profile_count: "4",
+  lora_name: "None",
+  loras: "[]",
+  profile_data: "{}",
+});
+
+const preservedProfileJson = ' {"1":{"style_prompt":"keep"}} ';
+const serializedValues = [
+  "style",
+  2,
+  "",
+  "legacy-name",
+  [{ name: "style/example.safetensors", strength: 0.75 }],
+  preservedProfileJson,
+];
+const serializedInfo = { widgets_values: serializedValues };
+assert.equal(normalizeSerializedWidgets(serializedInfo), undefined);
+assert.strictEqual(serializedInfo.widgets_values, serializedValues);
+assert.equal(serializedValues[WIDGET_INDEX.stylePrompt], "style");
+assert.equal(serializedValues[WIDGET_INDEX.profileIndex], 2);
+assert.equal(serializedValues[WIDGET_INDEX.profileCount], "4");
+assert.equal(serializedValues[WIDGET_INDEX.loraName], "None");
+assert.equal(
+  serializedValues[WIDGET_INDEX.loras],
+  '[{"name":"style/example.safetensors","strength":0.75}]',
+);
+assert.equal(serializedValues[WIDGET_INDEX.profileData], preservedProfileJson);
+
+const malformedLoraString = "[not-valid-json";
+const fallbackValues = ["", 1, null, "anything", malformedLoraString, "[]"];
+normalizeSerializedWidgets({ widgets_values: fallbackValues });
+assert.equal(fallbackValues[WIDGET_INDEX.profileCount], "4");
+assert.equal(fallbackValues[WIDGET_INDEX.loraName], "None");
+assert.equal(fallbackValues[WIDGET_INDEX.loras], malformedLoraString);
+assert.equal(fallbackValues[WIDGET_INDEX.profileData], "{}");
+
+const malformedProfileValues = ["", 1, "4", "anything", "[]", "{bad-json"];
+assert.doesNotThrow(() => normalizeSerializedWidgets({ widgets_values: malformedProfileValues }));
+assert.equal(malformedProfileValues[WIDGET_INDEX.profileData], "{}");
+
+const nonStringValues = ["", 1, "2", "anything", { invalid: true }, { "1": {} }];
+normalizeSerializedWidgets({ widgets_values: nonStringValues });
+assert.equal(nonStringValues[WIDGET_INDEX.profileCount], "2");
+assert.equal(nonStringValues[WIDGET_INDEX.loras], "[]");
+assert.equal(nonStringValues[WIDGET_INDEX.profileData], "{}");
+const nonArrayInfo = { widgets_values: { untouched: true } };
+assert.equal(normalizeSerializedWidgets(nonArrayInfo), undefined);
+assert.deepEqual(nonArrayInfo.widgets_values, { untouched: true });
+
+assert.equal(profileKey(-3), "1");
+assert.equal(profileKey("12suffix"), "12");
+assert.equal(profileKey(99), "16");
+assert.equal(profileKey("invalid"), "1");
+assert.equal(wrapProfileIndex(1, 4), 1);
+assert.equal(wrapProfileIndex(5, 4), 1);
+assert.equal(wrapProfileIndex(16, 20), 16);
+assert.equal(wrapProfileIndex(17, 20), 1);
+assert.equal(wrapProfileIndex(-1, 0), 1);
+
+const profileObject = { "1": { style_prompt: "same object" } };
+assert.strictEqual(normalizeProfileDataValue(profileObject), profileObject);
+assert.deepEqual(normalizeProfileDataValue('{"1":{"style_prompt":"json"}}'), {
+  "1": { style_prompt: "json" },
+});
+assert.deepEqual(normalizeProfileDataValue("invalid"), {});
+assert.deepEqual(normalizeProfileDataValue("[]"), {});
+assert.deepEqual(normalizeProfileDataValue([]), {});
+assert.deepEqual(normalizeProfileDataValue(null), {});
+
+assert.deepEqual(normalizeLoraEntry({
+  lora: " style/example.safetensors ",
+  active: false,
+  strength: "0.75",
+  clipStrength: "0.5",
+  unknown: "drop",
+}), {
+  name: "style/example.safetensors",
+  on: false,
+  strength: 0.75,
+  strengthTwo: 0.5,
+});
+assert.deepEqual(normalizeLoraEntry({
+  name: "bad.safetensors",
+  on: true,
+  strength: "bad",
+  strengthTwo: "bad",
+}), {
+  name: "bad.safetensors",
+  on: true,
+  strength: 1,
+  strengthTwo: null,
+});
+assert.deepEqual(normalizeLoraEntry({
+  name: "canonical.safetensors",
+  lora: "legacy.safetensors",
+  on: false,
+  active: true,
+  strength: 1,
+  strengthTwo: "",
+  clipStrength: "0.9",
+}), {
+  name: "canonical.safetensors",
+  on: false,
+  strength: 1,
+  strengthTwo: null,
+});
+assert.equal(normalizeLoraEntry({ name: "zero.safetensors", strength: "" }).strength, 0);
+
+const rawProfile = {
+  style_prompt: 123,
+  loras: [
+    { name: "", strength: 1 },
+    { lora: " kept.safetensors ", active: false, strength: "1.25" },
+  ],
+  saved_name: "must be stripped",
+  saved_snapshot: "must be stripped",
+  unknown: true,
+};
+const normalizedContent = profileContent(rawProfile);
+assert.deepEqual(normalizedContent, {
+  style_prompt: "123",
+  loras: [{
+    name: "kept.safetensors",
+    on: false,
+    strength: 1.25,
+    strengthTwo: null,
+  }],
+});
+assert.equal(
+  profileSnapshot(rawProfile),
+  '{"style_prompt":"123","loras":[{"name":"kept.safetensors","on":false,"strength":1.25,"strengthTwo":null}]}',
+);
+assert.equal(isMeaningfulProfile({ style_prompt: "   ", loras: [] }), false);
+assert.equal(isMeaningfulProfile({ style_prompt: "", loras: [{ name: "" }] }), false);
+assert.equal(isMeaningfulProfile({ style_prompt: " tag ", loras: [] }), true);
+assert.equal(isMeaningfulProfile({ style_prompt: "", loras: [{ name: "kept.safetensors" }] }), true);
+assert.equal(profileSavedName({ saved_name: " Saved Set " }), "Saved Set");
+
+const contentInput = { style_prompt: "prompt", loras: [] };
+const previousInput = { saved_name: " Saved Set ", saved_snapshot: "snapshot" };
+assert.deepEqual(withSavedMeta(contentInput, previousInput), {
+  style_prompt: "prompt",
+  loras: [],
+  saved_name: "Saved Set",
+  saved_snapshot: "snapshot",
+});
+assert.deepEqual(contentInput, { style_prompt: "prompt", loras: [] });
+assert.deepEqual(previousInput, { saved_name: " Saved Set ", saved_snapshot: "snapshot" });
+assert.deepEqual(withSavedMeta(contentInput, { saved_name: "Saved Set" }), {
+  style_prompt: "prompt",
+  loras: [],
+});
+assert.deepEqual(withSavedMeta(contentInput, { saved_snapshot: "snapshot" }), {
+  style_prompt: "prompt",
+  loras: [],
+});
+
+const firstEmpty = emptyProfile(1);
+const secondEmpty = emptyProfile(16);
+assert.deepEqual(firstEmpty, { style_prompt: "", loras: [] });
+assert.deepEqual(secondEmpty, { style_prompt: "", loras: [] });
+assert.notStrictEqual(firstEmpty, secondEmpty);
+assert.notStrictEqual(firstEmpty.loras, secondEmpty.loras);

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import re
 import shutil
 import subprocess
 import textwrap
@@ -8,9 +10,99 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+LORA_PRESET_ENTRY = ROOT / "web" / "js" / "easyuse_anima_lora_preset.js"
+LORA_PRESET_PROFILE_DATA = ROOT / "web" / "js" / "lora_preset" / "profile_data.js"
+LORA_PRESET_PROFILE_DATA_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_profile_data_smoke.mjs"
+)
+JSCONFIG = ROOT / "jsconfig.json"
+FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class LoraPresetFrontendTests(unittest.TestCase):
+    def test_profile_data_module_boundary(self):
+        module_source = LORA_PRESET_PROFILE_DATA.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        expected_exports = {
+            "INTERNAL_WIDGET_DEFAULTS",
+            "MAX_PROFILES",
+            "WIDGET_INDEX",
+            "emptyProfile",
+            "isMeaningfulProfile",
+            "normalizeLoraEntry",
+            "normalizeProfileDataValue",
+            "normalizeSerializedWidgets",
+            "profileContent",
+            "profileKey",
+            "profileSavedName",
+            "profileSnapshot",
+            "withSavedMeta",
+            "wrapProfileIndex",
+        }
+        exported_names = set(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            )
+        )
+        self.assertEqual(exported_names, expected_exports)
+
+        import_match = re.search(
+            r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*"\./lora_preset/profile_data\.js";',
+            entry_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip().rstrip(",")
+            for name in import_match.group("names").splitlines()
+            if name.strip()
+        }
+        self.assertEqual(imported_names, expected_exports)
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            r"\b(?:document|window|app|api|LiteGraph|fetch|registerExtension)\b",
+        )
+        for name in expected_exports:
+            with self.subTest(moved_declaration=name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\b(?:const|let|var|function|class)\s+{re.escape(name)}\b",
+                )
+
+        self.assertTrue(LORA_PRESET_PROFILE_DATA_SMOKE.is_file())
+        self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_lora_preset_profile_data_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_profile_data_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_PROFILE_DATA_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_lora_row_non_toggle_controls_do_not_throw(self):
         node_bin = shutil.which("node")
         if not node_bin:
@@ -23,8 +115,15 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const vm = require("vm");
 
             const sourcePath = process.argv[1];
+            const profileDataPath = process.argv[2];
+            let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
+            profileDataSource = profileDataSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
-            source = source.replace(/^import\s+.*;\r?\n/gm, "");
+            source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
+            source = `${profileDataSource}\n${source}`;
             source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems };\n";
 
             class StubElement {
@@ -264,7 +363,13 @@ class LoraPresetFrontendTests(unittest.TestCase):
         )
 
         completed = subprocess.run(
-            [node_bin, "-e", runner, str(ROOT / "web" / "js" / "easyuse_anima_lora_preset.js")],
+            [
+                node_bin,
+                "-e",
+                runner,
+                str(LORA_PRESET_ENTRY),
+                str(LORA_PRESET_PROFILE_DATA),
+            ],
             cwd=ROOT,
             text=True,
             capture_output=True,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -89,6 +89,11 @@ try {
         throw "Frontend Regional runtime lifecycle smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_profile_data_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset profile data smoke failed with exit code $LASTEXITCODE."
+    }
+
     & npx --yes --package "typescript@$TypeScriptVersion" -- tsc -p jsconfig.json
     if ($LASTEXITCODE -ne 0) {
         throw "TypeScript check failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -2,17 +2,24 @@ import { app } from "../../../scripts/app.js";
 import { api } from "../../../scripts/api.js";
 import { easyuseAnimaEncodeRFC3986URIComponent as encodeRFC3986URIComponent, easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
+import {
+  INTERNAL_WIDGET_DEFAULTS,
+  MAX_PROFILES,
+  WIDGET_INDEX,
+  emptyProfile,
+  isMeaningfulProfile,
+  normalizeLoraEntry,
+  normalizeProfileDataValue,
+  normalizeSerializedWidgets,
+  profileContent,
+  profileKey,
+  profileSavedName,
+  profileSnapshot,
+  withSavedMeta,
+  wrapProfileIndex,
+} from "./lora_preset/profile_data.js";
 
 const NODE_TYPE = "EasyUseAnimaLoraPreset";
-const MAX_PROFILES = 16;
-const WIDGET_INDEX = {
-  stylePrompt: 0,
-  profileIndex: 1,
-  profileCount: 2,
-  loraName: 3,
-  loras: 4,
-  profileData: 5,
-};
 const MIN_NODE_WIDTH = 520;
 const PROFILE_CONTROLS_HEIGHT = 30;
 const PROFILE_ROW_HEIGHT = 22;
@@ -194,13 +201,6 @@ const LORA_PRESET_TEXT = {
     "lora.add": "+ 添加 LoRA",
   },
 };
-const INTERNAL_WIDGET_DEFAULTS = {
-  profile_count: "4",
-  lora_name: "None",
-  loras: "[]",
-  profile_data: "{}",
-};
-
 function lpText(key) {
   return easyuseAnimaText(LORA_PRESET_TEXT, key);
 }
@@ -211,37 +211,6 @@ function lpFormat(key, values = {}) {
 
 function errorMessage(error) {
   return String(error?.message || error || "");
-}
-
-function looksLikeProfileData(value) {
-  if (typeof value !== "string") {
-    return false;
-  }
-  try {
-    const parsed = JSON.parse(value || "{}");
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed);
-  } catch {
-    return false;
-  }
-}
-
-function normalizeSerializedWidgets(info) {
-  const values = info?.widgets_values;
-  if (!Array.isArray(values)) {
-    return;
-  }
-  if (values[WIDGET_INDEX.profileCount] == null || values[WIDGET_INDEX.profileCount] === "") {
-    values[WIDGET_INDEX.profileCount] = INTERNAL_WIDGET_DEFAULTS.profile_count;
-  }
-  values[WIDGET_INDEX.loraName] = INTERNAL_WIDGET_DEFAULTS.lora_name;
-  if (Array.isArray(values[WIDGET_INDEX.loras])) {
-    values[WIDGET_INDEX.loras] = JSON.stringify(values[WIDGET_INDEX.loras]);
-  } else if (typeof values[WIDGET_INDEX.loras] !== "string") {
-    values[WIDGET_INDEX.loras] = INTERNAL_WIDGET_DEFAULTS.loras;
-  }
-  if (!looksLikeProfileData(values[WIDGET_INDEX.profileData])) {
-    values[WIDGET_INDEX.profileData] = INTERNAL_WIDGET_DEFAULTS.profile_data;
-  }
 }
 
 function createEl(tagName, options = {}) {
@@ -381,21 +350,8 @@ function resetInternalLoraSelector(node) {
   }
 }
 
-function profileKey(index) {
-  return String(Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(index, 10) || 1)));
-}
-
 function parseProfileData(widget) {
   return normalizeProfileDataValue(widgetValue(widget, "{}"));
-}
-
-function normalizeProfileDataValue(value) {
-  try {
-    const parsed = typeof value === "string" ? JSON.parse(String(value || "{}")) : value;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
 }
 
 function writeProfileData(widget, data) {
@@ -404,12 +360,6 @@ function writeProfileData(widget, data) {
 
 function profileCount(node) {
   return Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(widgetValue(findWidget(node, "profile_count"), 4), 10) || 4));
-}
-
-function wrapProfileIndex(index, count) {
-  const safeCount = Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(count, 10) || 1));
-  const safeIndex = Math.max(1, Number.parseInt(index, 10) || 1);
-  return ((safeIndex - 1) % safeCount) + 1;
 }
 
 function selectedProfileIndex(node) {
@@ -469,19 +419,6 @@ function lorasWidgetValue(node) {
   }
 }
 
-function normalizeLoraEntry(entry) {
-  const name = String(entry?.name ?? entry?.lora ?? "").trim();
-  const strength = Number.isFinite(Number(entry?.strength)) ? Number(entry.strength) : 1;
-  const strengthTwoRaw = entry?.strengthTwo ?? entry?.clipStrength;
-  const strengthTwo = strengthTwoRaw == null || strengthTwoRaw === "" ? null : Number(strengthTwoRaw);
-  return {
-    name,
-    on: entry?.on ?? entry?.active ?? true,
-    strength,
-    strengthTwo: Number.isFinite(strengthTwo) ? strengthTwo : null,
-  };
-}
-
 function setLorasWidgetValue(node, loras, options = {}) {
   const widget = findWidget(node, "loras");
   if (!widget) {
@@ -496,39 +433,6 @@ function setLorasWidgetValue(node, loras, options = {}) {
   } else {
     node.setDirtyCanvas?.(true, true);
   }
-}
-
-function profileContent(profile) {
-  return {
-    style_prompt: String(profile?.style_prompt || ""),
-    loras: Array.isArray(profile?.loras)
-      ? profile.loras.map(normalizeLoraEntry).filter((entry) => entry.name)
-      : [],
-  };
-}
-
-function profileSnapshot(profile) {
-  return JSON.stringify(profileContent(profile));
-}
-
-function isMeaningfulProfile(profile) {
-  const content = profileContent(profile);
-  return !!content.style_prompt.trim() || content.loras.length > 0;
-}
-
-function profileSavedName(profile) {
-  return String(profile?.saved_name || "").trim();
-}
-
-function withSavedMeta(content, previous) {
-  const profile = profileContent(content);
-  const savedName = profileSavedName(previous);
-  const savedSnapshot = String(previous?.saved_snapshot || "");
-  if (savedName && savedSnapshot) {
-    profile.saved_name = savedName;
-    profile.saved_snapshot = savedSnapshot;
-  }
-  return profile;
 }
 
 function currentProfileContent(node) {
@@ -554,13 +458,6 @@ function saveProfile(node, index) {
 
 function saveCurrentProfile(node) {
   saveProfile(node, activeProfileIndex(node));
-}
-
-function emptyProfile(index = 1) {
-  return {
-    style_prompt: "",
-    loras: [],
-  };
 }
 
 function loadProfile(node, index, options = {}) {

--- a/web/js/lora_preset/profile_data.js
+++ b/web/js/lora_preset/profile_data.js
@@ -1,0 +1,126 @@
+// @ts-check
+
+export const MAX_PROFILES = 16;
+
+export const WIDGET_INDEX = {
+  stylePrompt: 0,
+  profileIndex: 1,
+  profileCount: 2,
+  loraName: 3,
+  loras: 4,
+  profileData: 5,
+};
+
+export const INTERNAL_WIDGET_DEFAULTS = {
+  profile_count: "4",
+  lora_name: "None",
+  loras: "[]",
+  profile_data: "{}",
+};
+
+function looksLikeProfileData(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(value || "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeSerializedWidgets(info) {
+  const values = info?.widgets_values;
+  if (!Array.isArray(values)) {
+    return;
+  }
+  if (values[WIDGET_INDEX.profileCount] == null || values[WIDGET_INDEX.profileCount] === "") {
+    values[WIDGET_INDEX.profileCount] = INTERNAL_WIDGET_DEFAULTS.profile_count;
+  }
+  values[WIDGET_INDEX.loraName] = INTERNAL_WIDGET_DEFAULTS.lora_name;
+  if (Array.isArray(values[WIDGET_INDEX.loras])) {
+    values[WIDGET_INDEX.loras] = JSON.stringify(values[WIDGET_INDEX.loras]);
+  } else if (typeof values[WIDGET_INDEX.loras] !== "string") {
+    values[WIDGET_INDEX.loras] = INTERNAL_WIDGET_DEFAULTS.loras;
+  }
+  if (!looksLikeProfileData(values[WIDGET_INDEX.profileData])) {
+    values[WIDGET_INDEX.profileData] = INTERNAL_WIDGET_DEFAULTS.profile_data;
+  }
+}
+
+export function profileKey(index) {
+  return String(Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(index, 10) || 1)));
+}
+
+export function normalizeProfileDataValue(value) {
+  try {
+    const parsed = typeof value === "string" ? JSON.parse(String(value || "{}")) : value;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function wrapProfileIndex(index, count) {
+  const safeCount = Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(count, 10) || 1));
+  const safeIndex = Math.max(1, Number.parseInt(index, 10) || 1);
+  return ((safeIndex - 1) % safeCount) + 1;
+}
+
+export function normalizeLoraEntry(entry) {
+  const name = String(entry?.name ?? entry?.lora ?? "").trim();
+  const strength = Number.isFinite(Number(entry?.strength)) ? Number(entry.strength) : 1;
+  const strengthTwoRaw = entry?.strengthTwo ?? entry?.clipStrength;
+  const strengthTwo = strengthTwoRaw == null || strengthTwoRaw === "" ? null : Number(strengthTwoRaw);
+  return {
+    name,
+    on: entry?.on ?? entry?.active ?? true,
+    strength,
+    strengthTwo: Number.isFinite(strengthTwo) ? strengthTwo : null,
+  };
+}
+
+export function profileContent(profile) {
+  return {
+    style_prompt: String(profile?.style_prompt || ""),
+    loras: Array.isArray(profile?.loras)
+      ? profile.loras.map(normalizeLoraEntry).filter((entry) => entry.name)
+      : [],
+  };
+}
+
+export function profileSnapshot(profile) {
+  return JSON.stringify(profileContent(profile));
+}
+
+export function isMeaningfulProfile(profile) {
+  const content = profileContent(profile);
+  return !!content.style_prompt.trim() || content.loras.length > 0;
+}
+
+export function profileSavedName(profile) {
+  return String(profile?.saved_name || "").trim();
+}
+
+export function withSavedMeta(content, previous) {
+  const profile = profileContent(content);
+  const savedName = profileSavedName(previous);
+  const savedSnapshot = String(previous?.saved_snapshot || "");
+  if (savedName && savedSnapshot) {
+    return {
+      ...profile,
+      saved_name: savedName,
+      saved_snapshot: savedSnapshot,
+    };
+  }
+  return profile;
+}
+
+export function emptyProfile(_index = 1) {
+  void _index;
+  return {
+    style_prompt: "",
+    loras: [],
+  };
+}


### PR DESCRIPTION
## 변경 요약

- `easyuse_anima_lora_preset.js`에 섞여 있던 프로필/LoRA 순수 데이터 규칙을 import-free `web/js/lora_preset/profile_data.js`로 분리했습니다.
- 숫자 기반 widget index, hidden widget 기본값, legacy `widgets_values` 정규화, profile key/wrap, LoRA alias·strength 정규화, snapshot·saved metadata 규칙을 한 모듈이 소유합니다.
- node widget read/write, profile 전환, API/FIX, menu/preview, canvas widget, queue/save hook, extension lifecycle은 기존 entry에 그대로 유지했습니다.
- 새 모듈을 TypeScript check 범위와 official frontend semantic runner에 연결했습니다.

## 호환성

- widget index `0..5`와 profile 최대 16개 계약을 유지합니다.
- `profile_count` null/빈 값 복구, `lora_name="None"`, LoRA 배열 JSON 문자열화 동작을 유지합니다.
- 기존 LoRA 문자열과 유효한 profile JSON 문자열은 재직렬화하지 않고 그대로 보존합니다.
- `name/lora`, `on/active`, `strengthTwo/clipStrength` alias와 canonical 필드 우선순위를 유지합니다.
- profile content는 기존처럼 saved/unknown 필드를 제거하고, saved name과 snapshot이 모두 있을 때만 metadata를 보존합니다.
- DOM, API, listener, observer, node hook 동작은 변경하지 않습니다.

## 주요 파일

- `web/js/lora_preset/profile_data.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_profile_data_smoke.mjs`
- `tests/test_frontend_lora_preset.py`
- `tools/check_frontend.ps1`
- `jsconfig.json`

## 검증

- Focused Node syntax + profile-data semantic smoke: 통과
- Focused LoRA preset unittest: 3 tests 통과
- Focused TypeScript 6.0.3 check: 통과
- Official full profile (latest `dev`): Python unittest 335 tests 통과
- Official frontend profile (latest `dev`): 73 JavaScript files, TypeScript 6.0.3, 전체 semantic smoke 통과
- `git diff --check`: 통과
- 독립 boundary/test diff audit: blocker 없음

재실행 사유:
- 최초 focused 명령은 Windows sandbox의 `CreateProcessAsUserW 1312`로 테스트 본문이 시작되지 않아 같은 명령을 비샌드박스로 실행했습니다.
- 최초 static boundary unittest 1건은 테스트 정규식이 앞선 import까지 포함한 테스트 자체 오류였고, 정규식을 좁힌 뒤 해당 테스트만 재실행했습니다.
- 독립 테스트 감사에서 runner 연결과 누락된 호환성 단언을 보강한 뒤 변경된 focused tests만 재실행했습니다.
- 최초 PR-ready diff에서는 official full runner를 1회 실행했습니다.
- 이후 PR #68 병합으로 `dev`의 frontend runner와 TypeScript 대상이 바뀌어 기존 증거가 무효가 됐습니다. 최신 `dev` 재기준화 후 변경된 focused 검증과 official full runner를 최종 결합 상태에서 1회 재실행했습니다.

## 브라우저 및 사용자 인스턴스

- 이번 조각은 DOM-free 순수 데이터 이동이며 UI 동작 변경이 없어 legacy canvas/Node 2.0 browser smoke는 실행하지 않았습니다. Issue #55의 UI/lifecycle 경계가 완성되는 후속 조각에서 두 표면을 각각 검증합니다.
- 사용자 v0.27.0 인스턴스 수동 확인은 Issue #54–#57 전체 작업 완료 후 한 번만 진행합니다.

Refs #55

라벨 후보: `type: chore`, `area: frontend`, `status: ready` (저장소에 없으면 생성하지 않음)
