### PR TITLE
refactor: LoRA Preset API client 분리

### DIFF
--- a/tests/frontend_lora_preset_api_client_smoke.mjs
+++ b/tests/frontend_lora_preset_api_client_smoke.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const apiClientModule = await import(dataModule("../web/js/lora_preset/api_client.js"));
+
+assert.deepEqual(Object.keys(apiClientModule), ["createLoraPresetApiClient"]);
+
+const calls = [];
+const responses = [];
+const encodedValues = [];
+
+async function fetchJson(url, options) {
+  calls.push({
+    url,
+    options,
+    argumentCount: arguments.length,
+  });
+  const response = responses.shift();
+  if (response instanceof Error) {
+    throw response;
+  }
+  return response;
+}
+
+function encodeURIComponent(value) {
+  encodedValues.push(value);
+  return `encoded:${value.length}`;
+}
+
+const client = apiClientModule.createLoraPresetApiClient({
+  fetchJson,
+  encodeURIComponent,
+});
+
+assert.deepEqual(Object.keys(client).sort(), [
+  "fixProfile",
+  "listLoras",
+  "listProfiles",
+  "loadProfile",
+  "saveProfile",
+]);
+assert.equal(calls.length, 0, "factory creation must not make a request");
+assert.equal(encodedValues.length, 0, "factory creation must not encode a name");
+
+const profilesResponse = { profiles: [{ name: "A" }] };
+responses.push(profilesResponse);
+assert.equal(await client.listProfiles(), profilesResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/lora_profiles",
+  options: undefined,
+  argumentCount: 1,
+});
+
+const loadName = "set /?#[] !'()* 初音";
+const loadResponse = { profile: { name: loadName } };
+responses.push(loadResponse);
+assert.equal(await client.loadProfile(loadName), loadResponse);
+assert.deepEqual(encodedValues, [loadName]);
+assert.deepEqual(calls.at(-1), {
+  url: `/easyuse_anima/lora_profiles/load?name=encoded:${loadName.length}`,
+  options: undefined,
+  argumentCount: 1,
+});
+
+const savePayload = {
+  profile_count: 1,
+  profile_index: 1,
+  profile_data: {
+    "1": { style_prompt: "style", loras: [{ name: "a.safetensors" }] },
+  },
+};
+const savePayloadBefore = JSON.stringify(savePayload);
+const saveResponse = { profile: { name: "Demo" } };
+responses.push(saveResponse);
+assert.equal(await client.saveProfile("Demo", savePayload), saveResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/lora_profiles/save",
+  options: {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Demo", ...savePayload }),
+  },
+  argumentCount: 2,
+});
+assert.equal(JSON.stringify(savePayload), savePayloadBefore, "save must not mutate the payload");
+
+const fixPayload = {
+  profile_count: 2,
+  profile_index: 2,
+  profile_data: { "1": {}, "2": {} },
+};
+const fixPayloadBefore = JSON.stringify(fixPayload);
+const fixResponse = { profile: fixPayload, fixed: [], unresolved: [] };
+responses.push(fixResponse);
+assert.equal(await client.fixProfile(fixPayload), fixResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/lora_profiles/fix",
+  options: {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(fixPayload),
+  },
+  argumentCount: 2,
+});
+assert.equal(JSON.stringify(fixPayload), fixPayloadBefore, "fix must not mutate the payload");
+
+const lorasResponse = { loras: ["a.safetensors"] };
+responses.push(lorasResponse);
+assert.equal(await client.listLoras(), lorasResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/loras",
+  options: undefined,
+  argumentCount: 1,
+});
+
+const requestError = new Error("backend unavailable");
+responses.push(requestError);
+await assert.rejects(
+  client.listProfiles(),
+  (error) => error === requestError,
+  "request errors must propagate without UI policy or fallback",
+);
+
+assert.equal(responses.length, 0);
+console.log("LoRA preset API client smoke passed.");

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -11,6 +11,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 LORA_PRESET_ENTRY = ROOT / "web" / "js" / "easyuse_anima_lora_preset.js"
+LORA_PRESET_API_CLIENT = ROOT / "web" / "js" / "lora_preset" / "api_client.js"
+LORA_PRESET_API_CLIENT_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_api_client_smoke.mjs"
+)
 LORA_PRESET_PROFILE_DATA = ROOT / "web" / "js" / "lora_preset" / "profile_data.js"
 LORA_PRESET_PROFILE_DATA_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_profile_data_smoke.mjs"
