### PR TITLE
refactor: extract settings definition data

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -16,6 +16,7 @@
     "web/js/aio/**/*.js",
     "web/js/autocomplete/**/*.js",
     "web/js/lora_preset/**/*.js",
+    "web/js/settings/**/*.js",
     "web/js/easyuse_anima_prompt_studio.js",
     "web/js/easyuse_anima_prompt_studio_regional.js",
     "web/js/prompt_studio/**/*.js"

--- a/tests/frontend_settings_definition_data_smoke.mjs
+++ b/tests/frontend_settings_definition_data_smoke.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const definitionData = await import(dataModule("../web/js/settings/definition_data.js"));
+
+assert.deepEqual(Object.keys(definitionData).sort(), [
+  "INTERNAL_KEYS",
+  "LONG_TEXT_FIELDS",
+  "LONG_TEXT_FIELD_GROUPS",
+  "NAIA_PREPROCESSING_OPTIONS",
+  "NAIA_RESOLUTION_BUCKET_OPTIONS",
+  "NAIA_RESOLUTION_MODE_BUCKET",
+  "NAIA_RESOLUTION_MODE_SCALE",
+  "ROOT_CATEGORY",
+  "normalizeNaiaResolutionModeValue",
+  "normalizeNaiaResolutionScaleValue",
+  "normalizeValue",
+  "parseWildcardExtraPathItems",
+  "serializeWildcardExtraPathItems",
+].sort());
+
+const {
+  INTERNAL_KEYS,
+  LONG_TEXT_FIELDS,
+  LONG_TEXT_FIELD_GROUPS,
+  NAIA_PREPROCESSING_OPTIONS,
+  NAIA_RESOLUTION_BUCKET_OPTIONS,
+  NAIA_RESOLUTION_MODE_BUCKET,
+  NAIA_RESOLUTION_MODE_SCALE,
+  ROOT_CATEGORY,
+  normalizeNaiaResolutionModeValue,
+  normalizeNaiaResolutionScaleValue,
+  normalizeValue,
+  parseWildcardExtraPathItems,
+  serializeWildcardExtraPathItems,
+} = definitionData;
+
+assert.equal(ROOT_CATEGORY, "EASY USE ANIMA");
+assert.equal(NAIA_RESOLUTION_MODE_SCALE, "scale");
+assert.equal(NAIA_RESOLUTION_MODE_BUCKET, "bucket");
+assert.deepEqual(NAIA_RESOLUTION_BUCKET_OPTIONS, [
+  "512",
+  "768",
+  "896",
+  "1024",
+  "1280",
+  "1536",
+]);
+
+const preprocessingKeys = [
+  "remove_author",
+  "remove_work_title",
+  "remove_character_name",
+  "remove_character_features",
+  "remove_clothes",
+  "remove_color",
+  "remove_location_and_background_color",
+  "remove_expression",
+  "remove_pose_action",
+  "remove_meta_tags",
+  "remove_object_tags",
+  "remove_noise_tags",
+  "e621_auto_boost",
+  "danbooru_auto_weight",
+  "tag_implication_compression",
+];
+assert.deepEqual(NAIA_PREPROCESSING_OPTIONS.map(([key]) => key), preprocessingKeys);
+for (const [, labels] of NAIA_PREPROCESSING_OPTIONS) {
+  assert.deepEqual(Object.keys(labels).sort(), ["en", "ja", "ko", "zh"]);
+  for (const value of Object.values(labels)) {
+    assert.equal(typeof value, "string");
+    assert.ok(value.length > 0);
+  }
+}
+
+const expectedInternalKeys = {
+  "EasyUseAnima.Prompt.MetadataFilter": "prompt.metadata_filter_words",
+  "EasyUseAnima.Prompt.AutocompleteMode": "autocomplete.mode",
+  "EasyUseAnima.Prompt.AutocompleteSource": "autocomplete.source",
+  "EasyUseAnima.Prompt.AutocompleteLimit": "autocomplete.limit",
+  "EasyUseAnima.Prompt.AutocompleteCommitKey": "autocomplete.commit_key",
+  "EasyUseAnima.Prompt.AutocompleteAppendSeparator": "autocomplete.append_separator",
+  "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "autocomplete.no_comma_after_period",
+  "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "autocomplete.detect_natural_sentences",
+  "EasyUseAnima.Prompt.AutocompletePreviewCompletion": "autocomplete.preview_completion",
+  "EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets": "autocomplete.preview_closing_brackets",
+  "EasyUseAnima.Prompt.TypoIndicator": "prompt_studio.typo_indicator",
+  "EasyUseAnima.Prompt.WeightSyntaxUnderline": "prompt_studio.weight_syntax_underline",
+  "EasyUseAnima.Prompt.CommentItalic": "prompt_studio.comment_italic",
+  "EasyUseAnima.Prompt.FontOverride": "prompt_studio.font_override",
+  "EasyUseAnima.Prompt.FontFamily": "prompt_studio.font_family",
+  "EasyUseAnima.Prompt.FontSize": "prompt_studio.font_size",
+  "EasyUseAnima.Prompt.HighlightColors": "prompt_studio.colors",
+  "EasyUseAnima.Prompt.TrainedTagTooltip": "prompt_studio.trained_tag_tooltip",
+  "EasyUseAnima.Prompt.NaiaGeneralAutoToggle": "prompt_studio.naia_general_above_auto_toggle",
+  "EasyUseAnima.Prompt.TranslationProvider": "prompt_translation.provider",
+  "EasyUseAnima.Prompt.TranslationSource": "prompt_translation.source",
+  "EasyUseAnima.Prompt.TranslationTarget": "prompt_translation.target",
+  "EasyUseAnima.Wildcard.ExtraPaths": "wildcard.extra_paths",
+  "EasyUseAnima.LoraPreset.NameDisplay": "lora_preset.name_display",
+  "EasyUseAnima.LoraPreset.MenuMode": "lora_preset.menu_mode",
+  "EasyUseAnima.LoraPreset.StrengthButtonStep": "lora_preset.strength_button_step",
+  "EasyUseAnima.LoraPreset.StrengthDragStep": "lora_preset.strength_drag_step",
+  "EasyUseAnima.LoraPreset.StrengthDragPixels": "lora_preset.strength_drag_pixels",
+  "EasyUseAnima.NAIA.Host": "naia.host",
+  "EasyUseAnima.NAIA.Port": "naia.port",
+  "EasyUseAnima.NAIA.AllowRemoteAPI": "naia.allow_remote_api",
+  "EasyUseAnima.NAIA.UseDesktopPromptEngineering": "naia.use_naia_settings",
+  "EasyUseAnima.NAIA.ResolutionMode": "naia.resolution_mode",
+  "EasyUseAnima.NAIA.ResolutionBucket": "naia.resolution_bucket",
+  "EasyUseAnima.NAIA.ResolutionScale": "naia.resolution_scale",
+  "EasyUseAnima.NAIA.ResolutionMaxLongEdge": "naia.resolution_max_long_edge",
+  "EasyUseAnima.NAIA.pre_prompt": "naia.pre_prompt",
+  "EasyUseAnima.NAIA.post_prompt": "naia.post_prompt",
+  "EasyUseAnima.NAIA.auto_hide": "naia.auto_hide",
+};
+for (const key of preprocessingKeys) {
+  expectedInternalKeys[`EasyUseAnima.NAIA.${key}`] = `naia.${key}`;
+}
+assert.deepEqual(INTERNAL_KEYS, expectedInternalKeys);
+
+assert.deepEqual(LONG_TEXT_FIELDS, [
+  {
+    key: "prompt.metadata_filter_words",
+    labelKey: "metadataFilter",
+    tipKey: "metadataFilterTip",
+  },
+  { key: "naia.pre_prompt", labelKey: "prePrompt" },
+  { key: "naia.post_prompt", labelKey: "postPrompt" },
+  { key: "naia.auto_hide", labelKey: "autoHide" },
+]);
+assert.deepEqual(LONG_TEXT_FIELD_GROUPS, {
+  promptStudio: {
+    settingId: "EasyUseAnima.PromptStudio.EditLongText",
+    section: "PromptStudio",
+    nameKey: "editPromptStudioLongText",
+    tipKey: "editPromptStudioLongTextTip",
+    fields: [LONG_TEXT_FIELDS[0]],
+  },
+  naia: {
+    settingId: "EasyUseAnima.NAIA.EditLongText",
+    section: "NAIA",
+    nameKey: "editNaiaLongText",
+    tipKey: "editNaiaLongTextTip",
+    fields: LONG_TEXT_FIELDS.slice(1),
+  },
+});
+
+assert.equal(normalizeValue("boolean", true), "true");
+assert.equal(normalizeValue("boolean", false), "false");
+assert.equal(normalizeValue("boolean", 0), "false");
+assert.equal(normalizeValue("boolean", "false"), "true");
+assert.equal(normalizeValue("number", 0), "0");
+assert.equal(normalizeValue("text", null), "");
+assert.equal(normalizeValue("text", undefined), "");
+
+assert.deepEqual(
+  parseWildcardExtraPathItems(' D:/wildcards \r\n "relative path"\n\n"opening-only\nclosing-only" '),
+  ["D:/wildcards", "relative path", "opening-only", "closing-only"],
+);
+assert.deepEqual(parseWildcardExtraPathItems(null), []);
+const wildcardItems = [" D:/one ", "", null, " relative/two ", undefined];
+const wildcardItemsSnapshot = [...wildcardItems];
+assert.equal(serializeWildcardExtraPathItems(wildcardItems), "D:/one\nrelative/two");
+assert.deepEqual(wildcardItems, wildcardItemsSnapshot);
+
+assert.equal(normalizeNaiaResolutionModeValue("BUCKET"), "bucket");
+assert.equal(normalizeNaiaResolutionModeValue("bucket_fit"), "bucket");
+assert.equal(normalizeNaiaResolutionModeValue("scale"), "scale");
+assert.equal(normalizeNaiaResolutionModeValue("invalid"), "scale");
+assert.equal(normalizeNaiaResolutionModeValue(null), "scale");
+
+assert.equal(normalizeNaiaResolutionScaleValue("1,5"), "1.5");
+assert.equal(normalizeNaiaResolutionScaleValue("1.2346"), "1.235");
+assert.equal(normalizeNaiaResolutionScaleValue(2), "2.0");
+assert.equal(normalizeNaiaResolutionScaleValue(0), "0.25");
+assert.equal(normalizeNaiaResolutionScaleValue(9), "4.0");
+assert.equal(normalizeNaiaResolutionScaleValue("invalid"), "1.0");
+assert.equal(normalizeNaiaResolutionScaleValue("Infinity"), "1.0");

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_ENTRY = ROOT / "web" / "js" / "easyuse_anima_settings.js"
+SETTINGS_DEFINITION_DATA = ROOT / "web" / "js" / "settings" / "definition_data.js"
+SETTINGS_DEFINITION_DATA_SMOKE = (
+    ROOT / "tests" / "frontend_settings_definition_data_smoke.mjs"
+)
+JSCONFIG = ROOT / "jsconfig.json"
+FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
+
+
+class SettingsFrontendTests(unittest.TestCase):
+    def test_definition_data_module_boundary(self):
+        module_source = SETTINGS_DEFINITION_DATA.read_text(encoding="utf-8")
+        entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+        expected_exports = {
+            "INTERNAL_KEYS",
+            "LONG_TEXT_FIELDS",
+            "LONG_TEXT_FIELD_GROUPS",
+            "NAIA_PREPROCESSING_OPTIONS",
+            "NAIA_RESOLUTION_BUCKET_OPTIONS",
+            "NAIA_RESOLUTION_MODE_BUCKET",
+            "NAIA_RESOLUTION_MODE_SCALE",
+            "ROOT_CATEGORY",
+            "normalizeNaiaResolutionModeValue",
+            "normalizeNaiaResolutionScaleValue",
+            "normalizeValue",
+            "parseWildcardExtraPathItems",
+            "serializeWildcardExtraPathItems",
+        }
+        expected_imports = expected_exports - {"LONG_TEXT_FIELDS"}
+
+        exported_names = set(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            )
+        )
+        self.assertEqual(exported_names, expected_exports)
+
+        import_match = re.search(
+            r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*"\./settings/definition_data\.js";',
+            entry_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip().rstrip(",")
+            for name in import_match.group("names").splitlines()
+            if name.strip()
+        }
+        self.assertEqual(imported_names, expected_imports)
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertNotRegex(module_source, re.compile(r"^\s*import\b", re.MULTILINE))
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|registerExtension|"
+                r"addEventListener|removeEventListener|CustomEvent|"
+                r"HTMLElement|HTMLInputElement|HTMLTextAreaElement)\b"
+            ),
+        )
+
+        for name in expected_exports:
+            with self.subTest(moved_declaration=name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\b(?:const|let|var|function|class)\s+{re.escape(name)}\b",
+                )
+        self.assertNotIn(
+            "for (const [key] of NAIA_PREPROCESSING_OPTIONS)",
+            entry_source,
+        )
+
+        for adapter in (
+            "updateInternalSetting",
+            "loadLongTextSettings",
+            "saveLongTextSettings",
+            "createLongTextEditorButton",
+            "createPromptStudioColorEditorButton",
+            "createWildcardExtraPathsEditor",
+            "createNaiaResolutionModeEditor",
+            "createNaiaResolutionScaleEditor",
+            "setting",
+            "customSetting",
+            "loadInitialSettings",
+            "addSettingsFallback",
+        ):
+            with self.subTest(entry_adapter=adapter):
+                self.assertRegex(
+                    entry_source,
+                    rf"(?:async\s+)?function\s+{re.escape(adapter)}\(",
+                )
+        self.assertIn("const EASYUSE_ANIMA_SETTINGS = [", entry_source)
+        self.assertEqual(entry_source.count("app.registerExtension("), 1)
+
+        self.assertTrue(SETTINGS_DEFINITION_DATA_SMOKE.is_file())
+        self.assertIn("web/js/settings/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_settings_definition_data_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_definition_data_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(SETTINGS_DEFINITION_DATA_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -104,6 +104,11 @@ try {
         throw "Frontend autocomplete text model smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_settings_definition_data_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend settings definition data smoke failed with exit code $LASTEXITCODE."
+    }
+
     & npx --yes --package "typescript@$TypeScriptVersion" -- tsc -p jsconfig.json
     if ($LASTEXITCODE -ne 0) {
         throw "TypeScript check failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -4,8 +4,20 @@ import {
   easyuseAnimaLocaleText,
   easyuseAnimaText,
 } from "./easyuse_anima_i18n.js";
