### PR TITLE
refactor: 자동완성 텍스트 모델 경계 분리

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -14,6 +14,7 @@
   },
   "include": [
     "web/js/aio/**/*.js",
+    "web/js/autocomplete/**/*.js",
     "web/js/lora_preset/**/*.js",
     "web/js/easyuse_anima_prompt_studio.js",
     "web/js/easyuse_anima_prompt_studio_regional.js",

--- a/tests/frontend_autocomplete_text_model_smoke.mjs
+++ b/tests/frontend_autocomplete_text_model_smoke.mjs
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const textModel = await import(dataModule("../web/js/autocomplete/text_model.js"));
+
+assert.deepEqual(Object.keys(textModel).sort(), [
+  "autocompleteQuery",
+  "currentToken",
+  "currentWildcardToken",
+  "isCaretInComment",
+  "isCaretInPromptTranslationMarker",
+  "normalizeWildcardSearchText",
+  "parseAutocompleteText",
+  "planAutocompleteInsertion",
+  "wildcardAutocompleteQuery",
+].sort());
+
+const {
+  autocompleteQuery,
+  currentToken,
+  currentWildcardToken,
+  isCaretInComment,
+  isCaretInPromptTranslationMarker,
+  normalizeWildcardSearchText,
+  parseAutocompleteText,
+  planAutocompleteInsertion,
+  wildcardAutocompleteQuery,
+} = textModel;
+
+function appliedPlan(token, insert, options = {}) {
+  const plan = planAutocompleteInsertion(token, insert, options);
+  assert.ok(plan);
+  return {
+    ...plan,
+    value: token.value.slice(0, plan.start)
+      + plan.replacement
+      + token.value.slice(plan.end),
+    caret: plan.start + plan.caretOffset,
+  };
+}
+
+const segmented = currentToken(
+  "first tag, second tag\nthird tag",
+  "first tag, second".length,
+  { detectNaturalSentences: false, previewCompletion: true },
+);
+assert.equal(segmented.start, "first tag, ".length);
+assert.equal(segmented.end, "first tag, second tag".length);
+assert.equal(segmented.query, "second");
+assert.equal(segmented.tokenSegment, "second tag");
+assert.equal(segmented.active, true);
+
+for (const period of [".", "。", "．", "｡"]) {
+  const value = "alpha" + period + " beta gamma";
+  const caret = value.indexOf("beta") + "beta".length;
+  const token = currentToken(value, caret, {
+    detectNaturalSentences: true,
+    previewCompletion: true,
+  });
+  assert.equal(token.start, value.indexOf("beta"));
+  assert.equal(token.query, "beta");
+  assert.equal(token.sentenceDelimited, true);
+}
+
+const sentenceValue = "alpha. beta gamma";
+const sentenceCaret = sentenceValue.indexOf("beta") + "beta".length;
+assert.equal(
+  currentToken(sentenceValue, sentenceCaret, {
+    detectNaturalSentences: false,
+    previewCompletion: true,
+  }).query,
+  "alpha. beta",
+);
+assert.equal(
+  currentToken("version 1.5 beta", "version 1.5 beta".length, {
+    detectNaturalSentences: true,
+    previewCompletion: true,
+  }).sentenceDelimited,
+  false,
+);
+assert.equal(
+  currentToken("alpha\\. beta", "alpha\\. beta".length, {
+    detectNaturalSentences: true,
+    previewCompletion: true,
+  }).sentenceDelimited,
+  false,
+);
+
+const boundedSentenceValue = "alpha. beta gamma. delta";
+const boundedSentenceToken = currentToken(
+  boundedSentenceValue,
+  boundedSentenceValue.indexOf("beta") + "beta".length,
+  { detectNaturalSentences: true, previewCompletion: true },
+);
+assert.equal(boundedSentenceToken.start, boundedSentenceValue.indexOf("beta"));
+assert.equal(boundedSentenceToken.end, boundedSentenceValue.indexOf(". delta"));
+assert.equal(
+  appliedPlan(
+    boundedSentenceToken,
+    "beta tag",
+    { appendSeparator: false, noCommaAfterPeriod: true },
+  ).value,
+  "alpha. beta tag. delta",
+);
+
+const weightedValue = "[[ @old_name:1.25]]";
+const weightedCaret = weightedValue.indexOf(":");
+const weightedToken = currentToken(weightedValue, weightedCaret, {
+  detectNaturalSentences: true,
+  previewCompletion: true,
+});
+assert.equal(weightedToken.start, weightedValue.indexOf("@"));
+assert.equal(weightedToken.end, weightedValue.indexOf(":"));
+assert.equal(weightedToken.query, "@old_name");
+assert.equal(weightedToken.tokenSegment, "@old_name");
+assert.equal(
+  appliedPlan(weightedToken, "@new_name").value,
+  "[[ @new_name:1.25]]",
+);
+
+const strictAtClosing = currentToken(
+  weightedValue,
+  weightedValue.length,
+  { detectNaturalSentences: true, previewCompletion: true },
+);
+const legacyAtClosing = currentToken(
+  weightedValue,
+  weightedValue.length,
+  { detectNaturalSentences: true, previewCompletion: false },
+);
+assert.equal(strictAtClosing.active, false);
+assert.equal(strictAtClosing.query, "@old_name");
+assert.equal(legacyAtClosing.active, true);
+assert.equal(legacyAtClosing.query, weightedValue);
+
+const escapedLiteral = "\\(blue archive\\)";
+const escapedToken = currentToken(
+  escapedLiteral,
+  escapedLiteral.length,
+  { detectNaturalSentences: true, previewCompletion: true },
+);
+assert.equal(escapedToken.start, 0);
+assert.equal(escapedToken.end, escapedLiteral.length);
+assert.equal(escapedToken.query, escapedLiteral);
+
+assert.deepEqual(parseAutocompleteText("(@artist_name):1.25"), {
+  query: "artist_name",
+  artistOnly: true,
+});
+assert.deepEqual(parseAutocompleteText("[[ (@artist_name)))"), {
+  query: "artist_name",
+  artistOnly: true,
+});
+assert.deepEqual(autocompleteQuery({ query: "(@artist_name):1.25" }), {
+  query: "artist_name",
+  artistOnly: true,
+  category: "artist",
+});
+assert.deepEqual(autocompleteQuery({ query: "general_tag" }, true), {
+  query: "general_tag",
+  artistOnly: true,
+  category: "artist",
+});
+assert.deepEqual(wildcardAutocompleteQuery({ query: "Folder/표정" }), {
+  query: "folder/표정",
+  artistOnly: false,
+  category: "wildcard",
+  kind: "wildcard",
+});
+assert.equal(
+  normalizeWildcardSearchText("Ａ＿Ｂ\\Folder Name"),
+  "a-b/folder-name",
+);
+
+assert.deepEqual(
+  {
+    query: currentWildcardToken("__", 2)?.query,
+    active: currentWildcardToken("__", 2)?.active,
+  },
+  { query: "", active: true },
+);
+const unicodeWildcard = "prefix __캐릭터/표정";
+assert.equal(
+  currentWildcardToken(unicodeWildcard, unicodeWildcard.length)?.query,
+  "캐릭터/표정",
+);
+const closedWildcard = "__foo__";
+assert.equal(currentWildcardToken(closedWildcard, closedWildcard.length), null);
+assert.equal(currentWildcardToken(closedWildcard, 4)?.end, closedWildcard.length);
+const secondWildcard = "__one__ + __two";
+assert.equal(
+  currentWildcardToken(secondWildcard, secondWildcard.length)?.query,
+  "two",
+);
+assert.equal(currentWildcardToken("__bad,query", "__bad,query".length), null);
+assert.equal(currentWildcardToken("__bad\nquery", "__bad\nquery".length), null);
+
+const marker = "before %{inside} after";
+assert.equal(
+  isCaretInPromptTranslationMarker(marker, marker.indexOf("inside") + 3),
+  true,
+);
+assert.equal(
+  isCaretInPromptTranslationMarker(marker, marker.indexOf("}") + 1),
+  false,
+);
+assert.equal(
+  isCaretInPromptTranslationMarker("before %{inside", "before %{inside".length),
+  true,
+);
+assert.equal(
+  isCaretInPromptTranslationMarker("\\%{escaped}", "\\%{escaped}".length - 1),
+  false,
+);
+assert.equal(isCaretInComment("  # comment", "  # comment".length), true);
+assert.equal(isCaretInComment("tag # inline", "tag # inline".length), false);
+assert.equal(isCaretInComment("tag\n\t# next", "tag\n\t# next".length), true);
+
+const emptyToken = currentToken("", 0, {
+  detectNaturalSentences: true,
+  previewCompletion: true,
+});
+assert.deepEqual(
+  appliedPlan(emptyToken, "tag", {
+    appendSeparator: true,
+    noCommaAfterPeriod: true,
+  }),
+  {
+    start: 0,
+    end: 0,
+    replacement: "tag, ",
+    caretOffset: 5,
+    prefix: "",
+    suffix: ", ",
+    consumeAfter: 0,
+    caretExtra: 2,
+    value: "tag, ",
+    caret: 5,
+  },
+);
+
+const commaValue = "foo,bar";
+const commaToken = currentToken(commaValue, commaValue.length, {
+  detectNaturalSentences: false,
+  previewCompletion: true,
+});
+assert.equal(appliedPlan(commaToken, "baz").value, "foo, baz");
+
+const newlineValue = "foo\nbar";
+const newlineToken = currentToken(newlineValue, newlineValue.length, {
+  detectNaturalSentences: false,
+  previewCompletion: true,
+});
+assert.equal(appliedPlan(newlineToken, "baz").value, "foo\nbaz");
+
+const afterPeriod = {
+  value: "sentence.old",
+  start: "sentence.".length,
+  end: "sentence.old".length,
+};
+assert.equal(
+  appliedPlan(afterPeriod, "new", { noCommaAfterPeriod: true }).value,
+  "sentence. new",
+);
+assert.equal(
+  appliedPlan(afterPeriod, "new", { noCommaAfterPeriod: false }).value,
+  "sentence., new",
+);
+
+for (const [value, start, end, expected] of [
+  ["(old)", 1, 4, "(new)"],
+  ["[[old]]", 2, 5, "[[new]]"],
+  ["old:1.25", 0, 3, "new:1.25"],
+  ["old,next", 0, 3, "new,next"],
+  ["old\nnext", 0, 3, "new\nnext"],
+  ["old. next", 0, 3, "new. next"],
+]) {
+  assert.equal(
+    appliedPlan(
+      { value, start, end },
+      "new",
+      { appendSeparator: false, noCommaAfterPeriod: true },
+    ).value,
+    expected,
+  );
+}
+
+const regressionValue = "wisteria,dd";
+const regressionToken = currentToken(regressionValue, "wisteria".length, {
+  detectNaturalSentences: false,
+  previewCompletion: true,
+});
+const regression = appliedPlan(regressionToken, "wisteria", {
+  appendSeparator: true,
+  noCommaAfterPeriod: true,
+});
+assert.equal(regression.value, "wisteria, dd");
+assert.equal(regression.caret, "wisteria, ".length);
+assert.equal(regression.value.slice(regression.caret), "dd");
+
+const normalizedSeparator = appliedPlan(
+  { value: "old,   tail", start: 0, end: 3 },
+  "new",
+  { appendSeparator: true, noCommaAfterPeriod: true },
+);
+assert.equal(normalizedSeparator.value, "new, tail");
+assert.equal(normalizedSeparator.consumeAfter, 4);
+assert.equal(normalizedSeparator.caret, "new, ".length);
+
+const wildcardToken = currentWildcardToken("__old/path__", "__old".length);
+assert.ok(wildcardToken);
+assert.deepEqual(
+  appliedPlan(wildcardToken, "__new/path__"),
+  {
+    start: 0,
+    end: "__old/path__".length,
+    replacement: "__new/path__",
+    caretOffset: "__new/path__".length,
+    prefix: "",
+    suffix: "",
+    consumeAfter: 0,
+    caretExtra: 0,
+    value: "__new/path__",
+    caret: "__new/path__".length,
+  },
+);
+
+const frozenToken = Object.freeze({
+  value: "old",
+  start: 0,
+  end: 3,
+  wildcard: false,
+});
+const frozenOptions = Object.freeze({
+  appendSeparator: true,
+  noCommaAfterPeriod: true,
+});
+assert.doesNotThrow(() => planAutocompleteInsertion(frozenToken, "new", frozenOptions));
+assert.deepEqual(frozenToken, {
+  value: "old",
+  start: 0,
+  end: 3,
+  wildcard: false,
+});
+assert.deepEqual(frozenOptions, {
+  appendSeparator: true,
+  noCommaAfterPeriod: true,
+});
+
+assert.equal(planAutocompleteInsertion(null, "unused"), null);

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -14,6 +14,9 @@ AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
 AIO_PRESETS_JS = ROOT / "web" / "js" / "aio" / "presets.js"
 AUTOCOMPLETE_JS = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
+AUTOCOMPLETE_TEXT_MODEL_JS = (
+    ROOT / "web" / "js" / "autocomplete" / "text_model.js"
+)
 PROMPT_STUDIO_REGIONAL_ADAPTER_JS = (
     ROOT / "web" / "js" / "prompt_studio" / "regional" / "editor_adapter.js"
 )
@@ -486,7 +489,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("menu.scrollTop", scroll_body)
 
         start = source.index("function setActive")
-        end = source.index("\nfunction endsWithSentencePeriod", start)
+        end = source.index("\nfunction resetAutocompleteMenuToTop", start)
         set_active_body = source[start:end]
 
         self.assertIn("const menu = ensurePopup();", set_active_body)
@@ -526,7 +529,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("resetAutocompleteMenuToTop(menu);", reset_body)
 
         start = source.index("function resetVisibleAutocompleteMenuSoon")
-        end = source.index("\nfunction endsWithSentencePeriod", start)
+        end = source.index("\nfunction replaceInputRange", start)
         visible_reset_body = source[start:end]
 
         self.assertIn("resetAutocompleteMenuToTop(menu);", visible_reset_body)
@@ -535,7 +538,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("resetActiveAutocompleteMenu(menu);", visible_reset_body)
 
         start = source.index("function renderResults")
-        end = source.index("\nfunction isCaretInComment", start)
+        end = source.index("\nfunction debounce", start)
         body = source[start:end]
 
         self.assertIn("resetAutocompleteMenuToTop(menu);", body)
@@ -573,17 +576,21 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_autocomplete_wildcards_accept_empty_and_unicode_queries(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
-        start = source.index("function currentWildcardToken")
-        end = source.index("\nfunction autocompleteQuery", start)
-        token_body = source[start:end]
+        model_source = AUTOCOMPLETE_TEXT_MODEL_JS.read_text(encoding="utf-8")
+        start = model_source.index("export function currentWildcardToken")
+        end = model_source.index(
+            "\nexport function isCaretInPromptTranslationMarker",
+            start,
+        )
+        token_body = model_source[start:end]
 
-        self.assertIn("caret >= opening + 2", token_body)
+        self.assertIn("safeCaret >= opening + 2", token_body)
         self.assertIn(r"/[\r\n,]/.test(query)", token_body)
         self.assertNotIn(r"/^[\w.\-+/*\\]*$/i.test(query)", token_body)
 
-        start = source.index("function normalizeWildcardSearchText")
-        end = source.index("\nfunction strictAutocompleteResults", start)
-        normalize_body = source[start:end]
+        start = model_source.index("export function normalizeWildcardSearchText")
+        end = model_source.index("\nfunction endsWithSentencePeriod", start)
+        normalize_body = model_source[start:end]
 
         self.assertIn('replaceAll("\\\\", "/")', normalize_body)
         self.assertIn('replace(/[ _]+/g, "-")', normalize_body)
@@ -602,17 +609,17 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('return context.kind === "wildcard" ? results : [];', strict_body)
 
     def test_autocomplete_strips_prompt_syntax_from_search_query(self):
-        source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        source = AUTOCOMPLETE_TEXT_MODEL_JS.read_text(encoding="utf-8")
 
-        start = source.index("function autocompleteQuery")
-        end = source.index("\nfunction wildcardAutocompleteQuery", start)
+        start = source.index("export function autocompleteQuery")
+        end = source.index("\nexport function wildcardAutocompleteQuery", start)
         query_body = source[start:end]
 
         self.assertIn("const query = parsed.query;", query_body)
         self.assertNotIn("artistOnly ? parsed.query : raw.trim()", query_body)
 
-        start = source.index("function parseAutocompleteText")
-        end = source.index("\nfunction normalizeWildcardSearchText", start)
+        start = source.index("export function parseAutocompleteText")
+        end = source.index("\nexport function autocompleteQuery", start)
         parse_body = source[start:end]
 
         self.assertIn('query = query.replace(/^\\[\\[\\s*/g, "");', parse_body)
@@ -625,7 +632,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn('query = query.replace(/\\)+\\s*$/, "");', parse_body)
 
         start = source.index("function trimPromptSyntaxSuffix")
-        end = source.index("\nfunction currentToken", start)
+        end = source.index("\nexport function currentToken", start)
         trim_body = source[start:end]
 
         self.assertIn('value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)', trim_body)
@@ -644,7 +651,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("typeNames.includes(\"TEXTAREA\")", source)
 
         start = source.index("function findInputEl")
-        end = source.index("\nfunction isEscaped", start)
+        end = source.index("\nfunction currentToken", start)
         input_body = source[start:end]
 
         self.assertIn("widget?.inputEl || widget?.element", input_body)

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTOCOMPLETE_ENTRY = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
+AUTOCOMPLETE_TEXT_MODEL = (
+    ROOT / "web" / "js" / "autocomplete" / "text_model.js"
+)
+AUTOCOMPLETE_TEXT_MODEL_SMOKE = (
+    ROOT / "tests" / "frontend_autocomplete_text_model_smoke.mjs"
+)
+JSCONFIG = ROOT / "jsconfig.json"
+FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
+
+
+class AutocompleteFrontendBoundaryTests(unittest.TestCase):
+    def test_text_model_has_exact_dom_free_boundary(self):
+        module_source = AUTOCOMPLETE_TEXT_MODEL.read_text(encoding="utf-8")
+        entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
+        expected_exports = {
+            "autocompleteQuery",
+            "currentToken",
+            "currentWildcardToken",
+            "isCaretInComment",
+            "isCaretInPromptTranslationMarker",
+            "normalizeWildcardSearchText",
+            "parseAutocompleteText",
+            "planAutocompleteInsertion",
+            "wildcardAutocompleteQuery",
+        }
+        expected_imports = {
+            "autocompleteQuery",
+            "currentToken as currentAutocompleteToken",
+            "currentWildcardToken as currentAutocompleteWildcardToken",
+            "isCaretInComment",
+            (
+                "isCaretInPromptTranslationMarker "
+                "as caretInPromptTranslationMarker"
+            ),
+            "normalizeWildcardSearchText",
+            "parseAutocompleteText",
+            "planAutocompleteInsertion",
+            "wildcardAutocompleteQuery",
+        }
+
+        exported_names = set(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            )
+        )
+        self.assertEqual(exported_names, expected_exports)
+
+        import_match = re.search(
+            (
+                r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*'
+                r'"\./autocomplete/text_model\.js";'
+            ),
+            entry_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip().rstrip(",")
+            for name in import_match.group("names").splitlines()
+            if name.strip()
+        }
+        self.assertEqual(imported_names, expected_imports)
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|registerExtension|"
+                r"addEventListener|removeEventListener|MutationObserver|"
+                r"HTMLElement|HTMLInputElement|HTMLTextAreaElement)\b"
+            ),
+        )
+
+    def test_entry_delegates_text_rules_without_duplicate_ownership(self):
+        source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
+        moved_declarations = {
+            "autocompleteQuery",
+            "isCaretInComment",
+            "normalizeWildcardSearchText",
+            "parseAutocompleteText",
+            "planAutocompleteInsertion",
+            "wildcardAutocompleteQuery",
+        }
+        moved_private_helpers = {
+            "endsWithSentencePeriod",
+            "insertPrefixForBefore",
+            "insertSuffixForAfter",
+            "insertSuffixPlanForAfter",
+            "isEscaped",
+            "isSentencePeriod",
+            "naturalSentenceEnd",
+            "naturalSentenceStart",
+            "startsWithSentencePeriod",
+            "stripPromptSyntaxClosingParens",
+            "trimPromptSyntaxPrefix",
+            "trimPromptSyntaxSuffix",
+        }
+
+        for name in moved_declarations | moved_private_helpers:
+            with self.subTest(moved_declaration=name):
+                self.assertNotRegex(
+                    source,
+                    rf"\b(?:const|let|var|function|class)\s+{re.escape(name)}\b",
+                )
+
+        current_start = source.index("function currentToken")
+        wildcard_start = source.index("\nfunction currentWildcardToken", current_start)
+        marker_start = source.index(
+            "\nfunction isCaretInPromptTranslationMarker",
+            wildcard_start,
+        )
+        signature_start = source.index(
+            "\nfunction autocompleteStateSignature",
+            marker_start,
+        )
+        current_body = source[current_start:wildcard_start]
+        wildcard_body = source[wildcard_start:marker_start]
+        marker_body = source[marker_start:signature_start]
+
+        self.assertIn("currentAutocompleteToken(", current_body)
+        self.assertIn(
+            "detectNaturalSentences: autocompleteDetectNaturalSentences",
+            current_body,
+        )
+        self.assertIn(
+            "previewCompletion: autocompletePreviewCompletion",
+            current_body,
+        )
+        self.assertIn("currentAutocompleteWildcardToken(", wildcard_body)
+        self.assertIn("caretInPromptTranslationMarker(", marker_body)
+        for adapter_body in (current_body, wildcard_body, marker_body):
+            self.assertNotIn("while (", adapter_body)
+            self.assertNotIn(".indexOf(", adapter_body)
+
+        commit_start = source.index("function commitSuggestion")
+        commit_end = source.index("\nfunction displayTagText", commit_start)
+        preview_start = source.index("function completionPreviewPlan")
+        preview_end = source.index(
+            "\nfunction updateAutocompletePreview",
+            preview_start,
+        )
+        commit_body = source[commit_start:commit_end]
+        preview_body = source[preview_start:preview_end]
+        self.assertIn(
+            'if (entry?.kind === "wildcard" && !wildcardToken)',
+            preview_body,
+        )
+        for plan_consumer in (commit_body, preview_body):
+            self.assertIn("planAutocompleteInsertion(", plan_consumer)
+            self.assertIn(
+                "appendSeparator: autocompleteAppendSeparator",
+                plan_consumer,
+            )
+            self.assertIn(
+                "noCommaAfterPeriod: autocompleteNoCommaAfterPeriod",
+                plan_consumer,
+            )
+            self.assertIn("plan.replacement", plan_consumer)
+            self.assertIn("plan.start", plan_consumer)
+            self.assertIn("plan.end", plan_consumer)
+
+        self.assertEqual(source.count("planAutocompleteInsertion("), 2)
+        self.assertIn("app.registerExtension({", source)
+        self.assertIn('document.addEventListener("pointerdown"', source)
+        self.assertIn("function hookInput(", source)
+
+    def test_text_model_is_in_static_and_semantic_runners(self):
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(AUTOCOMPLETE_TEXT_MODEL_SMOKE.is_file())
+        self.assertIn("web/js/autocomplete/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_autocomplete_text_model_smoke.mjs"',
+            frontend_check_source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -94,6 +94,11 @@ try {
         throw "Frontend LoRA preset profile data smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_autocomplete_text_model_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend autocomplete text model smoke failed with exit code $LASTEXITCODE."
+    }
+
     & npx --yes --package "typescript@$TypeScriptVersion" -- tsc -p jsconfig.json
     if ($LASTEXITCODE -ne 0) {
         throw "TypeScript check failed with exit code $LASTEXITCODE."

--- a/web/js/autocomplete/text_model.js
+++ b/web/js/autocomplete/text_model.js
@@ -1,0 +1,367 @@
+// @ts-check
+
+const SENTENCE_PERIODS = new Set([".", "。", "．", "｡"]);
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function isEscaped(value, index) {
+  let count = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
+    count += 1;
+  }
+  return count % 2 === 1;
+}
+
+function isSentencePeriod(value, index) {
+  if (!SENTENCE_PERIODS.has(value[index]) || isEscaped(value, index)) {
+    return false;
+  }
+  return !(/\d/.test(value[index - 1] || "") && /\d/.test(value[index + 1] || ""));
+}
+
+function naturalSentenceStart(value, segmentStart, caret, detectNaturalSentences) {
+  if (!detectNaturalSentences) {
+    return segmentStart;
+  }
+  for (let index = caret - 1; index >= segmentStart; index -= 1) {
+    if (!isSentencePeriod(value, index)) {
+      continue;
+    }
+    let start = index + 1;
+    while (start < caret && /[ \t]/.test(value[start])) {
+      start += 1;
+    }
+    return start < caret ? start : segmentStart;
+  }
+  return segmentStart;
+}
+
+function naturalSentenceEnd(value, caret, segmentEnd) {
+  for (let index = caret; index < segmentEnd; index += 1) {
+    if (isSentencePeriod(value, index)) {
+      return index;
+    }
+  }
+  return segmentEnd;
+}
+
+function trimPromptSyntaxPrefix(value, start, end) {
+  let cursor = start;
+  while (cursor < end && /[ \t]/.test(value[cursor])) {
+    cursor += 1;
+  }
+  if (value.slice(cursor, cursor + 2) === "[[") {
+    cursor += 2;
+    while (cursor < end && /[ \t]/.test(value[cursor])) {
+      cursor += 1;
+    }
+  }
+  if (value[cursor] === "(") {
+    cursor += 1;
+    while (cursor < end && /[ \t]/.test(value[cursor])) {
+      cursor += 1;
+    }
+  }
+  return cursor;
+}
+
+function trimPromptSyntaxSuffix(value, start, end) {
+  let cursor = end;
+  while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
+    cursor -= 1;
+  }
+  if (value.slice(Math.max(start, cursor - 2), cursor) === "]]") {
+    cursor -= 2;
+    while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
+      cursor -= 1;
+    }
+  }
+  if (value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
+    cursor -= 1;
+    while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
+      cursor -= 1;
+    }
+  }
+  const tokenText = value.slice(start, cursor);
+  const weight = /\s*:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\s*$/.exec(tokenText);
+  if (weight) {
+    cursor -= weight[0].length;
+  }
+  return Math.max(start, cursor);
+}
+
+export function currentToken(value, caret, options = {}) {
+  const text = String(value || "");
+  const safeCaret = caret == null ? text.length : Number(caret);
+  let segmentStart = safeCaret;
+  while (segmentStart > 0 && text[segmentStart - 1] !== "," && text[segmentStart - 1] !== "\n") {
+    segmentStart -= 1;
+  }
+  let segmentEnd = safeCaret;
+  while (segmentEnd < text.length && text[segmentEnd] !== "," && text[segmentEnd] !== "\n") {
+    segmentEnd += 1;
+  }
+  const naturalStart = naturalSentenceStart(
+    text,
+    segmentStart,
+    safeCaret,
+    options.detectNaturalSentences !== false,
+  );
+  const sentenceDelimited = naturalStart > segmentStart;
+  if (sentenceDelimited) {
+    segmentStart = naturalStart;
+    segmentEnd = naturalSentenceEnd(text, safeCaret, segmentEnd);
+  }
+  const replaceStart = trimPromptSyntaxPrefix(text, segmentStart, segmentEnd);
+  const replaceEnd = trimPromptSyntaxSuffix(text, replaceStart, segmentEnd);
+  const queryEnd = clamp(safeCaret, replaceStart, replaceEnd);
+  const strictRaw = text.slice(replaceStart, queryEnd);
+  const legacyRaw = text.slice(segmentStart, safeCaret);
+  const segment = text.slice(segmentStart, segmentEnd);
+  const strictActive = safeCaret >= replaceStart && safeCaret <= replaceEnd && queryEnd > replaceStart;
+  const legacyActive = legacyRaw.trim().length > 0;
+  const useStrictToken = options.previewCompletion === true;
+  return {
+    value: text,
+    start: replaceStart,
+    end: replaceEnd,
+    caret: safeCaret,
+    segmentStart,
+    segmentEnd,
+    segment,
+    tokenSegment: text.slice(replaceStart, replaceEnd),
+    sentenceDelimited,
+    query: (useStrictToken ? strictRaw : legacyRaw).trim(),
+    active: useStrictToken ? strictActive : legacyActive,
+  };
+}
+
+export function currentWildcardToken(value, caret) {
+  const text = String(value || "");
+  const safeCaret = caret == null ? text.length : Number(caret);
+  let opening = -1;
+  let index = 0;
+  while (index < safeCaret) {
+    const found = text.indexOf("__", index);
+    if (found < 0 || found >= safeCaret) {
+      break;
+    }
+    opening = opening < 0 ? found : -1;
+    index = found + 2;
+  }
+  if (opening < 0) {
+    return null;
+  }
+  const query = text.slice(opening + 2, safeCaret);
+  if (/[\r\n,]/.test(query)) {
+    return null;
+  }
+  const closing = text.indexOf("__", safeCaret);
+  const end = closing >= 0 ? closing + 2 : safeCaret;
+  const active = safeCaret >= opening + 2 && (closing < 0 || safeCaret <= closing);
+  return {
+    value: text,
+    start: opening,
+    end,
+    caret: safeCaret,
+    segment: text.slice(opening, end),
+    query,
+    wildcard: true,
+    active,
+  };
+}
+
+export function isCaretInPromptTranslationMarker(value, caret) {
+  const text = String(value || "");
+  const safeCaret = caret == null ? text.length : Number(caret);
+  let index = 0;
+  while (index < safeCaret) {
+    const start = text.indexOf("%{", index);
+    if (start < 0 || start >= safeCaret) {
+      return false;
+    }
+    if (isEscaped(text, start)) {
+      index = start + 2;
+      continue;
+    }
+    let end = -1;
+    for (let cursor = start + 2; cursor < text.length; cursor += 1) {
+      if (text[cursor] === "}" && !isEscaped(text, cursor)) {
+        end = cursor + 1;
+        break;
+      }
+    }
+    if (end < 0) {
+      return safeCaret > start;
+    }
+    if (safeCaret > start && safeCaret < end) {
+      return true;
+    }
+    index = end;
+  }
+  return false;
+}
+
+export function isCaretInComment(value, caret) {
+  const text = String(value ?? "");
+  const safeCaret = Math.max(0, Math.min(Number(caret) || 0, text.length));
+  const lineStart = text.lastIndexOf("\n", safeCaret - 1) + 1;
+  return /^[ \t]*#/.test(text.slice(lineStart, safeCaret));
+}
+
+function stripPromptSyntaxClosingParens(value) {
+  let cursor = String(value || "").length;
+  while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
+    cursor -= 1;
+  }
+  while (cursor > 0 && value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
+    cursor -= 1;
+    while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
+      cursor -= 1;
+    }
+  }
+  return value.slice(0, cursor);
+}
+
+export function parseAutocompleteText(value) {
+  let query = String(value || "").trim();
+  query = query.replace(/^\[\[\s*/g, "");
+  query = query.replace(/^\(\s*/g, "");
+  const artistOnly = query.startsWith("@");
+  if (artistOnly) {
+    query = query.slice(1).trimStart();
+  }
+  query = stripPromptSyntaxClosingParens(query);
+  query = query.replace(/:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\s*$/, "");
+  query = stripPromptSyntaxClosingParens(query);
+  return { query, artistOnly };
+}
+
+export function autocompleteQuery(token, forceArtistOnly = false) {
+  const raw = String(token?.query || "");
+  const parsed = parseAutocompleteText(raw);
+  const artistOnly = forceArtistOnly || parsed.artistOnly;
+  const query = parsed.query;
+  const category = artistOnly ? "artist" : "";
+  return { query, artistOnly, category };
+}
+
+export function wildcardAutocompleteQuery(token) {
+  return {
+    query: String(token?.query || "").toLocaleLowerCase(),
+    artistOnly: false,
+    category: "wildcard",
+    kind: "wildcard",
+  };
+}
+
+export function normalizeWildcardSearchText(value) {
+  return String(value || "")
+    .normalize("NFKC")
+    .replaceAll("\\", "/")
+    .replace(/[ _]+/g, "-")
+    .trim()
+    .toLocaleLowerCase();
+}
+
+function endsWithSentencePeriod(value) {
+  const text = String(value || "").replace(/[ \t]+$/g, "");
+  return text.length > 0 && isSentencePeriod(text, text.length - 1);
+}
+
+function startsWithSentencePeriod(value) {
+  const text = String(value || "").replace(/^[ \t]+/g, "");
+  return text.length > 0 && isSentencePeriod(text, 0);
+}
+
+function insertPrefixForBefore(before, noCommaAfterPeriod) {
+  if (!before || before.endsWith("\n")) {
+    return "";
+  }
+  const trimmed = before.replace(/[ \t]+$/g, "");
+  if (trimmed.endsWith("(") || trimmed.endsWith("[[")) {
+    return "";
+  }
+  if (before.endsWith(",")) {
+    return " ";
+  }
+  if (/[ \t]$/.test(before)) {
+    return "";
+  }
+  if (noCommaAfterPeriod && endsWithSentencePeriod(before)) {
+    return " ";
+  }
+  return ", ";
+}
+
+function insertSuffixForAfter(after, appendSeparator, noCommaAfterPeriod) {
+  if (!after) {
+    return appendSeparator ? ", " : "";
+  }
+  if (/^[ \t]*:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)/.test(after) || /^[ \t]*(?:\)|\]\])/.test(after)) {
+    return "";
+  }
+  if (after.startsWith("\n") || after.startsWith(",")) {
+    return "";
+  }
+  if (noCommaAfterPeriod && startsWithSentencePeriod(after)) {
+    return "";
+  }
+  return ", ";
+}
+
+function insertSuffixPlanForAfter(after, appendSeparator, noCommaAfterPeriod) {
+  const text = String(after || "");
+  const suffix = insertSuffixForAfter(text, appendSeparator, noCommaAfterPeriod);
+  if (!text) {
+    return { suffix, consumeAfter: 0, caretExtra: suffix.length };
+  }
+  if (appendSeparator && text.startsWith(",")) {
+    const match = /^,[ \t]*/.exec(text);
+    return { suffix: ", ", consumeAfter: match?.[0]?.length || 1, caretExtra: 2 };
+  }
+  return { suffix, consumeAfter: 0, caretExtra: 0 };
+}
+
+export function planAutocompleteInsertion(token, insert, options = {}) {
+  if (!token) {
+    return null;
+  }
+  const sourceValue = String(token.value || "");
+  const start = Number(token.start) || 0;
+  const tokenEnd = Number(token.end) || start;
+  const insertedText = String(insert || "");
+  if (token.wildcard) {
+    return {
+      start,
+      end: tokenEnd,
+      replacement: insertedText,
+      caretOffset: insertedText.length,
+      prefix: "",
+      suffix: "",
+      consumeAfter: 0,
+      caretExtra: 0,
+    };
+  }
+
+  const before = sourceValue.slice(0, start);
+  const after = sourceValue.slice(tokenEnd);
+  const appendSeparator = options.appendSeparator === true;
+  const noCommaAfterPeriod = options.noCommaAfterPeriod !== false;
+  const prefix = insertPrefixForBefore(before, noCommaAfterPeriod);
+  const suffixPlan = insertSuffixPlanForAfter(after, appendSeparator, noCommaAfterPeriod);
+  const suffix = suffixPlan.suffix;
+  const replacement = `${prefix}${insertedText}${suffix}`;
+  return {
+    start,
+    end: tokenEnd + suffixPlan.consumeAfter,
+    replacement,
+    caretOffset: prefix.length + insertedText.length + suffixPlan.caretExtra,
+    prefix,
+    suffix,
+    consumeAfter: suffixPlan.consumeAfter,
+    caretExtra: suffixPlan.caretExtra,
+  };
+}

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -5,6 +5,17 @@ import {
 } from "./easyuse_anima_prompt_rules.js";
 import { easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText } from "./easyuse_anima_i18n.js";