@@ -24,6 +28,122 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class LoraPresetFrontendTests(unittest.TestCase):
+    def test_api_client_module_boundary(self):
+        module_source = LORA_PRESET_API_CLIENT.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createLoraPresetApiClient"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|LiteGraph|registerExtension|"
+                r"addEventListener|removeEventListener|MutationObserver)\b"
+            ),
+        )
+
+        self.assertIn(
+            'import { createLoraPresetApiClient } from '
+            '"./lora_preset/api_client.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+loraPresetApi\s*=\s*"
+            r"createLoraPresetApiClient"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().rstrip(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "fetchJson",
+                "encodeURIComponent: encodeRFC3986URIComponent",
+            },
+        )
+
+        self.assertNotIn("/easyuse_anima/lora_profiles", entry_source)
+        self.assertNotIn('"/easyuse_anima/loras"', entry_source)
+        self.assertEqual(
+            len(
+                re.findall(
+                    r'fetchJson\("/easyuse_anima/lora_profiles"\)',
+                    module_source,
+                )
+            ),
+            1,
+        )
+        for route in (
+            "/easyuse_anima/lora_profiles/load?name=",
+            "/easyuse_anima/lora_profiles/save",
+            "/easyuse_anima/lora_profiles/fix",
+            "/easyuse_anima/loras",
+        ):
+            with self.subTest(route=route):
+                self.assertEqual(module_source.count(route), 1)
+
+        self.assertEqual(entry_source.count("loraPresetApi.listProfiles()"), 1)
+        self.assertEqual(entry_source.count("loraPresetApi.loadProfile(name)"), 1)
+        self.assertEqual(entry_source.count("loraPresetApi.saveProfile("), 1)
+        self.assertEqual(entry_source.count("loraPresetApi.fixProfile("), 2)
+        self.assertEqual(entry_source.count("loraPresetApi.listLoras()"), 1)
+        self.assertRegex(
+            entry_source,
+            (
+                r"loraPresetApi\.saveProfile\(\s*"
+                r"trimmedName,\s*selectedProfilePayload\(node\),?\s*\)"
+            ),
+        )
+        self.assertIn(
+            "loraPresetApi.fixProfile(fullProfilePayload(node))",
+            entry_source,
+        )
+        self.assertIn("async function fetchJson(url, options = {})", entry_source)
+        self.assertIn("api.fetchApi(requestUrl, requestOptions)", entry_source)
+        self.assertIn("easyuseAnimaFetchJson(url, { ...options, fetcher })", entry_source)
+
+        self.assertTrue(LORA_PRESET_API_CLIENT_SMOKE.is_file())
+        self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_lora_preset_api_client_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_api_client_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_API_CLIENT_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_lora_state_module_boundary(self):
         module_source = LORA_PRESET_LORA_STATE.read_text(encoding="utf-8")
         entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
@@ -215,7 +335,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
         if completed.returncode != 0:
             self.fail((completed.stdout + completed.stderr).strip())
 
-    def test_lora_row_non_toggle_controls_do_not_throw(self):
+    def test_lora_row_controls_and_api_wiring_runtime(self):
         node_bin = shutil.which("node")
         if not node_bin:
             self.skipTest("node executable is not available")
@@ -229,6 +349,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const sourcePath = process.argv[1];
             const profileDataPath = process.argv[2];
             const loraStatePath = process.argv[3];
+            const apiClientPath = process.argv[4];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -239,10 +360,15 @@ class LoraPresetFrontendTests(unittest.TestCase):
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let apiClientSource = fs.readFileSync(apiClientPath, "utf8");
+            apiClientSource = apiClientSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${source}`;
-            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems };\n";
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${source}`;
+            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems, loraPresetApi, saveProfileSet };\n";
 
             class StubElement {
               constructor(tagName = "div") {
@@ -289,6 +415,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
               },
               easyuseAnimaText: (maps, key) => maps.en[key] || key,
               easyuseAnimaWatchLocale: () => {},
+              encodeRFC3986URIComponent: (value) => String(value),
             };
             context.globalThis = context;
             context.self = context;
@@ -331,6 +458,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
               applyLoraPresetSettings,
               loraMenuElementValue,
               loraMenuItems,
+              loraPresetApi,
+              saveProfileSet,
             } = context.__loraPresetTest;
 
             function widget(name, value) {
@@ -477,6 +606,32 @@ class LoraPresetFrontendTests(unittest.TestCase):
               assert.strictEqual(LORA_PRESET_SETTINGS.strengthDragStep, 0.025);
               assert.strictEqual(LORA_PRESET_SETTINGS.strengthDragPixels, 12);
             }
