### PR TITLE
refactor: wildcard 경로 편집기 모듈 분리

### DIFF
--- a/tests/frontend_settings_wildcard_path_editor_smoke.mjs
+++ b/tests/frontend_settings_wildcard_path_editor_smoke.mjs
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [from, to] of Object.entries(replacements)) {
+    source = source.replaceAll(from, to);
+  }
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const definitionDataUrl = dataModule("../web/js/settings/definition_data.js");
+const wildcardPathEditorModule = await import(
+  dataModule("../web/js/settings/wildcard_path_editor.js", {
+    "./definition_data.js": definitionDataUrl,
+  })
+);
+
+assert.deepEqual(
+  Object.keys(wildcardPathEditorModule),
+  ["createWildcardExtraPathsEditorFactory"],
+);
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this.style = { cssText: "" };
+    this.listeners = new Map();
+    this.attributes = new Map();
+    this.textContent = "";
+    this.title = "";
+    this.type = "";
+    this.value = "";
+    this.placeholder = "";
+    this.spellcheck = true;
+    this.focused = false;
+  }
+
+  append(...children) {
+    for (const child of children) {
+      child.parentElement = this;
+      this.children.push(child);
+    }
+  }
+
+  replaceChildren(...children) {
+    for (const child of this.children) {
+      child.parentElement = null;
+    }
+    this.children = [];
+    this.append(...children);
+  }
+
+  get lastElementChild() {
+    return this.children.at(-1) ?? null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) || [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  emit(type, event = {}) {
+    const nextEvent = {
+      target: this,
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+      ...event,
+    };
+    for (const handler of this.listeners.get(type) || []) {
+      handler(nextEvent);
+    }
+    return nextEvent;
+  }
+
+  querySelector(selector) {
+    const expectedTag = String(selector).toUpperCase();
+    return descendants(this).find((element) => element.tagName === expectedTag) ?? null;
+  }
+
+  focus() {
+    this.focused = true;
+  }
+
+  blur() {
+    this.focused = false;
+    this.emit("blur");
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.createdElements = [];
+  }
+
+  createElement(tagName) {
+    const element = new FakeElement(tagName);
+    this.createdElements.push(element);
+    return element;
+  }
+}
+
+function descendants(root) {
+  const values = [];
+  for (const child of root.children) {
+    values.push(child, ...descendants(child));
+  }
+  return values;
+}
+
+function findAll(root, tagName) {
+  return [root, ...descendants(root)].filter(
+    (element) => element.tagName === tagName,
+  );
+}
+
+function findOne(root, tagName) {
+  const matches = findAll(root, tagName);
+  assert.equal(matches.length, 1, `Expected one ${tagName}, got ${matches.length}`);
+  return matches[0];
+}
+
+function buttonsByText(root, text) {
+  return findAll(root, "BUTTON").filter((button) => button.textContent === text);
+}
+
+const TEXT = {
+  wildcardExtraPathsTip: "Path list help",
+  wildcardExtraPathPlaceholder: "D:/wildcards",
+  removeWildcardPath: "Remove path",
+  addWildcardPath: "Add path",
+};
+
+const document = new FakeDocument();
+const internalValues = new Map([
+  ["wildcard.extra_paths", '  first path  \r\n"second path"'],
+]);
+const readCalls = [];
+const updateCalls = [];
+const setterCalls = [];
+
+const createWildcardExtraPathsEditor =
+  wildcardPathEditorModule.createWildcardExtraPathsEditorFactory({
+    document,
+    text: (key) => TEXT[key] ?? key,
+    readInternalSetting(key, fallback) {
+      readCalls.push({ key, fallback });
+      return internalValues.has(key) ? internalValues.get(key) : fallback;
+    },
+    updateInternalSetting(id, value, type) {
+      updateCalls.push({ id, value, type });
+    },
+  });
+
+assert.equal(typeof createWildcardExtraPathsEditor, "function");
+assert.equal(document.createdElements.length, 0, "Factory must not create DOM eagerly");
+
+const row = createWildcardExtraPathsEditor(
+  "Extra wildcard paths",
+  (value) => setterCalls.push(value),
+  "renderer path",
+);
+const label = findOne(row, "LABEL");
+let inputs = findAll(row, "INPUT");
+let removeButtons = buttonsByText(row, "x");
+const addButton = buttonsByText(row, "+")[0];
+
+assert.deepEqual(row.children.map((child) => child.tagName), ["TD", "TD"]);
+assert.equal(label.textContent, "Extra wildcard paths");
+assert.equal(label.title, "Path list help");
+assert.deepEqual(inputs.map((input) => input.value), ["first path", "second path"]);
+assert.ok(inputs.every((input) => input.type === "text"));
+assert.ok(inputs.every((input) => input.placeholder === "D:/wildcards"));
+assert.ok(inputs.every((input) => input.spellcheck === false));
+assert.deepEqual(removeButtons.map((button) => button.title), [
+  "Remove path",
+  "Remove path",
+]);
+assert.equal(addButton.title, "Add path");
+assert.deepEqual(readCalls, [
+  { key: "wildcard.extra_paths", fallback: "renderer path" },
+]);
+assert.deepEqual(updateCalls, [], "Initial render must not update internal settings");
+assert.deepEqual(setterCalls, [], "Initial render must not call the setter");
+
+inputs[0].value = "  changed path  ";
+inputs[0].emit("input");
+assert.deepEqual(updateCalls.at(-1), {
+  id: "EasyUseAnima.Wildcard.ExtraPaths",
+  value: "changed path\nsecond path",
+  type: "text",
+});
+assert.equal(inputs[0].value, "  changed path  ", "Raw input must stay visible");
+assert.deepEqual(setterCalls, [], "Input must only sync internal state");
+
+inputs[0].emit("change");
+assert.deepEqual(setterCalls, ["changed path\nsecond path"]);
+inputs[0].emit("blur");
+assert.deepEqual(
+  setterCalls,
+  ["changed path\nsecond path"],
+  "Change followed by blur must not persist twice",
+);
+
+inputs[1].value = "enter path";
+inputs[1].emit("input");
+inputs[1].focus();
+const enterEvent = inputs[1].emit("keydown", { key: "Enter" });
+assert.equal(enterEvent.defaultPrevented, true);
+assert.equal(inputs[1].focused, false);
+assert.deepEqual(setterCalls, [
+  "changed path\nsecond path",
+  "changed path\nenter path",
+]);
+
+const updateCountBeforeAdd = updateCalls.length;
+const setterCountBeforeAdd = setterCalls.length;
+addButton.emit("click");
+inputs = findAll(row, "INPUT");
+assert.equal(inputs.length, 3);
+assert.equal(inputs[2].value, "");
+assert.equal(inputs[2].focused, true, "Added row input must receive focus");
+assert.equal(updateCalls.length, updateCountBeforeAdd, "Add must not persist eagerly");
+assert.equal(setterCalls.length, setterCountBeforeAdd, "Add must not call the setter");
+
+inputs[2].value = "third path";
+inputs[2].emit("input");
+inputs[2].emit("change");
+assert.equal(setterCalls.at(-1), "changed path\nenter path\nthird path");
+
+removeButtons = buttonsByText(row, "x");
+removeButtons[1].emit("click");
+inputs = findAll(row, "INPUT");
+assert.deepEqual(inputs.map((input) => input.value), ["  changed path  ", "third path"]);
+assert.equal(setterCalls.at(-1), "changed path\nthird path");
+
+removeButtons = buttonsByText(row, "x");
+removeButtons[0].emit("click");
+inputs = findAll(row, "INPUT");
+assert.deepEqual(inputs.map((input) => input.value), ["third path"]);
+assert.equal(setterCalls.at(-1), "third path");
+
+removeButtons = buttonsByText(row, "x");
+removeButtons[0].emit("click");
+inputs = findAll(row, "INPUT");
+assert.deepEqual(inputs.map((input) => input.value), [""]);
+assert.equal(setterCalls.at(-1), "");
+
+const setterCountBeforeEmptyRemove = setterCalls.length;
+buttonsByText(row, "x")[0].emit("click");
+assert.equal(findAll(row, "INPUT").length, 1);
+assert.equal(setterCalls.length, setterCountBeforeEmptyRemove);
+assert.equal(updateCalls.at(-1).value, "", "Empty-row removal must still sync internal state");
+assert.ok(
+  updateCalls.every((call) => call.type === "text"),
+  "Every internal update must preserve the text setting type",
+);
+
+const fallbackDocument = new FakeDocument();
+const fallbackEditor = wildcardPathEditorModule.createWildcardExtraPathsEditorFactory({
+  document: fallbackDocument,
+  text: (key) => TEXT[key] ?? key,
+  readInternalSetting: (_key, fallback) => fallback,
+  updateInternalSetting() {},
+});
+const explicitRow = fallbackEditor("Paths", null, ' explicit one \n"explicit two"');
+assert.deepEqual(findAll(explicitRow, "INPUT").map((input) => input.value), [
+  "explicit one",
+  "explicit two",
+]);
+const emptyRow = fallbackEditor("Paths", null, undefined);
+assert.deepEqual(findAll(emptyRow, "INPUT").map((input) => input.value), [""]);
+
+const emptyInternalEditor = wildcardPathEditorModule.createWildcardExtraPathsEditorFactory({
+  document: new FakeDocument(),
+  text: (key) => TEXT[key] ?? key,
+  readInternalSetting: () => "",
+  updateInternalSetting() {},
+});
+const emptyInternalRow = emptyInternalEditor("Paths", null, "must be ignored");
+assert.deepEqual(
+  findAll(emptyInternalRow, "INPUT").map((input) => input.value),
+  [""],
+  "An explicit empty internal value must win over the renderer value",
+);
+
+console.log("Settings wildcard path editor smoke passed.");

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -24,11 +24,127 @@ SETTINGS_RESOLUTION_EDITORS = (
 SETTINGS_RESOLUTION_EDITORS_SMOKE = (
     ROOT / "tests" / "frontend_settings_resolution_editors_smoke.mjs"
 )
+SETTINGS_WILDCARD_PATH_EDITOR = (
+    ROOT / "web" / "js" / "settings" / "wildcard_path_editor.js"
+)
+SETTINGS_WILDCARD_PATH_EDITOR_SMOKE = (
+    ROOT / "tests" / "frontend_settings_wildcard_path_editor_smoke.mjs"
+)
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class SettingsFrontendTests(unittest.TestCase):
+    def test_wildcard_path_editor_module_boundary(self):
+        module_source = SETTINGS_WILDCARD_PATH_EDITOR.read_text(encoding="utf-8")
+        entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createWildcardExtraPathsEditorFactory"],
+        )
+        module_import = re.search(
+            r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*"\./definition_data\.js";',
+            module_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(module_import)
+        self.assertEqual(
+            {
+                name.strip().rstrip(",")
+                for name in module_import.group("names").splitlines()
+                if name.strip()
+            },
+            {
+                "parseWildcardExtraPathItems",
+                "serializeWildcardExtraPathItems",
+            },
+        )
+        self.assertNotRegex(
+            module_source,
+            r"\b(?:window|app|api|fetch|registerExtension|CustomEvent)\b",
+        )
+
+        self.assertIn(
+            'import { createWildcardExtraPathsEditorFactory } from '
+            '"./settings/wildcard_path_editor.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+createWildcardExtraPathsEditor\s*=\s*"
+            r"createWildcardExtraPathsEditorFactory"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        self.assertEqual(
+            {
+                line.strip().rstrip(",")
+                for line in factory_match.group("dependencies").splitlines()
+                if line.strip()
+            },
+            {
+                "document",
+                "text: t",
+                "readInternalSetting",
+                "updateInternalSetting",
+            },
+        )
+        self.assertNotRegex(
+            entry_source,
+            r"(?:function|const|let|var)\s+wildcardExtraPathsSettingValue\b",
+        )
+        self.assertNotRegex(
+            entry_source,
+            r"function\s+createWildcardExtraPathsEditor\b",
+        )
+        self.assertIn("function wildcardExtraPathsSettingValue(value)", module_source)
+        self.assertIn("function createWildcardExtraPathsEditor(name, setter, value)", module_source)
+
+        setting_match = re.search(
+            r'customSetting\(\{\s*id:\s*"EasyUseAnima\.Wildcard\.ExtraPaths",'
+            r"(?P<body>.*?)\}\),",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(setting_match)
+        self.assertIn(
+            "render: createWildcardExtraPathsEditor,",
+            setting_match.group("body"),
+        )
+        self.assertRegex(entry_source, r"function\s+readInternalSetting\(")
+        self.assertRegex(entry_source, r"function\s+updateInternalSetting\(")
+        self.assertTrue(SETTINGS_WILDCARD_PATH_EDITOR_SMOKE.is_file())
+        self.assertIn("web/js/settings/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_settings_wildcard_path_editor_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_wildcard_path_editor_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(SETTINGS_WILDCARD_PATH_EDITOR_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_resolution_editors_module_boundary(self):
         module_source = SETTINGS_RESOLUTION_EDITORS.read_text(encoding="utf-8")
         entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
@@ -298,7 +414,16 @@ class SettingsFrontendTests(unittest.TestCase):
             "normalizeNaiaResolutionModeValue",
             "normalizeNaiaResolutionScaleValue",
         }
-        expected_imports = expected_exports - {"LONG_TEXT_FIELDS"} - resolution_imports
+        wildcard_imports = {
+            "parseWildcardExtraPathItems",
+            "serializeWildcardExtraPathItems",
+        }
+        expected_imports = (
+            expected_exports
+            - {"LONG_TEXT_FIELDS"}
+            - resolution_imports
+            - wildcard_imports
+        )
 
         exported_names = set(
             re.findall(
@@ -349,7 +474,6 @@ class SettingsFrontendTests(unittest.TestCase):
             "loadLongTextSettings",
             "saveLongTextSettings",
             "createPromptStudioColorEditorButton",
-            "createWildcardExtraPathsEditor",
             "setting",
             "customSetting",
             "loadInitialSettings",

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -129,6 +129,11 @@ try {
         throw "Frontend settings resolution editors smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_settings_wildcard_path_editor_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend settings wildcard path editor smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_settings_definition_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend settings definition data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -11,11 +11,10 @@ import {
   NAIA_RESOLUTION_BUCKET_OPTIONS,
   ROOT_CATEGORY,
   normalizeValue,
-  parseWildcardExtraPathItems,
-  serializeWildcardExtraPathItems,
 } from "./settings/definition_data.js";
 import { createLongTextEditorButtonFactory } from "./settings/long_text_editor.js";
 import { createResolutionEditors } from "./settings/resolution_editors.js";
+import { createWildcardExtraPathsEditorFactory } from "./settings/wildcard_path_editor.js";
 
 const PROMPT_STUDIO_COLORS = {
   quality: {
@@ -822,6 +821,13 @@ const {
   updateInternalSetting,
 });
 
+const createWildcardExtraPathsEditor = createWildcardExtraPathsEditorFactory({
+  document,
+  text: t,
+  readInternalSetting,
+  updateInternalSetting,
+});
+
 function promptStudioColorSettingValue(value) {
   if (
     window.__easyuseAnimaSettings
@@ -865,122 +871,6 @@ function createPromptStudioColorEditorButton(name, setter, value) {
 
   container.append(button, hint);
   return container;
-}
-
-function wildcardExtraPathsSettingValue(value) {
-  if (
-    window.__easyuseAnimaSettings
-    && Object.prototype.hasOwnProperty.call(window.__easyuseAnimaSettings, "wildcard.extra_paths")
-  ) {
-    return window.__easyuseAnimaSettings["wildcard.extra_paths"];
-  }
-  return value ?? "";
-}
-
-function createWildcardExtraPathsEditor(name, setter, value) {
-  const settingId = "EasyUseAnima.Wildcard.ExtraPaths";
-  let items = parseWildcardExtraPathItems(wildcardExtraPathsSettingValue(value));
-  if (!items.length) {
-    items = [""];
-  }
-
-  const row = document.createElement("tr");
-
-  const labelCell = document.createElement("td");
-  const labelEl = document.createElement("label");
-  labelEl.textContent = name;
-  labelEl.title = t("wildcardExtraPathsTip");
-  labelCell.append(labelEl);
-
-  const controlCell = document.createElement("td");
-  const wrapper = document.createElement("div");
-  wrapper.style.cssText = "display: flex; flex-direction: column; gap: 6px; min-width: 260px;";
-
-  const list = document.createElement("div");
-  list.style.cssText = "display: flex; flex-direction: column; gap: 6px;";
-
-  let persistedValue = serializeWildcardExtraPathItems(items);
-
-  const syncInternal = () => {
-    const serialized = serializeWildcardExtraPathItems(items);
-    updateInternalSetting(settingId, serialized, "text");
-  };
-
-  const persist = () => {
-    const serialized = serializeWildcardExtraPathItems(items);
-    updateInternalSetting(settingId, serialized, "text");
-    if (serialized === persistedValue) {
-      return;
-    }
-    persistedValue = serialized;
-    setter?.(serialized);
-  };
-
-  const render = () => {
-    list.replaceChildren();
-    if (!items.length) {
-      items = [""];
-    }
-
-    items.forEach((item, index) => {
-      const itemRow = document.createElement("div");
-      itemRow.style.cssText = "display: flex; align-items: center; gap: 6px; min-width: 0;";
-
-      const input = document.createElement("input");
-      input.type = "text";
-      input.value = item;
-      input.placeholder = t("wildcardExtraPathPlaceholder");
-      input.spellcheck = false;
-      input.style.cssText = "box-sizing: border-box; flex: 1 1 auto; min-width: 120px; padding: 4px 6px;";
-      input.addEventListener("input", () => {
-        items[index] = input.value;
-        syncInternal();
-      });
-      input.addEventListener("change", persist);
-      input.addEventListener("blur", persist);
-      input.addEventListener("keydown", (event) => {
-        if (event.key === "Enter") {
-          event.preventDefault();
-          input.blur();
-        }
-      });
-
-      const removeButton = document.createElement("button");
-      removeButton.type = "button";
-      removeButton.textContent = "x";
-      removeButton.title = t("removeWildcardPath");
-      removeButton.style.cssText = "width: 28px; min-width: 28px; height: 28px; padding: 0; cursor: pointer;";
-      removeButton.addEventListener("click", () => {
-        if (items.length <= 1) {
-          items[0] = "";
-        } else {
-          items.splice(index, 1);
-        }
-        persist();
-        render();
-      });
-
-      itemRow.append(input, removeButton);
-      list.append(itemRow);
-    });
-  };
-
-  const addButton = document.createElement("button");
-  addButton.type = "button";
-  addButton.textContent = "+";
-  addButton.title = t("addWildcardPath");
-  addButton.style.cssText = "align-self: flex-start; min-width: 32px; height: 28px; padding: 0 10px; cursor: pointer;";
-  addButton.addEventListener("click", () => {
-    items.push("");
-    render();
-    list.lastElementChild?.querySelector("input")?.focus();
-  });
-
-  render();
-  wrapper.append(list, addButton);
-  controlCell.append(wrapper);
-  row.append(labelCell, controlCell);
-  return row;
 }
 
 function closePromptStudioColorEditor() {

--- a/web/js/settings/wildcard_path_editor.js
+++ b/web/js/settings/wildcard_path_editor.js
@@ -1,0 +1,141 @@
+// @ts-check
+
+import {
+  parseWildcardExtraPathItems,
+  serializeWildcardExtraPathItems,
+} from "./definition_data.js";
+
+/**
+ * @typedef {object} WildcardExtraPathsEditorDependencies
+ * @property {Document} document
+ * @property {(key: string) => string} text
+ * @property {(key: string, fallback: any) => any} readInternalSetting
+ * @property {(id: string, value: any, type?: string) => void} updateInternalSetting
+ */
+
+/**
+ * Own the wildcard path-list DOM while leaving global settings lookup and
+ * persistence with the caller.
+ *
+ * @param {WildcardExtraPathsEditorDependencies} dependencies
+ */
+export function createWildcardExtraPathsEditorFactory(dependencies) {
+  const {
+    document,
+    text,
+    readInternalSetting,
+    updateInternalSetting,
+  } = dependencies;
+
+  function wildcardExtraPathsSettingValue(value) {
+    return readInternalSetting("wildcard.extra_paths", value ?? "");
+  }
+
+  function createWildcardExtraPathsEditor(name, setter, value) {
+    const settingId = "EasyUseAnima.Wildcard.ExtraPaths";
+    let items = parseWildcardExtraPathItems(wildcardExtraPathsSettingValue(value));
+    if (!items.length) {
+      items = [""];
+    }
+
+    const row = document.createElement("tr");
+
+    const labelCell = document.createElement("td");
+    const labelEl = document.createElement("label");
+    labelEl.textContent = name;
+    labelEl.title = text("wildcardExtraPathsTip");
+    labelCell.append(labelEl);
+
+    const controlCell = document.createElement("td");
+    const wrapper = document.createElement("div");
+    wrapper.style.cssText = "display: flex; flex-direction: column; gap: 6px; min-width: 260px;";
+
+    const list = document.createElement("div");
+    list.style.cssText = "display: flex; flex-direction: column; gap: 6px;";
+
+    let persistedValue = serializeWildcardExtraPathItems(items);
+
+    const syncInternal = () => {
+      const serialized = serializeWildcardExtraPathItems(items);
+      updateInternalSetting(settingId, serialized, "text");
+    };
+
+    const persist = () => {
+      const serialized = serializeWildcardExtraPathItems(items);
+      updateInternalSetting(settingId, serialized, "text");
+      if (serialized === persistedValue) {
+        return;
+      }
+      persistedValue = serialized;
+      setter?.(serialized);
+    };
+
+    const render = () => {
+      list.replaceChildren();
+      if (!items.length) {
+        items = [""];
+      }
+
+      items.forEach((item, index) => {
+        const itemRow = document.createElement("div");
+        itemRow.style.cssText = "display: flex; align-items: center; gap: 6px; min-width: 0;";
+
+        const input = document.createElement("input");
+        input.type = "text";
+        input.value = item;
+        input.placeholder = text("wildcardExtraPathPlaceholder");
+        input.spellcheck = false;
+        input.style.cssText = "box-sizing: border-box; flex: 1 1 auto; min-width: 120px; padding: 4px 6px;";
+        input.addEventListener("input", () => {
+          items[index] = input.value;
+          syncInternal();
+        });
+        input.addEventListener("change", persist);
+        input.addEventListener("blur", persist);
+        input.addEventListener("keydown", (event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            input.blur();
+          }
+        });
+
+        const removeButton = document.createElement("button");
+        removeButton.type = "button";
+        removeButton.textContent = "x";
+        removeButton.title = text("removeWildcardPath");
+        removeButton.style.cssText = "width: 28px; min-width: 28px; height: 28px; padding: 0; cursor: pointer;";
+        removeButton.addEventListener("click", () => {
+          if (items.length <= 1) {
+            items[0] = "";
+          } else {
+            items.splice(index, 1);
+          }
+          persist();
+          render();
+        });
+
+        itemRow.append(input, removeButton);
+        list.append(itemRow);
+      });
+    };
+
+    const addButton = document.createElement("button");
+    addButton.type = "button";
+    addButton.textContent = "+";
+    addButton.title = text("addWildcardPath");
+    addButton.style.cssText = "align-self: flex-start; min-width: 32px; height: 28px; padding: 0 10px; cursor: pointer;";
+    addButton.addEventListener("click", () => {
+      items.push("");
+      render();
+      list.lastElementChild?.querySelector("input")?.focus();
+    });
+
+    render();
+    wrapper.append(list, addButton);
+    controlCell.append(wrapper);
+    row.append(labelCell, controlCell);
+    return row;
+  }
+
+  return createWildcardExtraPathsEditor;
+}


### PR DESCRIPTION
## 요약

- settings entry에 있던 wildcard 추가 경로 목록 편집기를 전용 모듈로 분리했습니다.
- 전역 설정 조회와 저장은 entry가 계속 소유하고, 새 모듈에는 DOM 렌더링과 기존 parser/serializer만 주입합니다.
- 내부값 우선순위, 최초 무저장, input/change/blur/Enter, 추가·삭제·포커스, setter 중복 방지 동작을 semantic smoke로 고정했습니다.

## 주요 파일

- `web/js/settings/wildcard_path_editor.js`
- `web/js/easyuse_anima_settings.js`
- `tests/frontend_settings_wildcard_path_editor_smoke.mjs`
- `tests/test_frontend_settings.py`
- `tools/check_frontend.ps1`

## 검증

- `node --check` (entry, 새 모듈, smoke): 통과
- `node tests/frontend_settings_wildcard_path_editor_smoke.mjs`: 통과
- `python -m unittest tests.test_frontend_settings -v`: 8 tests 통과
- `npx --yes --package "typescript@6.0.3" -- tsc -p jsconfig.json`: 통과
- official full runner: Python 353 tests, frontend 82 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과

## 테스트 표면

- ComfyUI Codex test instance: official project validation
- Legacy canvas / Node 2.0 browser smoke: 동작 보존 모듈 추출이므로 이 조각에서는 반복하지 않음
- Issue #57 완료 전 최종 양쪽 캔버스 매트릭스에서 wildcard 추가·삭제·저장·재열기를 확인할 예정
- Live ComfyUI smoke: not run

## 남은 위험

- production DOM, CSS, 이벤트 및 저장 순서는 기존 구현과 동일하게 이동했습니다.
- 사용자 실사용 환경의 수동 확인은 전체 유지보수 작업 완료 후 별도 진행합니다.

Refs #57

라벨 후보: `type: chore`, `area: frontend`, `status: ready`