### PR TITLE
refactor: extract AIO preview settings dialog

### DIFF
--- a/tests/frontend_aio_preview_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_preview_settings_dialog_smoke.mjs
@@ -1,0 +1,442 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function merge(defaults, current) {
+  if (Array.isArray(current)) {
+    return clone(current);
+  }
+  if (!current || typeof current !== "object") {
+    return current === undefined ? clone(defaults) : current;
+  }
+  const output = defaults && typeof defaults === "object" && !Array.isArray(defaults)
+    ? clone(defaults)
+    : {};
+  for (const [key, value] of Object.entries(current)) {
+    output[key] = merge(output[key], value);
+  }
+  return output;
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.className = "";
+    this.textContent = "";
+    this.value = "";
+    this.checked = false;
+    this.disabled = false;
+    this.children = [];
+    this.parentElement = null;
+    this.listeners = new Map();
+  }
+
+  append(...children) {
+    for (const child of children) {
+      if (child && typeof child === "object") {
+        child.parentElement = this;
+      }
+      this.children.push(child);
+    }
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type) {
+    for (const listener of this.listeners.get(type) || []) {
+      listener({ target: this });
+    }
+  }
+}
+
+const previewDialogModule = await import(dataModule("../web/js/aio/preview_settings_dialog.js"));
+assert.deepEqual(
+  Object.keys(previewDialogModule),
+  ["aioCreatePreviewSettingsDialog"],
+  "Preview Settings dialog must expose only its factory contract",
+);
+
+const defaultGenerationSettings = {
+  schema_version: 4,
+  sampler: { seed: 0, default_sampler_field: "preserved" },
+  preview: {
+    intermediate_images: true,
+    compare_previous: false,
+    image_feed: true,
+    feed_count: 12,
+  },
+  upscale: { enabled: false, default_upscale_field: "preserved" },
+  postprocess: { enabled: false, default_postprocess_field: "preserved" },
+};
+
+let dependencyCalls = 0;
+let currentDialog = null;
+const dialogs = [];
+const findCalls = [];
+const settingsCalls = [];
+const settingsSnapshots = [];
+const mergeCalls = [];
+const clampCalls = [];
+const defaultIndexCalls = [];
+const visibleCalls = [];
+const writeAttempts = [];
+const writes = [];
+const renderCalls = [];
+
+const fakeDocument = {
+  createElement(tagName) {
+    dependencyCalls += 1;
+    return new FakeElement(tagName);
+  },
+};
+
+function createDialog(title, subtitle) {
+  dependencyCalls += 1;
+  const dialog = {
+    title,
+    subtitle,
+    body: new FakeElement("div"),
+    actions: new FakeElement("div"),
+    controls: new Map(),
+    tooltips: new Map(),
+    trace: [],
+  };
+  dialog.backdrop = new FakeElement("div");
+  dialog.backdrop.remove = () => dialog.trace.push("remove");
+  dialogs.push(dialog);
+  currentDialog = dialog;
+  return dialog;
+}
+
+function field(section, label, control, tooltipKey = "") {
+  dependencyCalls += 1;
+  const wrapper = new FakeElement("div");
+  wrapper.append(control);
+  section.append(wrapper);
+  currentDialog.controls.set(label, control);
+  currentDialog.tooltips.set(label, tooltipKey);
+  return control;
+}
+
+function checkbox(value) {
+  dependencyCalls += 1;
+  const control = new FakeElement("input");
+  control.checked = !!value;
+  return control;
+}
+
+function numberInput(value, step = "1") {
+  dependencyCalls += 1;
+  const control = new FakeElement("input");
+  control.value = String(value ?? "");
+  control.step = step;
+  return control;
+}
+
+function staticText(value) {
+  dependencyCalls += 1;
+  return `static:${value}`;
+}
+
+function text(key) {
+  dependencyCalls += 1;
+  return `text:${key}`;
+}
+
+function findWidget(node, name) {
+  dependencyCalls += 1;
+  findCalls.push({ node, name });
+  return node.widgets?.find((widget) => widget.name === name);
+}
+
+function generatorSettings(node) {
+  dependencyCalls += 1;
+  settingsCalls.push(node);
+  const widget = node.widgets?.find((candidate) => candidate.name === "generation_settings");
+  let current = widget?.value || {};
+  if (typeof current === "string") {
+    try {
+      current = JSON.parse(current);
+    } catch (_error) {
+      current = {};
+    }
+  }
+  const snapshot = merge(defaultGenerationSettings, current);
+  settingsSnapshots.push(snapshot);
+  return snapshot;
+}
+
+function mergeDefaults(defaults, current) {
+  dependencyCalls += 1;
+  if (currentDialog) {
+    currentDialog.trace.push("merge");
+  }
+  mergeCalls.push({ defaults, current });
+  return merge(defaults, current);
+}
+
+function clampNumber(value, fallback, min, max) {
+  dependencyCalls += 1;
+  currentDialog.trace.push("clamp");
+  clampCalls.push({ value, fallback, min, max });
+  const parsed = Number(value);
+  const next = Number.isFinite(parsed) ? parsed : fallback;
+  return Math.max(min, Math.min(max, next));
+}
+
+function defaultPreviewIndex(images) {
+  dependencyCalls += 1;
+  currentDialog.trace.push("default-index");
+  defaultIndexCalls.push(images);
+  return images.length ? images.length - 1 : -1;
+}
+
+function applyVisibleSettings(node, settings) {
+  dependencyCalls += 1;
+  currentDialog.trace.push("visible");
+  visibleCalls.push({ node, settings: clone(settings) });
+}
+
+function writeSettings(node, widget, settings) {
+  dependencyCalls += 1;
+  currentDialog.trace.push(widget ? "write" : "write-noop");
+  const attempt = { node, widget, settings: clone(settings) };
+  writeAttempts.push(attempt);
+  if (!widget) {
+    return;
+  }
+  widget.value = JSON.stringify(settings);
+  writes.push(attempt);
+}
+
+function renderGeneratorPanel(node) {
+  dependencyCalls += 1;
+  currentDialog.trace.push("render");
+  renderCalls.push(node);
+}
+
+const openPreviewSettings = previewDialogModule.aioCreatePreviewSettingsDialog({
+  document: fakeDocument,
+  createDialog,
+  field,
+  checkbox,
+  numberInput,
+  staticText,
+  text,
+  defaultGenerationSettings,
+  generatorSettingsWidget: "generation_settings",
+  findWidget,
+  generatorSettings,
+  mergeDefaults,
+  clampNumber,
+  defaultPreviewIndex,
+  applyVisibleSettings,
+  writeSettings,
+  renderGeneratorPanel,
+});
+
+assert.equal(typeof openPreviewSettings, "function");
+assert.equal(openPreviewSettings.name, "openPreviewSettings");
+assert.equal(dependencyCalls, 0, "Factory creation must have no side effects");
+
+function open(node) {
+  currentDialog = null;
+  openPreviewSettings(node);
+  return dialogs[dialogs.length - 1];
+}
+
+function cancel(dialog) {
+  dialog.actions.children[0].dispatch("click");
+}
+
+function apply(dialog) {
+  dialog.actions.children[1].dispatch("click");
+}
+
+const feedImages = ["feed-1", "feed-2", "feed-3", "feed-4", "feed-5"];
+const currentRunImages = ["current-1", "current-2"];
+const generatorNode = {
+  widgets: [{
+    name: "generation_settings",
+    value: JSON.stringify({
+      schema_version: 7,
+      sampler: { seed: 42, future_sampler_field: "preserved" },
+      preview: {
+        intermediate_images: false,
+        compare_previous: true,
+        image_feed: false,
+        feed_count: 4,
+        future_preview_field: "removed-on-apply",
+      },
+      upscale: { enabled: true, future_upscale_field: "preserved" },
+      postprocess: { enabled: true, future_postprocess_field: "preserved" },
+      future_root: { keep: true },
+    }),
+  }],
+  __easyuseAnimaGeneratorPreviewFeedImages: [...feedImages],
+  __easyuseAnimaGeneratorCurrentRunImages: currentRunImages,
+  __easyuseAnimaGeneratorPreviewImages: ["old-preview"],
+  __easyuseAnimaSelectedPreviewIndex: 99,
+};
+
+const defaultsBeforeInteractions = clone(defaultGenerationSettings);
+const nodeBeforeCancel = clone(generatorNode);
+const serializedBeforeCancel = generatorNode.widgets[0].value;
+const feedImagesBeforeCancel = generatorNode.__easyuseAnimaGeneratorPreviewFeedImages;
+const currentRunImagesBeforeCancel = generatorNode.__easyuseAnimaGeneratorCurrentRunImages;
+const previewImagesBeforeCancel = generatorNode.__easyuseAnimaGeneratorPreviewImages;
+let dialog = open(generatorNode);
+const firstSettingsSnapshot = clone(settingsSnapshots[0]);
+assert.equal(findCalls[0].node, generatorNode);
+assert.equal(findCalls[0].name, "generation_settings");
+assert.equal(settingsCalls.length, 1);
+assert.equal(dialog.title, "Preview Options");
+assert.equal(dialog.subtitle, "text:text.previewOptionsSubtitle");
+assert.equal(dialog.body.children[0].children[0].textContent, "static:Node Preview");
+assert.deepEqual([...dialog.controls.keys()], [
+  "Intermediate images",
+  "Compare previous",
+  "Image feed",
+  "Feed count",
+]);
+assert.equal(dialog.controls.get("Intermediate images").checked, false);
+assert.equal(dialog.controls.get("Compare previous").checked, true);
+assert.equal(dialog.controls.get("Image feed").checked, false);
+assert.equal(dialog.controls.get("Feed count").value, "4");
+assert.equal(dialog.controls.get("Feed count").step, "1");
+assert.equal(dialog.controls.get("Feed count").min, "1");
+assert.equal(dialog.controls.get("Feed count").max, "100");
+assert.equal(dialog.controls.get("Feed count").disabled, true);
+assert.equal(dialog.tooltips.get("Intermediate images"), "tip.previewIntermediate");
+assert.equal(dialog.tooltips.get("Compare previous"), "tip.previewComparePrevious");
+assert.equal(dialog.tooltips.get("Image feed"), "tip.previewImageFeed");
+assert.equal(dialog.tooltips.get("Feed count"), "tip.previewFeedCount");
+assert.equal(dialog.actions.children[0].textContent, "text:button.cancel");
+assert.equal(dialog.actions.children[1].textContent, "text:button.apply");
+assert.equal(dialog.actions.children[1].className, "primary");
+
+dialog.controls.get("Image feed").checked = true;
+dialog.controls.get("Image feed").dispatch("change");
+assert.equal(dialog.controls.get("Feed count").disabled, false);
+dialog.controls.get("Image feed").checked = false;
+dialog.controls.get("Image feed").dispatch("change");
+assert.equal(dialog.controls.get("Feed count").disabled, true);
+const mergeCountBeforeCancel = mergeCalls.length;
+cancel(dialog);
+assert.deepEqual(dialog.trace, ["remove"]);
+assert.equal(mergeCalls.length, mergeCountBeforeCancel);
+assert.equal(clampCalls.length, 0);
+assert.equal(defaultIndexCalls.length, 0);
+assert.equal(visibleCalls.length, 0);
+assert.equal(writeAttempts.length, 0);
+assert.equal(renderCalls.length, 0);
+assert.equal(generatorNode.widgets[0].value, serializedBeforeCancel);
+assert.deepEqual(generatorNode, nodeBeforeCancel);
+assert.equal(generatorNode.__easyuseAnimaGeneratorPreviewFeedImages, feedImagesBeforeCancel);
+assert.equal(generatorNode.__easyuseAnimaGeneratorCurrentRunImages, currentRunImagesBeforeCancel);
+assert.equal(generatorNode.__easyuseAnimaGeneratorPreviewImages, previewImagesBeforeCancel);
+assert.deepEqual(settingsSnapshots[0], firstSettingsSnapshot);
+
+dialog = open(generatorNode);
+const appliedSettingsSnapshot = clone(settingsSnapshots[1]);
+dialog.controls.get("Intermediate images").checked = true;
+dialog.controls.get("Compare previous").checked = false;
+dialog.controls.get("Image feed").checked = true;
+dialog.controls.get("Image feed").dispatch("change");
+dialog.controls.get("Feed count").value = "2.9";
+apply(dialog);
+assert.deepEqual(dialog.trace, [
+  "merge",
+  "clamp",
+  "default-index",
+  "visible",
+  "write",
+  "render",
+  "remove",
+]);
+assert.deepEqual(clampCalls[0], { value: "2.9", fallback: 4, min: 1, max: 100 });
+assert.deepEqual(generatorNode.__easyuseAnimaGeneratorPreviewFeedImages, ["feed-4", "feed-5"]);
+assert.equal(
+  generatorNode.__easyuseAnimaGeneratorPreviewImages,
+  generatorNode.__easyuseAnimaGeneratorPreviewFeedImages,
+);
+assert.equal(defaultIndexCalls[0], generatorNode.__easyuseAnimaGeneratorPreviewImages);
+assert.equal(generatorNode.__easyuseAnimaSelectedPreviewIndex, 1);
+assert.equal(visibleCalls.length, 1);
+assert.equal(writeAttempts.length, 1);
+assert.equal(writes.length, 1);
+assert.equal(writeAttempts[0].widget, generatorNode.widgets[0]);
+assert.equal(renderCalls.length, 1);
+assert.equal(renderCalls[0], generatorNode);
+const firstWritten = writes[0].settings;
+assert.deepEqual(firstWritten.preview, {
+  intermediate_images: true,
+  compare_previous: false,
+  image_feed: true,
+  feed_count: 2,
+});
+assert.equal(Object.hasOwn(firstWritten.preview, "future_preview_field"), false);
+assert.equal(firstWritten.future_root.keep, true);
+assert.equal(firstWritten.sampler.future_sampler_field, "preserved");
+assert.equal(firstWritten.sampler.default_sampler_field, "preserved");
+assert.equal(firstWritten.upscale.future_upscale_field, "preserved");
+assert.equal(firstWritten.postprocess.future_postprocess_field, "preserved");
+assert.deepEqual(visibleCalls[0].settings, firstWritten);
+assert.deepEqual(JSON.parse(generatorNode.widgets[0].value), firstWritten);
+assert.deepEqual(defaultGenerationSettings, defaultsBeforeInteractions);
+assert.deepEqual(settingsSnapshots[1], appliedSettingsSnapshot);
+
+dialog = open(generatorNode);
+dialog.controls.get("Image feed").checked = false;
+dialog.controls.get("Image feed").dispatch("change");
+dialog.controls.get("Feed count").value = "1.9";
+apply(dialog);
+assert.equal(dialog.controls.get("Feed count").disabled, true);
+assert.deepEqual(clampCalls[1], { value: "1.9", fallback: 2, min: 1, max: 100 });
+assert.deepEqual(generatorNode.__easyuseAnimaGeneratorPreviewFeedImages, ["feed-5"]);
+assert.equal(generatorNode.__easyuseAnimaGeneratorPreviewImages, currentRunImages);
+assert.equal(defaultIndexCalls[1], currentRunImages);
+assert.equal(generatorNode.__easyuseAnimaSelectedPreviewIndex, 1);
+assert.equal(writes[1].settings.preview.image_feed, false);
+assert.equal(writes[1].settings.preview.feed_count, 1);
+
+const missingWidgetNode = {
+  widgets: [],
+  __easyuseAnimaGeneratorPreviewFeedImages: ["only-feed"],
+  __easyuseAnimaGeneratorCurrentRunImages: ["only-current"],
+  unrelated: { keep: true },
+};
+const missingUnrelatedBefore = clone(missingWidgetNode.unrelated);
+dialog = open(missingWidgetNode);
+dialog.controls.get("Feed count").value = "invalid";
+apply(dialog);
+assert.deepEqual(dialog.trace, [
+  "merge",
+  "clamp",
+  "default-index",
+  "visible",
+  "write-noop",
+  "render",
+  "remove",
+]);
+assert.equal(writeAttempts[2].widget, undefined);
+assert.equal(writes.length, 2);
+assert.deepEqual(clampCalls[2], { value: "invalid", fallback: 12, min: 1, max: 100 });
+assert.equal(writeAttempts[2].settings.preview.feed_count, 12);
+assert.equal(missingWidgetNode.__easyuseAnimaGeneratorPreviewImages.length, 1);
+assert.equal(missingWidgetNode.__easyuseAnimaSelectedPreviewIndex, 0);
+assert.deepEqual(missingWidgetNode.unrelated, missingUnrelatedBefore);
+
+console.log("AiO Preview Settings dialog smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -31,6 +31,10 @@ AIO_POSTPROCESS_SETTINGS_DIALOG_JS = AIO_MODULES / "postprocess_settings_dialog.
 AIO_POSTPROCESS_SETTINGS_DIALOG_SMOKE = (
     ROOT / "tests" / "frontend_aio_postprocess_settings_dialog_smoke.mjs"
 )
+AIO_PREVIEW_SETTINGS_DIALOG_JS = AIO_MODULES / "preview_settings_dialog.js"
+AIO_PREVIEW_SETTINGS_DIALOG_SMOKE = (
+    ROOT / "tests" / "frontend_aio_preview_settings_dialog_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -579,12 +583,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
 
         self.assertNotRegex(entry_source, r"\bfunction\s+openInputSettings\(")
-        for entry_owned_dialog in ("openPreviewSettings",):
-            with self.subTest(entry_owned_dialog=entry_owned_dialog):
-                self.assertRegex(
-                    entry_source,
-                    rf"\bfunction\s+{entry_owned_dialog}\(",
-                )
+        self.assertIn(
+            "const openPreviewSettings = aioCreatePreviewSettingsDialog",
+            entry_source,
+        )
 
         hook_start = entry_source.index("function hookInputNode")
         hook_end = entry_source.index("\nfunction hookGeneratorNode", hook_start)
@@ -663,7 +665,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
 
         self.assertNotRegex(entry_source, r"\bfunction\s+openPostprocessSettings\(")
-        self.assertRegex(entry_source, r"\bfunction\s+openPreviewSettings\(")
+        self.assertIn(
+            "const openPreviewSettings = aioCreatePreviewSettingsDialog",
+            entry_source,
+        )
         self.assertIn("const openInputSettings = aioCreateInputSettingsDialog", entry_source)
 
         render_start = entry_source.index("function renderGeneratorPanel")
@@ -677,6 +682,80 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_POSTPROCESS_SETTINGS_DIALOG_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_postprocess_settings_dialog_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_preview_settings_dialog_has_closed_controller_boundary(self):
+        source = AIO_PREVIEW_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreatePreviewSettingsDialog"],
+        )
+        self.assertLessEqual(len(source.splitlines()), 150)
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:app|api)\b")
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("fetch(", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:window|globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+
+        self.assertIn(
+            'import { aioCreatePreviewSettingsDialog } from '
+            '"./aio/preview_settings_dialog.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+openPreviewSettings\s*=\s*"
+            r"aioCreatePreviewSettingsDialog"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().removesuffix(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "document",
+                "createDialog",
+                "field",
+                "checkbox",
+                "numberInput",
+                "staticText: aioStaticText",
+                "text: aioText",
+                "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS",
+                "generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET",
+                "findWidget",
+                "generatorSettings",
+                "mergeDefaults",
+                "clampNumber: clampGeneratorNumber",
+                "defaultPreviewIndex: aioDefaultPreviewIndex",
+                "applyVisibleSettings: applyVisibleGeneratorSettings",
+                "writeSettings",
+                "renderGeneratorPanel",
+            },
+        )
+
+        self.assertNotRegex(entry_source, r"\bfunction\s+openPreviewSettings\(")
+        render_start = entry_source.index("function renderGeneratorPanel")
+        render_end = entry_source.index("\nfunction ensureGeneratorPanel", render_start)
+        render_body = entry_source[render_start:render_end]
+        self.assertIn("openPreviewSettings(node)", render_body)
+        self.assertEqual(entry_source.count("openPreviewSettings(node)"), 1)
+
+        self.assertTrue(AIO_PREVIEW_SETTINGS_DIALOG_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_preview_settings_dialog_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -79,6 +79,11 @@ try {
         throw "Frontend AiO Postprocess Settings dialog smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_preview_settings_dialog_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Preview Settings dialog smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_regional_pure_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Regional pure data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/preview_settings_dialog.js
+++ b/web/js/aio/preview_settings_dialog.js
@@ -1,0 +1,126 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioPreviewSettingsDialogDependencies
+ * @property {any} document
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(value: any) => any} checkbox
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} text
+ * @property {any} defaultGenerationSettings
+ * @property {string} generatorSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(node: any) => any} generatorSettings
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(value: any, fallback: number, min: number, max: number) => number} clampNumber
+ * @property {(images: any[]) => number} defaultPreviewIndex
+ * @property {(node: any, settings: any) => void} applyVisibleSettings
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ * @property {(node: any) => void} renderGeneratorPanel
+ */
+
+/**
+ * Build the Preview Settings opener from shared DOM, settings, and preview adapters.
+ * Extension lifecycle and generator panel ownership remain in the entry module.
+ *
+ * @param {AioPreviewSettingsDialogDependencies} dependencies
+ * @returns {(node: any) => void}
+ */
+export function aioCreatePreviewSettingsDialog(dependencies) {
+  const {
+    document,
+    createDialog,
+    field,
+    checkbox,
+    numberInput,
+    staticText,
+    text,
+    defaultGenerationSettings,
+    generatorSettingsWidget,
+    findWidget,
+    generatorSettings,
+    mergeDefaults,
+    clampNumber,
+    defaultPreviewIndex,
+    applyVisibleSettings,
+    writeSettings,
+    renderGeneratorPanel,
+  } = dependencies;
+
+  return function openPreviewSettings(node) {
+    const widget = findWidget(node, generatorSettingsWidget);
+    const settings = generatorSettings(node);
+    const preview = mergeDefaults(defaultGenerationSettings.preview, settings.preview || {});
+    const { backdrop, body, actions } = createDialog(
+      "Preview Options",
+      text("text.previewOptionsSubtitle"),
+    );
+    const section = document.createElement("section");
+    section.className = "easyuse-anima-aio-section full";
+    section.append(Object.assign(document.createElement("h3"), { textContent: staticText("Node Preview") }));
+    const intermediate = field(
+      section,
+      "Intermediate images",
+      checkbox(preview.intermediate_images),
+      "tip.previewIntermediate",
+    );
+    const comparePrevious = field(
+      section,
+      "Compare previous",
+      checkbox(preview.compare_previous),
+      "tip.previewComparePrevious",
+    );
+    const imageFeed = field(
+      section,
+      "Image feed",
+      checkbox(preview.image_feed),
+      "tip.previewImageFeed",
+    );
+    const feedCount = field(
+      section,
+      "Feed count",
+      numberInput(preview.feed_count, "1"),
+      "tip.previewFeedCount",
+    );
+    feedCount.min = "1";
+    feedCount.max = "100";
+    const syncFeedCount = () => {
+      feedCount.disabled = !imageFeed.checked;
+    };
+    imageFeed.addEventListener("change", syncFeedCount);
+    syncFeedCount();
+    body.append(section);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = text("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = text("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(defaultGenerationSettings, settings);
+      next.preview = {
+        intermediate_images: intermediate.checked,
+        compare_previous: comparePrevious.checked,
+        image_feed: imageFeed.checked,
+        feed_count: Math.trunc(clampNumber(feedCount.value, preview.feed_count, 1, 100)),
+      };
+      if (Array.isArray(node.__easyuseAnimaGeneratorPreviewFeedImages)) {
+        node.__easyuseAnimaGeneratorPreviewFeedImages = node.__easyuseAnimaGeneratorPreviewFeedImages.slice(
+          -next.preview.feed_count,
+        );
+      }
+      node.__easyuseAnimaGeneratorPreviewImages = next.preview.image_feed
+        ? (node.__easyuseAnimaGeneratorPreviewFeedImages || [])
+        : (node.__easyuseAnimaGeneratorCurrentRunImages || []);
+      node.__easyuseAnimaSelectedPreviewIndex = defaultPreviewIndex(node.__easyuseAnimaGeneratorPreviewImages);
+      applyVisibleSettings(node, next);
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -15,6 +15,7 @@ import {
 import { aioCreateDialogPrimitives } from "./aio/dialog_primitives.js";
 import { aioCreateInputSettingsDialog } from "./aio/input_settings_dialog.js";
 import { aioCreatePostprocessSettingsDialog } from "./aio/postprocess_settings_dialog.js";
+import { aioCreatePreviewSettingsDialog } from "./aio/preview_settings_dialog.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -6806,81 +6807,6 @@ function createImageSaverCivitaiHashFetcherEditor(initialFetchers) {
   };
 }
 
-function openPreviewSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = generatorSettings(node);
-  const preview = mergeDefaults(DEFAULT_GENERATION_SETTINGS.preview, settings.preview || {});
-  const { backdrop, body, actions } = createDialog(
-    "Preview Options",
-    aioText("text.previewOptionsSubtitle"),
-  );
-  const section = document.createElement("section");
-  section.className = "easyuse-anima-aio-section full";
-  section.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Node Preview") }));
-  const intermediate = field(
-    section,
-    "Intermediate images",
-    checkbox(preview.intermediate_images),
-    "tip.previewIntermediate",
-  );
-  const comparePrevious = field(
-    section,
-    "Compare previous",
-    checkbox(preview.compare_previous),
-    "tip.previewComparePrevious",
-  );
-  const imageFeed = field(
-    section,
-    "Image feed",
-    checkbox(preview.image_feed),
-    "tip.previewImageFeed",
-  );
-  const feedCount = field(
-    section,
-    "Feed count",
-    numberInput(preview.feed_count, "1"),
-    "tip.previewFeedCount",
-  );
-  feedCount.min = "1";
-  feedCount.max = "100";
-  const syncFeedCount = () => {
-    feedCount.disabled = !imageFeed.checked;
-  };
-  imageFeed.addEventListener("change", syncFeedCount);
-  syncFeedCount();
-  body.append(section);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    next.preview = {
-      intermediate_images: intermediate.checked,
-      compare_previous: comparePrevious.checked,
-      image_feed: imageFeed.checked,
-      feed_count: Math.trunc(clampGeneratorNumber(feedCount.value, preview.feed_count, 1, 100)),
-    };
-    if (Array.isArray(node.__easyuseAnimaGeneratorPreviewFeedImages)) {
-      node.__easyuseAnimaGeneratorPreviewFeedImages = node.__easyuseAnimaGeneratorPreviewFeedImages.slice(
-        -next.preview.feed_count,
-      );
-    }
-    node.__easyuseAnimaGeneratorPreviewImages = next.preview.image_feed
-      ? (node.__easyuseAnimaGeneratorPreviewFeedImages || [])
-      : (node.__easyuseAnimaGeneratorCurrentRunImages || []);
-    node.__easyuseAnimaSelectedPreviewIndex = aioDefaultPreviewIndex(node.__easyuseAnimaGeneratorPreviewImages);
-    applyVisibleGeneratorSettings(node, next);
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
-
 function openSaveSettings(node) {
   const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
   const settings = generatorSettings(node);
@@ -7477,6 +7403,26 @@ const openPostprocessSettings = aioCreatePostprocessSettingsDialog({
   generatorSettings,
   mergeDefaults,
   clampNumber: clampGeneratorNumber,
+  writeSettings,
+  renderGeneratorPanel,
+});
+
+const openPreviewSettings = aioCreatePreviewSettingsDialog({
+  document,
+  createDialog,
+  field,
+  checkbox,
+  numberInput,
+  staticText: aioStaticText,
+  text: aioText,
+  defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+  generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+  findWidget,
+  generatorSettings,
+  mergeDefaults,
+  clampNumber: clampGeneratorNumber,
+  defaultPreviewIndex: aioDefaultPreviewIndex,
+  applyVisibleSettings: applyVisibleGeneratorSettings,
   writeSettings,
   renderGeneratorPanel,
 });


### PR DESCRIPTION
## 변경 요약

- AiO `Preview Options` 대화상자의 hydrate, Cancel, Apply, 피드 개수 처리 로직을 import-free factory 모듈로 분리했습니다.
- AiO 엔트리는 번역, DOM primitive, generator state adapter, extension/node lifecycle 조립을 계속 소유합니다.
- 기존 설정 병합·clamp·feed trim·preview source·visible sync·저장·렌더 순서를 exact semantic smoke로 고정했습니다.

## 주요 파일

- `web/js/aio/preview_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_preview_settings_dialog_smoke.mjs`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- focused Node syntax 및 Preview Settings semantic smoke: 통과
- focused Python module-boundary 검사: 통과
- TypeScript 6.0.3: 통과
- 공식 full runner: Python 343 tests 통과
- frontend runner: 77 JavaScript files 및 TypeScript 6.0.3 통과
- `git diff --check`: 통과

## 브라우저 검증

- Legacy canvas: 열기, Image feed toggle과 Feed count disabled/enabled, Cancel, Apply, 재열기, close, backdrop, reload 후 값 보존, queue success 확인
- Node 2.0: 동일 경계와 별도 값 적용/재로딩, queue success 확인
- 두 모드 모두 EasyUseAnima module 404 또는 관련 runtime error 없음
- 사용자 v0.27.0 인스턴스 수동 확인은 Issue #54-57 전체 완료 후 1회 수행 예정

## 라벨 후보

저장소에 아래 라벨이 없어 후보만 기록합니다.

- `type: chore`
- `area: frontend`
- `status: draft`

## 남은 위험

- 동작 변경이 아닌 controller 경계 추출이며 기존 preview runtime private state는 후속 유지보수 조각에서 별도 정리할 수 있습니다.

Refs #54
