### PR TITLE
refactor: extract LoRA lookup and FIX state

### DIFF
--- a/tests/frontend_lora_preset_lora_state_smoke.mjs
+++ b/tests/frontend_lora_preset_lora_state_smoke.mjs
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const loraState = await import(dataModule("../web/js/lora_preset/lora_state.js"));
+
+assert.deepEqual(Object.keys(loraState).sort(), [
+  "buildLoraLookup",
+  "comboEntryText",
+  "hasLoraPathProblem",
+  "isAnyLoraFixPending",
+  "isLoraFixPending",
+  "localLoraMatch",
+  "loraFileKey",
+  "loraFixPendingSet",
+  "normalizeLoraKey",
+  "normalizeLoraNameList",
+  "validComboEntryText",
+].sort());
+
+const {
+  buildLoraLookup,
+  comboEntryText,
+  hasLoraPathProblem,
+  isAnyLoraFixPending,
+  isLoraFixPending,
+  localLoraMatch,
+  loraFileKey,
+  loraFixPendingSet,
+  normalizeLoraKey,
+  normalizeLoraNameList,
+  validComboEntryText,
+} = loraState;
+
+const pendingNode = {};
+const firstPendingSet = loraFixPendingSet(pendingNode);
+assert.ok(firstPendingSet instanceof Set);
+assert.strictEqual(loraFixPendingSet(pendingNode), firstPendingSet);
+assert.equal(isLoraFixPending(pendingNode, 2), false);
+assert.equal(isAnyLoraFixPending(pendingNode), false);
+firstPendingSet.add(2);
+assert.equal(isLoraFixPending(pendingNode, 2), true);
+assert.equal(isLoraFixPending(pendingNode, 3), false);
+assert.equal(isAnyLoraFixPending(pendingNode), true);
+firstPendingSet.delete(2);
+pendingNode.__easyuseAnimaProfileFixPending = true;
+assert.equal(isLoraFixPending(pendingNode, 3), true);
+assert.equal(isAnyLoraFixPending(pendingNode), true);
+pendingNode.__easyuseAnimaProfileFixPending = false;
+assert.equal(isAnyLoraFixPending(pendingNode), false);
+
+assert.equal(comboEntryText("  style/foo.safetensors  "), "style/foo.safetensors");
+assert.equal(comboEntryText(42), "42");
+assert.equal(
+  comboEntryText([null, { content: " nested/path.safetensors " }]),
+  "nested/path.safetensors",
+);
+assert.equal(comboEntryText({ filename: "file-only.safetensors" }), "file-only.safetensors");
+assert.equal(comboEntryText({ unknown: "ignored" }), "");
+assert.equal(validComboEntryText("None"), "");
+assert.equal(validComboEntryText("None", { allowNone: true }), "None");
+assert.equal(validComboEntryText("[object Object]"), "");
+assert.equal(validComboEntryText({ label: " labeled.safetensors " }), "labeled.safetensors");
+
+const rawNames = [
+  " Style\\Foo.safetensors ",
+  "style/Foo.safetensors",
+  { name: "Other/Bar.safetensors" },
+  { value: "other\\bar.safetensors" },
+  "None",
+  "",
+  42,
+];
+const rawNamesSnapshot = structuredClone(rawNames);
+assert.deepEqual(normalizeLoraNameList(rawNames), [
+  "Style\\Foo.safetensors",
+  "Other/Bar.safetensors",
+  "42",
+]);
+assert.deepEqual(rawNames, rawNamesSnapshot);
+
+assert.equal(
+  normalizeLoraKey(" C:\\ComfyUI\\models\\loras\\Style\\Foo.safetensors "),
+  "style/foo.safetensors",
+);
+assert.equal(normalizeLoraKey("/Style/Foo.safetensors/"), "style/foo.safetensors");
+assert.equal(normalizeLoraKey(""), "");
+assert.equal(loraFileKey("Style\\Foo.safetensors"), "foo.safetensors");
+assert.equal(loraFileKey(""), "");
+
+const lookupValues = [
+  "Style\\Foo.safetensors",
+  "Other/Bar.safetensors",
+  "SetA/Shared.safetensors",
+  "SetB/Shared.safetensors",
+];
+const lookupValuesSnapshot = [...lookupValues];
+const lookup = buildLoraLookup(lookupValues);
+assert.deepEqual(lookupValues, lookupValuesSnapshot);
+assert.equal(lookup.byName.get("style/foo.safetensors"), "Style\\Foo.safetensors");
+assert.equal(lookup.byFile.get("foo.safetensors"), "Style\\Foo.safetensors");
+assert.equal(lookup.byFile.get("shared.safetensors"), null);
+
+assert.deepEqual(
+  localLoraMatch({ name: "Style\\Foo.safetensors" }, lookup),
+  {
+    state: "ok",
+    match: "Style\\Foo.safetensors",
+    reason: "name",
+  },
+);
+assert.deepEqual(
+  localLoraMatch({ lora: "style/foo.safetensors" }, lookup),
+  {
+    state: "fixable",
+    match: "Style\\Foo.safetensors",
+    reason: "name",
+  },
+);
+assert.deepEqual(
+  localLoraMatch({ lora: "Style/Foo.safetensors" }, lookup),
+  {
+    state: "ok",
+    match: "Style\\Foo.safetensors",
+    reason: "name",
+  },
+);
+assert.deepEqual(
+  localLoraMatch(
+    { name: "D:\\ComfyUI\\models\\loras\\Style\\Foo.safetensors" },
+    lookup,
+  ),
+  {
+    state: "fixable",
+    match: "Style\\Foo.safetensors",
+    reason: "name",
+  },
+);
+assert.deepEqual(
+  localLoraMatch({ name: "legacy/path/Bar.safetensors" }, lookup),
+  {
+    state: "fixable",
+    match: "Other/Bar.safetensors",
+    reason: "file",
+  },
+);
+assert.deepEqual(
+  localLoraMatch({ name: "legacy/path/Shared.safetensors" }, lookup),
+  {
+    state: "missing",
+    match: "",
+    reason: "",
+  },
+);
+assert.deepEqual(
+  localLoraMatch({ name: "missing/Unknown.safetensors" }, lookup),
+  {
+    state: "missing",
+    match: "",
+    reason: "",
+  },
+);
+assert.deepEqual(
+  localLoraMatch({ name: "" }, lookup),
+  {
+    state: "unknown",
+    match: "",
+    reason: "",
+  },
+);
+assert.deepEqual(
+  localLoraMatch({ name: "Style/Foo.safetensors" }, null),
+  {
+    state: "unknown",
+    match: "",
+    reason: "",
+  },
+);
+
+const conflictingLookup = buildLoraLookup([
+  "Style/Foo.safetensors",
+  "style\\foo.safetensors",
+]);
+assert.equal(conflictingLookup.byName.get("style/foo.safetensors"), null);
+assert.equal(conflictingLookup.byFile.get("foo.safetensors"), null);
+assert.deepEqual(
+  localLoraMatch({ name: "Style/Foo.safetensors" }, conflictingLookup),
+  {
+    state: "missing",
+    match: "",
+    reason: "",
+  },
+);
+
+assert.equal(hasLoraPathProblem({ state: "ok" }), false);
+assert.equal(hasLoraPathProblem({ state: "unknown" }), false);
+assert.equal(hasLoraPathProblem({ state: "fixable" }), true);
+assert.equal(hasLoraPathProblem({ state: "missing" }), true);
+assert.equal(hasLoraPathProblem(null), false);

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -15,11 +15,123 @@ LORA_PRESET_PROFILE_DATA = ROOT / "web" / "js" / "lora_preset" / "profile_data.j
 LORA_PRESET_PROFILE_DATA_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_profile_data_smoke.mjs"
 )