+import {
+  autocompleteQuery,
+  currentToken as currentAutocompleteToken,
+  currentWildcardToken as currentAutocompleteWildcardToken,
+  isCaretInComment,
+  isCaretInPromptTranslationMarker as caretInPromptTranslationMarker,
+  normalizeWildcardSearchText,
+  parseAutocompleteText,
+  planAutocompleteInsertion,
+  wildcardAutocompleteQuery,
+} from "./autocomplete/text_model.js";
 
 const TARGETS = {
   EasyUseAnimaPromptBuilder: new Set([
@@ -81,7 +92,6 @@ const AUTOCOMPLETE_COMMIT_KEYS = new Set([
   "enter",
   "tab",
 ]);
-const SENTENCE_PERIODS = new Set([".", "。", "．", "｡"]);
 const TEXT_EDITING_SHORTCUT_KEYS = new Set(["a", "c", "v", "x", "z", "y"]);
 const AUTOCOMPLETE_TEXT = {
   en: {
@@ -581,215 +591,32 @@ function findInputEl(widget) {
   return null;
 }
 
-function isEscaped(value, index) {
-  let count = 0;
-  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor -= 1) {
-    count += 1;
-  }
-  return count % 2 === 1;
-}
-
-function isSentencePeriod(value, index) {
-  if (!SENTENCE_PERIODS.has(value[index]) || isEscaped(value, index)) {
-    return false;
-  }
-  return !(/\d/.test(value[index - 1] || "") && /\d/.test(value[index + 1] || ""));
-}
-
-function naturalSentenceStart(value, segmentStart, caret) {
-  if (!autocompleteDetectNaturalSentences) {
-    return segmentStart;
-  }
-  for (let index = caret - 1; index >= segmentStart; index -= 1) {
-    if (!isSentencePeriod(value, index)) {
-      continue;
-    }
-    let start = index + 1;
-    while (start < caret && /[ \t]/.test(value[start])) {
-      start += 1;
-    }
-    return start < caret ? start : segmentStart;
-  }
-  return segmentStart;
-}
-
-function naturalSentenceEnd(value, caret, segmentEnd) {
-  for (let index = caret; index < segmentEnd; index += 1) {
-    if (isSentencePeriod(value, index)) {
-      return index;
-    }
-  }
-  return segmentEnd;
-}
-
-function trimPromptSyntaxPrefix(value, start, end) {
-  let cursor = start;
-  while (cursor < end && /[ \t]/.test(value[cursor])) {
-    cursor += 1;
-  }
-  if (value.slice(cursor, cursor + 2) === "[[") {
-    cursor += 2;
-    while (cursor < end && /[ \t]/.test(value[cursor])) {
-      cursor += 1;
-    }
-  }
-  if (value[cursor] === "(") {
-    cursor += 1;
-    while (cursor < end && /[ \t]/.test(value[cursor])) {
-      cursor += 1;
-    }
-  }
-  return cursor;
-}
-
-function trimPromptSyntaxSuffix(value, start, end) {
-  let cursor = end;
-  while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
-    cursor -= 1;
-  }
-  if (value.slice(Math.max(start, cursor - 2), cursor) === "]]") {
-    cursor -= 2;
-    while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
-      cursor -= 1;
-    }
-  }
-  if (value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
-    cursor -= 1;
-    while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
-      cursor -= 1;
-    }
-  }
-  const tokenText = value.slice(start, cursor);
-  const weight = /\s*:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\s*$/.exec(tokenText);
-  if (weight) {
-    cursor -= weight[0].length;
-  }
-  return Math.max(start, cursor);
-}
-
 function currentToken(input) {
-  const value = input.value || "";
-  const caret = input.selectionStart ?? value.length;
-  let segmentStart = caret;
-  while (segmentStart > 0 && value[segmentStart - 1] !== "," && value[segmentStart - 1] !== "\n") {
-    segmentStart -= 1;
-  }
-  let segmentEnd = caret;
-  while (segmentEnd < value.length && value[segmentEnd] !== "," && value[segmentEnd] !== "\n") {
-    segmentEnd += 1;
-  }
-  const naturalStart = naturalSentenceStart(value, segmentStart, caret);
-  const sentenceDelimited = naturalStart > segmentStart;
-  if (sentenceDelimited) {
-    segmentStart = naturalStart;
-    segmentEnd = naturalSentenceEnd(value, caret, segmentEnd);
-  }
-  const replaceStart = trimPromptSyntaxPrefix(value, segmentStart, segmentEnd);
-  const replaceEnd = trimPromptSyntaxSuffix(value, replaceStart, segmentEnd);
-  const queryEnd = clamp(caret, replaceStart, replaceEnd);
-  const strictRaw = value.slice(replaceStart, queryEnd);
-  const legacyRaw = value.slice(segmentStart, caret);
-  const segment = value.slice(segmentStart, segmentEnd);
-  const strictActive = caret >= replaceStart && caret <= replaceEnd && queryEnd > replaceStart;
-  const legacyActive = legacyRaw.trim().length > 0;
-  const useStrictToken = !!autocompletePreviewCompletion;
-  return {
+  const value = input?.value || "";
+  return currentAutocompleteToken(
     value,
-    start: replaceStart,
-    end: replaceEnd,
-    caret,
-    segmentStart,
-    segmentEnd,
-    segment,
-    tokenSegment: value.slice(replaceStart, replaceEnd),
-    sentenceDelimited,
-    query: (useStrictToken ? strictRaw : legacyRaw).trim(),
-    active: useStrictToken ? strictActive : legacyActive,
-  };
+    input?.selectionStart ?? value.length,
+    {
+      detectNaturalSentences: autocompleteDetectNaturalSentences,
+      previewCompletion: autocompletePreviewCompletion,
+    },
+  );
 }
 
 function currentWildcardToken(input) {
-  const value = input.value || "";
-  const caret = input.selectionStart ?? value.length;
-  let opening = -1;
-  let index = 0;
-  while (index < caret) {
-    const found = value.indexOf("__", index);
-    if (found < 0 || found >= caret) {
-      break;
-    }
-    opening = opening < 0 ? found : -1;
-    index = found + 2;
-  }
-  if (opening < 0) {
-    return null;
-  }
-  const query = value.slice(opening + 2, caret);
-  if (/[\r\n,]/.test(query)) {
-    return null;
-  }
-  const closing = value.indexOf("__", caret);
-  const end = closing >= 0 ? closing + 2 : caret;
-  const active = caret >= opening + 2 && (closing < 0 || caret <= closing);
-  return {
+  const value = input?.value || "";
+  return currentAutocompleteWildcardToken(
     value,
-    start: opening,
-    end,
-    caret,
-    segment: value.slice(opening, end),
-    query,
-    wildcard: true,
-    active,
-  };
+    input?.selectionStart ?? value.length,
+  );
 }
 
 function isCaretInPromptTranslationMarker(input) {
   const value = input?.value || "";
-  const caret = input?.selectionStart ?? value.length;
-  let index = 0;
-  while (index < caret) {
-    const start = value.indexOf("%{", index);
-    if (start < 0 || start >= caret) {
-      return false;
-    }
-    if (isEscaped(value, start)) {
-      index = start + 2;
-      continue;
-    }
-    let end = -1;
-    for (let cursor = start + 2; cursor < value.length; cursor += 1) {
-      if (value[cursor] === "}" && !isEscaped(value, cursor)) {
-        end = cursor + 1;
-        break;
-      }
-    }
-    if (end < 0) {
-      return caret > start;
-    }
-    if (caret > start && caret < end) {
-      return true;
-    }
-    index = end;
-  }
-  return false;
-}
-
-function autocompleteQuery(token, forceArtistOnly = false) {
-  const raw = String(token.query || "");
-  const parsed = parseAutocompleteText(raw);
-  const artistOnly = forceArtistOnly || parsed.artistOnly;
-  const query = parsed.query;
-  const category = artistOnly ? "artist" : "";
-  return { query, artistOnly, category };
-}
-
-function wildcardAutocompleteQuery(token) {
-  return {
-    query: String(token?.query || "").toLocaleLowerCase(),
-    artistOnly: false,
-    category: "wildcard",
-    kind: "wildcard",
-  };
+  return caretInPromptTranslationMarker(
+    value,
+    input?.selectionStart ?? value.length,
+  );
 }
 
 function autocompleteStateSignature(token, context, state) {
@@ -808,43 +635,6 @@ function autocompleteStateSignature(token, context, state) {
     previewClosingBrackets: autocompletePreviewClosingBrackets,
     previewCompletion: autocompletePreviewCompletion,
   });
-}
-
-function stripPromptSyntaxClosingParens(value) {
-  let cursor = String(value || "").length;
-  while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
-    cursor -= 1;
-  }
-  while (cursor > 0 && value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
-    cursor -= 1;
-    while (cursor > 0 && /[ \t]/.test(value[cursor - 1])) {
-      cursor -= 1;
-    }
-  }
-  return value.slice(0, cursor);
-}
-
-function parseAutocompleteText(value) {
-  let query = String(value || "").trim();
-  query = query.replace(/^\[\[\s*/g, "");
-  query = query.replace(/^\(\s*/g, "");
-  const artistOnly = query.startsWith("@");
-  if (artistOnly) {
-    query = query.slice(1).trimStart();
-  }
-  query = stripPromptSyntaxClosingParens(query);
-  query = query.replace(/:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)\s*$/, "");
-  query = stripPromptSyntaxClosingParens(query);
-  return { query, artistOnly };
-}
-
-function normalizeWildcardSearchText(value) {
-  return String(value || "")
-    .normalize("NFKC")
-    .replaceAll("\\", "/")
-    .replace(/[ _]+/g, "-")
-    .trim()
-    .toLocaleLowerCase();
 }
 
 function strictAutocompleteResults(context, token, state, results) {
@@ -1091,65 +881,6 @@ function resetVisibleAutocompleteMenuSoon(menu, input) {
   });
 }
 
-function endsWithSentencePeriod(value) {
-  const text = String(value || "").replace(/[ \t]+$/g, "");
-  return text.length > 0 && isSentencePeriod(text, text.length - 1);
-}
-
-function startsWithSentencePeriod(value) {
-  const text = String(value || "").replace(/^[ \t]+/g, "");
-  return text.length > 0 && isSentencePeriod(text, 0);
-}
-
-function insertPrefixForBefore(before) {
-  if (!before || before.endsWith("\n")) {
-    return "";
-  }
-  const trimmed = before.replace(/[ \t]+$/g, "");
-  if (trimmed.endsWith("(") || trimmed.endsWith("[[")) {
-    return "";
-  }
-  if (before.endsWith(",")) {
-    return " ";
-  }
-  if (/[ \t]$/.test(before)) {
-    return "";
-  }
-  if (autocompleteNoCommaAfterPeriod && endsWithSentencePeriod(before)) {
-    return " ";
-  }
-  return ", ";
-}
-
-function insertSuffixForAfter(after, appendSeparator = false) {
-  if (!after) {
-    return appendSeparator ? ", " : "";
-  }
-  if (/^[ \t]*:\s*[+-]?(?:\d+(?:\.\d*)?|\.\d+)/.test(after) || /^[ \t]*(?:\)|\]\])/.test(after)) {
-    return "";
-  }
-  if (after.startsWith("\n") || after.startsWith(",")) {
-    return "";
-  }
-  if (autocompleteNoCommaAfterPeriod && startsWithSentencePeriod(after)) {
-    return "";
-  }
-  return ", ";
-}
-
-function insertSuffixPlanForAfter(after, appendSeparator = false) {
-  const text = String(after || "");
-  const suffix = insertSuffixForAfter(text, appendSeparator);
-  if (!text) {
-    return { suffix, consumeAfter: 0, caretExtra: suffix.length };
-  }
-  if (appendSeparator && text.startsWith(",")) {
-    const match = /^,[ \t]*/.exec(text);
-    return { suffix: ", ", consumeAfter: match?.[0]?.length || 1, caretExtra: 2 };
-  }
-  return { suffix, consumeAfter: 0, caretExtra: 0 };
-}
-
 function replaceInputRange(input, start, end, replacement, caretOffset) {
   input.focus?.();
   input.setSelectionRange(start, end);
@@ -1294,30 +1025,24 @@ function forwardMiddlePanFromAutocompleteInput(event) {
 }
 
 function commitSuggestion(state, entry, options = {}) {
-  const token = currentToken(state.input);
+  const promptToken = currentToken(state.input);
   const wildcardToken = entry?.kind === "wildcard" ? currentWildcardToken(state.input) : null;
-  if (wildcardToken) {
-    const replacement = `__${String(entry.tag || "").replace(/^__|__$/g, "")}__`;
-    replaceInputRange(state.input, wildcardToken.start, wildcardToken.end, replacement, replacement.length);
-    syncWidgetValue(state);
-    state.onCommit?.(state.input.value);
-    if (options.suppressPopup) {
-      suppressAutocompleteUntilInputChanges(state.input);
-    }
-    hidePopup();
+  const token = wildcardToken || promptToken;
+  const insert = completionText(token, entry, state.forceArtistOnly);
+  const plan = planAutocompleteInsertion(token, insert, {
+    appendSeparator: autocompleteAppendSeparator,
+    noCommaAfterPeriod: autocompleteNoCommaAfterPeriod,
+  });
+  if (!plan) {
     return;
   }
-  const before = token.value.slice(0, token.start);
-  const after = token.value.slice(token.end);
-  const insert = completionText(token, entry, state.forceArtistOnly);
-  const prefix = insertPrefixForBefore(before);
-  const suffixPlan = insertSuffixPlanForAfter(after, autocompleteAppendSeparator);
-  const suffix = suffixPlan.suffix;
-  const replacement = `${prefix}${insert}${suffix}`;
-  const caretOffset = prefix.length
-    + insert.length
-    + suffixPlan.caretExtra;
-  replaceInputRange(state.input, token.start, token.end + suffixPlan.consumeAfter, replacement, caretOffset);
+  replaceInputRange(
+    state.input,
+    plan.start,
+    plan.end,
+    plan.replacement,
+    plan.caretOffset,
+  );
   syncWidgetValue(state);
   state.onCommit?.(state.input.value);
   if (options.suppressPopup) {
@@ -1420,41 +1145,32 @@ function completionPreviewPlan(state, entry) {
     return null;
   }
   const sourceValue = String(state.input.value || "");
-  if (entry?.kind === "wildcard") {
-    const token = currentWildcardToken(state.input);
-    if (!token) {
-      return null;
-    }
-    const insert = `__${String(entry.tag || "").replace(/^__|__$/g, "")}__`;
+  const wildcardToken = entry?.kind === "wildcard" ? currentWildcardToken(state.input) : null;
+  if (entry?.kind === "wildcard" && !wildcardToken) {
+    return null;
+  }
+  const token = wildcardToken || currentToken(state.input);
+  const insert = completionText(token, entry, state.forceArtistOnly);
+  const plan = planAutocompleteInsertion(token, insert, {
+    appendSeparator: autocompleteAppendSeparator,
+    noCommaAfterPeriod: autocompleteNoCommaAfterPeriod,
+  });
+  if (!plan) {
+    return null;
+  }
+  let typedLength;
+  if (token.wildcard) {
     const typed = token.value.slice(token.start, token.caret);
     const lowerInsert = insert.toLocaleLowerCase();
     const lowerTyped = typed.toLocaleLowerCase();
-    const typedLength = typed && lowerInsert.startsWith(lowerTyped)
+    typedLength = typed && lowerInsert.startsWith(lowerTyped)
       ? typed.length
       : 0;
-    const value = `${sourceValue.slice(0, token.start)}${insert}${sourceValue.slice(token.end)}`;
-    return {
-      sourceValue,
-      value,
-      candidateStart: token.start,
-      candidateEnd: token.start + insert.length,
-      ghostStart: token.start + typedLength,
-      ghostEnd: token.start + insert.length,
-      category: "wildcard",
-    };
+  } else {
+    typedLength = plan.prefix ? 0 : typedCompletionLength(token, insert);
   }
-  const token = currentToken(state.input);
-  const insert = completionText(token, entry, state.forceArtistOnly);
-  const before = token.value.slice(0, token.start);
-  const after = token.value.slice(token.end);
-  const prefix = insertPrefixForBefore(before);
-  const suffixPlan = insertSuffixPlanForAfter(after, autocompleteAppendSeparator);
-  const suffix = suffixPlan.suffix;
-  const replacement = `${prefix}${insert}${suffix}`;
-  const replaceEnd = token.end + suffixPlan.consumeAfter;
-  const value = `${sourceValue.slice(0, token.start)}${replacement}${sourceValue.slice(replaceEnd)}`;
-  const typedLength = prefix ? 0 : typedCompletionLength(token, insert);
-  const candidateStart = token.start + prefix.length;
+  const value = `${sourceValue.slice(0, plan.start)}${plan.replacement}${sourceValue.slice(plan.end)}`;
+  const candidateStart = plan.start + plan.prefix.length;
   const candidateEnd = candidateStart + insert.length;
   const ghostStart = candidateStart + typedLength;
   const ghostEnd = candidateEnd;
@@ -1465,7 +1181,9 @@ function completionPreviewPlan(state, entry) {
     candidateEnd,
     ghostStart,
     ghostEnd,
-    category: autocompletePreviewCategory(state, entry, token),
+    category: token.wildcard
+      ? "wildcard"
+      : autocompletePreviewCategory(state, entry, token),
   };
 }
 
@@ -1629,13 +1347,6 @@ function renderResults(state, results, signature = "") {
   resetActiveAutocompleteMenu(menu);
   resetVisibleAutocompleteMenuSoon(menu, state.input);
   updateAutocompletePreview();
-}
-
-function isCaretInComment(value, caret) {
-  const text = String(value ?? "");
-  const safeCaret = Math.max(0, Math.min(Number(caret) || 0, text.length));
-  const lineStart = text.lastIndexOf("\n", safeCaret - 1) + 1;
-  return /^[ \t]*#/.test(text.slice(lineStart, safeCaret));
 }
 
 function debounce(fn, delay = 120) {


### PR DESCRIPTION
## 변경 요약

- 2천 줄 규모의 자동완성 엔트리에서 token/wildcard/marker/comment 파싱과 삽입 계획을 import-free DOM-free `web/js/autocomplete/text_model.js`로 분리했습니다.
- 엔트리는 input adapter, 검색/cache, popup/caret DOM, widget 동기화, listener와 extension lifecycle을 계속 소유합니다.
- commit과 inline preview가 동일한 `planAutocompleteInsertion`을 사용하도록 중복된 separator/span/caret 계산을 통합했습니다.
- 자연문장 감지와 preview 모드 설정을 adapter가 순수 모델에 명시적으로 전달합니다.
- wildcard 결과가 stale 상태일 때 일반 prompt 위치에 ghost preview를 만들지 않도록 기존 null guard를 유지했습니다.

## 호환성

- 쉼표/개행, 4종 마침표와 decimal/escaped period 예외를 유지합니다.
- `[[...]]`, 괄호, weight, `@artist` query와 wrapper 보존을 유지합니다.
- 빈 값/Unicode/path wildcard, 닫힌 delimiter, 두 번째 wildcard, 쉼표·개행 거부를 유지합니다.
- `%{...}` marker와 whole-line comment 판정을 유지합니다.
- append separator, no-comma-after-period, 기존 `,   ` 소비와 caret 위치를 동일 insertion plan으로 고정했습니다.
- DOM/API/listener/controller 동작은 변경하지 않습니다.

## 주요 파일

- `web/js/autocomplete/text_model.js`
- `web/js/easyuse_anima_autocomplete.js`
- `tests/frontend_autocomplete_text_model_smoke.mjs`
- `tests/test_autocomplete_frontend.py`
- `tests/test_aio_frontend.py`
- `tools/check_frontend.ps1`
- `jsconfig.json`

## 검증

- Focused model/entry `node --check`: 통과
- Autocomplete text-model semantic smoke: 통과
- Focused boundary unittest와 관련 AiO frontend source tests: 통과
- TypeScript 6.0.3 focused check: 통과
- Official full profile: Python unittest 338 tests 통과
- Official frontend profile: 74 JavaScript files, TypeScript 6.0.3, 전체 semantic smoke 통과
- `git diff --check`: 통과
- 독립 behavior/test diff audit 2회: blocker 없음

재실행 사유:
- Windows sandbox가 이 세션에서 `CreateProcessAsUserW 1312`로 프로세스를 시작하지 못해 focused 명령은 동일 명령을 비샌드박스로 실행했습니다.
- 이동된 helper 이름을 source 구간의 끝 anchor로 사용하던 기존 테스트 4건은 새 모듈 경계에 맞는 anchor로 수정한 뒤 해당 테스트만 재실행했습니다.
- 독립 리뷰에서 stale wildcard preview guard를 복원하고, 변경된 entry syntax·semantic/static 계약만 재검증했습니다.
- official full runner는 최종 diff에서 1회만 실행했습니다.

## 브라우저 및 사용자 인스턴스

- 이번 조각은 DOM-free 순수 로직 이동이며 frontend UI 동작 변경이 없어 legacy canvas/Node 2.0 browser smoke는 실행하지 않았습니다.
- 사용자 v0.27.0 인스턴스 수동 확인은 Issue #54–#57 전체 작업 완료 후 한 번만 진행합니다.

Refs #56

라벨 후보: `type: chore`, `area: frontend`, `status: draft` (저장소에 없으면 생성하지 않음)