-
-const ROOT_CATEGORY = "EASY USE ANIMA";
+import {
+  INTERNAL_KEYS,
+  LONG_TEXT_FIELD_GROUPS,
+  NAIA_PREPROCESSING_OPTIONS,
+  NAIA_RESOLUTION_BUCKET_OPTIONS,
+  NAIA_RESOLUTION_MODE_BUCKET,
+  NAIA_RESOLUTION_MODE_SCALE,
+  ROOT_CATEGORY,
+  normalizeNaiaResolutionModeValue,
+  normalizeNaiaResolutionScaleValue,
+  normalizeValue,
+  parseWildcardExtraPathItems,
+  serializeWildcardExtraPathItems,
+} from "./settings/definition_data.js";
 
 const PROMPT_STUDIO_COLORS = {
   quality: {
@@ -234,28 +246,6 @@ const PROMPT_STUDIO_COLOR_GROUPS = [
     ],
   },
 ];
-
-const NAIA_PREPROCESSING_OPTIONS = [
-  ["remove_author", { en: "Remove author", ko: "작가 제거", ja: "作者を削除", zh: "移除作者" }],
-  ["remove_work_title", { en: "Remove work title", ko: "작품명 제거", ja: "作品名を削除", zh: "移除作品名" }],
-  ["remove_character_name", { en: "Remove character name", ko: "캐릭터명 제거", ja: "キャラクター名を削除", zh: "移除角色名" }],
-  ["remove_character_features", { en: "Remove character features", ko: "캐릭터 특징 제거", ja: "キャラクター特徴を削除", zh: "移除角色特征" }],
-  ["remove_clothes", { en: "Remove clothes", ko: "의상 제거", ja: "衣装を削除", zh: "移除服装" }],
-  ["remove_color", { en: "Remove color", ko: "색상 제거", ja: "色を削除", zh: "移除颜色" }],
-  ["remove_location_and_background_color", { en: "Remove location/background color", ko: "장소/배경색 제거", ja: "場所/背景色を削除", zh: "移除地点/背景色" }],
-  ["remove_expression", { en: "Remove expression", ko: "표정 제거", ja: "表情を削除", zh: "移除表情" }],
-  ["remove_pose_action", { en: "Remove pose/action", ko: "포즈/동작 제거", ja: "ポーズ/動作を削除", zh: "移除姿势/动作" }],
-  ["remove_meta_tags", { en: "Remove meta tags", ko: "메타 태그 제거", ja: "メタタグを削除", zh: "移除元数据标签" }],
-  ["remove_object_tags", { en: "Remove object tags", ko: "오브젝트 태그 제거", ja: "オブジェクトタグを削除", zh: "移除物体标签" }],
-  ["remove_noise_tags", { en: "Remove noise tags", ko: "노이즈 태그 제거", ja: "ノイズタグを削除", zh: "移除噪声标签" }],
-  ["e621_auto_boost", { en: "e621 auto boost", ko: "e621 자동 강화", ja: "e621 自動強化", zh: "e621 自动增强" }],
-  ["danbooru_auto_weight", { en: "Danbooru auto weight", ko: "Danbooru 자동 가중치", ja: "Danbooru 自動重み付け", zh: "Danbooru 自动加权" }],
-  ["tag_implication_compression", { en: "Tag implication compression", ko: "태그 함의 압축", ja: "タグ含意圧縮", zh: "标签含义压缩" }],
-];
-
-const NAIA_RESOLUTION_MODE_SCALE = "scale";
-const NAIA_RESOLUTION_MODE_BUCKET = "bucket";
-const NAIA_RESOLUTION_BUCKET_OPTIONS = ["512", "768", "896", "1024", "1280", "1536"];
 
 const TEXT = {
   en: {
@@ -748,91 +738,8 @@ const TEXT = {
   },
 };
 
-const INTERNAL_KEYS = {
-  "EasyUseAnima.Prompt.MetadataFilter": "prompt.metadata_filter_words",
-  "EasyUseAnima.Prompt.AutocompleteMode": "autocomplete.mode",
-  "EasyUseAnima.Prompt.AutocompleteSource": "autocomplete.source",
-  "EasyUseAnima.Prompt.AutocompleteLimit": "autocomplete.limit",
-  "EasyUseAnima.Prompt.AutocompleteCommitKey": "autocomplete.commit_key",
-  "EasyUseAnima.Prompt.AutocompleteAppendSeparator": "autocomplete.append_separator",
-  "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "autocomplete.no_comma_after_period",
-  "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "autocomplete.detect_natural_sentences",
-  "EasyUseAnima.Prompt.AutocompletePreviewCompletion": "autocomplete.preview_completion",
-  "EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets": "autocomplete.preview_closing_brackets",
-  "EasyUseAnima.Prompt.TypoIndicator": "prompt_studio.typo_indicator",
-  "EasyUseAnima.Prompt.WeightSyntaxUnderline": "prompt_studio.weight_syntax_underline",
-  "EasyUseAnima.Prompt.CommentItalic": "prompt_studio.comment_italic",
-  "EasyUseAnima.Prompt.FontOverride": "prompt_studio.font_override",
-  "EasyUseAnima.Prompt.FontFamily": "prompt_studio.font_family",
-  "EasyUseAnima.Prompt.FontSize": "prompt_studio.font_size",
-  "EasyUseAnima.Prompt.HighlightColors": "prompt_studio.colors",
-  "EasyUseAnima.Prompt.TrainedTagTooltip": "prompt_studio.trained_tag_tooltip",
-  "EasyUseAnima.Prompt.NaiaGeneralAutoToggle": "prompt_studio.naia_general_above_auto_toggle",
-  "EasyUseAnima.Prompt.TranslationProvider": "prompt_translation.provider",
-  "EasyUseAnima.Prompt.TranslationSource": "prompt_translation.source",
-  "EasyUseAnima.Prompt.TranslationTarget": "prompt_translation.target",
-  "EasyUseAnima.Wildcard.ExtraPaths": "wildcard.extra_paths",
-  "EasyUseAnima.LoraPreset.NameDisplay": "lora_preset.name_display",
-  "EasyUseAnima.LoraPreset.MenuMode": "lora_preset.menu_mode",
-  "EasyUseAnima.LoraPreset.StrengthButtonStep": "lora_preset.strength_button_step",
-  "EasyUseAnima.LoraPreset.StrengthDragStep": "lora_preset.strength_drag_step",
-  "EasyUseAnima.LoraPreset.StrengthDragPixels": "lora_preset.strength_drag_pixels",
-  "EasyUseAnima.NAIA.Host": "naia.host",
-  "EasyUseAnima.NAIA.Port": "naia.port",
-  "EasyUseAnima.NAIA.AllowRemoteAPI": "naia.allow_remote_api",
-  "EasyUseAnima.NAIA.UseDesktopPromptEngineering": "naia.use_naia_settings",
-  "EasyUseAnima.NAIA.ResolutionMode": "naia.resolution_mode",
-  "EasyUseAnima.NAIA.ResolutionBucket": "naia.resolution_bucket",
-  "EasyUseAnima.NAIA.ResolutionScale": "naia.resolution_scale",
-  "EasyUseAnima.NAIA.ResolutionMaxLongEdge": "naia.resolution_max_long_edge",
-  "EasyUseAnima.NAIA.pre_prompt": "naia.pre_prompt",
-  "EasyUseAnima.NAIA.post_prompt": "naia.post_prompt",
-  "EasyUseAnima.NAIA.auto_hide": "naia.auto_hide",
-};
-
-const LONG_TEXT_FIELDS = [
-  {
-    key: "prompt.metadata_filter_words",
-    labelKey: "metadataFilter",
-    tipKey: "metadataFilterTip",
-  },
-  {
-    key: "naia.pre_prompt",
-    labelKey: "prePrompt",
-  },
-  {
-    key: "naia.post_prompt",
-    labelKey: "postPrompt",
-  },
-  {
-    key: "naia.auto_hide",
-    labelKey: "autoHide",
-  },
-];
-
-const LONG_TEXT_FIELD_GROUPS = {
-  promptStudio: {
-    settingId: "EasyUseAnima.PromptStudio.EditLongText",
-    section: "PromptStudio",
-    nameKey: "editPromptStudioLongText",
-    tipKey: "editPromptStudioLongTextTip",
-    fields: LONG_TEXT_FIELDS.filter((field) => field.key === "prompt.metadata_filter_words"),
-  },
-  naia: {
-    settingId: "EasyUseAnima.NAIA.EditLongText",
-    section: "NAIA",
-    nameKey: "editNaiaLongText",
-    tipKey: "editNaiaLongTextTip",
-    fields: LONG_TEXT_FIELDS.filter((field) => field.key !== "prompt.metadata_filter_words"),
-  },
-};
-
 let activeLongTextEditor = null;
 let activePromptStudioColorEditor = null;
-
-for (const [key] of NAIA_PREPROCESSING_OPTIONS) {
-  INTERNAL_KEYS[`EasyUseAnima.NAIA.${key}`] = `naia.${key}`;
-}
 
 function t(key) {
   return easyuseAnimaText(TEXT, key);
@@ -853,13 +760,6 @@ function parseColors(value) {
   } catch {
     return {};
   }
-}
-
-function normalizeValue(type, value) {
-  if (type === "boolean") {
-    return value ? "true" : "false";
-  }
-  return String(value ?? "");
 }
 
 function updateInternalSetting(id, value, type = "text") {
@@ -958,20 +858,6 @@ function createPromptStudioColorEditorButton(name, setter, value) {
 
   container.append(button, hint);
   return container;
-}
-
-function parseWildcardExtraPathItems(value) {
-  return String(value ?? "")
-    .split(/\r?\n/)
-    .map((item) => item.trim().replace(/^"|"$/g, ""))
-    .filter(Boolean);
-}
-
-function serializeWildcardExtraPathItems(items) {
-  return items
-    .map((item) => String(item ?? "").trim())
-    .filter(Boolean)
-    .join("\n");
 }
 
 function wildcardExtraPathsSettingValue(value) {
@@ -1090,14 +976,6 @@ function createWildcardExtraPathsEditor(name, setter, value) {
   return row;
 }
 
-function normalizeNaiaResolutionModeValue(value) {
-  const raw = String(value ?? "").trim().toLowerCase();
-  if (raw === NAIA_RESOLUTION_MODE_BUCKET || raw === "bucket_fit") {
-    return NAIA_RESOLUTION_MODE_BUCKET;
-  }
-  return NAIA_RESOLUTION_MODE_SCALE;
-}
-
 function naiaResolutionModeSettingValue(value) {
   if (
     window.__easyuseAnimaSettings
@@ -1161,15 +1039,6 @@ function naiaResolutionScaleSettingValue(value) {
     return window.__easyuseAnimaSettings["naia.resolution_scale"];
   }
   return value ?? "1.0";
-}
-
-function normalizeNaiaResolutionScaleValue(value) {
-  const parsed = Number.parseFloat(String(value ?? "").replace(",", "."));
-  const clamped = Number.isFinite(parsed)
-    ? Math.min(4.0, Math.max(0.25, parsed))
-    : 1.0;
-  const rounded = Math.round(clamped * 1000) / 1000;
-  return Number.isInteger(rounded) ? `${rounded}.0` : String(rounded);
 }
 
 function createNaiaResolutionScaleEditor(name, setter, value) {

--- a/web/js/settings/definition_data.js
+++ b/web/js/settings/definition_data.js
@@ -1,0 +1,146 @@
+// @ts-check
+
+export const ROOT_CATEGORY = "EASY USE ANIMA";
+
+export const NAIA_PREPROCESSING_OPTIONS = [
+  ["remove_author", { en: "Remove author", ko: "작가 제거", ja: "作者を削除", zh: "移除作者" }],
+  ["remove_work_title", { en: "Remove work title", ko: "작품명 제거", ja: "作品名を削除", zh: "移除作品名" }],
+  ["remove_character_name", { en: "Remove character name", ko: "캐릭터명 제거", ja: "キャラクター名を削除", zh: "移除角色名" }],
+  ["remove_character_features", { en: "Remove character features", ko: "캐릭터 특징 제거", ja: "キャラクター特徴を削除", zh: "移除角色特征" }],
+  ["remove_clothes", { en: "Remove clothes", ko: "의상 제거", ja: "衣装を削除", zh: "移除服装" }],
+  ["remove_color", { en: "Remove color", ko: "색상 제거", ja: "色を削除", zh: "移除颜色" }],
+  ["remove_location_and_background_color", { en: "Remove location/background color", ko: "장소/배경색 제거", ja: "場所/背景色を削除", zh: "移除地点/背景色" }],
+  ["remove_expression", { en: "Remove expression", ko: "표정 제거", ja: "表情を削除", zh: "移除表情" }],
+  ["remove_pose_action", { en: "Remove pose/action", ko: "포즈/동작 제거", ja: "ポーズ/動作を削除", zh: "移除姿势/动作" }],
+  ["remove_meta_tags", { en: "Remove meta tags", ko: "메타 태그 제거", ja: "メタタグを削除", zh: "移除元数据标签" }],
+  ["remove_object_tags", { en: "Remove object tags", ko: "오브젝트 태그 제거", ja: "オブジェクトタグを削除", zh: "移除物体标签" }],
+  ["remove_noise_tags", { en: "Remove noise tags", ko: "노이즈 태그 제거", ja: "ノイズタグを削除", zh: "移除噪声标签" }],
+  ["e621_auto_boost", { en: "e621 auto boost", ko: "e621 자동 강화", ja: "e621 自動強化", zh: "e621 自动增强" }],
+  ["danbooru_auto_weight", { en: "Danbooru auto weight", ko: "Danbooru 자동 가중치", ja: "Danbooru 自動重み付け", zh: "Danbooru 自动加权" }],
+  ["tag_implication_compression", { en: "Tag implication compression", ko: "태그 함의 압축", ja: "タグ含意圧縮", zh: "标签含义压缩" }],
+];
+
+export const NAIA_RESOLUTION_MODE_SCALE = "scale";
+export const NAIA_RESOLUTION_MODE_BUCKET = "bucket";
+export const NAIA_RESOLUTION_BUCKET_OPTIONS = ["512", "768", "896", "1024", "1280", "1536"];
+
+export const INTERNAL_KEYS = {
+  "EasyUseAnima.Prompt.MetadataFilter": "prompt.metadata_filter_words",
+  "EasyUseAnima.Prompt.AutocompleteMode": "autocomplete.mode",
+  "EasyUseAnima.Prompt.AutocompleteSource": "autocomplete.source",
+  "EasyUseAnima.Prompt.AutocompleteLimit": "autocomplete.limit",
+  "EasyUseAnima.Prompt.AutocompleteCommitKey": "autocomplete.commit_key",
+  "EasyUseAnima.Prompt.AutocompleteAppendSeparator": "autocomplete.append_separator",
+  "EasyUseAnima.Prompt.AutocompleteNoCommaAfterPeriod": "autocomplete.no_comma_after_period",
+  "EasyUseAnima.Prompt.AutocompleteDetectNaturalSentences": "autocomplete.detect_natural_sentences",
+  "EasyUseAnima.Prompt.AutocompletePreviewCompletion": "autocomplete.preview_completion",
+  "EasyUseAnima.Prompt.AutocompletePreviewClosingBrackets": "autocomplete.preview_closing_brackets",
+  "EasyUseAnima.Prompt.TypoIndicator": "prompt_studio.typo_indicator",
+  "EasyUseAnima.Prompt.WeightSyntaxUnderline": "prompt_studio.weight_syntax_underline",
+  "EasyUseAnima.Prompt.CommentItalic": "prompt_studio.comment_italic",
+  "EasyUseAnima.Prompt.FontOverride": "prompt_studio.font_override",
+  "EasyUseAnima.Prompt.FontFamily": "prompt_studio.font_family",
+  "EasyUseAnima.Prompt.FontSize": "prompt_studio.font_size",
+  "EasyUseAnima.Prompt.HighlightColors": "prompt_studio.colors",
+  "EasyUseAnima.Prompt.TrainedTagTooltip": "prompt_studio.trained_tag_tooltip",
+  "EasyUseAnima.Prompt.NaiaGeneralAutoToggle": "prompt_studio.naia_general_above_auto_toggle",
+  "EasyUseAnima.Prompt.TranslationProvider": "prompt_translation.provider",
+  "EasyUseAnima.Prompt.TranslationSource": "prompt_translation.source",
+  "EasyUseAnima.Prompt.TranslationTarget": "prompt_translation.target",
+  "EasyUseAnima.Wildcard.ExtraPaths": "wildcard.extra_paths",
+  "EasyUseAnima.LoraPreset.NameDisplay": "lora_preset.name_display",
+  "EasyUseAnima.LoraPreset.MenuMode": "lora_preset.menu_mode",
+  "EasyUseAnima.LoraPreset.StrengthButtonStep": "lora_preset.strength_button_step",
+  "EasyUseAnima.LoraPreset.StrengthDragStep": "lora_preset.strength_drag_step",
+  "EasyUseAnima.LoraPreset.StrengthDragPixels": "lora_preset.strength_drag_pixels",
+  "EasyUseAnima.NAIA.Host": "naia.host",
+  "EasyUseAnima.NAIA.Port": "naia.port",
+  "EasyUseAnima.NAIA.AllowRemoteAPI": "naia.allow_remote_api",
+  "EasyUseAnima.NAIA.UseDesktopPromptEngineering": "naia.use_naia_settings",
+  "EasyUseAnima.NAIA.ResolutionMode": "naia.resolution_mode",
+  "EasyUseAnima.NAIA.ResolutionBucket": "naia.resolution_bucket",
+  "EasyUseAnima.NAIA.ResolutionScale": "naia.resolution_scale",
+  "EasyUseAnima.NAIA.ResolutionMaxLongEdge": "naia.resolution_max_long_edge",
+  "EasyUseAnima.NAIA.pre_prompt": "naia.pre_prompt",
+  "EasyUseAnima.NAIA.post_prompt": "naia.post_prompt",
+  "EasyUseAnima.NAIA.auto_hide": "naia.auto_hide",
+};
+
+for (const [key] of NAIA_PREPROCESSING_OPTIONS) {
+  INTERNAL_KEYS[`EasyUseAnima.NAIA.${key}`] = `naia.${key}`;
+}
+
+export const LONG_TEXT_FIELDS = [
+  {
+    key: "prompt.metadata_filter_words",
+    labelKey: "metadataFilter",
+    tipKey: "metadataFilterTip",
+  },
+  {
+    key: "naia.pre_prompt",
+    labelKey: "prePrompt",
+  },
+  {
+    key: "naia.post_prompt",
+    labelKey: "postPrompt",
+  },
+  {
+    key: "naia.auto_hide",
+    labelKey: "autoHide",
+  },
+];
+
+export const LONG_TEXT_FIELD_GROUPS = {
+  promptStudio: {
+    settingId: "EasyUseAnima.PromptStudio.EditLongText",
+    section: "PromptStudio",
+    nameKey: "editPromptStudioLongText",
+    tipKey: "editPromptStudioLongTextTip",
+    fields: LONG_TEXT_FIELDS.filter((field) => field.key === "prompt.metadata_filter_words"),
+  },
+  naia: {
+    settingId: "EasyUseAnima.NAIA.EditLongText",
+    section: "NAIA",
+    nameKey: "editNaiaLongText",
+    tipKey: "editNaiaLongTextTip",
+    fields: LONG_TEXT_FIELDS.filter((field) => field.key !== "prompt.metadata_filter_words"),
+  },
+};
+
+export function normalizeValue(type, value) {
+  if (type === "boolean") {
+    return value ? "true" : "false";
+  }
+  return String(value ?? "");
+}
+
+export function parseWildcardExtraPathItems(value) {
+  return String(value ?? "")
+    .split(/\r?\n/)
+    .map((item) => item.trim().replace(/^"|"$/g, ""))
+    .filter(Boolean);
+}
+
+export function serializeWildcardExtraPathItems(items) {
+  return items
+    .map((item) => String(item ?? "").trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function normalizeNaiaResolutionModeValue(value) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  if (raw === NAIA_RESOLUTION_MODE_BUCKET || raw === "bucket_fit") {
+    return NAIA_RESOLUTION_MODE_BUCKET;
+  }
+  return NAIA_RESOLUTION_MODE_SCALE;
+}
+
+export function normalizeNaiaResolutionScaleValue(value) {
+  const parsed = Number.parseFloat(String(value ?? "").replace(",", "."));
+  const clamped = Number.isFinite(parsed)
+    ? Math.min(4.0, Math.max(0.25, parsed))
+    : 1.0;
+  const rounded = Math.round(clamped * 1000) / 1000;
+  return Number.isInteger(rounded) ? `${rounded}.0` : String(rounded);
+}


### PR DESCRIPTION
## 변경 요약

- 설정 ID 매핑, long-text 필드 정의, NAIA preprocessing/resolution 상수를 `settings/definition_data.js`로 분리했습니다.
- 일반 설정값, wildcard 추가 경로, NAIA resolution mode/scale 정규화를 DOM/API-free 모듈로 이동했습니다.
- 기존 editor, persistence, `window` 상태 동기화, extension 등록은 settings 엔트리에 유지했습니다.
- setting ID와 저장값 migration 계약을 exact semantic smoke로 고정했습니다.

## 주요 파일

- `web/js/settings/definition_data.js`
- `web/js/easyuse_anima_settings.js`
- `tests/frontend_settings_definition_data_smoke.mjs`
- `tests/test_frontend_settings.py`
- `tools/check_frontend.ps1`
- `jsconfig.json`

## 검증

- focused Node syntax + semantic smoke: 통과
- `python -m unittest tests.test_frontend_settings -v`: 2 tests 통과
- `npx --yes --package typescript@6.0.3 -- tsc -p jsconfig.json`: 통과
- workspace full runner → repository `tools/check_project.ps1 -Profile full`: 342 Python tests 통과
- frontend runner: 76 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과

## 테스트 표면 및 남은 위험

- ComfyUI Codex test surface: compile, unittest, frontend semantic/static checks
- 브라우저 smoke: 실행하지 않음 — DOM, editor, persistence, canvas, serialization 동작을 바꾸지 않은 순수 경계 추출
- 사용자 인스턴스 수동 확인: 전체 Issue #54–57 유지보수 완료 후 1회 수행 예정
- 후속 범위: settings schema 조립, editor lifecycle, persistence/registration 경계 분리 및 두 canvas 모드 검증

Refs #57
