### PR TITLE
refactor: settings long-text editor 모듈 분리

### DIFF
--- a/tests/frontend_settings_long_text_editor_smoke.mjs
+++ b/tests/frontend_settings_long_text_editor_smoke.mjs
@@ -1,0 +1,421 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const longTextEditorModule = await import(
+  dataModule("../web/js/settings/long_text_editor.js")
+);
+const definitionData = await import(
+  dataModule("../web/js/settings/definition_data.js")
+);
+
+assert.deepEqual(Object.keys(longTextEditorModule), [
+  "createLongTextEditorButtonFactory",
+]);
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this.style = { cssText: "" };
+    this.listeners = new Map();
+    this.className = "";
+    this.textContent = "";
+    this.type = "";
+    this.value = "";
+    this.rows = 0;
+    this.spellcheck = true;
+    this.disabled = false;
+    this.focused = false;
+    this.removed = false;
+    this.onclick = null;
+  }
+
+  append(...children) {
+    for (const child of children) {
+      child.parentElement = this;
+      this.children.push(child);
+    }
+  }
+
+  prepend(...children) {
+    for (const child of [...children].reverse()) {
+      child.parentElement = this;
+      this.children.unshift(child);
+    }
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) || [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  emit(type, event = {}) {
+    const nextEvent = {
+      target: this,
+      stopPropagation() {},
+      ...event,
+    };
+    for (const handler of this.listeners.get(type) || []) {
+      handler(nextEvent);
+    }
+    return nextEvent;
+  }
+
+  focus() {
+    this.focused = true;
+  }
+
+  remove() {
+    if (this.parentElement) {
+      const index = this.parentElement.children.indexOf(this);
+      if (index >= 0) {
+        this.parentElement.children.splice(index, 1);
+      }
+    }
+    this.parentElement = null;
+    this.removed = true;
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.body = new FakeElement("body");
+    this.createdElements = [];
+    this.listeners = new Map();
+  }
+
+  createElement(tagName) {
+    const element = new FakeElement(tagName);
+    this.createdElements.push(element);
+    return element;
+  }
+
+  addEventListener(type, handler, capture = false) {
+    const entries = this.listeners.get(type) || [];
+    entries.push({ handler, capture });
+    this.listeners.set(type, entries);
+  }
+
+  removeEventListener(type, handler, capture = false) {
+    const entries = this.listeners.get(type) || [];
+    this.listeners.set(
+      type,
+      entries.filter((entry) => entry.handler !== handler || entry.capture !== capture),
+    );
+  }
+
+  dispatchKey(key) {
+    for (const entry of [...(this.listeners.get("keydown") || [])]) {
+      entry.handler({ key });
+    }
+  }
+
+  listenerCount(type) {
+    return (this.listeners.get(type) || []).length;
+  }
+}
+
+function descendants(root) {
+  const values = [];
+  for (const child of root.children) {
+    values.push(child, ...descendants(child));
+  }
+  return values;
+}
+
+function findOne(root, predicate, message) {
+  const found = [root, ...descendants(root)].find(predicate);
+  assert.ok(found, message);
+  return found;
+}
+
+function findAll(root, predicate) {
+  return [root, ...descendants(root)].filter(predicate);
+}
+
+function button(root, label) {
+  return findOne(
+    root,
+    (element) => element.tagName === "BUTTON" && element.textContent === label,
+    `Missing button: ${label}`,
+  );
+}
+
+function overlay(document) {
+  return findOne(
+    document.body,
+    (element) => element.className === "easyuse-anima-long-text-overlay",
+    "Missing long-text overlay",
+  );
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const TEXT = {
+  openEditor: "Open editor",
+  cancel: "Cancel",
+  save: "Save",
+  saved: "Saved",
+  saveFailed: "Save failed",
+  editPromptStudioLongText: "Prompt Studio long text",
+  editPromptStudioLongTextTip: "Prompt Studio long text help",
+  editNaiaLongText: "NAIA long text",
+  editNaiaLongTextTip: "NAIA long text help",
+  metadataFilter: "Metadata filter",
+  metadataFilterTip: "Metadata filter help",
+  prePrompt: "Pre prompt",
+  postPrompt: "Post prompt",
+  autoHide: "Auto hide",
+};
+
+const document = new FakeDocument();
+const loadCalls = [];
+const saveCalls = [];
+const scheduled = [];
+
+function loadSettings() {
+  const task = deferred();
+  loadCalls.push(task);
+  return task.promise;
+}
+
+function saveSettings(values) {
+  const task = deferred();
+  saveCalls.push({ values: structuredClone(values), task });
+  return task.promise;
+}
+
+function schedule(callback, delay) {
+  scheduled.push({ callback, delay });
+}
+
+const createLongTextEditorButton = (
+  longTextEditorModule.createLongTextEditorButtonFactory({
+    document,
+    fieldGroups: definitionData.LONG_TEXT_FIELD_GROUPS,
+    text: (key) => TEXT[key] || key,
+    loadSettings,
+    saveSettings,
+    schedule,
+  })
+);
+
+assert.equal(document.createdElements.length, 0, "factory creation must not touch the DOM");
+assert.equal(document.listenerCount("keydown"), 0);
+assert.equal(loadCalls.length, 0);
+assert.equal(saveCalls.length, 0);
+assert.equal(scheduled.length, 0);
+
+const promptButtonRow = createLongTextEditorButton("promptStudio");
+assert.equal(button(promptButtonRow, "Open editor").type, "button");
+assert.ok(
+  descendants(promptButtonRow).some(
+    (element) => element.textContent === "Prompt Studio long text help",
+  ),
+);
+
+button(promptButtonRow, "Open editor").onclick();
+let currentOverlay = overlay(document);
+let currentPanel = findOne(
+  currentOverlay,
+  (element) => element.className === "comfy-settings easyuse-anima-long-text-panel",
+  "Missing long-text panel",
+);
+assert.equal(document.listenerCount("keydown"), 1);
+assert.equal(document.listeners.get("keydown")[0].capture, true);
+assert.equal(loadCalls.length, 1);
+
+const promptTextareas = findAll(
+  currentPanel,
+  (element) => element.tagName === "TEXTAREA",
+);
+assert.equal(promptTextareas.length, 1);
+assert.equal(promptTextareas[0].rows, 8);
+assert.equal(promptTextareas[0].spellcheck, false);
+loadCalls[0].resolve({
+  "prompt.metadata_filter_words": "line one\n초기값 初音",
+});
+await flushPromises();
+assert.equal(promptTextareas[0].value, "line one\n초기값 初音");
+assert.equal(promptTextareas[0].focused, true);
+assert.ok(
+  descendants(currentPanel).some(
+    (element) => element.textContent === "Metadata filter help",
+  ),
+);
+
+let panelStopped = false;
+currentPanel.emit("mousedown", {
+  target: currentPanel,
+  stopPropagation() {
+    panelStopped = true;
+  },
+});
+assert.equal(panelStopped, true);
+currentOverlay.emit("mousedown", { target: currentPanel });
+assert.equal(currentOverlay.removed, false, "panel mousedown must not close the dialog");
+
+button(currentPanel, "Cancel").onclick();
+assert.equal(currentOverlay.removed, true);
+assert.equal(document.listenerCount("keydown"), 0);
+assert.equal(saveCalls.length, 0);
+
+button(promptButtonRow, "Open editor").onclick();
+currentOverlay = overlay(document);
+currentPanel = findOne(
+  currentOverlay,
+  (element) => element.className === "comfy-settings easyuse-anima-long-text-panel",
+  "Missing reopened panel",
+);
+const staleTextarea = findAll(currentPanel, (element) => element.tagName === "TEXTAREA")[0];
+currentOverlay.emit("mousedown", { target: currentOverlay });
+assert.equal(currentOverlay.removed, true);
+assert.equal(document.listenerCount("keydown"), 0);
+loadCalls[1].resolve({ "prompt.metadata_filter_words": "stale response" });
+await flushPromises();
+assert.equal(staleTextarea.value, "", "closed dialog must ignore a stale load response");
+assert.equal(staleTextarea.focused, false);
+
+button(promptButtonRow, "Open editor").onclick();
+currentOverlay = overlay(document);
+loadCalls[2].resolve({});
+await flushPromises();
+document.dispatchKey("Escape");
+assert.equal(currentOverlay.removed, true);
+assert.equal(document.listenerCount("keydown"), 0);
+
+const naiaButtonRow = createLongTextEditorButton("naia");
+button(naiaButtonRow, "Open editor").onclick();
+currentOverlay = overlay(document);
+currentPanel = findOne(
+  currentOverlay,
+  (element) => element.className === "comfy-settings easyuse-anima-long-text-panel",
+  "Missing NAIA panel",
+);
+const naiaTextareas = findAll(currentPanel, (element) => element.tagName === "TEXTAREA");
+assert.equal(naiaTextareas.length, 3);
+assert.deepEqual(naiaTextareas.map((textarea) => textarea.rows), [7, 7, 7]);
+loadCalls[3].resolve({
+  "naia.pre_prompt": "pre\n한글",
+  "naia.post_prompt": "post 初音",
+  "naia.auto_hide": "hide\nvalue",
+});
+await flushPromises();
+assert.deepEqual(
+  naiaTextareas.map((textarea) => textarea.value),
+  ["pre\n한글", "post 初音", "hide\nvalue"],
+);
+assert.equal(naiaTextareas[0].focused, true);
+button(currentPanel, "Cancel").onclick();
+
+button(promptButtonRow, "Open editor").onclick();
+currentOverlay = overlay(document);
+currentPanel = findOne(
+  currentOverlay,
+  (element) => element.className === "comfy-settings easyuse-anima-long-text-panel",
+  "Missing save panel",
+);
+loadCalls[4].resolve({ "prompt.metadata_filter_words": "before" });
+await flushPromises();
+const saveTextarea = findAll(currentPanel, (element) => element.tagName === "TEXTAREA")[0];
+saveTextarea.value = "  line one\n저장 初音  ";
+const saveButton = button(currentPanel, "Save");
+const savePromise = saveButton.onclick();
+assert.equal(saveButton.disabled, true);
+assert.equal(saveCalls.length, 1);
+assert.deepEqual(saveCalls[0].values, {
+  "prompt.metadata_filter_words": "  line one\n저장 初音  ",
+});
+assert.ok(
+  descendants(currentPanel).some((element) => element.textContent === "..."),
+);
+saveCalls[0].task.resolve({});
+await savePromise;
+assert.equal(saveButton.disabled, false);
+assert.equal(scheduled.length, 1);
+assert.equal(scheduled[0].delay, 150);
+assert.ok(
+  descendants(currentPanel).some(
+    (element) => element.textContent === "Saved" && element.style.color === "#16a34a",
+  ),
+);
+
+button(naiaButtonRow, "Open editor").onclick();
+const newerOverlay = overlay(document);
+assert.notEqual(newerOverlay, currentOverlay);
+assert.equal(currentOverlay.removed, true);
+scheduled[0].callback();
+assert.equal(newerOverlay.removed, false, "an older delayed close must not close a newer dialog");
+loadCalls[5].resolve({});
+await flushPromises();
+button(findOne(
+  newerOverlay,
+  (element) => element.className === "comfy-settings easyuse-anima-long-text-panel",
+  "Missing newer panel",
+), "Cancel").onclick();
+
+button(promptButtonRow, "Open editor").onclick();
+currentOverlay = overlay(document);
+currentPanel = findOne(
+  currentOverlay,
+  (element) => element.className === "comfy-settings easyuse-anima-long-text-panel",
+  "Missing close-after-save panel",
+);
+loadCalls[6].resolve({});
+await flushPromises();
+const closeSaveButton = button(currentPanel, "Save");
+const closeSavePromise = closeSaveButton.onclick();
+saveCalls[1].task.resolve({});
+await closeSavePromise;
+assert.equal(scheduled[1].delay, 150);
+scheduled[1].callback();
+assert.equal(currentOverlay.removed, true);
+assert.equal(document.listenerCount("keydown"), 0);
+
+button(promptButtonRow, "Open editor").onclick();
+currentOverlay = overlay(document);
+currentPanel = findOne(
+  currentOverlay,
+  (element) => element.className === "comfy-settings easyuse-anima-long-text-panel",
+  "Missing failure panel",
+);
+loadCalls[7].resolve({});
+await flushPromises();
+const failedSaveButton = button(currentPanel, "Save");
+const failedSavePromise = failedSaveButton.onclick();
+saveCalls[2].task.reject(new Error("backend unavailable"));
+await failedSavePromise;
+assert.equal(failedSaveButton.disabled, false);
+assert.equal(currentOverlay.removed, false);
+assert.ok(
+  descendants(currentPanel).some(
+    (element) => element.textContent === "Save failed: backend unavailable"
+      && element.style.color === "#dc2626",
+  ),
+);
+assert.equal(scheduled.length, 2, "failed saves must not schedule a close");
+button(currentPanel, "Cancel").onclick();
+
+assert.equal(document.body.children.length, 0);
+assert.equal(document.listenerCount("keydown"), 0);
+console.log("Settings long-text editor smoke passed.");

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -12,11 +12,119 @@ SETTINGS_DEFINITION_DATA = ROOT / "web" / "js" / "settings" / "definition_data.j
 SETTINGS_DEFINITION_DATA_SMOKE = (
     ROOT / "tests" / "frontend_settings_definition_data_smoke.mjs"
 )
+SETTINGS_LONG_TEXT_EDITOR = (
+    ROOT / "web" / "js" / "settings" / "long_text_editor.js"
+)
+SETTINGS_LONG_TEXT_EDITOR_SMOKE = (
+    ROOT / "tests" / "frontend_settings_long_text_editor_smoke.mjs"
+)
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class SettingsFrontendTests(unittest.TestCase):
+    def test_long_text_editor_module_boundary(self):
+        module_source = SETTINGS_LONG_TEXT_EDITOR.read_text(encoding="utf-8")
+        entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createLongTextEditorButtonFactory"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            r"\b(?:app|api|registerExtension|window|CustomEvent)\b",
+        )
+        self.assertNotIn("/easyuse_anima/long_text_settings", module_source)
+
+        self.assertIn(
+            'import { createLongTextEditorButtonFactory } from '
+            '"./settings/long_text_editor.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+createLongTextEditorButton\s*=\s*"
+            r"createLongTextEditorButtonFactory"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().rstrip(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "document",
+                "fieldGroups: LONG_TEXT_FIELD_GROUPS",
+                "text: t",
+                "loadSettings: loadLongTextSettings",
+                "saveSettings: saveLongTextSettings",
+                "schedule: setTimeout",
+            },
+        )
+
+        for moved_name in (
+            "activeLongTextEditor",
+            "openLongTextEditor",
+            "closeLongTextEditor",
+        ):
+            with self.subTest(moved_name=moved_name):
+                self.assertNotIn(moved_name, entry_source)
+                self.assertIn(moved_name, module_source)
+        self.assertNotRegex(
+            entry_source,
+            r"function\s+createLongTextEditorButton\(",
+        )
+        self.assertNotIn("easyuse-anima-long-text-overlay", entry_source)
+        self.assertNotIn("easyuse-anima-long-text-panel", entry_source)
+        self.assertIn("easyuse-anima-long-text-overlay", module_source)
+        self.assertIn("easyuse-anima-long-text-panel", module_source)
+
+        self.assertIn("async function loadLongTextSettings()", entry_source)
+        self.assertIn("async function saveLongTextSettings(values)", entry_source)
+        self.assertIn('"/easyuse_anima/long_text_settings"', entry_source)
+        self.assertIn('"/easyuse_anima/long_text_settings/save"', entry_source)
+        self.assertIn("window.__easyuseAnimaSettings", entry_source)
+        self.assertIn('new CustomEvent("easyuse-anima-settings-updated"', entry_source)
+
+        self.assertTrue(SETTINGS_LONG_TEXT_EDITOR_SMOKE.is_file())
+        self.assertIn("web/js/settings/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_settings_long_text_editor_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_long_text_editor_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(SETTINGS_LONG_TEXT_EDITOR_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_definition_data_module_boundary(self):
         module_source = SETTINGS_DEFINITION_DATA.read_text(encoding="utf-8")
         entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
@@ -87,7 +195,6 @@ class SettingsFrontendTests(unittest.TestCase):
             "updateInternalSetting",
             "loadLongTextSettings",
             "saveLongTextSettings",
-            "createLongTextEditorButton",
             "createPromptStudioColorEditorButton",
             "createWildcardExtraPathsEditor",
             "createNaiaResolutionModeEditor",

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -119,6 +119,11 @@ try {
         throw "Frontend autocomplete text model smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_settings_long_text_editor_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend settings long-text editor smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_settings_definition_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend settings definition data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -18,6 +18,7 @@ import {
   parseWildcardExtraPathItems,
   serializeWildcardExtraPathItems,
 } from "./settings/definition_data.js";
+import { createLongTextEditorButtonFactory } from "./settings/long_text_editor.js";
 
 const PROMPT_STUDIO_COLORS = {
   quality: {
@@ -738,7 +739,6 @@ const TEXT = {
   },
 };
 
-let activeLongTextEditor = null;
 let activePromptStudioColorEditor = null;
 
 function t(key) {
@@ -796,24 +796,14 @@ async function saveLongTextSettings(values) {
   return data;
 }
 
-function createLongTextEditorButton(groupKey) {
-  const group = LONG_TEXT_FIELD_GROUPS[groupKey];
-  const container = document.createElement("div");
-  container.style.cssText = "display: flex; align-items: center; gap: 10px; min-width: 0;";
-
-  const button = document.createElement("button");
-  button.type = "button";
-  button.textContent = t("openEditor");
-  button.style.cssText = "padding: 6px 12px; cursor: pointer;";
-  button.onclick = () => openLongTextEditor(groupKey);
-
-  const hint = document.createElement("span");
-  hint.textContent = t(group.tipKey);
-  hint.style.cssText = "opacity: 0.68; font-size: 0.9em; line-height: 1.35;";
-
-  container.append(button, hint);
-  return container;
-}
+const createLongTextEditorButton = createLongTextEditorButtonFactory({
+  document,
+  fieldGroups: LONG_TEXT_FIELD_GROUPS,
+  text: t,
+  loadSettings: loadLongTextSettings,
+  saveSettings: saveLongTextSettings,
+  schedule: setTimeout,
+});
 
 function promptStudioColorSettingValue(value) {
   if (
@@ -1090,157 +1080,6 @@ function createNaiaResolutionScaleEditor(name, setter, value) {
   row.append(labelCell, controlCell);
   updateInternalSetting(settingId, persistedValue, "text");
   return row;
-}
-
-function closeLongTextEditor() {
-  if (!activeLongTextEditor) {
-    return;
-  }
-  const { overlay, keyHandler } = activeLongTextEditor;
-  document.removeEventListener("keydown", keyHandler, true);
-  overlay.remove();
-  activeLongTextEditor = null;
-}
-
-function openLongTextEditor(groupKey) {
-  const group = LONG_TEXT_FIELD_GROUPS[groupKey];
-  if (!group) {
-    return;
-  }
-  closeLongTextEditor();
-
-  const overlay = document.createElement("div");
-  overlay.className = "easyuse-anima-long-text-overlay";
-  overlay.style.cssText =
-    "position: fixed; inset: 0; z-index: 2147483000; display: flex; align-items: center; justify-content: center; padding: 24px; box-sizing: border-box; background: rgba(0, 0, 0, 0.52);";
-
-  const panel = document.createElement("div");
-  panel.className = "comfy-settings easyuse-anima-long-text-panel";
-  panel.style.cssText =
-    "box-sizing: border-box; width: min(820px, 92vw); max-height: min(780px, 86vh); overflow: hidden; display: flex; flex-direction: column; gap: 12px; padding: 18px; border-radius: 8px; background: var(--comfy-menu-bg, #202020); color: var(--fg-color, #ddd); box-shadow: 0 18px 60px rgba(0, 0, 0, 0.55);";
-
-  const container = document.createElement("div");
-  container.style.cssText =
-    "box-sizing: border-box; overflow: auto; display: flex; flex-direction: column; gap: 14px; padding-right: 4px;";
-
-  const title = document.createElement("h3");
-  title.textContent = t(group.nameKey);
-  title.style.margin = "0 0 2px";
-
-  const description = document.createElement("div");
-  description.textContent = t(group.tipKey);
-  description.style.cssText = "opacity: 0.72; line-height: 1.45;";
-
-  const status = document.createElement("div");
-  status.style.cssText = "min-height: 1.4em; opacity: 0.76;";
-
-  const textareas = new Map();
-  for (const field of group.fields) {
-    const wrapper = document.createElement("label");
-    wrapper.style.cssText = "display: flex; flex-direction: column; gap: 6px;";
-
-    const labelText = document.createElement("span");
-    labelText.textContent = t(field.labelKey);
-    labelText.style.fontWeight = "600";
-
-    const textarea = document.createElement("textarea");
-    textarea.spellcheck = false;
-    textarea.rows = field.key === "prompt.metadata_filter_words" ? 8 : 7;
-    textarea.style.cssText =
-      "box-sizing: border-box; width: 100%; min-height: 130px; resize: vertical; padding: 8px; font-family: monospace; white-space: pre-wrap;";
-
-    const help = document.createElement("span");
-    help.textContent = field.tipKey ? t(field.tipKey) : "";
-    help.style.cssText = "opacity: 0.62; font-size: 0.9em;";
-
-    wrapper.append(labelText, textarea);
-    if (help.textContent) {
-      wrapper.append(help);
-    }
-    container.append(wrapper);
-    textareas.set(field.key, textarea);
-  }
-
-  container.prepend(title, description);
-  container.append(status);
-
-  const setStatus = (message, color = "") => {
-    status.textContent = message;
-    status.style.color = color;
-  };
-
-  const actions = document.createElement("div");
-  actions.style.cssText = "display: flex; justify-content: flex-end; gap: 8px; flex: 0 0 auto;";
-
-  const cancelButton = document.createElement("button");
-  cancelButton.type = "button";
-  cancelButton.textContent = t("cancel");
-  cancelButton.style.cssText = "padding: 6px 12px; cursor: pointer;";
-  cancelButton.onclick = closeLongTextEditor;
-
-  const saveButton = document.createElement("button");
-  saveButton.type = "button";
-  saveButton.textContent = t("save");
-  saveButton.style.cssText = "padding: 6px 12px; cursor: pointer;";
-
-  saveButton.onclick = async () => {
-    const values = {};
-    for (const [key, textarea] of textareas.entries()) {
-      values[key] = textarea.value;
-    }
-    saveButton.disabled = true;
-    setStatus("...");
-    try {
-      await saveLongTextSettings(values);
-      setStatus(t("saved"), "#16a34a");
-      setTimeout(() => {
-        if (activeLongTextEditor?.overlay === overlay) {
-          closeLongTextEditor();
-        }
-      }, 150);
-    } catch (error) {
-      setStatus(`${t("saveFailed")}: ${error.message || error}`, "#dc2626");
-    } finally {
-      saveButton.disabled = false;
-    }
-  };
-
-  actions.append(cancelButton, saveButton);
-  panel.append(container, actions);
-  overlay.append(panel);
-
-  overlay.addEventListener("mousedown", (event) => {
-    if (event.target === overlay) {
-      closeLongTextEditor();
-    }
-  });
-  panel.addEventListener("mousedown", (event) => event.stopPropagation());
-
-  const keyHandler = (event) => {
-    if (event.key === "Escape") {
-      closeLongTextEditor();
-    }
-  };
-  document.addEventListener("keydown", keyHandler, true);
-  activeLongTextEditor = { overlay, keyHandler };
-
-  document.body.append(overlay);
-  loadLongTextSettings()
-    .then((settings) => {
-      if (activeLongTextEditor?.overlay !== overlay) {
-        return;
-      }
-      for (const [key, textarea] of textareas.entries()) {
-        textarea.value = settings[key] || "";
-      }
-      textareas.values().next().value?.focus();
-    })
-    .catch((error) => {
-      if (activeLongTextEditor?.overlay !== overlay) {
-        return;
-      }
-      setStatus(`${t("saveFailed")}: ${error.message || error}`, "#dc2626");
-    });
 }
 
 function closePromptStudioColorEditor() {

--- a/web/js/settings/long_text_editor.js
+++ b/web/js/settings/long_text_editor.js
@@ -1,0 +1,200 @@
+// @ts-check
+
+/**
+ * @typedef {object} LongTextEditorDependencies
+ * @property {Document} document
+ * @property {Record<string, any>} fieldGroups
+ * @property {(key: string) => string} text
+ * @property {() => Promise<Record<string, any>>} loadSettings
+ * @property {(values: Record<string, string>) => Promise<any>} saveSettings
+ * @property {(callback: () => void, delay: number) => any} schedule
+ */
+
+/**
+ * Own the long-text settings dialog DOM and listener lifecycle while leaving
+ * endpoint access and global settings synchronization with the caller.
+ *
+ * @param {LongTextEditorDependencies} dependencies
+ */
+export function createLongTextEditorButtonFactory(dependencies) {
+  const {
+    document,
+    fieldGroups,
+    text,
+    loadSettings,
+    saveSettings,
+    schedule,
+  } = dependencies;
+  let activeLongTextEditor = null;
+
+  function closeLongTextEditor() {
+    if (!activeLongTextEditor) {
+      return;
+    }
+    const { overlay, keyHandler } = activeLongTextEditor;
+    document.removeEventListener("keydown", keyHandler, true);
+    overlay.remove();
+    activeLongTextEditor = null;
+  }
+
+  function openLongTextEditor(groupKey) {
+    const group = fieldGroups[groupKey];
+    if (!group) {
+      return;
+    }
+    closeLongTextEditor();
+
+    const overlay = document.createElement("div");
+    overlay.className = "easyuse-anima-long-text-overlay";
+    overlay.style.cssText =
+      "position: fixed; inset: 0; z-index: 2147483000; display: flex; align-items: center; justify-content: center; padding: 24px; box-sizing: border-box; background: rgba(0, 0, 0, 0.52);";
+
+    const panel = document.createElement("div");
+    panel.className = "comfy-settings easyuse-anima-long-text-panel";
+    panel.style.cssText =
+      "box-sizing: border-box; width: min(820px, 92vw); max-height: min(780px, 86vh); overflow: hidden; display: flex; flex-direction: column; gap: 12px; padding: 18px; border-radius: 8px; background: var(--comfy-menu-bg, #202020); color: var(--fg-color, #ddd); box-shadow: 0 18px 60px rgba(0, 0, 0, 0.55);";
+
+    const container = document.createElement("div");
+    container.style.cssText =
+      "box-sizing: border-box; overflow: auto; display: flex; flex-direction: column; gap: 14px; padding-right: 4px;";
+
+    const title = document.createElement("h3");
+    title.textContent = text(group.nameKey);
+    title.style.margin = "0 0 2px";
+
+    const description = document.createElement("div");
+    description.textContent = text(group.tipKey);
+    description.style.cssText = "opacity: 0.72; line-height: 1.45;";
+
+    const status = document.createElement("div");
+    status.style.cssText = "min-height: 1.4em; opacity: 0.76;";
+
+    const textareas = new Map();
+    for (const field of group.fields) {
+      const wrapper = document.createElement("label");
+      wrapper.style.cssText = "display: flex; flex-direction: column; gap: 6px;";
+
+      const labelText = document.createElement("span");
+      labelText.textContent = text(field.labelKey);
+      labelText.style.fontWeight = "600";
+
+      const textarea = document.createElement("textarea");
+      textarea.spellcheck = false;
+      textarea.rows = field.key === "prompt.metadata_filter_words" ? 8 : 7;
+      textarea.style.cssText =
+        "box-sizing: border-box; width: 100%; min-height: 130px; resize: vertical; padding: 8px; font-family: monospace; white-space: pre-wrap;";
+
+      const help = document.createElement("span");
+      help.textContent = field.tipKey ? text(field.tipKey) : "";
+      help.style.cssText = "opacity: 0.62; font-size: 0.9em;";
+
+      wrapper.append(labelText, textarea);
+      if (help.textContent) {
+        wrapper.append(help);
+      }
+      container.append(wrapper);
+      textareas.set(field.key, textarea);
+    }
+
+    container.prepend(title, description);
+    container.append(status);
+
+    const setStatus = (message, color = "") => {
+      status.textContent = message;
+      status.style.color = color;
+    };
+
+    const actions = document.createElement("div");
+    actions.style.cssText = "display: flex; justify-content: flex-end; gap: 8px; flex: 0 0 auto;";
+
+    const cancelButton = document.createElement("button");
+    cancelButton.type = "button";
+    cancelButton.textContent = text("cancel");
+    cancelButton.style.cssText = "padding: 6px 12px; cursor: pointer;";
+    cancelButton.onclick = closeLongTextEditor;
+
+    const saveButton = document.createElement("button");
+    saveButton.type = "button";
+    saveButton.textContent = text("save");
+    saveButton.style.cssText = "padding: 6px 12px; cursor: pointer;";
+
+    saveButton.onclick = async () => {
+      /** @type {Record<string, string>} */
+      const values = {};
+      for (const [key, textarea] of textareas.entries()) {
+        values[key] = textarea.value;
+      }
+      saveButton.disabled = true;
+      setStatus("...");
+      try {
+        await saveSettings(values);
+        setStatus(text("saved"), "#16a34a");
+        schedule(() => {
+          if (activeLongTextEditor?.overlay === overlay) {
+            closeLongTextEditor();
+          }
+        }, 150);
+      } catch (error) {
+        setStatus(`${text("saveFailed")}: ${error.message || error}`, "#dc2626");
+      } finally {
+        saveButton.disabled = false;
+      }
+    };
+
+    actions.append(cancelButton, saveButton);
+    panel.append(container, actions);
+    overlay.append(panel);
+
+    overlay.addEventListener("mousedown", (event) => {
+      if (event.target === overlay) {
+        closeLongTextEditor();
+      }
+    });
+    panel.addEventListener("mousedown", (event) => event.stopPropagation());
+
+    const keyHandler = (event) => {
+      if (event.key === "Escape") {
+        closeLongTextEditor();
+      }
+    };
+    document.addEventListener("keydown", keyHandler, true);
+    activeLongTextEditor = { overlay, keyHandler };
+
+    document.body.append(overlay);
+    loadSettings()
+      .then((settings) => {
+        if (activeLongTextEditor?.overlay !== overlay) {
+          return;
+        }
+        for (const [key, textarea] of textareas.entries()) {
+          textarea.value = settings[key] || "";
+        }
+        textareas.values().next().value?.focus();
+      })
+      .catch((error) => {
+        if (activeLongTextEditor?.overlay !== overlay) {
+          return;
+        }
+        setStatus(`${text("saveFailed")}: ${error.message || error}`, "#dc2626");
+      });
+  }
+
+  return function createLongTextEditorButton(groupKey) {
+    const group = fieldGroups[groupKey];
+    const container = document.createElement("div");
+    container.style.cssText = "display: flex; align-items: center; gap: 10px; min-width: 0;";
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = text("openEditor");
+    button.style.cssText = "padding: 6px 12px; cursor: pointer;";
+    button.onclick = () => openLongTextEditor(groupKey);
+
+    const hint = document.createElement("span");
+    hint.textContent = text(group.tipKey);
+    hint.style.cssText = "opacity: 0.68; font-size: 0.9em; line-height: 1.35;";
+
+    container.append(button, hint);
+    return container;
+  };
+}


### PR DESCRIPTION
## 변경 요약

- 설정 장문 편집기의 DOM 생성, 열기/닫기, 키보드·backdrop listener, 비동기 load/save 상태 수명을 `settings/long_text_editor.js`로 분리했습니다.
- endpoint 호출, `window.__easyuseAnimaSettings` 동기화, `CustomEvent` 발행은 기존 settings entry에 유지했습니다.
- PromptStudio/NAIA 필드 순서, textarea 행 수, 공백·개행 보존, stale 응답 및 delayed-close guard를 고정하는 semantic smoke와 Python boundary test를 추가했습니다.

## 주요 파일

- `web/js/settings/long_text_editor.js`
- `web/js/easyuse_anima_settings.js`
- `tests/frontend_settings_long_text_editor_smoke.mjs`
- `tests/test_frontend_settings.py`
- `tools/check_frontend.ps1`

## 검증

- focused syntax/semantic/Python boundary 검사: 통과
- TypeScript 6.0.3: 통과
- official full runner: Python 349 tests 통과, frontend 80 JS files 통과, diff check 통과
- ComfyUI Codex test instance 0.27.0, legacy canvas: PromptStudio 열기/Cancel/저장/재열기/backdrop/Escape 및 NAIA 3필드 표시 통과
- ComfyUI Codex test instance 0.27.0, Nodes 2.0: 동일 시나리오 통과, 동일 워크플로의 Vue node 8개로 모드 확인
- ComfyUI v0.27.0 user instance: 최종 유지보수 작업 완료 후 수동 확인 예정

## 호환성 및 남은 위험

- 설정 key, endpoint, 저장 payload, DOM class와 사용자 동작은 변경하지 않았습니다.
- 브라우저 검증 중 사용한 설정 값과 canvas mode는 원래 상태로 복원했습니다.
- 사용자 인스턴스 수동 확인은 Issue #54-#57 전체 완료 뒤 한 번 수행합니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`

Refs #57