+
+            (async () => {
+              const node = makeNode();
+              let saveCall = null;
+              loraPresetApi.saveProfile = async (name, payload) => {
+                saveCall = { name, payload };
+                return { profile: { name } };
+              };
+              context.window.prompt = () => "  Demo  ";
+
+              await saveProfileSet(node);
+
+              assert.ok(saveCall, "saveProfileSet must call the API client");
+              assert.strictEqual(saveCall.name, "Demo");
+              const payload = JSON.parse(JSON.stringify(saveCall.payload));
+              assert.strictEqual(payload.profile_count, 1);
+              assert.strictEqual(payload.profile_index, 1);
+              assert.strictEqual(payload.profile_data["1"].style_prompt, "");
+              assert.strictEqual(
+                payload.profile_data["1"].loras[0].name,
+                "style/foo.safetensors",
+              );
+            })().catch((error) => {
+              console.error(error);
+              process.exitCode = 1;
+            });
             """
         )
 
@@ -488,6 +643,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_ENTRY),
                 str(LORA_PRESET_PROFILE_DATA),
                 str(LORA_PRESET_LORA_STATE),
+                str(LORA_PRESET_API_CLIENT),
             ],
             cwd=ROOT,
             text=True,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -94,6 +94,11 @@ try {
         throw "Frontend Regional runtime lifecycle smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_api_client_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset API client smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_lora_preset_profile_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend LoRA preset profile data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -2,6 +2,7 @@ import { app } from "../../../scripts/app.js";
 import { api } from "../../../scripts/api.js";
 import { easyuseAnimaEncodeRFC3986URIComponent as encodeRFC3986URIComponent, easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
+import { createLoraPresetApiClient } from "./lora_preset/api_client.js";
 import {
   INTERNAL_WIDGET_DEFAULTS,
   MAX_PROFILES,
@@ -291,6 +292,11 @@ async function fetchJson(url, options = {}) {
     : fetch;
   return easyuseAnimaFetchJson(url, { ...options, fetcher });
 }
+
+const loraPresetApi = createLoraPresetApiClient({
+  fetchJson,
+  encodeURIComponent: encodeRFC3986URIComponent,
+});
 
 function firstValue(value, fallback = null) {
   if (Array.isArray(value)) {
@@ -666,14 +672,10 @@ async function saveProfileSet(node) {
     return;
   }
   try {
-    const data = await fetchJson("/easyuse_anima/lora_profiles/save", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: trimmedName,
-        ...selectedProfilePayload(node),
-      }),
-    });
+    const data = await loraPresetApi.saveProfile(
+      trimmedName,
+      selectedProfilePayload(node),
+    );
     markSelectedProfileSaved(node, data?.profile?.name || trimmedName);
     renderProfileBar(node);
     node.setDirtyCanvas?.(true, true);
@@ -684,7 +686,7 @@ async function saveProfileSet(node) {
 
 async function loadProfileSet(node, name) {
   try {
-    const data = await fetchJson(`/easyuse_anima/lora_profiles/load?name=${encodeRFC3986URIComponent(name)}`);
+    const data = await loraPresetApi.loadProfile(name);
     appendProfilePayload(node, data.profile);
   } catch (error) {
     window.alert(lpFormat("profile.loadFailed", { message: errorMessage(error) }));
@@ -694,7 +696,7 @@ async function loadProfileSet(node, name) {
 async function openProfileLoadMenu(node, event, pos) {
   let profiles = [];
   try {
-    const data = await fetchJson("/easyuse_anima/lora_profiles");
+    const data = await loraPresetApi.listProfiles();
     profiles = Array.isArray(data?.profiles) ? data.profiles : [];
   } catch (error) {
     window.alert(lpFormat("profile.listFailed", { message: errorMessage(error) }));
@@ -792,11 +794,7 @@ async function fixProfileLoras(node) {
       window.alert(lpText("profile.fixNoIssue"));
       return;
     }
-    const data = await fetchJson("/easyuse_anima/lora_profiles/fix", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(fullProfilePayload(node)),
-    });
+    const data = await loraPresetApi.fixProfile(fullProfilePayload(node));
     const profile = data?.profile || data || {};
     applyFixedProfilePayload(node, profile);
     window.alert(lpFormat("profile.fixResult", {
@@ -832,19 +830,15 @@ async function fixSingleLoraEntry(node, index) {
       window.alert(lpText("lora.fixNoIssue"));
       return;
     }
-    const data = await fetchJson("/easyuse_anima/lora_profiles/fix", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        profile_count: 1,
-        profile_index: 1,
-        profile_data: {
-          "1": {
-            style_prompt: "",
-            loras: [lora],
-          },
+    const data = await loraPresetApi.fixProfile({
+      profile_count: 1,
+      profile_index: 1,
+      profile_data: {
+        "1": {
+          style_prompt: "",
+          loras: [lora],
         },
-      }),
+      },
     });
     const profile = data?.profile || data || {};
     const fixedLora = normalizeLoraEntry(profile?.profile_data?.["1"]?.loras?.[0] || {});
@@ -899,7 +893,7 @@ function setLoraLookup(node, values) {
 
 async function fetchLoraNameValues(node) {
   try {
-    const data = await fetchJson("/easyuse_anima/loras");
+    const data = await loraPresetApi.listLoras();
     const values = normalizeLoraNameList(data?.loras);
     for (const name of values) {
       missingPreviewNames.delete(name);

--- a/web/js/lora_preset/api_client.js
+++ b/web/js/lora_preset/api_client.js
@@ -1,0 +1,61 @@
+// @ts-check
+
+/**
+ * @typedef {object} LoraPresetApiClientDependencies
+ * @property {(url: string, options?: Record<string, any>) => Promise<any>} fetchJson
+ * @property {(value: string) => string} encodeURIComponent
+ */
+
+/**
+ * Own the LoRA preset endpoint and JSON request contract without taking
+ * ownership of Comfy transport selection, response policy, or UI lifecycle.
+ *
+ * @param {LoraPresetApiClientDependencies} dependencies
+ */
+export function createLoraPresetApiClient(dependencies) {
+  const {
+    fetchJson,
+    encodeURIComponent,
+  } = dependencies;
+
+  function postJson(url, payload) {
+    return fetchJson(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  function listProfiles() {
+    return fetchJson("/easyuse_anima/lora_profiles");
+  }
+
+  function loadProfile(name) {
+    return fetchJson(
+      `/easyuse_anima/lora_profiles/load?name=${encodeURIComponent(name)}`,
+    );
+  }
+
+  function saveProfile(name, payload) {
+    return postJson("/easyuse_anima/lora_profiles/save", {
+      name,
+      ...payload,
+    });
+  }
+
+  function fixProfile(payload) {
+    return postJson("/easyuse_anima/lora_profiles/fix", payload);
+  }
+
+  function listLoras() {
+    return fetchJson("/easyuse_anima/loras");
+  }
+
+  return {
+    listProfiles,
+    loadProfile,
+    saveProfile,
+    fixProfile,
+    listLoras,
+  };
+}


### PR DESCRIPTION
## 변경 요약

- LoRA Preset의 profile 목록·불러오기·저장·FIX 및 LoRA 목록 endpoint를 `lora_preset/api_client.js`의 import-free factory로 분리했습니다.
- Comfy transport 선택(`api.fetchApi`/browser fetch), 응답 해석, alert/fallback, pending 상태와 UI lifecycle은 기존 엔트리에 유지했습니다.
- profile 저장 payload와 FIX payload, RFC3986 profile 이름 인코딩, raw response/error 전파 동작을 그대로 보존했습니다.
- API client semantic smoke와 엔트리→client runtime wiring 검증을 공식 frontend runner에 연결했습니다.

## 주요 파일

- `web/js/lora_preset/api_client.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_api_client_smoke.mjs`
- `tests/test_frontend_lora_preset.py`
- `tools/check_frontend.ps1`

## 검증

- `node --check`: 새 API client, LoRA Preset 엔트리, semantic smoke 통과
- `node tests/frontend_lora_preset_api_client_smoke.mjs`: 통과
- 영향 범위 Python `unittest`: client boundary/semantics 및 VM runtime wiring 통과
- `npx --yes --package typescript@6.0.3 -- tsc -p jsconfig.json`: 통과
- 저장소 공식 full runner (`Profile full`): Python 347 tests, frontend 79 JavaScript files, TypeScript 6.0.3, git diff check 통과

## 테스트 표면 및 남은 확인

- 이번 변경은 endpoint/JSON 요청 경계만 이동하고 menu, canvas, extension lifecycle 동작을 변경하지 않습니다.
- 따라서 레거시 캔버스 및 Node 2.0 browser smoke는 동작 변경이 없는 이번 조각에서는 생략했습니다.
- 사용자 ComfyUI v0.27.0 인스턴스 반영/수동 확인은 Issue #54~#57 전체 유지보수 완료 후 한 번만 진행합니다.
- 라벨 후보: `type: chore`, `area: frontend`, `status: ready`

Refs #55
