### PR TITLE
test(settings): share fake DOM harness

### DIFF
--- a/tests/frontend_settings_color_editor_smoke.mjs
+++ b/tests/frontend_settings_color_editor_smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createFakeDocument, descendants } from "./frontend_support/fake_dom.mjs";
 
 function dataModule(relativePath) {
   const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -13,124 +14,6 @@ const colorEditorModule = await import(
 assert.deepEqual(Object.keys(colorEditorModule), [
   "createPromptStudioColorEditorButtonFactory",
 ]);
-
-class FakeElement {
-  constructor(tagName) {
-    this.tagName = String(tagName).toUpperCase();
-    this.children = [];
-    this.parentElement = null;
-    this.style = { cssText: "", background: "", borderColor: "" };
-    this.listeners = new Map();
-    this.attributes = new Map();
-    this.className = "";
-    this.textContent = "";
-    this.type = "";
-    this.value = "";
-    this.removed = false;
-    this.onclick = null;
-  }
-
-  append(...children) {
-    for (const child of children) {
-      child.parentElement = this;
-      this.children.push(child);
-    }
-  }
-
-  replaceChildren(...children) {
-    for (const child of this.children) {
-      child.parentElement = null;
-    }
-    this.children = [];
-    this.append(...children);
-  }
-
-  setAttribute(name, value) {
-    this.attributes.set(name, String(value));
-  }
-
-  getAttribute(name) {
-    return this.attributes.get(name) ?? null;
-  }
-
-  addEventListener(type, handler) {
-    const handlers = this.listeners.get(type) || [];
-    handlers.push(handler);
-    this.listeners.set(type, handlers);
-  }
-
-  emit(type, event = {}) {
-    const nextEvent = {
-      target: this,
-      propagationStopped: false,
-      stopPropagation() {
-        this.propagationStopped = true;
-      },
-      ...event,
-    };
-    for (const handler of this.listeners.get(type) || []) {
-      handler(nextEvent);
-    }
-    return nextEvent;
-  }
-
-  remove() {
-    if (this.parentElement) {
-      const index = this.parentElement.children.indexOf(this);
-      if (index >= 0) {
-        this.parentElement.children.splice(index, 1);
-      }
-    }
-    this.parentElement = null;
-    this.removed = true;
-  }
-}
-
-class FakeDocument {
-  constructor() {
-    this.body = new FakeElement("body");
-    this.createdElements = [];
-    this.listeners = new Map();
-  }
-
-  createElement(tagName) {
-    const element = new FakeElement(tagName);
-    this.createdElements.push(element);
-    return element;
-  }
-
-  addEventListener(type, handler, capture = false) {
-    const entries = this.listeners.get(type) || [];
-    entries.push({ handler, capture });
-    this.listeners.set(type, entries);
-  }
-
-  removeEventListener(type, handler, capture = false) {
-    const entries = this.listeners.get(type) || [];
-    this.listeners.set(
-      type,
-      entries.filter((entry) => entry.handler !== handler || entry.capture !== capture),
-    );
-  }
-
-  dispatchKey(key) {
-    for (const entry of [...(this.listeners.get("keydown") || [])]) {
-      entry.handler({ key });
-    }
-  }
-
-  listenerCount(type) {
-    return (this.listeners.get(type) || []).length;
-  }
-}
-
-function descendants(root) {
-  const values = [];
-  for (const child of root.children) {
-    values.push(child, ...descendants(child));
-  }
-  return values;
-}
 
 function findAll(root, predicate) {
   return [root, ...descendants(root)].filter(predicate);
@@ -224,7 +107,7 @@ const SYNTAX_LABELS = [
 ];
 const SYNTAX_DEFAULTS = ["#cbd5e1", "#22d3ee", "#c084fc", "#9ca3af"];
 
-const document = new FakeDocument();
+const document = createFakeDocument();
 const internalValues = new Map([
   ["prompt_studio.colors", '{"quality":"#000000"}'],
 ]);

--- a/tests/frontend_settings_long_text_editor_smoke.mjs
+++ b/tests/frontend_settings_long_text_editor_smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createFakeDocument, descendants } from "./frontend_support/fake_dom.mjs";
 
 function dataModule(relativePath) {
   const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -16,119 +17,6 @@ const definitionData = await import(
 assert.deepEqual(Object.keys(longTextEditorModule), [
   "createLongTextEditorButtonFactory",
 ]);
-
-class FakeElement {
-  constructor(tagName) {
-    this.tagName = String(tagName).toUpperCase();
-    this.children = [];
-    this.parentElement = null;
-    this.style = { cssText: "" };
-    this.listeners = new Map();
-    this.className = "";
-    this.textContent = "";
-    this.type = "";
-    this.value = "";
-    this.rows = 0;
-    this.spellcheck = true;
-    this.disabled = false;
-    this.focused = false;
-    this.removed = false;
-    this.onclick = null;
-  }
-
-  append(...children) {
-    for (const child of children) {
-      child.parentElement = this;
-      this.children.push(child);
-    }
-  }
-
-  prepend(...children) {
-    for (const child of [...children].reverse()) {
-      child.parentElement = this;
-      this.children.unshift(child);
-    }
-  }
-
-  addEventListener(type, handler) {
-    const handlers = this.listeners.get(type) || [];
-    handlers.push(handler);
-    this.listeners.set(type, handlers);
-  }
-
-  emit(type, event = {}) {
-    const nextEvent = {
-      target: this,
-      stopPropagation() {},
-      ...event,
-    };
-    for (const handler of this.listeners.get(type) || []) {
-      handler(nextEvent);
-    }
-    return nextEvent;
-  }
-
-  focus() {
-    this.focused = true;
-  }
-
-  remove() {
-    if (this.parentElement) {
-      const index = this.parentElement.children.indexOf(this);
-      if (index >= 0) {
-        this.parentElement.children.splice(index, 1);
-      }
-    }
-    this.parentElement = null;
-    this.removed = true;
-  }
-}
-
-class FakeDocument {
-  constructor() {
-    this.body = new FakeElement("body");
-    this.createdElements = [];
-    this.listeners = new Map();
-  }
-
-  createElement(tagName) {
-    const element = new FakeElement(tagName);
-    this.createdElements.push(element);
-    return element;
-  }
-
-  addEventListener(type, handler, capture = false) {
-    const entries = this.listeners.get(type) || [];
-    entries.push({ handler, capture });
-    this.listeners.set(type, entries);
-  }
-
-  removeEventListener(type, handler, capture = false) {
-    const entries = this.listeners.get(type) || [];
-    this.listeners.set(
-      type,
-      entries.filter((entry) => entry.handler !== handler || entry.capture !== capture),
-    );
-  }
-
-  dispatchKey(key) {
-    for (const entry of [...(this.listeners.get("keydown") || [])]) {
-      entry.handler({ key });
-    }
-  }
-
-  listenerCount(type) {
-    return (this.listeners.get(type) || []).length;
-  }
-}
-
-function descendants(root) {
-  const values = [];
-  for (const child of root.children) {
-    values.push(child, ...descendants(child));
-  }
-  return values;
-}
 
 function findOne(root, predicate, message) {
   const found = [root, ...descendants(root)].find(predicate);
@@ -188,7 +76,7 @@ const TEXT = {
   autoHide: "Auto hide",
 };
 
-const document = new FakeDocument();
+const document = createFakeDocument();
 const loadCalls = [];
 const saveCalls = [];
 const scheduled = [];

--- a/tests/frontend_settings_resolution_editors_smoke.mjs
+++ b/tests/frontend_settings_resolution_editors_smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createFakeDocument, descendants } from "./frontend_support/fake_dom.mjs";
 
 function dataModule(relativePath, replacements = {}) {
   let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -17,94 +18,6 @@ const resolutionEditorsModule = await import(
 );
 
 assert.deepEqual(Object.keys(resolutionEditorsModule), ["createResolutionEditors"]);
-
-class FakeElement {
-  constructor(tagName) {
-    this.tagName = String(tagName).toUpperCase();
-    this.children = [];
-    this.parentElement = null;
-    this.style = { cssText: "" };
-    this.listeners = new Map();
-    this.attributes = new Map();
-    this.textContent = "";
-    this.title = "";
-    this.type = "";
-    this.inputMode = "";
-    this.value = "";
-    this.placeholder = "";
-    this.spellcheck = true;
-    this.selected = false;
-    this.focused = false;
-  }
-
-  append(...children) {
-    for (const child of children) {
-      child.parentElement = this;
-      this.children.push(child);
-      if (this.tagName === "SELECT" && child.tagName === "OPTION" && child.selected) {
-        this.value = child.value;
-      }
-    }
-  }
-
-  setAttribute(name, value) {
-    this.attributes.set(name, String(value));
-  }
-
-  getAttribute(name) {
-    return this.attributes.get(name) ?? null;
-  }
-
-  addEventListener(type, handler) {
-    const handlers = this.listeners.get(type) || [];
-    handlers.push(handler);
-    this.listeners.set(type, handlers);
-  }
-
-  emit(type, event = {}) {
-    const nextEvent = {
-      target: this,
-      defaultPrevented: false,
-      preventDefault() {
-        this.defaultPrevented = true;
-      },
-      ...event,
-    };
-    for (const handler of this.listeners.get(type) || []) {
-      handler(nextEvent);
-    }
-    return nextEvent;
-  }
-
-  focus() {
-    this.focused = true;
-  }
-
-  blur() {
-    this.focused = false;
-    this.emit("blur");
-  }
-}
-
-class FakeDocument {
-  constructor() {
-    this.createdElements = [];
-  }
-
-  createElement(tagName) {
-    const element = new FakeElement(tagName);
-    this.createdElements.push(element);
-    return element;
-  }
-}
-
-function descendants(root) {
-  const values = [];
-  for (const child of root.children) {
-    values.push(child, ...descendants(child));
-  }
-  return values;
-}
 
 function findAll(root, tagName) {
   return [root, ...descendants(root)].filter(
@@ -125,7 +38,7 @@ const TEXT = {
   naiaResolutionScaleTip: "Scale help",
 };
 
-const document = new FakeDocument();
+const document = createFakeDocument();
 const internalValues = new Map([
   ["naia.resolution_mode", "bucket_fit"],
   ["naia.resolution_scale", "1,75"],
@@ -239,7 +152,7 @@ assert.ok(
   "Every internal update must preserve the text setting type",
 );
 
-const fallbackDocument = new FakeDocument();
+const fallbackDocument = createFakeDocument();
 const fallbackEditors = resolutionEditorsModule.createResolutionEditors({
   document: fallbackDocument,
   text: (key) => TEXT[key] ?? key,

--- a/tests/frontend_settings_wildcard_path_editor_smoke.mjs
+++ b/tests/frontend_settings_wildcard_path_editor_smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createFakeDocument, descendants } from "./frontend_support/fake_dom.mjs";
 
 function dataModule(relativePath, replacements = {}) {
   let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -20,102 +21,6 @@ assert.deepEqual(
   Object.keys(wildcardPathEditorModule),
   ["createWildcardExtraPathsEditorFactory"],
 );
-
-class FakeElement {
-  constructor(tagName) {
-    this.tagName = String(tagName).toUpperCase();
-    this.children = [];
-    this.parentElement = null;
-    this.style = { cssText: "" };
-    this.listeners = new Map();
-    this.attributes = new Map();
-    this.textContent = "";
-    this.title = "";
-    this.type = "";
-    this.value = "";
-    this.placeholder = "";
-    this.spellcheck = true;
-    this.focused = false;
-  }
-
-  append(...children) {
-    for (const child of children) {
-      child.parentElement = this;
-      this.children.push(child);
-    }
-  }
-
-  replaceChildren(...children) {
-    for (const child of this.children) {
-      child.parentElement = null;
-    }
-    this.children = [];
-    this.append(...children);
-  }
-
-  get lastElementChild() {
-    return this.children.at(-1) ?? null;
-  }
-
-  setAttribute(name, value) {
-    this.attributes.set(name, String(value));
-  }
-
-  addEventListener(type, handler) {
-    const handlers = this.listeners.get(type) || [];
-    handlers.push(handler);
-    this.listeners.set(type, handlers);
-  }
-
-  emit(type, event = {}) {
-    const nextEvent = {
-      target: this,
-      defaultPrevented: false,
-      preventDefault() {
-        this.defaultPrevented = true;
-      },
-      ...event,
-    };
-    for (const handler of this.listeners.get(type) || []) {
-      handler(nextEvent);
-    }
-    return nextEvent;
-  }
-
-  querySelector(selector) {
-    const expectedTag = String(selector).toUpperCase();
-    return descendants(this).find((element) => element.tagName === expectedTag) ?? null;
-  }
-
-  focus() {
-    this.focused = true;
-  }
-
-  blur() {
-    this.focused = false;
-    this.emit("blur");
-  }
-}
-
-class FakeDocument {
-  constructor() {
-    this.createdElements = [];
-  }
-
-  createElement(tagName) {
-    const element = new FakeElement(tagName);
-    this.createdElements.push(element);
-    return element;
-  }
-}
-
-function descendants(root) {
-  const values = [];
-  for (const child of root.children) {
-    values.push(child, ...descendants(child));
-  }
-  return values;
-}
 
 function findAll(root, tagName) {
   return [root, ...descendants(root)].filter(
@@ -140,7 +45,7 @@ const TEXT = {
   addWildcardPath: "Add path",
 };
 
-const document = new FakeDocument();
+const document = createFakeDocument();
 const internalValues = new Map([
   ["wildcard.extra_paths", '  first path  \r\n"second path"'],
 ]);
@@ -265,7 +170,7 @@ assert.ok(
   "Every internal update must preserve the text setting type",
 );
 
-const fallbackDocument = new FakeDocument();
+const fallbackDocument = createFakeDocument();
 const fallbackEditor = wildcardPathEditorModule.createWildcardExtraPathsEditorFactory({
   document: fallbackDocument,
   text: (key) => TEXT[key] ?? key,
@@ -281,7 +186,7 @@ const emptyRow = fallbackEditor("Paths", null, undefined);
 assert.deepEqual(findAll(emptyRow, "INPUT").map((input) => input.value), [""]);
 
 const emptyInternalEditor = wildcardPathEditorModule.createWildcardExtraPathsEditorFactory({
-  document: new FakeDocument(),
+  document: createFakeDocument(),
   text: (key) => TEXT[key] ?? key,
   readInternalSetting: () => "",
   updateInternalSetting() {},

--- a/tests/frontend_support/fake_dom.mjs
+++ b/tests/frontend_support/fake_dom.mjs
@@ -1,0 +1,161 @@
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this.style = { cssText: "", background: "", borderColor: "" };
+    this.listeners = new Map();
+    this.attributes = new Map();
+    this.className = "";
+    this.textContent = "";
+    this.title = "";
+    this.type = "";
+    this.inputMode = "";
+    this.value = "";
+    this.placeholder = "";
+    this.rows = 0;
+    this.spellcheck = true;
+    this.disabled = false;
+    this.selected = false;
+    this.focused = false;
+    this.removed = false;
+    this.onclick = null;
+  }
+
+  append(...children) {
+    for (const child of children) {
+      child.parentElement = this;
+      this.children.push(child);
+      if (this.tagName === "SELECT" && child.tagName === "OPTION" && child.selected) {
+        this.value = child.value;
+      }
+    }
+  }
+
+  prepend(...children) {
+    for (const child of [...children].reverse()) {
+      child.parentElement = this;
+      this.children.unshift(child);
+    }
+  }
+
+  replaceChildren(...children) {
+    for (const child of this.children) {
+      child.parentElement = null;
+    }
+    this.children = [];
+    this.append(...children);
+  }
+
+  get lastElementChild() {
+    return this.children.at(-1) ?? null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) || [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  emit(type, event = {}) {
+    const nextEvent = {
+      target: this,
+      defaultPrevented: false,
+      propagationStopped: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+      stopPropagation() {
+        this.propagationStopped = true;
+      },
+      ...event,
+    };
+    for (const handler of this.listeners.get(type) || []) {
+      handler(nextEvent);
+    }
+    return nextEvent;
+  }
+
+  querySelector(selector) {
+    const expectedTag = String(selector).toUpperCase();
+    return descendants(this).find((element) => element.tagName === expectedTag) ?? null;
+  }
+
+  focus() {
+    this.focused = true;
+  }
+
+  blur() {
+    this.focused = false;
+    this.emit("blur");
+  }
+
+  remove() {
+    if (this.parentElement) {
+      const index = this.parentElement.children.indexOf(this);
+      if (index >= 0) {
+        this.parentElement.children.splice(index, 1);
+      }
+    }
+    this.parentElement = null;
+    this.removed = true;
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.body = new FakeElement("body");
+    this.createdElements = [];
+    this.listeners = new Map();
+  }
+
+  createElement(tagName) {
+    const element = new FakeElement(tagName);
+    this.createdElements.push(element);
+    return element;
+  }
+
+  addEventListener(type, handler, capture = false) {
+    const entries = this.listeners.get(type) || [];
+    entries.push({ handler, capture });
+    this.listeners.set(type, entries);
+  }
+
+  removeEventListener(type, handler, capture = false) {
+    const entries = this.listeners.get(type) || [];
+    this.listeners.set(
+      type,
+      entries.filter((entry) => entry.handler !== handler || entry.capture !== capture),
+    );
+  }
+
+  dispatchKey(key) {
+    for (const entry of [...(this.listeners.get("keydown") || [])]) {
+      entry.handler({ key });
+    }
+  }
+
+  listenerCount(type) {
+    return (this.listeners.get(type) || []).length;
+  }
+}
+
+export function createFakeDocument() {
+  return new FakeDocument();
+}
+
+export function descendants(root) {
+  const values = [];
+  for (const child of root.children) {
+    values.push(child, ...descendants(child));
+  }
+  return values;
+}

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -40,11 +40,46 @@ SETTINGS_WILDCARD_PATH_EDITOR = (
 SETTINGS_WILDCARD_PATH_EDITOR_SMOKE = (
     ROOT / "tests" / "frontend_settings_wildcard_path_editor_smoke.mjs"
 )
+SETTINGS_FAKE_DOM_HARNESS = ROOT / "tests" / "frontend_support" / "fake_dom.mjs"
+SETTINGS_EDITOR_SMOKES = (
+    SETTINGS_COLOR_EDITOR_SMOKE,
+    SETTINGS_LONG_TEXT_EDITOR_SMOKE,
+    SETTINGS_RESOLUTION_EDITORS_SMOKE,
+    SETTINGS_WILDCARD_PATH_EDITOR_SMOKE,
+)
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class SettingsFrontendTests(unittest.TestCase):
+    def test_editor_smokes_share_fake_dom_harness(self):
+        harness_source = SETTINGS_FAKE_DOM_HARNESS.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:class|function)\s+([A-Za-z0-9_]+)",
+                harness_source,
+                re.MULTILINE,
+            ),
+            ["createFakeDocument", "descendants"],
+        )
+
+        for smoke_path in SETTINGS_EDITOR_SMOKES:
+            with self.subTest(smoke=smoke_path.name):
+                smoke_source = smoke_path.read_text(encoding="utf-8")
+                self.assertIn(
+                    'from "./frontend_support/fake_dom.mjs";',
+                    smoke_source,
+                )
+                self.assertNotRegex(
+                    smoke_source,
+                    re.compile(
+                        r"^(?:class\s+Fake(?:Element|Document)|"
+                        r"function\s+descendants)\b",
+                        re.MULTILINE,
+                    ),
+                )
+
     def test_runtime_module_boundary(self):
         module_source = SETTINGS_RUNTIME.read_text(encoding="utf-8")
         entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")


### PR DESCRIPTION
## 변경 요약

- settings editor semantic smoke 4개에 반복되던 Fake DOM 구현을 `tests/frontend_support/fake_dom.mjs`로 통합했습니다.
- helper는 `createFakeDocument()`와 tree traversal만 공개하고, FakeElement/FakeDocument 구현은 내부에 유지합니다.
- long-text의 첫 일치 semantics와 color/resolution/wildcard의 정확히 1개 semantics는 각 테스트에 그대로 남겼습니다.
- Python boundary test가 네 consumer의 공용 import와 로컬 Fake DOM 재정의 금지를 고정합니다.
- production 코드와 frontend runner 목록은 변경하지 않았습니다.

## 주요 파일

- `tests/frontend_support/fake_dom.mjs`
- `tests/frontend_settings_long_text_editor_smoke.mjs`
- `tests/frontend_settings_resolution_editors_smoke.mjs`
- `tests/frontend_settings_wildcard_path_editor_smoke.mjs`
- `tests/frontend_settings_color_editor_smoke.mjs`
- `tests/test_frontend_settings.py`

## 검증

- helper `node --check`: 통과
- settings editor semantic smoke 4개: 통과
- focused `test_frontend_settings.py`: 15 tests 통과
- 동작 보존/테스트 강도 감사: blocker, P2, P3 없음
- 공식 full runner: Python unittest **360 tests** 통과
- frontend runner: **85 JavaScript files**, TypeScript 6.0.3 통과
- `git diff --check`: 통과
- Legacy canvas / Node 2.0 browser smoke: 미실행 — production과 UI 동작을 바꾸지 않은 test-only infrastructure 조각
- ComfyUI v0.27.0 user instance manual browser check: not run
- Live ComfyUI smoke: not run

## 호환성과 후속 범위

- 기존 네 smoke의 event, select value, focus/blur, querySelector, remove, capture listener 계약을 동일하게 유지했습니다.
- AiO 계열 Fake DOM은 classList/isConnected/trace 등 별도 계약이 있어 이번 조각에 포함하지 않았습니다.
- 반복 가능한 legacy/Node 2.0 browser matrix 절차는 별도 후속 조각에서 정리합니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`

Follow-up to #57