### PR TITLE
refactor: 자동완성 데이터 어댑터 분리

### DIFF
--- a/tests/frontend_autocomplete_data_adapter_smoke.mjs
+++ b/tests/frontend_autocomplete_data_adapter_smoke.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const dataAdapterModule = await import(dataModule("../web/js/autocomplete/data_adapter.js"));
+const textModel = await import(dataModule("../web/js/autocomplete/text_model.js"));
+
+assert.deepEqual(Object.keys(dataAdapterModule), ["createAutocompleteDataAdapter"]);
+
+const fetchCalls = [];
+const autocompleteFetchCounts = new Map();
+let wildcardFetchCount = 0;
+let normalizeCalls = 0;
+let limitCalls = 0;
+let limit = 20;
+
+async function fetchJson(url) {
+  fetchCalls.push(url);
+  if (url === "/easyuse_anima/wildcards") {
+    wildcardFetchCount += 1;
+    return {
+      items: [
+        "Folder/表情",
+        "Ｆｏｌｄｅｒ\\Alt Path",
+        "",
+        null,
+        42,
+        "Other",
+      ],
+    };
+  }
+
+  const count = (autocompleteFetchCounts.get(url) || 0) + 1;
+  autocompleteFetchCounts.set(url, count);
+  if (url.includes("q=retry") && count === 1) {
+    throw new Error("transient fetch failure");
+  }
+  if (url.includes("q=nonarray")) {
+    return { results: null };
+  }
+  return {
+    results: [{
+      tag: `result:${url}`,
+      category: "general",
+      count,
+    }],
+  };
+}
+
+function normalizeWildcardSearchText(value) {
+  normalizeCalls += 1;
+  return textModel.normalizeWildcardSearchText(value);
+}
+
+function getLimit() {
+  limitCalls += 1;
+  return limit;
+}
+
+const adapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson,
+  normalizeWildcardSearchText,
+  getLimit,
+});
+
+assert.deepEqual(Object.keys(adapter).sort(), [
+  "clearResults",
+  "clearWildcards",
+  "search",
+  "searchWildcards",
+]);
+assert.equal(fetchCalls.length, 0, "factory creation must not fetch data");
+assert.equal(normalizeCalls, 0, "factory creation must not normalize data");
+assert.equal(limitCalls, 0, "factory creation must not read settings");
+
+const firstQuery = "Miku Hatsune/初音";
+const firstCategory = "artist,general";
+const firstUrl = "/easyuse_anima/autocomplete"
+  + `?q=${encodeURIComponent(firstQuery)}`
+  + "&limit=20"
+  + `&category=${encodeURIComponent(firstCategory)}`;
+const firstResults = await adapter.search(firstQuery, firstCategory);
+assert.equal(fetchCalls.at(-1), firstUrl);
+assert.deepEqual(firstResults, [{
+  tag: `result:${firstUrl}`,
+  category: "general",
+  count: 1,
+}]);
+
+const warmResults = await adapter.search("miku hatsune/初音", firstCategory);
+assert.equal(warmResults, firstResults, "case-folded warm query must reuse cached result identity");
+assert.equal(autocompleteFetchCounts.get(firstUrl), 1);
+
+const artistUrl = "/easyuse_anima/autocomplete"
+  + `?q=${encodeURIComponent(firstQuery)}`
+  + "&limit=20&category=artist";
+await adapter.search(firstQuery, "artist");
+assert.equal(autocompleteFetchCounts.get(artistUrl), 1, "category must partition the cache");
+
+limit = 5;
+const limitedUrl = "/easyuse_anima/autocomplete"
+  + `?q=${encodeURIComponent(firstQuery)}`
+  + "&limit=5"
+  + `&category=${encodeURIComponent(firstCategory)}`;
+await adapter.search(firstQuery, firstCategory);
+assert.equal(autocompleteFetchCounts.get(limitedUrl), 1, "limit must partition the cache");
+limit = 20;
+assert.equal(await adapter.search(firstQuery, firstCategory), firstResults);
+
+const emptyResults = await adapter.search("nonarray");
+assert.deepEqual(emptyResults, []);
+assert.equal(await adapter.search("NONARRAY"), emptyResults);
+const nonarrayUrl = "/easyuse_anima/autocomplete?q=nonarray&limit=20";
+assert.equal(autocompleteFetchCounts.get(nonarrayUrl), 1);
+
+await assert.rejects(adapter.search("retry"), /transient fetch failure/);
+const retryResults = await adapter.search("retry");
+const retryUrl = "/easyuse_anima/autocomplete?q=retry&limit=20";
+assert.equal(autocompleteFetchCounts.get(retryUrl), 2, "failed requests must not enter the cache");
+assert.equal(retryResults[0].count, 2);
+
+limit = 2;
+const wildcardResults = await adapter.searchWildcards("ＦＯＬＤＥＲ\\表情");
+assert.deepEqual(wildcardResults, [{
+  tag: "Folder/表情",
+  category: "wildcard",
+  count: 0,
+  kind: "wildcard",
+}]);
+assert.equal(wildcardFetchCount, 1);
+const warmWildcardResults = await adapter.searchWildcards("folder/表情");
+assert.equal(warmWildcardResults, wildcardResults);
+assert.equal(wildcardFetchCount, 1);
+
+const folderResults = await adapter.searchWildcards("folder");
+assert.deepEqual(folderResults, [
+  { tag: "Folder/表情", category: "wildcard", count: 0, kind: "wildcard" },
+  { tag: "Ｆｏｌｄｅｒ\\Alt Path", category: "wildcard", count: 0, kind: "wildcard" },
+]);
+assert.equal(wildcardFetchCount, 1, "different wildcard queries must reuse source items");
+
+const clearableUrl = "/easyuse_anima/autocomplete?q=clearable&limit=2";
+const clearableBefore = await adapter.search("clearable");
+const clearResultsReturn = adapter.clearResults();
+assert.equal(clearResultsReturn, undefined);
+const clearableAfter = await adapter.search("clearable");
+assert.notEqual(clearableAfter, clearableBefore);
+assert.equal(autocompleteFetchCounts.get(clearableUrl), 2);
+const folderAfterClearResults = await adapter.searchWildcards("folder");
+assert.notEqual(folderAfterClearResults, folderResults);
+assert.deepEqual(folderAfterClearResults, folderResults);
+assert.equal(wildcardFetchCount, 1, "result invalidation must preserve wildcard source items");
+
+const clearWildcardsReturn = adapter.clearWildcards();
+assert.equal(clearWildcardsReturn, undefined);
+const folderAfterClearWildcards = await adapter.searchWildcards("folder");
+assert.deepEqual(folderAfterClearWildcards, folderResults);
+assert.equal(wildcardFetchCount, 2, "wildcard invalidation must reload source items");
+await adapter.search("clearable");
+assert.equal(
+  autocompleteFetchCounts.get(clearableUrl),
+  3,
+  "wildcard invalidation must also clear autocomplete result entries",
+);
+
+limit = 1;
+const oneWildcard = await adapter.searchWildcards("folder");
+assert.deepEqual(oneWildcard, [folderResults[0]]);
+assert.equal(wildcardFetchCount, 2, "limit changes must not reload wildcard source items");
+
+console.log("Autocomplete data adapter smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -14,6 +14,9 @@ AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
 AIO_PRESETS_JS = ROOT / "web" / "js" / "aio" / "presets.js"
 AUTOCOMPLETE_JS = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
+AUTOCOMPLETE_DATA_ADAPTER_JS = (
+    ROOT / "web" / "js" / "autocomplete" / "data_adapter.js"
+)
 AUTOCOMPLETE_TEXT_MODEL_JS = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -576,6 +579,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_autocomplete_wildcards_accept_empty_and_unicode_queries(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        data_adapter_source = AUTOCOMPLETE_DATA_ADAPTER_JS.read_text(encoding="utf-8")
         model_source = AUTOCOMPLETE_TEXT_MODEL_JS.read_text(encoding="utf-8")
         start = model_source.index("export function currentWildcardToken")
         end = model_source.index(
@@ -595,9 +599,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('replaceAll("\\\\", "/")', normalize_body)
         self.assertIn('replace(/[ _]+/g, "-")', normalize_body)
 
-        start = source.index("async function searchWildcards")
-        end = source.index("\nfunction scrollActiveAutocompleteItemIntoView", start)
-        search_body = source[start:end]
+        start = data_adapter_source.index("async function searchWildcards")
+        end = data_adapter_source.index("\n\n  return {", start)
+        search_body = data_adapter_source[start:end]
 
         self.assertIn("normalizeWildcardSearchText(query)", search_body)
         self.assertIn("normalizeWildcardSearchText(item).includes(normalized)", search_body)

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -8,6 +8,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 AUTOCOMPLETE_ENTRY = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
+AUTOCOMPLETE_DATA_ADAPTER = (
+    ROOT / "web" / "js" / "autocomplete" / "data_adapter.js"
+)
+AUTOCOMPLETE_DATA_ADAPTER_SMOKE = (
+    ROOT / "tests" / "frontend_autocomplete_data_adapter_smoke.mjs"
+)
 AUTOCOMPLETE_TEXT_MODEL = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -19,6 +25,103 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class AutocompleteFrontendBoundaryTests(unittest.TestCase):
+    def test_data_adapter_has_exact_io_boundary(self):
+        module_source = AUTOCOMPLETE_DATA_ADAPTER.read_text(encoding="utf-8")
+        entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createAutocompleteDataAdapter"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|registerExtension|"
+                r"addEventListener|removeEventListener|MutationObserver|"
+                r"HTMLElement|HTMLInputElement|HTMLTextAreaElement)\b"
+            ),
+        )
+
+        self.assertIn(
+            'import { createAutocompleteDataAdapter } from '
+            '"./autocomplete/data_adapter.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+autocompleteData\s*=\s*"
+            r"createAutocompleteDataAdapter"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().rstrip(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "fetchJson: easyuseAnimaFetchJson",
+                "normalizeWildcardSearchText",
+                "getLimit: () => maxResults",
+            },
+        )
+
+        for moved_declaration in (
+            "cache",
+            "wildcardItemsCache",
+            "search",
+            "loadWildcardItems",
+            "searchWildcards",
+        ):
+            with self.subTest(moved_declaration=moved_declaration):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\b(?:const|let|var|function|class)\s+"
+                    rf"{re.escape(moved_declaration)}\b",
+                )
+
+        self.assertNotIn("/easyuse_anima/autocomplete", entry_source)
+        self.assertNotIn("/easyuse_anima/wildcards", entry_source)
+        self.assertEqual(entry_source.count("autocompleteData.search("), 1)
+        self.assertEqual(
+            entry_source.count("autocompleteData.searchWildcards("),
+            1,
+        )
+        self.assertEqual(
+            entry_source.count("autocompleteData.clearResults()"),
+            4,
+        )
+        self.assertEqual(
+            entry_source.count("autocompleteData.clearWildcards()"),
+            1,
+        )
+        self.assertIn("app.registerExtension({", entry_source)
+        self.assertIn('document.addEventListener("pointerdown"', entry_source)
+        self.assertIn("function hookInput(", entry_source)
+
+    def test_data_adapter_is_in_static_and_semantic_runners(self):
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(AUTOCOMPLETE_DATA_ADAPTER_SMOKE.is_file())
+        self.assertIn("web/js/autocomplete/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_autocomplete_data_adapter_smoke.mjs"',
+            frontend_check_source,
+        )
+
     def test_text_model_has_exact_dom_free_boundary(self):
         module_source = AUTOCOMPLETE_TEXT_MODEL.read_text(encoding="utf-8")
         entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -104,6 +104,11 @@ try {
         throw "Frontend LoRA preset state smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_autocomplete_data_adapter_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_text_model_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete text model smoke failed with exit code $LASTEXITCODE."

--- a/web/js/autocomplete/data_adapter.js
+++ b/web/js/autocomplete/data_adapter.js
@@ -1,0 +1,85 @@
+// @ts-check
+
+/**
+ * @typedef {object} AutocompleteDataAdapterDependencies
+ * @property {(url: string) => Promise<any>} fetchJson
+ * @property {(value: any) => string} normalizeWildcardSearchText
+ * @property {() => number} getLimit
+ */
+
+/**
+ * Own autocomplete result caching and wildcard source loading without taking
+ * ownership of settings, DOM, popup, or extension lifecycle.
+ *
+ * @param {AutocompleteDataAdapterDependencies} dependencies
+ */
+export function createAutocompleteDataAdapter(dependencies) {
+  const {
+    fetchJson,
+    normalizeWildcardSearchText,
+    getLimit,
+  } = dependencies;
+  const cache = new Map();
+  let wildcardItemsCache = null;
+
+  function clearResults() {
+    cache.clear();
+  }
+
+  function clearWildcards() {
+    wildcardItemsCache = null;
+    cache.clear();
+  }
+
+  async function search(query, category = "") {
+    const key = `${category || "all"}:${getLimit()}:${query.toLocaleLowerCase()}`;
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    const categoryParam = category ? `&category=${encodeURIComponent(category)}` : "";
+    const data = await fetchJson(
+      `/easyuse_anima/autocomplete?q=${encodeURIComponent(query)}&limit=${getLimit()}${categoryParam}`,
+    );
+    const results = Array.isArray(data.results) ? data.results : [];
+    cache.set(key, results);
+    return results;
+  }
+
+  async function loadWildcardItems() {
+    if (Array.isArray(wildcardItemsCache)) {
+      return wildcardItemsCache;
+    }
+    const data = await fetchJson("/easyuse_anima/wildcards");
+    wildcardItemsCache = Array.isArray(data.items)
+      ? data.items.map((item) => String(item || "")).filter(Boolean)
+      : [];
+    return wildcardItemsCache;
+  }
+
+  async function searchWildcards(query) {
+    const normalized = normalizeWildcardSearchText(query);
+    const key = `wildcard:${getLimit()}:${normalized}`;
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    const items = await loadWildcardItems();
+    const results = items
+      .filter((item) => !normalized || normalizeWildcardSearchText(item).includes(normalized))
+      .slice(0, getLimit())
+      .map((item) => ({
+        tag: item,
+        category: "wildcard",
+        count: 0,
+        kind: "wildcard",
+      }));
+    cache.set(key, results);
+    return results;
+  }
+
+  return {
+    search,
+    searchWildcards,
+    clearResults,
+    clearWildcards,
+  };
+}

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -5,6 +5,7 @@ import {
 } from "./easyuse_anima_prompt_rules.js";
 import { easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText } from "./easyuse_anima_i18n.js";
+import { createAutocompleteDataAdapter } from "./autocomplete/data_adapter.js";
 import {
   autocompleteQuery,
   currentToken as currentAutocompleteToken,
@@ -162,8 +163,6 @@ const PREVIEW_STYLES = {
   unknown: { color: "#cbd5e1", background: "transparent", weight: 500 },
 };
 const MIN_QUERY_LENGTH = 1;
-const cache = new Map();
-let wildcardItemsCache = null;
 
 let maxResults = DEFAULT_MAX_RESULTS;
 let autocompleteMode = DEFAULT_AUTOCOMPLETE_MODE;
@@ -179,6 +178,12 @@ let activeRefreshFrame = null;
 let middlePanForwardActive = false;
 const hookedAutocompleteInputs = new Set();
 window.__easyuseAnimaPendingAutocompleteInputs ||= [];
+
+const autocompleteData = createAutocompleteDataAdapter({
+  fetchJson: easyuseAnimaFetchJson,
+  normalizeWildcardSearchText,
+  getLimit: () => maxResults,
+});
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -278,7 +283,7 @@ function setAutocompleteMode(value) {
   if (!autocompleteEnabledForState(activeState)) {
     hidePopup();
   }
-  cache.clear();
+  autocompleteData.clearResults();
 }
 
 function isEasyUseAnimaNode(node) {
@@ -343,7 +348,7 @@ async function refreshAutocompleteSettings() {
     const nextMaxResults = clampMaxResults(settings["autocomplete.limit"]);
     if (nextMaxResults !== maxResults) {
       maxResults = nextMaxResults;
-      cache.clear();
+      autocompleteData.clearResults();
     }
     setAutocompleteMode(settings["autocomplete.mode"]);
     setAutocompleteCommitKey(settings["autocomplete.commit_key"]);
@@ -770,49 +775,6 @@ function positionPopup(input) {
   menu.style.top = `${top}px`;
   menu.style.width = `${width}px`;
   menu.style.maxHeight = `${Math.min(280, maxHeight)}px`;
-}
-
-async function search(query, category = "") {
-  const key = `${category || "all"}:${maxResults}:${query.toLocaleLowerCase()}`;
-  if (cache.has(key)) {
-    return cache.get(key);
-  }
-  const categoryParam = category ? `&category=${encodeURIComponent(category)}` : "";
-  const data = await easyuseAnimaFetchJson(
-    `/easyuse_anima/autocomplete?q=${encodeURIComponent(query)}&limit=${maxResults}${categoryParam}`,
-  );
-  const results = Array.isArray(data.results) ? data.results : [];
-  cache.set(key, results);
-  return results;
-}
-
-async function loadWildcardItems() {
-  if (Array.isArray(wildcardItemsCache)) {
-    return wildcardItemsCache;
-  }
-  const data = await easyuseAnimaFetchJson("/easyuse_anima/wildcards");
-  wildcardItemsCache = Array.isArray(data.items) ? data.items.map((item) => String(item || "")).filter(Boolean) : [];
-  return wildcardItemsCache;
-}
-
-async function searchWildcards(query) {
-  const normalized = normalizeWildcardSearchText(query);
-  const key = `wildcard:${maxResults}:${normalized}`;
-  if (cache.has(key)) {
-    return cache.get(key);
-  }
-  const items = await loadWildcardItems();
-  const results = items
-    .filter((item) => !normalized || normalizeWildcardSearchText(item).includes(normalized))
-    .slice(0, maxResults)
-    .map((item) => ({
-      tag: item,
-      category: "wildcard",
-      count: 0,
-      kind: "wildcard",
-    }));
-  cache.set(key, results);
-  return results;
 }
 
 function scrollActiveAutocompleteItemIntoView(menu, index) {
@@ -1452,8 +1414,8 @@ function hookInput(input, options = {}) {
     const seq = ++updateSeq;
     try {
       const results = context.kind === "wildcard"
-        ? await searchWildcards(context.query)
-        : await search(context.query, context.category);
+        ? await autocompleteData.searchWildcards(context.query)
+        : await autocompleteData.search(context.query, context.category);
       if (document.activeElement === input && seq === updateSeq && !shouldSuppressAutocomplete(input)) {
         renderResults(state, strictAutocompleteResults(context, token, state, results), signature);
       }
@@ -1738,15 +1700,14 @@ window.addEventListener("easyuse-anima-settings-updated", (event) => {
   }
   if ("autocomplete.limit" in detail) {
     maxResults = clampMaxResults(detail["autocomplete.limit"]);
-    cache.clear();
+    autocompleteData.clearResults();
   }
   if ("autocomplete.source" in detail) {
-    cache.clear();
+    autocompleteData.clearResults();
     hidePopup();
   }
   if ("wildcard.extra_paths" in detail) {
-    wildcardItemsCache = null;
-    cache.clear();
+    autocompleteData.clearWildcards();
     hidePopup();
   }
   scheduleActiveRefresh();


### PR DESCRIPTION
## 변경 요약

- 자동완성 태그 검색과 wildcard 원본 로드/결과 캐시를 `autocomplete/data_adapter.js`의 import-free factory로 분리했습니다.
- 엔트리는 현재 limit getter, JSON fetcher, wildcard 정규화 함수만 주입하고 검색 및 무효화를 위임합니다.
- 검색 URL, 캐시 키, 실패 시 재시도, wildcard 필터/limit 및 설정 변경 시 무효화 동작은 기존과 동일하게 유지했습니다.
- 새 모듈의 semantic smoke와 소스 경계 테스트를 공식 frontend runner에 연결했습니다.

## 주요 파일

- `web/js/autocomplete/data_adapter.js`
- `web/js/easyuse_anima_autocomplete.js`
- `tests/frontend_autocomplete_data_adapter_smoke.mjs`
- `tests/test_autocomplete_frontend.py`
- `tests/test_aio_frontend.py`
- `tools/check_frontend.ps1`

## 검증

- `node --check`: 새 모듈, 엔트리, semantic smoke 통과
- `node tests/frontend_autocomplete_data_adapter_smoke.mjs`: 통과
- 영향 범위 Python `unittest` 3개: 통과
- `npx --yes --package typescript@6.0.3 -- tsc -p jsconfig.json`: 통과
- 저장소 공식 full runner (`Profile full`): Python 345 tests, frontend 78 JavaScript files, TypeScript 6.0.3, git diff check 통과

첫 full 실행에서는 이동 전 엔트리의 `searchWildcards` 위치를 직접 찾던 기존 소스 경계 테스트 1개가 실패했습니다. 해당 테스트가 새 data adapter 모듈을 검사하도록 갱신한 뒤 영향 범위 테스트와 full runner를 재실행해 통과했습니다.

## 테스트 표면 및 남은 확인

- 이번 변경은 DOM, popup, 입력 이벤트, extension lifecycle을 바꾸지 않는 순수 데이터/IO 경계 추출입니다.
- 따라서 레거시 캔버스 및 Node 2.0 browser smoke는 동작 변경이 없는 이번 조각에서는 생략했습니다.
- 사용자 ComfyUI v0.27.0 인스턴스 반영/수동 확인은 Issue #54~#57 전체 유지보수 완료 후 한 번만 진행합니다.
- 라벨 후보: `type: chore`, `area: frontend`, `status: draft`

Refs #56