+LORA_PRESET_LORA_STATE = ROOT / "web" / "js" / "lora_preset" / "lora_state.js"
+LORA_PRESET_LORA_STATE_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_lora_state_smoke.mjs"
+)
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class LoraPresetFrontendTests(unittest.TestCase):
+    def test_lora_state_module_boundary(self):
+        module_source = LORA_PRESET_LORA_STATE.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+        expected_exports = {
+            "buildLoraLookup",
+            "comboEntryText",
+            "hasLoraPathProblem",
+            "isAnyLoraFixPending",
+            "isLoraFixPending",
+            "localLoraMatch",
+            "loraFileKey",
+            "loraFixPendingSet",
+            "normalizeLoraKey",
+            "normalizeLoraNameList",
+            "validComboEntryText",
+        }
+        expected_imports = expected_exports - {
+            "comboEntryText",
+            "loraFileKey",
+            "normalizeLoraKey",
+        }
+
+        exported_names = set(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            )
+        )
+        self.assertEqual(exported_names, expected_exports)
+
+        import_match = re.search(
+            r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*"\./lora_preset/lora_state\.js";',
+            entry_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip().rstrip(",")
+            for name in import_match.group("names").splitlines()
+            if name.strip()
+        }
+        self.assertEqual(imported_names, expected_imports)
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|registerExtension|"
+                r"addEventListener|removeEventListener|MutationObserver|"
+                r"HTMLElement|HTMLInputElement|HTMLTextAreaElement)\b"
+            ),
+        )
+        for name in expected_exports | {"putUniqueLoraMatch"}:
+            with self.subTest(moved_declaration=name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\b(?:const|let|var|function|class)\s+{re.escape(name)}\b",
+                )
+
+        for adapter in (
+            "comboValues",
+            "loraNameValues",
+            "loraResolveState",
+            "setLoraLookup",
+            "fetchLoraNameValues",
+            "refreshLoraAvailability",
+            "fixProfileLoras",
+            "fixSingleLoraEntry",
+        ):
+            with self.subTest(entry_adapter=adapter):
+                self.assertIn(f"function {adapter}(", entry_source)
+        self.assertIn(
+            "return localLoraMatch(normalizeLoraEntry(lora), node?.__easyuseAnimaLoraLookup);",
+            entry_source,
+        )
+        self.assertIn("return normalizeLoraNameList(comboValues(", entry_source)
+        self.assertIn("node.__easyuseAnimaLoraLookup = buildLoraLookup(values);", entry_source)
+
+        self.assertTrue(LORA_PRESET_LORA_STATE_SMOKE.is_file())
+        self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_lora_preset_lora_state_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_lora_state_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_LORA_STATE_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_profile_data_module_boundary(self):
         module_source = LORA_PRESET_PROFILE_DATA.read_text(encoding="utf-8")
         entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
