### PR TITLE
refactor: settings persistence runtime 모듈 분리

### DIFF
--- a/tests/frontend_settings_runtime_smoke.mjs
+++ b/tests/frontend_settings_runtime_smoke.mjs
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const runtimeModule = await import(dataModule("../web/js/settings/runtime.js"));
+
+assert.deepEqual(Object.keys(runtimeModule), ["createSettingsRuntime"]);
+
+let state;
+const setStateCalls = [];
+const notifyCalls = [];
+const normalizeCalls = [];
+const initialCalls = [];
+const fetchCalls = [];
+const postCalls = [];
+
+let initialImplementation = async () => ({ source: "initial" });
+let fetchImplementation = async () => ({});
+let postImplementation = async () => ({});
+
+const internalKeys = {
+  "Known.Text": "known.text",
+  "Known.Boolean": "known.boolean",
+  "Known.Number": "known.number",
+};
+
+const runtime = runtimeModule.createSettingsRuntime({
+  getSettingsState: () => state,
+  setSettingsState(value) {
+    state = value;
+    setStateCalls.push(value);
+  },
+  notifySettingsUpdated(detail) {
+    notifyCalls.push(detail);
+  },
+  internalKeys,
+  normalizeValue(type, value) {
+    normalizeCalls.push({ type, value });
+    if (type === "boolean") {
+      return value ? "true" : "false";
+    }
+    return String(value ?? "");
+  },
+  fetchInitialSettings() {
+    initialCalls.push({});
+    return initialImplementation();
+  },
+  fetchJson(route, options) {
+    fetchCalls.push({ route, options });
+    return fetchImplementation(route, options);
+  },
+  postJson(route, body, options) {
+    postCalls.push({ route, body, options });
+    return postImplementation(route, body, options);
+  },
+});
+
+assert.deepEqual(Object.keys(runtime), [
+  "updateInternalSetting",
+  "readInternalSetting",
+  "loadLongTextSettings",
+  "saveLongTextSettings",
+  "loadInitialSettings",
+]);
+assert.equal(state, undefined, "Factory creation must not create state");
+assert.deepEqual(setStateCalls, []);
+assert.deepEqual(notifyCalls, []);
+assert.deepEqual(normalizeCalls, []);
+assert.deepEqual(initialCalls, []);
+assert.deepEqual(fetchCalls, []);
+assert.deepEqual(postCalls, []);
+
+assert.equal(runtime.readInternalSetting("missing", "fallback"), "fallback");
+assert.equal(state, undefined, "Read must not create state");
+
+state = Object.create({ inherited: "prototype value" });
+Object.assign(state, {
+  empty: "",
+  falseValue: false,
+  zero: 0,
+  nullValue: null,
+  undefinedValue: undefined,
+});
+assert.equal(runtime.readInternalSetting("empty", "fallback"), "");
+assert.equal(runtime.readInternalSetting("falseValue", "fallback"), false);
+assert.equal(runtime.readInternalSetting("zero", "fallback"), 0);
+assert.equal(runtime.readInternalSetting("nullValue", "fallback"), null);
+assert.equal(runtime.readInternalSetting("undefinedValue", "fallback"), undefined);
+assert.equal(runtime.readInternalSetting("inherited", "fallback"), "fallback");
+
+state = undefined;
+runtime.updateInternalSetting("Unknown", "ignored");
+assert.equal(state, undefined, "Unknown IDs must not create state");
+assert.deepEqual(normalizeCalls, []);
+assert.deepEqual(notifyCalls, []);
+
+runtime.updateInternalSetting("Known.Text", null);
+assert.deepEqual(normalizeCalls, [{ type: "text", value: null }]);
+assert.deepEqual(state, { "known.text": "" });
+assert.equal(setStateCalls.at(-1), state);
+assert.deepEqual(notifyCalls, [{ "known.text": "" }]);
+assert.notEqual(notifyCalls[0], state, "Notifications must use a state snapshot");
+
+runtime.updateInternalSetting("Known.Boolean", false, "boolean");
+assert.deepEqual(normalizeCalls.at(-1), { type: "boolean", value: false });
+assert.deepEqual(state, {
+  "known.text": "",
+  "known.boolean": "false",
+});
+assert.deepEqual(notifyCalls.at(-1), {
+  "known.text": "",
+  "known.boolean": "false",
+});
+assert.deepEqual(
+  notifyCalls[0],
+  { "known.text": "" },
+  "Later updates must not mutate prior notification details",
+);
+
+runtime.updateInternalSetting("Known.Number", 0, "number");
+assert.deepEqual(normalizeCalls.at(-1), { type: "number", value: 0 });
+assert.equal(state["known.number"], "0");
+const notifyCountBeforeRepeat = notifyCalls.length;
+runtime.updateInternalSetting("Known.Number", 0, "number");
+assert.equal(
+  notifyCalls.length,
+  notifyCountBeforeRepeat + 1,
+  "Known updates must notify even when the normalized value is unchanged",
+);
+
+state = { keep: "original", shared: "before" };
+fetchImplementation = async () => ({
+  settings: { shared: "settings", fromSettings: "yes" },
+  values: { shared: "values", fromValues: "yes" },
+});
+const notifyCountBeforeLoad = notifyCalls.length;
+const loaded = await runtime.loadLongTextSettings();
+assert.deepEqual(fetchCalls.at(-1), {
+  route: "/easyuse_anima/long_text_settings",
+  options: { fallbackJson: {} },
+});
+assert.deepEqual(state, {
+  keep: "original",
+  shared: "values",
+  fromSettings: "yes",
+  fromValues: "yes",
+});
+assert.deepEqual(loaded, state);
+assert.notEqual(loaded, state, "Long-text load must return a shallow clone");
+loaded.keep = "changed clone";
+assert.equal(state.keep, "original");
+assert.equal(notifyCalls.length, notifyCountBeforeLoad, "Long-text load must not notify");
+
+const stateBeforeLoadFailure = { ...state };
+const loadFailure = new Error("load failed");
+fetchImplementation = async () => {
+  throw loadFailure;
+};
+await assert.rejects(runtime.loadLongTextSettings(), (error) => error === loadFailure);
+assert.deepEqual(state, stateBeforeLoadFailure);
+assert.equal(notifyCalls.length, notifyCountBeforeLoad);
+
+const saveResponse = {
+  settings: { shared: "save settings", fromSaveSettings: "yes" },
+  values: { shared: "save values", fromSaveValues: "yes" },
+  marker: "raw response",
+};
+postImplementation = async () => saveResponse;
+const values = { field: "submitted" };
+const notifyCountBeforeSave = notifyCalls.length;
+const saved = await runtime.saveLongTextSettings(values);
+assert.deepEqual(postCalls.at(-1), {
+  route: "/easyuse_anima/long_text_settings/save",
+  body: { values },
+  options: { fallbackJson: {} },
+});
+assert.equal(saved, saveResponse, "Save must return the raw API response object");
+assert.equal(state.shared, "save values");
+assert.equal(state.fromSaveSettings, "yes");
+assert.equal(state.fromSaveValues, "yes");
+assert.equal(notifyCalls.length, notifyCountBeforeSave + 1);
+assert.deepEqual(notifyCalls.at(-1), state);
+assert.notEqual(notifyCalls.at(-1), state);
+
+const stateBeforeSaveFailure = { ...state };
+const saveFailure = new Error("save failed");
+postImplementation = async () => {
+  throw saveFailure;
+};
+await assert.rejects(
+  runtime.saveLongTextSettings({ field: "rejected" }),
+  (error) => error === saveFailure,
+);
+assert.deepEqual(state, stateBeforeSaveFailure);
+assert.equal(notifyCalls.length, notifyCountBeforeSave + 1);
+
+postImplementation = async () => ({});
+const notifyCountBeforeEmptySave = notifyCalls.length;
+const emptySave = await runtime.saveLongTextSettings({});
+assert.deepEqual(emptySave, {});
+assert.deepEqual(state, stateBeforeSaveFailure);
+assert.equal(
+  notifyCalls.length,
+  notifyCountBeforeEmptySave + 1,
+  "An empty fallback response must still preserve the existing save notification",
+);
+
+const stateBeforeInitialLoad = state;
+const notifyCountBeforeInitialLoad = notifyCalls.length;
+const initialResponse = { initial: "settings" };
+initialImplementation = async () => initialResponse;
+assert.equal(await runtime.loadInitialSettings(), initialResponse);
+assert.equal(state, stateBeforeInitialLoad, "Initial load must not assign host state itself");
+assert.equal(notifyCalls.length, notifyCountBeforeInitialLoad);
+
+initialImplementation = async () => {
+  throw new Error("initial failed");
+};
+assert.deepEqual(await runtime.loadInitialSettings(), {});
+assert.equal(state, stateBeforeInitialLoad);
+assert.equal(notifyCalls.length, notifyCountBeforeInitialLoad);
+assert.equal(initialCalls.length, 2);
+
+console.log("Settings runtime smoke passed.");

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -28,6 +28,8 @@ SETTINGS_RESOLUTION_EDITORS = (
 SETTINGS_RESOLUTION_EDITORS_SMOKE = (
     ROOT / "tests" / "frontend_settings_resolution_editors_smoke.mjs"
 )
+SETTINGS_RUNTIME = ROOT / "web" / "js" / "settings" / "runtime.js"
+SETTINGS_RUNTIME_SMOKE = ROOT / "tests" / "frontend_settings_runtime_smoke.mjs"
 SETTINGS_WILDCARD_PATH_EDITOR = (
     ROOT / "web" / "js" / "settings" / "wildcard_path_editor.js"
 )
@@ -39,6 +41,138 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class SettingsFrontendTests(unittest.TestCase):
+    def test_runtime_module_boundary(self):
+        module_source = SETTINGS_RUNTIME.read_text(encoding="utf-8")
+        entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createSettingsRuntime"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            r"\b(?:window|CustomEvent|app|registerExtension|document|localStorage)\b",
+        )
+
+        self.assertIn(
+            'import { createSettingsRuntime } from "./settings/runtime.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s*\{\s*"
+            r"updateInternalSetting\s*,\s*"
+            r"readInternalSetting\s*,\s*"
+            r"loadLongTextSettings\s*,\s*"
+            r"saveLongTextSettings\s*,\s*"
+            r"loadInitialSettings\s*,?\s*"
+            r"\}\s*=\s*createSettingsRuntime"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        self.assertEqual(
+            {
+                line.strip().rstrip(",")
+                for line in factory_match.group("dependencies").splitlines()
+                if line.strip()
+            },
+            {
+                "getSettingsState: () => window.__easyuseAnimaSettings",
+                "setSettingsState: (value) => {",
+                "window.__easyuseAnimaSettings = value;",
+                "}",
+                "notifySettingsUpdated: (detail) => {",
+                "window.dispatchEvent(",
+                'new CustomEvent("easyuse-anima-settings-updated", { detail })',
+                ");",
+                "internalKeys: INTERNAL_KEYS",
+                "normalizeValue",
+                "fetchInitialSettings: easyuseAnimaGetSettings",
+                "fetchJson: easyuseAnimaFetchJson",
+                "postJson: easyuseAnimaPostJson",
+            },
+        )
+
+        for moved_name in (
+            "updateInternalSetting",
+            "readInternalSetting",
+            "loadLongTextSettings",
+            "saveLongTextSettings",
+            "loadInitialSettings",
+        ):
+            with self.subTest(moved_name=moved_name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"(?:async\s+)?function\s+{re.escape(moved_name)}\b",
+                )
+                self.assertIn(moved_name, module_source)
+
+        for endpoint in (
+            '"/easyuse_anima/long_text_settings"',
+            '"/easyuse_anima/long_text_settings/save"',
+        ):
+            with self.subTest(endpoint=endpoint):
+                self.assertNotIn(endpoint, entry_source)
+                self.assertIn(endpoint, module_source)
+
+        self.assertIn(
+            'new CustomEvent("easyuse-anima-settings-updated", { detail })',
+            entry_source,
+        )
+        self.assertRegex(entry_source, r"function\s+addSettingsFallback\(")
+        self.assertEqual(entry_source.count("app.registerExtension("), 1)
+        setup_match = re.search(
+            r"app\.registerExtension\(\{.*?async\s+setup\(\)\s*\{"
+            r"(?P<body>.*?)\}\s*,?\s*\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(setup_match)
+        self.assertIn('name: "easyuse-anima.settings"', setup_match.group(0))
+        self.assertIn(
+            "settings: EASYUSE_ANIMA_SETTINGS",
+            setup_match.group(0),
+        )
+        self.assertRegex(
+            setup_match.group("body"),
+            r"window\.__easyuseAnimaSettings\s*=\s*await\s+loadInitialSettings\(\);"
+            r"\s*addSettingsFallback\(\);",
+        )
+        self.assertTrue(SETTINGS_RUNTIME_SMOKE.is_file())
+        self.assertIn("web/js/settings/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_settings_runtime_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_runtime_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(SETTINGS_RUNTIME_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_color_editor_module_boundary(self):
         module_source = SETTINGS_COLOR_EDITOR.read_text(encoding="utf-8")
         entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
@@ -135,8 +269,6 @@ class SettingsFrontendTests(unittest.TestCase):
         )
         self.assertRegex(entry_source, r"function\s+label\(")
         self.assertRegex(entry_source, r"function\s+tip\(")
-        self.assertRegex(entry_source, r"function\s+readInternalSetting\(")
-        self.assertRegex(entry_source, r"function\s+updateInternalSetting\(")
         self.assertTrue(SETTINGS_COLOR_EDITOR_SMOKE.is_file())
         self.assertIn("web/js/settings/**/*.js", config["include"])
         self.assertIn(
@@ -245,8 +377,6 @@ class SettingsFrontendTests(unittest.TestCase):
             "render: createWildcardExtraPathsEditor,",
             setting_match.group("body"),
         )
-        self.assertRegex(entry_source, r"function\s+readInternalSetting\(")
-        self.assertRegex(entry_source, r"function\s+updateInternalSetting\(")
         self.assertTrue(SETTINGS_WILDCARD_PATH_EDITOR_SMOKE.is_file())
         self.assertIn("web/js/settings/**/*.js", config["include"])
         self.assertIn(
@@ -374,19 +504,6 @@ class SettingsFrontendTests(unittest.TestCase):
                     setting_match.group("body"),
                 )
 
-        self.assertIn(
-            """function readInternalSetting(key, fallback) {
-  if (
-    window.__easyuseAnimaSettings
-    && Object.prototype.hasOwnProperty.call(window.__easyuseAnimaSettings, key)
-  ) {
-    return window.__easyuseAnimaSettings[key];
-  }
-  return fallback;
-}""",
-            entry_source,
-        )
-        self.assertRegex(entry_source, r"function\s+updateInternalSetting\(")
         self.assertIn("window.__easyuseAnimaSettings", entry_source)
         self.assertTrue(SETTINGS_RESOLUTION_EDITORS_SMOKE.is_file())
         self.assertIn("web/js/settings/**/*.js", config["include"])
@@ -483,10 +600,6 @@ class SettingsFrontendTests(unittest.TestCase):
         self.assertIn("easyuse-anima-long-text-overlay", module_source)
         self.assertIn("easyuse-anima-long-text-panel", module_source)
 
-        self.assertIn("async function loadLongTextSettings()", entry_source)
-        self.assertIn("async function saveLongTextSettings(values)", entry_source)
-        self.assertIn('"/easyuse_anima/long_text_settings"', entry_source)
-        self.assertIn('"/easyuse_anima/long_text_settings/save"', entry_source)
         self.assertIn("window.__easyuseAnimaSettings", entry_source)
         self.assertIn('new CustomEvent("easyuse-anima-settings-updated"', entry_source)
 
@@ -595,12 +708,8 @@ class SettingsFrontendTests(unittest.TestCase):
         )
 
         for adapter in (
-            "updateInternalSetting",
-            "loadLongTextSettings",
-            "saveLongTextSettings",
             "setting",
             "customSetting",
-            "loadInitialSettings",
             "addSettingsFallback",
         ):
             with self.subTest(entry_adapter=adapter):

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -139,6 +139,11 @@ try {
         throw "Frontend settings color editor smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_settings_runtime_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend settings runtime smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_settings_definition_data_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend settings definition data smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -15,6 +15,7 @@ import {
 import { createPromptStudioColorEditorButtonFactory } from "./settings/color_editor.js";
 import { createLongTextEditorButtonFactory } from "./settings/long_text_editor.js";
 import { createResolutionEditors } from "./settings/resolution_editors.js";
+import { createSettingsRuntime } from "./settings/runtime.js";
 import { createWildcardExtraPathsEditorFactory } from "./settings/wildcard_path_editor.js";
 
 
@@ -521,50 +522,28 @@ function tip(item) {
   return easyuseAnimaLocaleText(item?.tip);
 }
 
-
-function updateInternalSetting(id, value, type = "text") {
-  const internalKey = INTERNAL_KEYS[id];
-  if (!internalKey) {
-    return;
-  }
-  window.__easyuseAnimaSettings ||= {};
-  window.__easyuseAnimaSettings[internalKey] = normalizeValue(type, value);
-  window.dispatchEvent(
-    new CustomEvent("easyuse-anima-settings-updated", {
-      detail: { ...window.__easyuseAnimaSettings },
-    }),
-  );
-}
-
-function readInternalSetting(key, fallback) {
-  if (
-    window.__easyuseAnimaSettings
-    && Object.prototype.hasOwnProperty.call(window.__easyuseAnimaSettings, key)
-  ) {
-    return window.__easyuseAnimaSettings[key];
-  }
-  return fallback;
-}
-
-async function loadLongTextSettings() {
-  const data = await easyuseAnimaFetchJson("/easyuse_anima/long_text_settings", { fallbackJson: {} });
-  const values = data.values || {};
-  window.__easyuseAnimaSettings ||= {};
-  Object.assign(window.__easyuseAnimaSettings, data.settings || {}, values);
-  return { ...window.__easyuseAnimaSettings };
-}
-
-async function saveLongTextSettings(values) {
-  const data = await easyuseAnimaPostJson("/easyuse_anima/long_text_settings/save", { values }, { fallbackJson: {} });
-  window.__easyuseAnimaSettings ||= {};
-  Object.assign(window.__easyuseAnimaSettings, data.settings || {}, data.values || {});
-  window.dispatchEvent(
-    new CustomEvent("easyuse-anima-settings-updated", {
-      detail: { ...window.__easyuseAnimaSettings },
-    }),
-  );
-  return data;
-}
+const {
+  updateInternalSetting,
+  readInternalSetting,
+  loadLongTextSettings,
+  saveLongTextSettings,
+  loadInitialSettings,
+} = createSettingsRuntime({
+  getSettingsState: () => window.__easyuseAnimaSettings,
+  setSettingsState: (value) => {
+    window.__easyuseAnimaSettings = value;
+  },
+  notifySettingsUpdated: (detail) => {
+    window.dispatchEvent(
+      new CustomEvent("easyuse-anima-settings-updated", { detail }),
+    );
+  },
+  internalKeys: INTERNAL_KEYS,
+  normalizeValue,
+  fetchInitialSettings: easyuseAnimaGetSettings,
+  fetchJson: easyuseAnimaFetchJson,
+  postJson: easyuseAnimaPostJson,
+});
 
 const createLongTextEditorButton = createLongTextEditorButtonFactory({
   document,
@@ -979,14 +958,6 @@ const EASYUSE_ANIMA_SETTINGS = [
     }),
   ),
 ];
-
-async function loadInitialSettings() {
-  try {
-    return await easyuseAnimaGetSettings();
-  } catch {
-    return {};
-  }
-}
 
 function addSettingsFallback() {
   const addSetting = app?.ui?.settings?.addSetting;

--- a/web/js/settings/runtime.js
+++ b/web/js/settings/runtime.js
@@ -1,0 +1,99 @@
+// @ts-check
+
+/** @typedef {Record<string, any>} SettingsState */
+
+/**
+ * @typedef {object} SettingsRuntimeDependencies
+ * @property {() => SettingsState | null | undefined} getSettingsState
+ * @property {(value: any) => void} setSettingsState
+ * @property {(detail: SettingsState) => void} notifySettingsUpdated
+ * @property {Record<string, string>} internalKeys
+ * @property {(type: string, value: any) => string} normalizeValue
+ * @property {() => Promise<any>} fetchInitialSettings
+ * @property {(route: string, options?: object) => Promise<any>} fetchJson
+ * @property {(route: string, body: object, options?: object) => Promise<any>} postJson
+ */
+
+/**
+ * Own settings state normalization, persistence, and initial loading while
+ * leaving browser globals and ComfyUI registration with the caller.
+ *
+ * @param {SettingsRuntimeDependencies} dependencies
+ */
+export function createSettingsRuntime(dependencies) {
+  const {
+    getSettingsState,
+    setSettingsState,
+    notifySettingsUpdated,
+    internalKeys,
+    normalizeValue,
+    fetchInitialSettings,
+    fetchJson,
+    postJson,
+  } = dependencies;
+
+  function ensureSettingsState() {
+    let state = getSettingsState();
+    if (!state) {
+      state = {};
+      setSettingsState(state);
+    }
+    return state;
+  }
+
+  function updateInternalSetting(id, value, type = "text") {
+    const internalKey = internalKeys[id];
+    if (!internalKey) {
+      return;
+    }
+    const state = ensureSettingsState();
+    state[internalKey] = normalizeValue(type, value);
+    notifySettingsUpdated({ ...state });
+  }
+
+  function readInternalSetting(key, fallback) {
+    const state = getSettingsState();
+    if (state && Object.prototype.hasOwnProperty.call(state, key)) {
+      return state[key];
+    }
+    return fallback;
+  }
+
+  async function loadLongTextSettings() {
+    const data = await fetchJson("/easyuse_anima/long_text_settings", {
+      fallbackJson: {},
+    });
+    const values = data.values || {};
+    const state = ensureSettingsState();
+    Object.assign(state, data.settings || {}, values);
+    return { ...state };
+  }
+
+  async function saveLongTextSettings(values) {
+    const data = await postJson(
+      "/easyuse_anima/long_text_settings/save",
+      { values },
+      { fallbackJson: {} },
+    );
+    const state = ensureSettingsState();
+    Object.assign(state, data.settings || {}, data.values || {});
+    notifySettingsUpdated({ ...state });
+    return data;
+  }
+
+  async function loadInitialSettings() {
+    try {
+      return await fetchInitialSettings();
+    } catch {
+      return {};
+    }
+  }
+
+  return {
+    updateInternalSetting,
+    readInternalSetting,
+    loadLongTextSettings,
+    saveLongTextSettings,
+    loadInitialSettings,
+  };
+}


### PR DESCRIPTION
## 변경 요약

- settings 상태 읽기·쓰기와 초기 로드 API 흐름을 `settings/runtime.js`의 주입 가능한 runtime factory로 분리했습니다.
- ComfyUI extension 등록과 `app.ui.settings.addSetting` 호출은 entry 모듈에 유지해 import 시 side effect가 생기지 않도록 했습니다.
- 상태 생성, 정규화, 알림, GET/POST 병합 및 오류 전파 계약을 semantic smoke와 Python 경계 테스트로 고정했습니다.

## 주요 파일

- `web/js/settings/runtime.js`
- `web/js/easyuse_anima_settings.js`
- `tests/frontend_settings_runtime_smoke.mjs`
- `tests/test_frontend_settings.py`
- `tools/check_frontend.ps1`

## 검증

- focused Python settings tests: 12 tests, OK
- settings runtime semantic smoke: PASS
- TypeScript 6.0.3: PASS
- official full runner: Python 357 tests, frontend 84 JavaScript files, PASS
- `git diff --check`: PASS
- ComfyUI browser smoke: 미실행 — 사용자 동작을 바꾸지 않는 persistence runtime 추출이며, Issue #57 마지막 UI/hardening 조각에서 legacy canvas와 Node 2.0을 각각 검증합니다.
- Live ComfyUI smoke: not run

## 남은 범위와 위험

- settings definitions 분리와 상속 프로퍼티 이름을 color key로 허용하지 않는 hardening은 다음 작은 조각에서 처리합니다.
- 사용자 v0.27.0 인스턴스 반영 및 수동 확인은 #54–#57 전체 완료 후 한 번 수행합니다.

Refs #57

라벨 후보: `type: chore`, `area: frontend`, `status: ready`