### PR TITLE
refactor: settings resolution editor 모듈 분리

### DIFF
--- a/tests/frontend_settings_resolution_editors_smoke.mjs
+++ b/tests/frontend_settings_resolution_editors_smoke.mjs
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [from, to] of Object.entries(replacements)) {
+    source = source.replaceAll(from, to);
+  }
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const definitionDataUrl = dataModule("../web/js/settings/definition_data.js");
+const resolutionEditorsModule = await import(
+  dataModule("../web/js/settings/resolution_editors.js", {
+    "./definition_data.js": definitionDataUrl,
+  })
+);
+
+assert.deepEqual(Object.keys(resolutionEditorsModule), ["createResolutionEditors"]);
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this.style = { cssText: "" };
+    this.listeners = new Map();
+    this.attributes = new Map();
+    this.textContent = "";
+    this.title = "";
+    this.type = "";
+    this.inputMode = "";
+    this.value = "";
+    this.placeholder = "";
+    this.spellcheck = true;
+    this.selected = false;
+    this.focused = false;
+  }
+
+  append(...children) {
+    for (const child of children) {
+      child.parentElement = this;
+      this.children.push(child);
+      if (this.tagName === "SELECT" && child.tagName === "OPTION" && child.selected) {
+        this.value = child.value;
+      }
+    }
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) || [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  emit(type, event = {}) {
+    const nextEvent = {
+      target: this,
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+      ...event,
+    };
+    for (const handler of this.listeners.get(type) || []) {
+      handler(nextEvent);
+    }
+    return nextEvent;
+  }
+
+  focus() {
+    this.focused = true;
+  }
+
+  blur() {
+    this.focused = false;
+    this.emit("blur");
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.createdElements = [];
+  }
+
+  createElement(tagName) {
+    const element = new FakeElement(tagName);
+    this.createdElements.push(element);
+    return element;
+  }
+}
+
+function descendants(root) {
+  const values = [];
+  for (const child of root.children) {
+    values.push(child, ...descendants(child));
+  }
+  return values;
+}
+
+function findAll(root, tagName) {
+  return [root, ...descendants(root)].filter(
+    (element) => element.tagName === tagName,
+  );
+}
+
+function findOne(root, tagName) {
+  const matches = findAll(root, tagName);
+  assert.equal(matches.length, 1, `Expected one ${tagName}, got ${matches.length}`);
+  return matches[0];
+}
+
+const TEXT = {
+  naiaResolutionModeTip: "Mode help",
+  naiaResolutionModeOriginalScale: "Original scale",
+  naiaResolutionModeBucketFit: "Bucket fit",
+  naiaResolutionScaleTip: "Scale help",
+};
+
+const document = new FakeDocument();
+const internalValues = new Map([
+  ["naia.resolution_mode", "bucket_fit"],
+  ["naia.resolution_scale", "1,75"],
+]);
+const readCalls = [];
+const updateCalls = [];
+const modeSetterCalls = [];
+const scaleSetterCalls = [];
+
+const editors = resolutionEditorsModule.createResolutionEditors({
+  document,
+  text: (key) => TEXT[key] ?? key,
+  readInternalSetting(key, fallback) {
+    readCalls.push({ key, fallback });
+    return internalValues.has(key) ? internalValues.get(key) : fallback;
+  },
+  updateInternalSetting(id, value, type) {
+    updateCalls.push({ id, value, type });
+  },
+});
+
+assert.deepEqual(Object.keys(editors), [
+  "createNaiaResolutionModeEditor",
+  "createNaiaResolutionScaleEditor",
+]);
+assert.equal(document.createdElements.length, 0, "Factory must not create DOM eagerly");
+
+const modeRow = editors.createNaiaResolutionModeEditor(
+  "Resolution mode",
+  (value) => modeSetterCalls.push(value),
+  "scale",
+);
+const modeLabel = findOne(modeRow, "LABEL");
+const modeSelect = findOne(modeRow, "SELECT");
+const modeOptions = findAll(modeRow, "OPTION");
+
+assert.equal(modeLabel.textContent, "Resolution mode");
+assert.equal(modeLabel.title, "Mode help");
+assert.equal(modeSelect.getAttribute("aria-label"), "Resolution mode");
+assert.equal(modeSelect.value, "bucket", "Internal bucket_fit alias must win");
+assert.deepEqual(modeOptions.map((option) => option.value), ["scale", "bucket"]);
+assert.deepEqual(modeOptions.map((option) => option.textContent), [
+  "Original scale",
+  "Bucket fit",
+]);
+assert.deepEqual(updateCalls, [
+  {
+    id: "EasyUseAnima.NAIA.ResolutionMode",
+    value: "bucket",
+    type: "text",
+  },
+]);
+assert.deepEqual(modeSetterCalls, []);
+
+modeSelect.value = "scale";
+modeSelect.emit("change");
+assert.equal(updateCalls.at(-1).value, "scale");
+assert.deepEqual(modeSetterCalls, ["scale"]);
+modeSelect.emit("change");
+assert.deepEqual(modeSetterCalls, ["scale"], "Unchanged mode must not persist twice");
+
+const scaleRow = editors.createNaiaResolutionScaleEditor(
+  "Resolution scale",
+  (value) => scaleSetterCalls.push(value),
+  "3.0",
+);
+const scaleLabel = findOne(scaleRow, "LABEL");
+const scaleInput = findOne(scaleRow, "INPUT");
+
+assert.equal(scaleLabel.textContent, "Resolution scale");
+assert.equal(scaleLabel.title, "Scale help");
+assert.equal(scaleInput.type, "text");
+assert.equal(scaleInput.inputMode, "decimal");
+assert.equal(scaleInput.placeholder, "1.5");
+assert.equal(scaleInput.spellcheck, false);
+assert.equal(scaleInput.value, "1.75", "Internal comma decimal must win");
+assert.equal(updateCalls.at(-1).id, "EasyUseAnima.NAIA.ResolutionScale");
+assert.equal(updateCalls.at(-1).value, "1.75");
+assert.deepEqual(scaleSetterCalls, []);
+
+scaleInput.value = "2,375";
+scaleInput.emit("input");
+assert.equal(updateCalls.at(-1).value, "2.375", "Input must sync raw comma form");
+assert.deepEqual(scaleSetterCalls, [], "Raw input must not call the setter");
+scaleInput.emit("change");
+assert.equal(scaleInput.value, "2.375");
+assert.deepEqual(scaleSetterCalls, ["2.375"]);
+
+scaleInput.value = "9";
+scaleInput.emit("blur");
+assert.equal(scaleInput.value, "4.0");
+assert.deepEqual(scaleSetterCalls, ["2.375", "4.0"]);
+
+scaleInput.value = "0,1";
+const enterEvent = scaleInput.emit("keydown", { key: "Enter" });
+assert.equal(enterEvent.defaultPrevented, true);
+assert.equal(scaleInput.value, "0.25");
+assert.deepEqual(scaleSetterCalls, ["2.375", "4.0", "0.25"]);
+
+scaleInput.value = "invalid";
+scaleInput.emit("change");
+assert.equal(scaleInput.value, "1.0");
+assert.deepEqual(scaleSetterCalls, ["2.375", "4.0", "0.25", "1.0"]);
+
+assert.deepEqual(readCalls, [
+  { key: "naia.resolution_mode", fallback: "scale" },
+  { key: "naia.resolution_scale", fallback: "3.0" },
+]);
+assert.ok(
+  updateCalls.every((call) => call.type === "text"),
+  "Every internal update must preserve the text setting type",
+);
+
+const fallbackDocument = new FakeDocument();
+const fallbackEditors = resolutionEditorsModule.createResolutionEditors({
+  document: fallbackDocument,
+  text: (key) => TEXT[key] ?? key,
+  readInternalSetting: (_key, fallback) => fallback,
+  updateInternalSetting() {},
+});
+const explicitMode = findOne(
+  fallbackEditors.createNaiaResolutionModeEditor("Mode", null, "bucket_fit"),
+  "SELECT",
+);
+const explicitScale = findOne(
+  fallbackEditors.createNaiaResolutionScaleEditor("Scale", null, "2,5"),
+  "INPUT",
+);
+assert.equal(explicitMode.value, "bucket");
+assert.equal(explicitScale.value, "2.5");
+
+const fallbackMode = findOne(
+  fallbackEditors.createNaiaResolutionModeEditor("Mode", null, undefined),
+  "SELECT",
+);
+const fallbackScale = findOne(
+  fallbackEditors.createNaiaResolutionScaleEditor("Scale", null, undefined),
+  "INPUT",
+);
+assert.equal(fallbackMode.value, "scale");
+assert.equal(fallbackScale.value, "1.0");
+
+console.log("Settings resolution editors smoke passed.");

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -18,11 +18,158 @@ SETTINGS_LONG_TEXT_EDITOR = (
 SETTINGS_LONG_TEXT_EDITOR_SMOKE = (
     ROOT / "tests" / "frontend_settings_long_text_editor_smoke.mjs"
 )
+SETTINGS_RESOLUTION_EDITORS = (
+    ROOT / "web" / "js" / "settings" / "resolution_editors.js"
+)
+SETTINGS_RESOLUTION_EDITORS_SMOKE = (
+    ROOT / "tests" / "frontend_settings_resolution_editors_smoke.mjs"
+)
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class SettingsFrontendTests(unittest.TestCase):
+    def test_resolution_editors_module_boundary(self):
+        module_source = SETTINGS_RESOLUTION_EDITORS.read_text(encoding="utf-8")
+        entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createResolutionEditors"],
+        )
+        module_import = re.search(
+            r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*"\./definition_data\.js";',
+            module_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(module_import)
+        self.assertEqual(
+            {
+                name.strip().rstrip(",")
+                for name in module_import.group("names").splitlines()
+                if name.strip()
+            },
+            {
+                "NAIA_RESOLUTION_MODE_BUCKET",
+                "NAIA_RESOLUTION_MODE_SCALE",
+                "normalizeNaiaResolutionModeValue",
+                "normalizeNaiaResolutionScaleValue",
+            },
+        )
+        self.assertNotRegex(
+            module_source,
+            r"\b(?:window|app|api|fetch|registerExtension|CustomEvent)\b",
+        )
+
+        self.assertIn(
+            'import { createResolutionEditors } from '
+            '"./settings/resolution_editors.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s*\{\s*"
+            r"createNaiaResolutionModeEditor\s*,\s*"
+            r"createNaiaResolutionScaleEditor\s*,?\s*"
+            r"\}\s*=\s*createResolutionEditors"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        self.assertEqual(
+            {
+                line.strip().rstrip(",")
+                for line in factory_match.group("dependencies").splitlines()
+                if line.strip()
+            },
+            {
+                "document",
+                "text: t",
+                "readInternalSetting",
+                "updateInternalSetting",
+            },
+        )
+
+        for moved_name in (
+            "naiaResolutionModeSettingValue",
+            "createNaiaResolutionModeEditor",
+            "naiaResolutionScaleSettingValue",
+            "createNaiaResolutionScaleEditor",
+        ):
+            with self.subTest(moved_name=moved_name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"(?:function|const|let|var)\s+{re.escape(moved_name)}\b",
+                )
+                self.assertIn(moved_name, module_source)
+
+        for setting_id, render_name in (
+            (
+                "EasyUseAnima.NAIA.ResolutionMode",
+                "createNaiaResolutionModeEditor",
+            ),
+            (
+                "EasyUseAnima.NAIA.ResolutionScale",
+                "createNaiaResolutionScaleEditor",
+            ),
+        ):
+            with self.subTest(setting_id=setting_id):
+                setting_match = re.search(
+                    rf'customSetting\(\{{\s*id:\s*"{re.escape(setting_id)}",'
+                    r"(?P<body>.*?)\}\),",
+                    entry_source,
+                    re.DOTALL,
+                )
+                self.assertIsNotNone(setting_match)
+                self.assertIn(
+                    f"render: {render_name},",
+                    setting_match.group("body"),
+                )
+
+        self.assertIn(
+            """function readInternalSetting(key, fallback) {
+  if (
+    window.__easyuseAnimaSettings
+    && Object.prototype.hasOwnProperty.call(window.__easyuseAnimaSettings, key)
+  ) {
+    return window.__easyuseAnimaSettings[key];
+  }
+  return fallback;
+}""",
+            entry_source,
+        )
+        self.assertRegex(entry_source, r"function\s+updateInternalSetting\(")
+        self.assertIn("window.__easyuseAnimaSettings", entry_source)
+        self.assertTrue(SETTINGS_RESOLUTION_EDITORS_SMOKE.is_file())
+        self.assertIn("web/js/settings/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_settings_resolution_editors_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_resolution_editors_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(SETTINGS_RESOLUTION_EDITORS_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_long_text_editor_module_boundary(self):
         module_source = SETTINGS_LONG_TEXT_EDITOR.read_text(encoding="utf-8")
         entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
@@ -145,7 +292,13 @@ class SettingsFrontendTests(unittest.TestCase):
             "parseWildcardExtraPathItems",
             "serializeWildcardExtraPathItems",
         }
-        expected_imports = expected_exports - {"LONG_TEXT_FIELDS"}
+        resolution_imports = {
+            "NAIA_RESOLUTION_MODE_BUCKET",
+            "NAIA_RESOLUTION_MODE_SCALE",
+            "normalizeNaiaResolutionModeValue",
+            "normalizeNaiaResolutionScaleValue",
+        }
+        expected_imports = expected_exports - {"LONG_TEXT_FIELDS"} - resolution_imports
 
         exported_names = set(
             re.findall(
@@ -197,8 +350,6 @@ class SettingsFrontendTests(unittest.TestCase):
             "saveLongTextSettings",
             "createPromptStudioColorEditorButton",
             "createWildcardExtraPathsEditor",
-            "createNaiaResolutionModeEditor",
-            "createNaiaResolutionScaleEditor",
             "setting",
             "customSetting",
             "loadInitialSettings",

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -124,6 +124,11 @@ try {
         throw "Frontend settings long-text editor smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_settings_resolution_editors_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend settings resolution editors smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_settings_definition_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend settings definition data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -9,16 +9,13 @@ import {
   LONG_TEXT_FIELD_GROUPS,
   NAIA_PREPROCESSING_OPTIONS,
   NAIA_RESOLUTION_BUCKET_OPTIONS,
-  NAIA_RESOLUTION_MODE_BUCKET,
-  NAIA_RESOLUTION_MODE_SCALE,
   ROOT_CATEGORY,
-  normalizeNaiaResolutionModeValue,
-  normalizeNaiaResolutionScaleValue,
   normalizeValue,
   parseWildcardExtraPathItems,
   serializeWildcardExtraPathItems,
 } from "./settings/definition_data.js";
 import { createLongTextEditorButtonFactory } from "./settings/long_text_editor.js";
+import { createResolutionEditors } from "./settings/resolution_editors.js";
 
 const PROMPT_STUDIO_COLORS = {
   quality: {
@@ -776,6 +773,16 @@ function updateInternalSetting(id, value, type = "text") {
   );
 }
 
+function readInternalSetting(key, fallback) {
+  if (
+    window.__easyuseAnimaSettings
+    && Object.prototype.hasOwnProperty.call(window.__easyuseAnimaSettings, key)
+  ) {
+    return window.__easyuseAnimaSettings[key];
+  }
+  return fallback;
+}
+
 async function loadLongTextSettings() {
   const data = await easyuseAnimaFetchJson("/easyuse_anima/long_text_settings", { fallbackJson: {} });
   const values = data.values || {};
@@ -803,6 +810,16 @@ const createLongTextEditorButton = createLongTextEditorButtonFactory({
   loadSettings: loadLongTextSettings,
   saveSettings: saveLongTextSettings,
   schedule: setTimeout,
+});
+
+const {
+  createNaiaResolutionModeEditor,
+  createNaiaResolutionScaleEditor,
+} = createResolutionEditors({
+  document,
+  text: t,
+  readInternalSetting,
+  updateInternalSetting,
 });
 
 function promptStudioColorSettingValue(value) {
@@ -963,122 +980,6 @@ function createWildcardExtraPathsEditor(name, setter, value) {
   wrapper.append(list, addButton);
   controlCell.append(wrapper);
   row.append(labelCell, controlCell);
-  return row;
-}
-
-function naiaResolutionModeSettingValue(value) {
-  if (
-    window.__easyuseAnimaSettings
-    && Object.prototype.hasOwnProperty.call(window.__easyuseAnimaSettings, "naia.resolution_mode")
-  ) {
-    return window.__easyuseAnimaSettings["naia.resolution_mode"];
-  }
-  return value ?? NAIA_RESOLUTION_MODE_SCALE;
-}
-
-function createNaiaResolutionModeEditor(name, setter, value) {
-  const settingId = "EasyUseAnima.NAIA.ResolutionMode";
-  let persistedValue = normalizeNaiaResolutionModeValue(naiaResolutionModeSettingValue(value));
-
-  const row = document.createElement("tr");
-
-  const labelCell = document.createElement("td");
-  const labelEl = document.createElement("label");
-  labelEl.textContent = name;
-  labelEl.title = t("naiaResolutionModeTip");
-  labelCell.append(labelEl);
-
-  const controlCell = document.createElement("td");
-  const select = document.createElement("select");
-  select.setAttribute("aria-label", name);
-  select.style.cssText = "box-sizing: border-box; min-width: 150px; padding: 4px 6px;";
-  for (const [mode, labelKey] of [
-    [NAIA_RESOLUTION_MODE_SCALE, "naiaResolutionModeOriginalScale"],
-    [NAIA_RESOLUTION_MODE_BUCKET, "naiaResolutionModeBucketFit"],
-  ]) {
-    const option = document.createElement("option");
-    option.value = mode;
-    option.textContent = t(labelKey);
-    option.selected = mode === persistedValue;
-    select.append(option);
-  }
-
-  const persist = () => {
-    const nextValue = normalizeNaiaResolutionModeValue(select.value);
-    select.value = nextValue;
-    updateInternalSetting(settingId, nextValue, "text");
-    if (nextValue === persistedValue) {
-      return;
-    }
-    persistedValue = nextValue;
-    setter?.(nextValue);
-  };
-
-  select.addEventListener("change", persist);
-  controlCell.append(select);
-  row.append(labelCell, controlCell);
-  updateInternalSetting(settingId, persistedValue, "text");
-  return row;
-}
-
-function naiaResolutionScaleSettingValue(value) {
-  if (
-    window.__easyuseAnimaSettings
-    && Object.prototype.hasOwnProperty.call(window.__easyuseAnimaSettings, "naia.resolution_scale")
-  ) {
-    return window.__easyuseAnimaSettings["naia.resolution_scale"];
-  }
-  return value ?? "1.0";
-}
-
-function createNaiaResolutionScaleEditor(name, setter, value) {
-  const settingId = "EasyUseAnima.NAIA.ResolutionScale";
-  let persistedValue = normalizeNaiaResolutionScaleValue(naiaResolutionScaleSettingValue(value));
-
-  const row = document.createElement("tr");
-
-  const labelCell = document.createElement("td");
-  const labelEl = document.createElement("label");
-  labelEl.textContent = name;
-  labelEl.title = t("naiaResolutionScaleTip");
-  labelCell.append(labelEl);
-
-  const controlCell = document.createElement("td");
-  const input = document.createElement("input");
-  input.type = "text";
-  input.inputMode = "decimal";
-  input.value = persistedValue;
-  input.placeholder = "1.5";
-  input.spellcheck = false;
-  input.style.cssText = "box-sizing: border-box; width: 92px; padding: 4px 6px;";
-
-  const syncRaw = () => {
-    updateInternalSetting(settingId, input.value.replace(",", "."), "text");
-  };
-  const persist = () => {
-    const normalized = normalizeNaiaResolutionScaleValue(input.value);
-    input.value = normalized;
-    updateInternalSetting(settingId, normalized, "text");
-    if (normalized === persistedValue) {
-      return;
-    }
-    persistedValue = normalized;
-    setter?.(normalized);
-  };
-
-  input.addEventListener("input", syncRaw);
-  input.addEventListener("change", persist);
-  input.addEventListener("blur", persist);
-  input.addEventListener("keydown", (event) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      input.blur();
-    }
-  });
-
-  controlCell.append(input);
-  row.append(labelCell, controlCell);
-  updateInternalSetting(settingId, persistedValue, "text");
   return row;
 }
 

--- a/web/js/settings/resolution_editors.js
+++ b/web/js/settings/resolution_editors.js
@@ -1,0 +1,147 @@
+// @ts-check
+
+import {
+  NAIA_RESOLUTION_MODE_BUCKET,
+  NAIA_RESOLUTION_MODE_SCALE,
+  normalizeNaiaResolutionModeValue,
+  normalizeNaiaResolutionScaleValue,
+} from "./definition_data.js";
+
+/**
+ * @typedef {object} ResolutionEditorDependencies
+ * @property {Document} document
+ * @property {(key: string) => string} text
+ * @property {(key: string, fallback: any) => any} readInternalSetting
+ * @property {(id: string, value: any, type?: string) => void} updateInternalSetting
+ */
+
+/**
+ * Own the NAIA resolution-mode and scale DOM controls while leaving global
+ * settings lookup and persistence with the caller.
+ *
+ * @param {ResolutionEditorDependencies} dependencies
+ */
+export function createResolutionEditors(dependencies) {
+  const {
+    document,
+    text,
+    readInternalSetting,
+    updateInternalSetting,
+  } = dependencies;
+
+  function naiaResolutionModeSettingValue(value) {
+    return readInternalSetting(
+      "naia.resolution_mode",
+      value ?? NAIA_RESOLUTION_MODE_SCALE,
+    );
+  }
+
+  function createNaiaResolutionModeEditor(name, setter, value) {
+    const settingId = "EasyUseAnima.NAIA.ResolutionMode";
+    let persistedValue = normalizeNaiaResolutionModeValue(
+      naiaResolutionModeSettingValue(value),
+    );
+
+    const row = document.createElement("tr");
+
+    const labelCell = document.createElement("td");
+    const labelEl = document.createElement("label");
+    labelEl.textContent = name;
+    labelEl.title = text("naiaResolutionModeTip");
+    labelCell.append(labelEl);
+
+    const controlCell = document.createElement("td");
+    const select = document.createElement("select");
+    select.setAttribute("aria-label", name);
+    select.style.cssText = "box-sizing: border-box; min-width: 150px; padding: 4px 6px;";
+    for (const [mode, labelKey] of [
+      [NAIA_RESOLUTION_MODE_SCALE, "naiaResolutionModeOriginalScale"],
+      [NAIA_RESOLUTION_MODE_BUCKET, "naiaResolutionModeBucketFit"],
+    ]) {
+      const option = document.createElement("option");
+      option.value = mode;
+      option.textContent = text(labelKey);
+      option.selected = mode === persistedValue;
+      select.append(option);
+    }
+
+    const persist = () => {
+      const nextValue = normalizeNaiaResolutionModeValue(select.value);
+      select.value = nextValue;
+      updateInternalSetting(settingId, nextValue, "text");
+      if (nextValue === persistedValue) {
+        return;
+      }
+      persistedValue = nextValue;
+      setter?.(nextValue);
+    };
+
+    select.addEventListener("change", persist);
+    controlCell.append(select);
+    row.append(labelCell, controlCell);
+    updateInternalSetting(settingId, persistedValue, "text");
+    return row;
+  }
+
+  function naiaResolutionScaleSettingValue(value) {
+    return readInternalSetting("naia.resolution_scale", value ?? "1.0");
+  }
+
+  function createNaiaResolutionScaleEditor(name, setter, value) {
+    const settingId = "EasyUseAnima.NAIA.ResolutionScale";
+    let persistedValue = normalizeNaiaResolutionScaleValue(
+      naiaResolutionScaleSettingValue(value),
+    );
+
+    const row = document.createElement("tr");
+
+    const labelCell = document.createElement("td");
+    const labelEl = document.createElement("label");
+    labelEl.textContent = name;
+    labelEl.title = text("naiaResolutionScaleTip");
+    labelCell.append(labelEl);
+
+    const controlCell = document.createElement("td");
+    const input = document.createElement("input");
+    input.type = "text";
+    input.inputMode = "decimal";
+    input.value = persistedValue;
+    input.placeholder = "1.5";
+    input.spellcheck = false;
+    input.style.cssText = "box-sizing: border-box; width: 92px; padding: 4px 6px;";
+
+    const syncRaw = () => {
+      updateInternalSetting(settingId, input.value.replace(",", "."), "text");
+    };
+    const persist = () => {
+      const normalized = normalizeNaiaResolutionScaleValue(input.value);
+      input.value = normalized;
+      updateInternalSetting(settingId, normalized, "text");
+      if (normalized === persistedValue) {
+        return;
+      }
+      persistedValue = normalized;
+      setter?.(normalized);
+    };
+
+    input.addEventListener("input", syncRaw);
+    input.addEventListener("change", persist);
+    input.addEventListener("blur", persist);
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        input.blur();
+      }
+    });
+
+    controlCell.append(input);
+    row.append(labelCell, controlCell);
+    updateInternalSetting(settingId, persistedValue, "text");
+    return row;
+  }
+
+  return {
+    createNaiaResolutionModeEditor,
+    createNaiaResolutionScaleEditor,
+  };
+}


### PR DESCRIPTION
## 변경 요약

- NAIA 해상도 적용 방식과 배율 custom editor를 `settings/resolution_editors.js`로 분리했습니다.
- 새 모듈은 DOM control과 normalization 흐름만 소유하고, 전역 settings 조회·갱신 및 실제 setter 호출은 settings entry가 주입합니다.
- setting ID, option 순서, render 시 초기 internal sync, raw input 처리, change/blur/Enter 정규화와 중복 setter 억제를 그대로 유지했습니다.
- 실제 setting ID → render 연결과 global-value 우선순위를 고정하는 boundary/semantic smoke를 추가했습니다.

## 주요 파일

- `web/js/settings/resolution_editors.js`
- `web/js/easyuse_anima_settings.js`
- `tests/frontend_settings_resolution_editors_smoke.mjs`
- `tests/test_frontend_settings.py`
- `tools/check_frontend.ps1`

## 검증

- focused syntax/semantic/settings boundary 검사: 통과
- TypeScript 6.0.3: 통과
- official full runner: Python 351 tests 통과, frontend 81 JS files 통과, diff check 통과
- browser smoke: 미실행 — DOM·event·persistence 동작을 바꾸지 않은 기계적 factory 추출이며 semantic smoke로 기존 계약을 고정함
- ComfyUI v0.27.0 user instance: Issue #54-#57 전체 완료 후 수동 확인 예정

## 호환성 및 남은 위험

- `EasyUseAnima.NAIA.ResolutionMode`, `EasyUseAnima.NAIA.ResolutionScale` ID와 저장 형식은 변경하지 않았습니다.
- `bucket_fit → bucket`, comma decimal, 0.25–4.0 clamp, 3자리 반올림과 정수 `.0` 형식을 유지합니다.
- Issue #57의 color/path editor, persistence/registration 경계와 최종 양 canvas matrix는 후속 조각에서 진행합니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`

Refs #57