@@ -116,14 +228,20 @@ class LoraPresetFrontendTests(unittest.TestCase):
 
             const sourcePath = process.argv[1];
             const profileDataPath = process.argv[2];
+            const loraStatePath = process.argv[3];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let loraStateSource = fs.readFileSync(loraStatePath, "utf8");
+            loraStateSource = loraStateSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${source}`;
+            source = `${profileDataSource}\n${loraStateSource}\n${source}`;
             source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems };\n";
 
             class StubElement {
@@ -369,6 +487,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 runner,
                 str(LORA_PRESET_ENTRY),
                 str(LORA_PRESET_PROFILE_DATA),
+                str(LORA_PRESET_LORA_STATE),
             ],
             cwd=ROOT,
             text=True,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -94,6 +94,11 @@ try {
         throw "Frontend LoRA preset profile data smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_lora_state_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset state smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_text_model_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete text model smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -18,6 +18,16 @@ import {
   withSavedMeta,
   wrapProfileIndex,
 } from "./lora_preset/profile_data.js";
+import {
+  buildLoraLookup,
+  hasLoraPathProblem,
+  isAnyLoraFixPending,
+  isLoraFixPending,
+  localLoraMatch,
+  loraFixPendingSet,
+  normalizeLoraNameList,
+  validComboEntryText,
+} from "./lora_preset/lora_state.js";
 
 const NODE_TYPE = "EasyUseAnimaLoraPreset";
 const MIN_NODE_WIDTH = 520;
@@ -738,19 +748,6 @@ async function refreshLoraLookupForFix(node) {
   await fetchLoraNameValues(node);
 }
 
-function loraFixPendingSet(node) {
-  node.__easyuseAnimaLoraFixPending ||= new Set();
-  return node.__easyuseAnimaLoraFixPending;
-}
-
-function isLoraFixPending(node, index) {
-  return !!node?.__easyuseAnimaProfileFixPending || loraFixPendingSet(node).has(index);
-}
-
-function isAnyLoraFixPending(node) {
-  return !!node?.__easyuseAnimaProfileFixPending || loraFixPendingSet(node).size > 0;
-}
-
 function applyFixedProfilePayload(node, payload) {
   const dataWidget = findWidget(node, "profile_data");
   if (!dataWidget || !payload || typeof payload !== "object") {
@@ -884,137 +881,12 @@ function comboValues(widget) {
   return [];
 }
 
-function comboEntryText(value, depth = 0) {
-  if (value == null || depth > 2) {
-    return "";
-  }
-  if (typeof value === "string" || typeof value === "number") {
-    return String(value).trim();
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const text = comboEntryText(item, depth + 1);
-      if (text) {
-        return text;
-      }
-    }
-    return "";
-  }
-  if (typeof value === "object") {
-    for (const key of ["value", "content", "name", "title", "text", "label", "path", "filename"]) {
-      const text = comboEntryText(value[key], depth + 1);
-      if (text && text !== "[object Object]") {
-        return text;
-      }
-    }
-  }
-  return "";
-}
-
-function validComboEntryText(value, options = {}) {
-  const text = comboEntryText(value);
-  if (!text || text === "[object Object]" || (!options.allowNone && text === "None")) {
-    return "";
-  }
-  return text;
-}
-
-function normalizeLoraNameList(values) {
-  const seen = new Set();
-  const names = [];
-  for (const value of values || []) {
-    const text = validComboEntryText(value);
-    if (!text) {
-      continue;
-    }
-    const key = text.replace(/\\/g, "/").toLowerCase();
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    names.push(text);
-  }
-  return names;
-}
-
 function loraNameValues(node) {
   return normalizeLoraNameList(comboValues(findWidget(node, "lora_name")));
 }
 
-function normalizeLoraKey(value) {
-  let text = String(value || "").trim().replace(/\\/g, "/");
-  const marker = "/models/loras/";
-  const markerIndex = text.toLowerCase().lastIndexOf(marker);
-  if (markerIndex >= 0) {
-    text = text.slice(markerIndex + marker.length);
-  }
-  return text.replace(/^\/+|\/+$/g, "").toLowerCase();
-}
-
-function loraFileKey(value) {
-  return (String(value || "").trim().replace(/\\/g, "/").split("/").pop() || "").toLowerCase();
-}
-
-function putUniqueLoraMatch(map, key, value) {
-  if (!key) {
-    return;
-  }
-  if (!map.has(key)) {
-    map.set(key, value);
-    return;
-  }
-  if (map.get(key) !== value) {
-    map.set(key, null);
-  }
-}
-
-function buildLoraLookup(values) {
-  const lookup = {
-    byName: new Map(),
-    byFile: new Map(),
-  };
-  for (const name of values || []) {
-    putUniqueLoraMatch(lookup.byName, normalizeLoraKey(name), name);
-    putUniqueLoraMatch(lookup.byFile, loraFileKey(name), name);
-  }
-  return lookup;
-}
-
-function localLoraMatch(lora, lookup) {
-  if (!lookup) {
-    return { state: "unknown", match: "", reason: "" };
-  }
-  const rawName = String(lora?.name || lora?.lora || "").trim();
-  if (!rawName) {
-    return { state: "unknown", match: "", reason: "" };
-  }
-  const slashName = rawName.replace(/\\/g, "/");
-  const exact = lookup.byName.get(normalizeLoraKey(rawName));
-  if (exact) {
-    const exactSlash = String(exact).replace(/\\/g, "/");
-    return {
-      state: exactSlash === slashName ? "ok" : "fixable",
-      match: exact,
-      reason: "name",
-    };
-  }
-  const byFile = lookup.byFile.get(loraFileKey(rawName));
-  if (byFile) {
-    return { state: "fixable", match: byFile, reason: "file" };
-  }
-  return {
-    state: "missing",
-    match: "",
-    reason: "",
-  };
-}
-
 function loraResolveState(node, lora) {
   return localLoraMatch(normalizeLoraEntry(lora), node?.__easyuseAnimaLoraLookup);
-}
-
-function hasLoraPathProblem(state) {
-  return state?.state === "fixable" || state?.state === "missing";
 }
 
 function setLoraLookup(node, values) {

--- a/web/js/lora_preset/lora_state.js
+++ b/web/js/lora_preset/lora_state.js
@@ -1,0 +1,139 @@
+// @ts-check
+
+export function loraFixPendingSet(node) {
+  node.__easyuseAnimaLoraFixPending ||= new Set();
+  return node.__easyuseAnimaLoraFixPending;
+}
+
+export function isLoraFixPending(node, index) {
+  return !!node?.__easyuseAnimaProfileFixPending || loraFixPendingSet(node).has(index);
+}
+
+export function isAnyLoraFixPending(node) {
+  return !!node?.__easyuseAnimaProfileFixPending || loraFixPendingSet(node).size > 0;
+}
+
+export function comboEntryText(value, depth = 0) {
+  if (value == null || depth > 2) {
+    return "";
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value).trim();
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const text = comboEntryText(item, depth + 1);
+      if (text) {
+        return text;
+      }
+    }
+    return "";
+  }
+  if (typeof value === "object") {
+    for (const key of ["value", "content", "name", "title", "text", "label", "path", "filename"]) {
+      const text = comboEntryText(value[key], depth + 1);
+      if (text && text !== "[object Object]") {
+        return text;
+      }
+    }
+  }
+  return "";
+}
+
+export function validComboEntryText(value, options = {}) {
+  const text = comboEntryText(value);
+  if (!text || text === "[object Object]" || (!options.allowNone && text === "None")) {
+    return "";
+  }
+  return text;
+}
+
+export function normalizeLoraNameList(values) {
+  const seen = new Set();
+  const names = [];
+  for (const value of values || []) {
+    const text = validComboEntryText(value);
+    if (!text) {
+      continue;
+    }
+    const key = text.replace(/\\/g, "/").toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    names.push(text);
+  }
+  return names;
+}
+
+export function normalizeLoraKey(value) {
+  let text = String(value || "").trim().replace(/\\/g, "/");
+  const marker = "/models/loras/";
+  const markerIndex = text.toLowerCase().lastIndexOf(marker);
+  if (markerIndex >= 0) {
+    text = text.slice(markerIndex + marker.length);
+  }
+  return text.replace(/^\/+|\/+$/g, "").toLowerCase();
+}
+
+export function loraFileKey(value) {
+  return (String(value || "").trim().replace(/\\/g, "/").split("/").pop() || "").toLowerCase();
+}
+
+function putUniqueLoraMatch(map, key, value) {
+  if (!key) {
+    return;
+  }
+  if (!map.has(key)) {
+    map.set(key, value);
+    return;
+  }
+  if (map.get(key) !== value) {
+    map.set(key, null);
+  }
+}
+
+export function buildLoraLookup(values) {
+  const lookup = {
+    byName: new Map(),
+    byFile: new Map(),
+  };
+  for (const name of values || []) {
+    putUniqueLoraMatch(lookup.byName, normalizeLoraKey(name), name);
+    putUniqueLoraMatch(lookup.byFile, loraFileKey(name), name);
+  }
+  return lookup;
+}
+
+export function localLoraMatch(lora, lookup) {
+  if (!lookup) {
+    return { state: "unknown", match: "", reason: "" };
+  }
+  const rawName = String(lora?.name || lora?.lora || "").trim();
+  if (!rawName) {
+    return { state: "unknown", match: "", reason: "" };
+  }
+  const slashName = rawName.replace(/\\/g, "/");
+  const exact = lookup.byName.get(normalizeLoraKey(rawName));
+  if (exact) {
+    const exactSlash = String(exact).replace(/\\/g, "/");
+    return {
+      state: exactSlash === slashName ? "ok" : "fixable",
+      match: exact,
+      reason: "name",
+    };
+  }
+  const byFile = lookup.byFile.get(loraFileKey(rawName));
+  if (byFile) {
+    return { state: "fixable", match: byFile, reason: "file" };
+  }
+  return {
+    state: "missing",
+    match: "",
+    reason: "",
+  };
+}
+
+export function hasLoraPathProblem(state) {
+  return state?.state === "fixable" || state?.state === "missing";
+}


### PR DESCRIPTION
## 변경 요약

- LoRA FIX pending 상태와 로컬 LoRA 경로 lookup/matching 로직을 `lora_preset/lora_state.js`로 분리했습니다.
- 기존 엔트리에는 ComfyUI widget/API/render adapter와 lifecycle만 유지했습니다.
- Windows/Unix 경로, 대소문자, basename 충돌, normalized full-name 충돌 동작을 semantic smoke로 고정했습니다.
- 새 smoke를 공식 frontend runner와 Python 경계 테스트에 연결했습니다.

## 주요 파일

- `web/js/lora_preset/lora_state.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_lora_state_smoke.mjs`
- `tests/test_frontend_lora_preset.py`
- `tools/check_frontend.ps1`

## 검증

- focused Node syntax + semantic smoke: 통과
- `python -m unittest tests.test_frontend_lora_preset -v`: 5 tests 통과
- `npx --yes --package typescript@6.0.3 -- tsc -p jsconfig.json`: 통과
- workspace full runner → repository `tools/check_project.ps1 -Profile full`: 340 Python tests 통과
- frontend runner: 75 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과

## 테스트 표면 및 남은 위험

- ComfyUI Codex test surface: compile, unittest, frontend semantic/static checks
- 브라우저 smoke: 실행하지 않음 — DOM, canvas, API, serialization 동작을 바꾸지 않은 경계 추출
- 사용자 인스턴스 수동 확인: 전체 Issue #54–57 유지보수 완료 후 1회 수행 예정
- 후속 범위: LoRA API/menu/canvas/lifecycle 경계 분리

Refs #55
