### PR TITLE
refactor: extract AiO profile settings runtime

### DIFF
--- a/tests/frontend_aio_profile_api_client_smoke.mjs
+++ b/tests/frontend_aio_profile_api_client_smoke.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const apiClientModule = await import(dataModule("../web/js/aio/profile_api_client.js"));
+
+assert.deepEqual(
+  Object.keys(apiClientModule),
+  ["createAioProfileApiClient"],
+  "AiO profile API client must expose only its factory contract",
+);
+
+const calls = [];
+const responses = [];
+const encodedValues = [];
+
+async function fetchJson(url, options) {
+  calls.push({
+    url,
+    options,
+    argumentCount: arguments.length,
+  });
+  const response = responses.shift();
+  if (response instanceof Error) {
+    throw response;
+  }
+  return response;
+}
+
+function encodeURIComponent(value) {
+  encodedValues.push(value);
+  return `encoded:${value.length}`;
+}
+
+const client = apiClientModule.createAioProfileApiClient({
+  fetchJson,
+  encodeURIComponent,
+});
+
+assert.deepEqual(Object.keys(client).sort(), [
+  "deleteProfile",
+  "listProfiles",
+  "loadProfile",
+  "renameProfile",
+  "saveProfile",
+]);
+assert.equal(calls.length, 0, "factory creation must not make a request");
+assert.equal(encodedValues.length, 0, "factory creation must not encode a name");
+
+const profilesResponse = { profiles: [{ name: "Portrait" }] };
+responses.push(profilesResponse);
+assert.equal(await client.listProfiles(), profilesResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/aio_profiles",
+  options: undefined,
+  argumentCount: 1,
+});
+
+const loadName = "set /?#[] !'()* 初音";
+const loadResponse = { profile: { name: loadName, settings: { sampler: { steps: 20 } } } };
+responses.push(loadResponse);
+assert.equal(await client.loadProfile(loadName), loadResponse);
+assert.deepEqual(encodedValues, [loadName]);
+assert.deepEqual(calls.at(-1), {
+  url: `/easyuse_anima/aio_profiles/load?name=encoded:${loadName.length}`,
+  options: undefined,
+  argumentCount: 1,
+});
+
+const settings = {
+  schema_version: 4,
+  sampler: { steps: 28 },
+  future: { keep: true },
+};
+const settingsBefore = JSON.stringify(settings);
+const saveResponse = { profile: { name: "Portrait" } };
+responses.push(saveResponse);
+assert.equal(await client.saveProfile("Portrait", true, settings), saveResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/aio_profiles/save",
+  options: {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: "Portrait",
+      overwrite: true,
+      settings,
+    }),
+  },
+  argumentCount: 2,
+});
+assert.equal(JSON.stringify(settings), settingsBefore, "save must not mutate settings");
+
+const renameResponse = { profile: { name: "Portrait 2" } };
+responses.push(renameResponse);
+assert.equal(await client.renameProfile("Portrait", "Portrait 2", false), renameResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/aio_profiles/rename",
+  options: {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      old_name: "Portrait",
+      new_name: "Portrait 2",
+      overwrite: false,
+    }),
+  },
+  argumentCount: 2,
+});
+
+const deleteResponse = { profile: { name: "Portrait 2" } };
+responses.push(deleteResponse);
+assert.equal(await client.deleteProfile("Portrait 2"), deleteResponse);
+assert.deepEqual(calls.at(-1), {
+  url: "/easyuse_anima/aio_profiles/delete",
+  options: {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Portrait 2" }),
+  },
+  argumentCount: 2,
+});
+
+const requestError = new Error("backend unavailable");
+responses.push(requestError);
+await assert.rejects(
+  client.listProfiles(),
+  (error) => error === requestError,
+  "transport errors must propagate without UI fallback",
+);
+
+assert.equal(responses.length, 0);
+console.log("AiO profile API client smoke passed.");

--- a/tests/frontend_aio_profile_settings_runtime_smoke.mjs
+++ b/tests/frontend_aio_profile_settings_runtime_smoke.mjs
@@ -1,0 +1,830 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+class FakeClassList {
+  constructor() {
+    this.values = new Set();
+  }
+
+  add(...names) {
+    for (const name of names) {
+      this.values.add(name);
+    }
+  }
+
+  contains(name) {
+    return this.values.has(name);
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.className = "";
+    this.classList = new FakeClassList();
+    this.textContent = "";
+    this.value = "";
+    this.title = "";
+    this.type = "";
+    this.label = "";
+    this.disabled = false;
+    this.isConnected = true;
+    this.children = [];
+    this.parentElement = null;
+    this.listeners = new Map();
+    this.removeCount = 0;
+  }
+
+  append(...children) {
+    for (const child of children) {
+      if (child && typeof child === "object") {
+        child.parentElement = this;
+      }
+      this.children.push(child);
+    }
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  async dispatch(type) {
+    const results = [];
+    for (const listener of [...(this.listeners.get(type) || [])]) {
+      results.push(listener({ target: this }));
+    }
+    await Promise.all(results);
+  }
+
+  remove() {
+    this.removeCount += 1;
+    this.isConnected = false;
+  }
+}
+
+const runtimeModule = await import(dataModule("../web/js/aio/profile_settings_runtime.js"));
+assert.deepEqual(
+  Object.keys(runtimeModule),
+  ["aioCreateProfileSettingsRuntime"],
+  "AiO profile settings runtime must expose only its factory contract",
+);
+
+function createFixture() {
+  let dependencyCalls = 0;
+  let currentDialog = null;
+  const dialogs = [];
+  const alerts = [];
+  const promptCalls = [];
+  const confirmCalls = [];
+  const resolveCalls = [];
+  const prompts = [];
+  const confirms = [];
+  const trace = [];
+  const apiCalls = {
+    listProfiles: [],
+    loadProfile: [],
+    saveProfile: [],
+    renameProfile: [],
+    deleteProfile: [],
+  };
+  const apiQueues = {
+    listProfiles: [],
+    loadProfile: [],
+    saveProfile: [],
+    renameProfile: [],
+    deleteProfile: [],
+  };
+
+  function queuedResult(method, args) {
+    dependencyCalls += 1;
+    apiCalls[method].push(args);
+    const value = apiQueues[method].shift();
+    if (value instanceof Error) {
+      return Promise.reject(value);
+    }
+    if (value && typeof value.then === "function") {
+      return value;
+    }
+    return Promise.resolve(value);
+  }
+
+  const profileApi = {
+    listProfiles() {
+      return queuedResult("listProfiles", []);
+    },
+    loadProfile(name) {
+      return queuedResult("loadProfile", [name]);
+    },
+    saveProfile(name, overwrite, settings) {
+      return queuedResult("saveProfile", [name, overwrite, clone(settings)]);
+    },
+    renameProfile(oldName, newName, overwrite) {
+      return queuedResult("renameProfile", [oldName, newName, overwrite]);
+    },
+    deleteProfile(name) {
+      return queuedResult("deleteProfile", [name]);
+    },
+  };
+
+  const fakeDocument = {
+    createElement(tagName) {
+      dependencyCalls += 1;
+      return new FakeElement(tagName);
+    },
+  };
+
+  function createDialog(title, subtitle) {
+    dependencyCalls += 1;
+    const dialog = {
+      title,
+      subtitle,
+      backdrop: new FakeElement("div"),
+      body: new FakeElement("div"),
+      actions: new FakeElement("div"),
+      controls: new Map(),
+      tooltips: new Map(),
+    };
+    dialogs.push(dialog);
+    currentDialog = dialog;
+    return dialog;
+  }
+
+  function field(section, label, control, tooltipKey = "") {
+    dependencyCalls += 1;
+    const wrapper = new FakeElement("div");
+    wrapper.append(control);
+    section.append(wrapper);
+    currentDialog.controls.set(label, control);
+    currentDialog.tooltips.set(label, tooltipKey);
+    return control;
+  }
+
+  function text(key) {
+    dependencyCalls += 1;
+    return `text:${key}`;
+  }
+
+  function format(key, values = {}) {
+    dependencyCalls += 1;
+    return `format:${key}:${JSON.stringify(values)}`;
+  }
+
+  const profileCore = {
+    customValue: "custom",
+    builtinIds() {
+      dependencyCalls += 1;
+      return ["normal", "turbo", "optimized"];
+    },
+    builtinSettings(profileId, defaultSettings) {
+      dependencyCalls += 1;
+      trace.push("builtin-settings");
+      return { ...clone(defaultSettings), builtin_profile: profileId };
+    },
+    fingerprint(settings) {
+      dependencyCalls += 1;
+      trace.push("fingerprint");
+      return `fingerprint:${JSON.stringify(settings)}`;
+    },
+    userValue(name) {
+      dependencyCalls += 1;
+      return `user:${String(name || "")}`;
+    },
+    userName(value) {
+      dependencyCalls += 1;
+      const textValue = String(value || "");
+      return textValue.startsWith("user:") ? textValue.slice(5) : "";
+    },
+    findUser(profiles, name) {
+      dependencyCalls += 1;
+      const expected = String(name || "").toLowerCase();
+      return profiles.find((profile) => String(profile?.name || "").toLowerCase() === expected) || null;
+    },
+    resolveValue(options) {
+      dependencyCalls += 1;
+      trace.push("resolve");
+      resolveCalls.push({
+        settings: clone(options.settings),
+        defaultSettings: clone(options.defaultSettings),
+        selectedValue: options.selectedValue,
+        selectedFingerprint: options.selectedFingerprint,
+        profiles: clone(options.profiles),
+        customValue: options.customValue,
+      });
+      const selected = String(options.selectedValue || "");
+      if (selected.startsWith("builtin:")) {
+        return selected;
+      }
+      if (
+        selected.startsWith("user:")
+        && options.profiles.some((profile) => (
+          `user:${String(profile.name || "")}`.toLowerCase() === selected.toLowerCase()
+        ))
+      ) {
+        return selected;
+      }
+      return options.customValue;
+    },
+  };
+
+  const defaultSettings = {
+    schema_version: 4,
+    sampler: { steps: 20 },
+    future_default: { keep: true },
+  };
+  const settingsCore = {
+    defaultSettings,
+    mergeDefaults(defaults, current) {
+      dependencyCalls += 1;
+      trace.push("merge");
+      return { ...clone(defaults), ...clone(current) };
+    },
+    migratePostprocess(settings) {
+      dependencyCalls += 1;
+      trace.push("migrate");
+      return { ...settings, migrated: true };
+    },
+  };
+
+  const nodeAdapter = {
+    getSettings(node) {
+      dependencyCalls += 1;
+      trace.push("get-settings");
+      return node.settings;
+    },
+    applyVisibleSettings(node, settings) {
+      dependencyCalls += 1;
+      trace.push("visible");
+      node.visibleSettings = clone(settings);
+    },
+    writeSettings(node, settings, markDirty) {
+      dependencyCalls += 1;
+      trace.push(`write:${markDirty}`);
+      node.settings = clone(settings);
+    },
+    renderPanel(node) {
+      dependencyCalls += 1;
+      trace.push("render");
+      node.renderCount = (node.renderCount || 0) + 1;
+    },
+    refreshPanels() {
+      dependencyCalls += 1;
+      trace.push("refresh-panels");
+    },
+    markDirty(node) {
+      dependencyCalls += 1;
+      trace.push("dirty");
+      node.dirtyCount = (node.dirtyCount || 0) + 1;
+    },
+  };
+
+  const dialogsAdapter = {
+    prompt(message, defaultValue = "") {
+      dependencyCalls += 1;
+      trace.push("prompt");
+      promptCalls.push({ message, defaultValue });
+      return prompts.shift();
+    },
+    alert(message) {
+      dependencyCalls += 1;
+      trace.push("alert");
+      alerts.push(message);
+    },
+    confirm(message) {
+      dependencyCalls += 1;
+      trace.push("confirm");
+      confirmCalls.push(message);
+      return confirms.shift();
+    },
+  };
+
+  const runtime = runtimeModule.aioCreateProfileSettingsRuntime({
+    document: fakeDocument,
+    createDialog,
+    field,
+    text,
+    format,
+    dialogs: dialogsAdapter,
+    profileApi,
+    profileCore,
+    settingsCore,
+    nodeAdapter,
+  });
+
+  return {
+    runtime,
+    apiCalls,
+    apiQueues,
+    dialogs,
+    alerts,
+    prompts,
+    confirms,
+    promptCalls,
+    confirmCalls,
+    resolveCalls,
+    trace,
+    defaultSettings,
+    dependencyCalls: () => dependencyCalls,
+  };
+}
+
+function dialogButtons(dialog) {
+  const section = dialog.body.children[0];
+  const managerActions = section.children.at(-1);
+  return {
+    select: dialog.controls.get("Profile"),
+    save: managerActions.children[0],
+    rename: managerActions.children[1],
+    delete: managerActions.children[2],
+    cancel: dialog.actions.children[0],
+    apply: dialog.actions.children[1],
+  };
+}
+
+function profileOptions(select) {
+  return select.children.map((child) => ({
+    tagName: child.tagName,
+    label: child.label,
+    value: child.value,
+    textContent: child.textContent,
+    options: child.children.map((option) => ({
+      value: option.value,
+      textContent: option.textContent,
+    })),
+  }));
+}
+
+function userProfileOptions(dialog) {
+  const userGroup = profileOptions(dialogButtons(dialog).select).find(
+    (entry) => entry.label === "text:profile.groupUser",
+  );
+  return userGroup?.options || [];
+}
+
+const fixture = createFixture();
+assert.deepEqual(Object.keys(fixture.runtime).sort(), [
+  "displayLabel",
+  "loadProfiles",
+  "open",
+  "syncValue",
+]);
+assert.equal(fixture.dependencyCalls(), 0, "factory creation must have no side effects");
+
+const firstList = deferred();
+fixture.apiQueues.listProfiles.push(firstList.promise);
+const firstLoad = fixture.runtime.loadProfiles();
+const concurrentLoad = fixture.runtime.loadProfiles();
+const forcedConcurrentLoad = fixture.runtime.loadProfiles({ force: true });
+assert.equal(fixture.apiCalls.listProfiles.length, 1, "concurrent loads must share one request");
+firstList.resolve({
+  profiles: [
+    { name: "Portrait", modified: 1 },
+    { name: "  " },
+    { name: "Landscape", modified: 2 },
+  ],
+});
+assert.deepEqual(await firstLoad, [
+  { name: "Portrait", modified: 1 },
+  { name: "Landscape", modified: 2 },
+]);
+assert.deepEqual(await concurrentLoad, await firstLoad);
+assert.deepEqual(await forcedConcurrentLoad, await firstLoad);
+assert.deepEqual(await fixture.runtime.loadProfiles(), await firstLoad);
+assert.equal(fixture.apiCalls.listProfiles.length, 1, "loaded cache must avoid another request");
+
+fixture.apiQueues.listProfiles.push({ profiles: [{ name: "Refreshed" }] });
+assert.deepEqual(await fixture.runtime.loadProfiles({ force: true }), [{ name: "Refreshed" }]);
+assert.equal(fixture.apiCalls.listProfiles.length, 2);
+
+const retryFixture = createFixture();
+const listError = new Error("list failed");
+retryFixture.apiQueues.listProfiles.push(listError, { profiles: [{ name: "Recovered" }] });
+await assert.rejects(
+  retryFixture.runtime.loadProfiles(),
+  (error) => error === listError,
+  "list failure must propagate",
+);
+assert.deepEqual(await retryFixture.runtime.loadProfiles(), [{ name: "Recovered" }]);
+assert.equal(retryFixture.apiCalls.listProfiles.length, 2, "failed loads must release the retry gate");
+
+fixture.apiQueues.listProfiles.push({
+  profiles: [{ name: "Portrait" }, { name: "Landscape" }],
+});
+await fixture.runtime.loadProfiles({ force: true });
+
+const node = {
+  settings: { sampler: { steps: 31 }, current: true },
+  __easyuseAnimaGeneratorProfileValue: "custom",
+  __easyuseAnimaGeneratorProfileFingerprint: "stale",
+};
+fixture.runtime.open(node);
+let dialog = fixture.dialogs.at(-1);
+let buttons = dialogButtons(dialog);
+assert.deepEqual(fixture.resolveCalls.at(-1), {
+  settings: { sampler: { steps: 31 }, current: true },
+  defaultSettings: fixture.defaultSettings,
+  selectedValue: "custom",
+  selectedFingerprint: "stale",
+  profiles: [{ name: "Portrait" }, { name: "Landscape" }],
+  customValue: "custom",
+});
+assert.equal(dialog.title, "text:dialog.profile.title");
+assert.equal(dialog.subtitle, "text:dialog.profile.subtitle");
+assert.equal(dialog.body.classList.contains("easyuse-anima-aio-one-column"), true);
+assert.equal(dialog.tooltips.get("Profile"), "profile.selectTip");
+assert.equal(buttons.select.title, "text:profile.selectTip");
+assert.deepEqual(profileOptions(buttons.select), [
+  {
+    tagName: "OPTION",
+    label: "",
+    value: "custom",
+    textContent: "text:profile.custom",
+    options: [],
+  },
+  {
+    tagName: "OPTGROUP",
+    label: "text:profile.groupBuiltIn",
+    value: "",
+    textContent: "",
+    options: [
+      { value: "builtin:normal", textContent: "text:profile.normal" },
+      { value: "builtin:turbo", textContent: "text:profile.turbo" },
+      { value: "builtin:optimized", textContent: "text:profile.optimized" },
+    ],
+  },
+  {
+    tagName: "OPTGROUP",
+    label: "text:profile.groupUser",
+    value: "",
+    textContent: "",
+    options: [
+      { value: "user:Portrait", textContent: "Portrait" },
+      { value: "user:Landscape", textContent: "Landscape" },
+    ],
+  },
+]);
+assert.equal(buttons.select.value, "custom");
+assert.equal(buttons.save.disabled, false);
+assert.equal(buttons.rename.disabled, true);
+assert.equal(buttons.delete.disabled, true);
+assert.equal(buttons.cancel.disabled, false);
+assert.equal(buttons.apply.disabled, true);
+
+buttons.select.value = "user:Portrait";
+await buttons.select.dispatch("change");
+assert.equal(buttons.rename.disabled, false);
+assert.equal(buttons.delete.disabled, false);
+assert.equal(buttons.apply.disabled, false);
+buttons.select.value = "builtin:normal";
+await buttons.select.dispatch("change");
+assert.equal(buttons.rename.disabled, true);
+assert.equal(buttons.delete.disabled, true);
+assert.equal(buttons.apply.disabled, false);
+
+const dialogsBeforeCancel = fixture.dialogs.length;
+await buttons.cancel.dispatch("click");
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(fixture.dialogs.length, dialogsBeforeCancel, "Cancel must not reopen the dialog");
+
+fixture.runtime.open(node);
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+buttons.select.value = "builtin:normal";
+fixture.trace.length = 0;
+await buttons.apply.dispatch("click");
+assert.deepEqual(fixture.trace, [
+  "builtin-settings",
+  "merge",
+  "migrate",
+  "visible",
+  "write:true",
+  "get-settings",
+  "fingerprint",
+  "render",
+  "dirty",
+]);
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(node.__easyuseAnimaGeneratorProfileValue, "builtin:normal");
+assert.equal(node.settings.builtin_profile, "normal");
+assert.equal(node.settings.migrated, true);
+assert.equal(node.renderCount, 1);
+assert.equal(node.dirtyCount, 1);
+assert.equal(fixture.apiCalls.loadProfile.length, 0, "built-in apply must remain local");
+
+fixture.runtime.open(node);
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+buttons.select.value = "user:Portrait";
+fixture.apiQueues.loadProfile.push({
+  profile: { name: "Portrait Canonical", settings: { sampler: { steps: 44 }, user: true } },
+});
+await buttons.apply.dispatch("click");
+assert.deepEqual(fixture.apiCalls.loadProfile.at(-1), ["Portrait"]);
+assert.equal(node.__easyuseAnimaGeneratorProfileValue, "user:Portrait Canonical");
+assert.equal(node.settings.user, true);
+assert.equal(dialog.backdrop.isConnected, false);
+
+node.__easyuseAnimaGeneratorProfileValue = "user:Portrait";
+fixture.runtime.open(node);
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+buttons.select.value = "user:Portrait";
+fixture.apiQueues.loadProfile.push({ profile: null });
+const dialogsBeforeLoadError = fixture.dialogs.length;
+await buttons.apply.dispatch("click");
+assert.equal(dialog.backdrop.isConnected, true, "failed apply must keep the dialog open");
+assert.equal(fixture.dialogs.length, dialogsBeforeLoadError);
+assert.match(fixture.alerts.at(-1), /profile\.requestFailed/);
+assert.match(fixture.alerts.at(-1), /Profile settings are missing/);
+assert.equal(buttons.save.disabled, false);
+assert.equal(buttons.cancel.disabled, false);
+assert.equal(buttons.apply.disabled, false);
+
+const saveNode = {
+  settings: { sampler: { steps: 55 }, save_snapshot: true },
+  __easyuseAnimaGeneratorProfileValue: "user:Portrait",
+  __easyuseAnimaGeneratorProfileFingerprint: "old-fingerprint",
+};
+fixture.runtime.open(saveNode);
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+fixture.prompts.push(" Landscape ");
+fixture.confirms.push(true);
+fixture.apiQueues.saveProfile.push({ profile: { name: "Landscape" } });
+fixture.apiQueues.listProfiles.push({ profiles: [{ name: "Landscape" }, { name: "Portrait" }] });
+const dialogsBeforeSave = fixture.dialogs.length;
+const listCallsBeforeSave = fixture.apiCalls.listProfiles.length;
+fixture.trace.length = 0;
+await buttons.save.dispatch("click");
+assert.deepEqual(fixture.promptCalls.at(-1), {
+  message: "text:profile.savePrompt",
+  defaultValue: "Portrait",
+});
+assert.match(fixture.confirmCalls.at(-1), /Landscape/);
+assert.deepEqual(fixture.apiCalls.saveProfile.at(-1), [
+  "Landscape",
+  true,
+  { sampler: { steps: 55 }, save_snapshot: true },
+]);
+assert.equal(saveNode.__easyuseAnimaGeneratorProfileValue, "user:Landscape");
+assert.match(saveNode.__easyuseAnimaGeneratorProfileFingerprint, /^fingerprint:/);
+assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeSave + 1);
+assert.equal(fixture.trace.includes("refresh-panels"), true);
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(fixture.dialogs.length, dialogsBeforeSave + 1, "successful save must reopen");
+const reopenedAfterSave = fixture.dialogs.at(-1);
+assert.equal(reopenedAfterSave.backdrop.isConnected, true);
+assert.deepEqual(userProfileOptions(reopenedAfterSave), [
+  { value: "user:Landscape", textContent: "Landscape" },
+  { value: "user:Portrait", textContent: "Portrait" },
+]);
+
+dialog = reopenedAfterSave;
+buttons = dialogButtons(dialog);
+fixture.prompts.push(null);
+const saveCallsBeforePromptCancel = fixture.apiCalls.saveProfile.length;
+const dialogsBeforePromptCancel = fixture.dialogs.length;
+await buttons.save.dispatch("click");
+assert.equal(fixture.apiCalls.saveProfile.length, saveCallsBeforePromptCancel);
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(
+  fixture.dialogs.length,
+  dialogsBeforePromptCancel + 1,
+  "prompt cancel is currently treated as a successful CRUD callback and reopens",
+);
+
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+fixture.prompts.push("   ");
+const dialogsBeforeBlankName = fixture.dialogs.length;
+await buttons.save.dispatch("click");
+assert.equal(fixture.alerts.at(-1), "text:profile.nameRequired");
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(fixture.dialogs.length, dialogsBeforeBlankName + 1);
+
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+buttons.select.value = "user:Landscape";
+await buttons.select.dispatch("change");
+fixture.prompts.push("Portrait");
+fixture.confirms.push(false);
+const renameCallsBeforeDecline = fixture.apiCalls.renameProfile.length;
+const dialogsBeforeRenameDecline = fixture.dialogs.length;
+await buttons.rename.dispatch("click");
+assert.equal(fixture.apiCalls.renameProfile.length, renameCallsBeforeDecline);
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(fixture.dialogs.length, dialogsBeforeRenameDecline + 1);
+
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+buttons.select.value = "user:Landscape";
+await buttons.select.dispatch("change");
+saveNode.__easyuseAnimaGeneratorProfileValue = "user:Landscape";
+fixture.prompts.push("Cinematic");
+fixture.apiQueues.renameProfile.push({ profile: { name: "Cinematic" } });
+fixture.apiQueues.listProfiles.push({ profiles: [{ name: "Portrait" }, { name: "Cinematic" }] });
+const dialogsBeforeRename = fixture.dialogs.length;
+const listCallsBeforeRename = fixture.apiCalls.listProfiles.length;
+fixture.trace.length = 0;
+await buttons.rename.dispatch("click");
+assert.ok(
+  fixture.trace.indexOf("resolve") < fixture.trace.indexOf("prompt"),
+  "rename must sync the current selection before prompting",
+);
+assert.deepEqual(fixture.apiCalls.renameProfile.at(-1), ["Landscape", "Cinematic", false]);
+assert.equal(saveNode.__easyuseAnimaGeneratorProfileValue, "user:Cinematic");
+assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeRename + 1);
+assert.equal(fixture.trace.includes("refresh-panels"), true);
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(fixture.dialogs.length, dialogsBeforeRename + 1);
+const reopenedAfterRename = fixture.dialogs.at(-1);
+assert.equal(reopenedAfterRename.backdrop.isConnected, true);
+assert.deepEqual(userProfileOptions(reopenedAfterRename), [
+  { value: "user:Portrait", textContent: "Portrait" },
+  { value: "user:Cinematic", textContent: "Cinematic" },
+]);
+
+dialog = reopenedAfterRename;
+buttons = dialogButtons(dialog);
+buttons.select.value = "user:Cinematic";
+await buttons.select.dispatch("change");
+fixture.confirms.push(false);
+const deleteCallsBeforeDecline = fixture.apiCalls.deleteProfile.length;
+const dialogsBeforeDeleteDecline = fixture.dialogs.length;
+await buttons.delete.dispatch("click");
+assert.equal(fixture.apiCalls.deleteProfile.length, deleteCallsBeforeDecline);
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(fixture.dialogs.length, dialogsBeforeDeleteDecline + 1);
+
+dialog = fixture.dialogs.at(-1);
+buttons = dialogButtons(dialog);
+buttons.select.value = "user:Cinematic";
+await buttons.select.dispatch("change");
+saveNode.__easyuseAnimaGeneratorProfileValue = "user:Cinematic";
+saveNode.__easyuseAnimaGeneratorProfileFingerprint = "delete-me";
+fixture.confirms.push(true);
+fixture.apiQueues.deleteProfile.push({ profile: { name: "Cinematic" } });
+fixture.apiQueues.listProfiles.push({ profiles: [{ name: "Portrait" }] });
+const dialogsBeforeDelete = fixture.dialogs.length;
+const listCallsBeforeDelete = fixture.apiCalls.listProfiles.length;
+fixture.trace.length = 0;
+await buttons.delete.dispatch("click");
+assert.deepEqual(fixture.apiCalls.deleteProfile.at(-1), ["Cinematic"]);
+assert.equal(saveNode.__easyuseAnimaGeneratorProfileValue, "custom");
+assert.equal(Object.hasOwn(saveNode, "__easyuseAnimaGeneratorProfileFingerprint"), false);
+assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeDelete + 1);
+assert.equal(fixture.trace.includes("refresh-panels"), true);
+assert.equal(dialog.backdrop.isConnected, false);
+assert.equal(fixture.dialogs.length, dialogsBeforeDelete + 1);
+const reopenedAfterDelete = fixture.dialogs.at(-1);
+assert.equal(reopenedAfterDelete.backdrop.isConnected, true);
+assert.deepEqual(userProfileOptions(reopenedAfterDelete), [
+  { value: "user:Portrait", textContent: "Portrait" },
+]);
+
+dialog = reopenedAfterDelete;
+buttons = dialogButtons(dialog);
+buttons.select.value = "user:Portrait";
+await buttons.select.dispatch("change");
+assert.equal(buttons.rename.disabled, false);
+assert.equal(buttons.delete.disabled, false);
+assert.equal(buttons.apply.disabled, false);
+fixture.prompts.push("Busy Save", "must-not-run");
+const saveDeferred = deferred();
+fixture.apiQueues.saveProfile.push(saveDeferred.promise);
+fixture.apiQueues.listProfiles.push({ profiles: [{ name: "Portrait" }, { name: "Busy Save" }] });
+const saveCallCountBeforeBusy = fixture.apiCalls.saveProfile.length;
+const promptCallCountBeforeBusy = fixture.promptCalls.length;
+const pendingSave = buttons.save.dispatch("click");
+await Promise.resolve();
+assert.equal(buttons.save.disabled, true);
+assert.equal(buttons.cancel.disabled, true);
+assert.equal(buttons.rename.disabled, true);
+assert.equal(buttons.delete.disabled, true);
+assert.equal(buttons.apply.disabled, true);
+const ignoredSave = buttons.save.dispatch("click");
+await Promise.resolve();
+assert.equal(fixture.apiCalls.saveProfile.length, saveCallCountBeforeBusy + 1);
+assert.equal(fixture.promptCalls.length, promptCallCountBeforeBusy + 1);
+dialog.backdrop.remove();
+saveDeferred.resolve({ profile: { name: "Busy Save" } });
+await Promise.all([pendingSave, ignoredSave]);
+assert.equal(
+  fixture.dialogs.at(-1) === dialog,
+  false,
+  "successful CRUD must reopen even if the original backdrop closed while busy",
+);
+const reopenedAfterBusySave = fixture.dialogs.at(-1);
+assert.equal(reopenedAfterBusySave.backdrop.isConnected, true);
+assert.deepEqual(userProfileOptions(reopenedAfterBusySave), [
+  { value: "user:Portrait", textContent: "Portrait" },
+  { value: "user:Busy Save", textContent: "Busy Save" },
+]);
+assert.equal(fixture.prompts.shift(), "must-not-run");
+
+dialog = reopenedAfterBusySave;
+buttons = dialogButtons(dialog);
+fixture.prompts.push("Failure");
+const saveError = new Error("save failed");
+fixture.apiQueues.saveProfile.push(saveError);
+const dialogsBeforeSaveError = fixture.dialogs.length;
+await buttons.save.dispatch("click");
+assert.equal(dialog.backdrop.isConnected, true, "failed CRUD must retain its dialog");
+assert.equal(fixture.dialogs.length, dialogsBeforeSaveError);
+assert.match(fixture.alerts.at(-1), /save failed/);
+assert.equal(buttons.save.disabled, false);
+assert.equal(buttons.cancel.disabled, false);
+
+fixture.prompts.push("Refresh Failure");
+fixture.apiQueues.saveProfile.push({ profile: { name: "Refresh Failure" } });
+const refreshError = new Error("refresh failed");
+fixture.apiQueues.listProfiles.push(refreshError);
+const dialogsBeforeRefreshError = fixture.dialogs.length;
+const listCallsBeforeRefreshError = fixture.apiCalls.listProfiles.length;
+await buttons.save.dispatch("click");
+assert.deepEqual(fixture.apiCalls.saveProfile.at(-1), [
+  "Refresh Failure",
+  false,
+  { sampler: { steps: 55 }, save_snapshot: true },
+]);
+assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeRefreshError + 1);
+assert.equal(dialog.backdrop.isConnected, true, "refresh failure must retain its dialog");
+assert.equal(fixture.dialogs.length, dialogsBeforeRefreshError);
+assert.match(fixture.alerts.at(-1), /refresh failed/);
+assert.equal(buttons.save.disabled, false);
+assert.equal(buttons.cancel.disabled, false);
+fixture.apiQueues.listProfiles.push({ profiles: [{ name: "Recovered After Refresh" }] });
+assert.deepEqual(await fixture.runtime.loadProfiles({ force: true }), [
+  { name: "Recovered After Refresh" },
+]);
+
+const preserveFixture = createFixture();
+preserveFixture.apiQueues.listProfiles.push({
+  profiles: [{ name: "Current" }, { name: "Managed" }],
+});
+await preserveFixture.runtime.loadProfiles();
+const preserveNode = {
+  settings: { sampler: { steps: 42 } },
+  __easyuseAnimaGeneratorProfileValue: "user:Current",
+  __easyuseAnimaGeneratorProfileFingerprint: "keep-fingerprint",
+};
+preserveFixture.runtime.open(preserveNode);
+let preserveDialog = preserveFixture.dialogs.at(-1);
+let preserveButtons = dialogButtons(preserveDialog);
+preserveButtons.select.value = "user:Managed";
+await preserveButtons.select.dispatch("change");
+preserveFixture.prompts.push("Managed Renamed");
+preserveFixture.apiQueues.renameProfile.push({ profile: { name: "Managed Renamed" } });
+preserveFixture.apiQueues.listProfiles.push({
+  profiles: [{ name: "Current" }, { name: "Managed Renamed" }],
+});
+await preserveButtons.rename.dispatch("click");
+assert.equal(preserveNode.__easyuseAnimaGeneratorProfileValue, "user:Current");
+assert.equal(preserveNode.__easyuseAnimaGeneratorProfileFingerprint, "keep-fingerprint");
+
+preserveDialog = preserveFixture.dialogs.at(-1);
+preserveButtons = dialogButtons(preserveDialog);
+preserveButtons.select.value = "user:Managed Renamed";
+await preserveButtons.select.dispatch("change");
+preserveFixture.confirms.push(true);
+preserveFixture.apiQueues.deleteProfile.push({ profile: { name: "Managed Renamed" } });
+preserveFixture.apiQueues.listProfiles.push({ profiles: [{ name: "Current" }] });
+await preserveButtons.delete.dispatch("click");
+assert.equal(preserveNode.__easyuseAnimaGeneratorProfileValue, "user:Current");
+assert.equal(preserveNode.__easyuseAnimaGeneratorProfileFingerprint, "keep-fingerprint");
+
+assert.equal(fixture.runtime.displayLabel("custom"), "text:profile.custom");
+assert.equal(fixture.runtime.displayLabel("user:Portrait"), "Portrait");
+assert.equal(fixture.runtime.displayLabel("builtin:turbo"), "text:profile.turbo");
+assert.equal(fixture.runtime.displayLabel("builtin:unknown"), "text:profile.custom");
+
+const transientNode = {
+  settings: { keep: true },
+  __easyuseAnimaGeneratorProfileValue: "user:Missing",
+  __easyuseAnimaGeneratorProfileFingerprint: "remove-me",
+};
+assert.equal(fixture.runtime.syncValue(transientNode), "custom");
+assert.equal(transientNode.__easyuseAnimaGeneratorProfileValue, "custom");
+assert.equal(Object.hasOwn(transientNode, "__easyuseAnimaGeneratorProfileFingerprint"), false);
+
+console.log("AiO profile settings runtime smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -9,6 +9,12 @@ AIO_JS = ROOT / "web" / "js" / "easyuse_anima_aio.js"
 AIO_POSTPROCESS_SETTINGS_DIALOG_JS = (
     ROOT / "web" / "js" / "aio" / "postprocess_settings_dialog.js"
 )
+AIO_PROFILE_API_CLIENT_JS = (
+    ROOT / "web" / "js" / "aio" / "profile_api_client.js"
+)
+AIO_PROFILE_SETTINGS_RUNTIME_JS = (
+    ROOT / "web" / "js" / "aio" / "profile_settings_runtime.js"
+)
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
@@ -30,24 +36,13 @@ class AIOFrontendSourceTests(unittest.TestCase):
     def test_generator_profile_ui_uses_versioned_settings_and_user_storage_api(self):
         source = AIO_JS.read_text(encoding="utf-8")
         presets_source = AIO_PRESETS_JS.read_text(encoding="utf-8")
+        api_client_source = AIO_PROFILE_API_CLIENT_JS.read_text(encoding="utf-8")
         render_start = source.index("function renderGeneratorPanel")
         render_end = source.index("\nfunction ensureGeneratorPanel", render_start)
         render_body = source[render_start:render_end]
         header_start = render_body.index("const samplerHeader = makeCardHeader")
         header_end = render_body.index("const settingsScroll", header_start)
         header_body = render_body[header_start:header_end]
-        dialog_start = source.index("function openGeneratorProfileSettings")
-        dialog_end = source.index("\nfunction findWidget", dialog_start)
-        dialog_body = source[dialog_start:dialog_end]
-        apply_start = source.index("function applyGeneratorProfileSettings")
-        apply_end = source.index("\nasync function applyGeneratorProfile", apply_start)
-        apply_body = source[apply_start:apply_end]
-        lookup_start = source.index("function generatorUserProfileByName")
-        lookup_end = source.index("\nasync function loadGeneratorUserProfiles", lookup_start)
-        lookup_body = source[lookup_start:lookup_end]
-        resolve_start = source.index("function resolvedGeneratorProfileValue")
-        resolve_end = source.index("\nfunction generatorProfileDisplayLabel", resolve_start)
-        resolve_body = source[resolve_start:resolve_end]
         summary_start = source.index("function updateGeneratorDomSummary")
         summary_end = source.index("\nfunction renderGeneratorPreviewFeed", summary_start)
         summary_body = source[summary_start:summary_end]
@@ -56,12 +51,19 @@ class AIOFrontendSourceTests(unittest.TestCase):
         serialize_body = source[serialize_start:serialize_end]
 
         self.assertIn('from "./aio/presets.js"', source)
-        self.assertIn("aioBuiltinProfileIdForSettings", source)
         self.assertIn("aioProfileSettingsFingerprint", source)
         for helper in ("aioFindUserProfileByName", "aioResolvedProfileValue"):
             with self.subTest(profile_core_helper=helper):
                 self.assertIn(f"export function {helper}(", presets_source)
                 self.assertIn(helper, source)
+        self.assertIn(
+            'from "./aio/profile_api_client.js"',
+            source,
+        )
+        self.assertIn(
+            'from "./aio/profile_settings_runtime.js"',
+            source,
+        )
         self.assertIn('"profile.custom": "Custom"', source)
         self.assertIn('"normal", "turbo", "optimized"', presets_source)
         self.assertIn('settings.sampler.steps = 10', presets_source)
@@ -69,41 +71,16 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('target.dit_corrections.dcw_mode = enabled ? "auto" : "off"', presets_source)
         self.assertIn('kj.sage_attention = enabled ? "auto" : "disabled"', presets_source)
         self.assertIn("compile.enabled = enabled", presets_source)
-        self.assertIn("applyVisibleGeneratorSettings(node, next)", apply_body)
-        self.assertIn("writeGeneratorSettingsFromState(node, next, true)", apply_body)
-        self.assertIn("aioProfileSettingsFingerprint", apply_body)
-        self.assertIn(
-            "aioFindUserProfileByName(generatorProfileState.profiles, name)",
-            lookup_body,
-        )
-        self.assertIn("return aioResolvedProfileValue({", resolve_body)
-        self.assertIn("settings,", resolve_body)
-        for option in (
-            "defaultSettings",
-            "selectedValue",
-            "selectedFingerprint",
-            "profiles",
-            "customValue",
-        ):
-            with self.subTest(profile_resolution_option=option):
-                self.assertIn(f"{option}:", resolve_body)
         self.assertIn("syncGeneratorProfileValue(node, settings)", render_body)
         self.assertIn('profileButton.setAttribute("data-aio-profile-button", "")', render_body)
         self.assertIn('panel.querySelector("[data-aio-profile-button]")', summary_body)
         self.assertIn("generatorProfileDisplayLabel(profileValue)", summary_body)
         self.assertIn("profileButton,", header_body)
         self.assertLess(header_body.index("profileButton,"), header_body.index('makeIconButton("⚙"'))
-        self.assertIn("function openGeneratorProfileSettings", source)
-        self.assertIn('field(section, "Profile", profileSelect, "profile.selectTip")', dialog_body)
-        self.assertIn("currentValue === GENERATOR_PROFILE_CUSTOM_VALUE", dialog_body)
-        self.assertIn('customOption.textContent = aioText("profile.custom")', dialog_body)
-        self.assertIn("profileSelect.value = currentValue", dialog_body)
-        self.assertIn("apply.disabled = busy || profileSelect.value === GENERATOR_PROFILE_CUSTOM_VALUE", dialog_body)
-        self.assertIn("managerActions.append(saveProfile, renameProfile, deleteProfile)", dialog_body)
-        self.assertIn("actions.append(cancel, apply)", dialog_body)
+        self.assertNotIn("function openGeneratorProfileSettings", source)
+        self.assertIn("open: openGeneratorProfileSettings,", source)
         self.assertIn('panel.append(main)', render_body)
         self.assertNotIn("profileBar", render_body)
-        self.assertIn('generatorSettings(node)', source[source.index("async function saveGeneratorUserProfile"):render_start])
         for path in (
             "/easyuse_anima/aio_profiles",
             "/easyuse_anima/aio_profiles/save",
@@ -111,7 +88,15 @@ class AIOFrontendSourceTests(unittest.TestCase):
             "/easyuse_anima/aio_profiles/rename",
             "/easyuse_anima/aio_profiles/delete",
         ):
-            self.assertIn(path, source)
+            self.assertIn(path, api_client_source)
+            self.assertNotIn(path, source)
+        self.assertIn(
+            "fetchJson: (url, options) => easyuseAnimaFetchComfyJson(api, url, options)",
+            source,
+        )
+        self.assertIn("profileApi: generatorProfileApi", source)
+        self.assertIn("getSettings: generatorSettings", source)
+        self.assertIn("writeSettings: writeGeneratorSettingsFromState", source)
         self.assertNotIn("__easyuseAnimaGeneratorProfileValue", serialize_body)
 
     def test_generator_panel_height_is_owned_by_comfyui(self):

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -35,6 +35,14 @@ AIO_PREVIEW_SETTINGS_DIALOG_JS = AIO_MODULES / "preview_settings_dialog.js"
 AIO_PREVIEW_SETTINGS_DIALOG_SMOKE = (
     ROOT / "tests" / "frontend_aio_preview_settings_dialog_smoke.mjs"
 )
+AIO_PROFILE_API_CLIENT_JS = AIO_MODULES / "profile_api_client.js"
+AIO_PROFILE_API_CLIENT_SMOKE = (
+    ROOT / "tests" / "frontend_aio_profile_api_client_smoke.mjs"
+)
+AIO_PROFILE_SETTINGS_RUNTIME_JS = AIO_MODULES / "profile_settings_runtime.js"
+AIO_PROFILE_SETTINGS_RUNTIME_SMOKE = (
+    ROOT / "tests" / "frontend_aio_profile_settings_runtime_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -110,6 +118,192 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_PROFILE_CORE_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_profile_core_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_profile_api_client_has_closed_transport_boundary(self):
+        source = AIO_PROFILE_API_CLIENT_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["createAioProfileApiClient"],
+        )
+        self.assertLessEqual(len(source.splitlines()), 80)
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:document|window|app|api)\b")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+
+        self.assertIn(
+            'import { createAioProfileApiClient } from "./aio/profile_api_client.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+generatorProfileApi\s*=\s*createAioProfileApiClient"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        self.assertIn(
+            "fetchJson: (url, options) => easyuseAnimaFetchComfyJson(api, url, options)",
+            factory_match.group("dependencies"),
+        )
+        self.assertIn("encodeURIComponent", factory_match.group("dependencies"))
+
+        for path in (
+            "/easyuse_anima/aio_profiles",
+            "/easyuse_anima/aio_profiles/save",
+            "/easyuse_anima/aio_profiles/load",
+            "/easyuse_anima/aio_profiles/rename",
+            "/easyuse_anima/aio_profiles/delete",
+        ):
+            with self.subTest(path=path):
+                self.assertIn(path, source)
+                self.assertNotIn(path, entry_source)
+
+        self.assertTrue(AIO_PROFILE_API_CLIENT_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_profile_api_client_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_profile_settings_runtime_has_closed_controller_boundary(self):
+        source = AIO_PROFILE_SETTINGS_RUNTIME_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreateProfileSettingsRuntime"],
+        )
+        self.assertLessEqual(len(source.splitlines()), 430)
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:window|app|api)\b")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+
+        self.assertIn(
+            'import { aioCreateProfileSettingsRuntime } from '
+            '"./aio/profile_settings_runtime.js";',
+            entry_source,
+        )
+        self.assertIn(
+            "const generatorProfileRuntime = aioCreateProfileSettingsRuntime({",
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+generatorProfileRuntime\s*=\s*"
+            r"aioCreateProfileSettingsRuntime\(\{(?P<dependencies>.*?)\n\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        runtime_dependencies = factory_match.group("dependencies")
+        for dependency in (
+            "document,",
+            "createDialog,",
+            "field,",
+            "text: aioText,",
+            "format: aioFormat,",
+            "profileApi: generatorProfileApi,",
+        ):
+            with self.subTest(dependency=dependency):
+                self.assertRegex(
+                    runtime_dependencies,
+                    rf"(?m)^  {re.escape(dependency)}$",
+                )
+
+        nested_dependencies = {
+            "dialogs": [
+                "prompt: (message, defaultValue) => window.prompt(message, defaultValue),",
+                "alert: (message) => window.alert(message),",
+                "confirm: (message) => window.confirm(message),",
+            ],
+            "profileCore": [
+                "customValue: GENERATOR_PROFILE_CUSTOM_VALUE,",
+                "builtinIds: aioBuiltinProfileIds,",
+                "builtinSettings: aioBuiltinProfileSettings,",
+                "fingerprint: aioProfileSettingsFingerprint,",
+                "userValue: aioUserProfileValue,",
+                "userName: aioUserProfileName,",
+                "findUser: aioFindUserProfileByName,",
+                "resolveValue: aioResolvedProfileValue,",
+            ],
+            "settingsCore": [
+                "defaultSettings: DEFAULT_GENERATION_SETTINGS,",
+                "mergeDefaults,",
+                "migratePostprocess: migrateGeneratorPostprocessSettings,",
+            ],
+            "nodeAdapter": [
+                "getSettings: generatorSettings,",
+                "applyVisibleSettings: applyVisibleGeneratorSettings,",
+                "writeSettings: writeGeneratorSettingsFromState,",
+                "renderPanel: renderGeneratorPanel,",
+                "refreshPanels: refreshGeneratorPanels,",
+                "markDirty: markNodeDirty,",
+            ],
+        }
+        for group_name, expected_lines in nested_dependencies.items():
+            with self.subTest(dependency_group=group_name):
+                group_match = re.search(
+                    rf"(?ms)^  {group_name}: \{{\n(?P<body>.*?)^  \}},$",
+                    runtime_dependencies,
+                )
+                self.assertIsNotNone(group_match)
+                self.assertEqual(
+                    [line.strip() for line in group_match.group("body").splitlines()],
+                    expected_lines,
+                )
+
+        self.assertIn(
+            "loadProfiles: loadGeneratorUserProfiles,",
+            entry_source,
+        )
+        self.assertIn("syncValue: syncGeneratorProfileValue,", entry_source)
+        self.assertIn("displayLabel: generatorProfileDisplayLabel,", entry_source)
+        self.assertIn("open: openGeneratorProfileSettings,", entry_source)
+
+        for local_function in (
+            "generatorProfileErrorMessage",
+            "generatorUserProfileByName",
+            "loadGeneratorUserProfiles",
+            "postGeneratorProfile",
+            "loadGeneratorUserProfile",
+            "applyGeneratorProfileSettings",
+            "applyGeneratorProfile",
+            "saveGeneratorUserProfile",
+            "renameGeneratorUserProfile",
+            "deleteGeneratorUserProfile",
+            "resolvedGeneratorProfileValue",
+            "syncGeneratorProfileValue",
+            "generatorProfileDisplayLabel",
+            "openGeneratorProfileSettings",
+        ):
+            with self.subTest(local_function=local_function):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\bfunction\s+{local_function}\(",
+                )
+
+        setup_start = entry_source.index("  async setup() {")
+        setup_end = entry_source.index("\n  async beforeRegisterNodeDef", setup_start)
+        setup_body = entry_source[setup_start:setup_end]
+        self.assertEqual(setup_body.count("loadGeneratorUserProfiles()"), 1)
+        self.assertIn(".then(refreshGeneratorPanels)", setup_body)
+        self.assertNotIn("__easyuseAnimaGeneratorProfileValue", source[source.index("return {"):])
+
+        self.assertTrue(AIO_PROFILE_SETTINGS_RUNTIME_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_profile_settings_runtime_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -44,6 +44,16 @@ try {
         throw "Frontend AiO profile core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_profile_api_client_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO profile API client smoke failed with exit code $LASTEXITCODE."
+    }
+
+    & node "tests\frontend_aio_profile_settings_runtime_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO profile settings runtime smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_dependency_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/profile_api_client.js
+++ b/web/js/aio/profile_api_client.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioProfileApiClientDependencies
+ * @property {(url: string, options?: Record<string, any>) => Promise<any>} fetchJson
+ * @property {(value: string) => string} encodeURIComponent
+ */
+
+/**
+ * Own the AiO profile endpoint and JSON payload contract without taking
+ * ownership of Comfy transport selection or profile UI lifecycle.
+ *
+ * @param {AioProfileApiClientDependencies} dependencies
+ */
+export function createAioProfileApiClient(dependencies) {
+  const {
+    fetchJson,
+    encodeURIComponent,
+  } = dependencies;
+
+  function postJson(url, payload) {
+    return fetchJson(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload || {}),
+    });
+  }
+
+  function listProfiles() {
+    return fetchJson("/easyuse_anima/aio_profiles");
+  }
+
+  function loadProfile(name) {
+    return fetchJson(
+      `/easyuse_anima/aio_profiles/load?name=${encodeURIComponent(name)}`,
+    );
+  }
+
+  function saveProfile(name, overwrite, settings) {
+    return postJson("/easyuse_anima/aio_profiles/save", {
+      name,
+      overwrite,
+      settings,
+    });
+  }
+
+  function renameProfile(oldName, newName, overwrite) {
+    return postJson("/easyuse_anima/aio_profiles/rename", {
+      old_name: oldName,
+      new_name: newName,
+      overwrite,
+    });
+  }
+
+  function deleteProfile(name) {
+    return postJson("/easyuse_anima/aio_profiles/delete", { name });
+  }
+
+  return {
+    listProfiles,
+    loadProfile,
+    saveProfile,
+    renameProfile,
+    deleteProfile,
+  };
+}

--- a/web/js/aio/profile_settings_runtime.js
+++ b/web/js/aio/profile_settings_runtime.js
@@ -1,0 +1,394 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioProfileApi
+ * @property {() => Promise<any>} listProfiles
+ * @property {(name: string) => Promise<any>} loadProfile
+ * @property {(name: string, overwrite: boolean, settings: any) => Promise<any>} saveProfile
+ * @property {(oldName: string, newName: string, overwrite: boolean) => Promise<any>} renameProfile
+ * @property {(name: string) => Promise<any>} deleteProfile
+ */
+
+/**
+ * @typedef {object} AioProfileCore
+ * @property {string} customValue
+ * @property {() => string[]} builtinIds
+ * @property {(profileId: string, defaultSettings: any) => any} builtinSettings
+ * @property {(settings: any) => string} fingerprint
+ * @property {(name: string) => string} userValue
+ * @property {(value: string) => string} userName
+ * @property {(profiles: any[], name: string) => any} findUser
+ * @property {(options: Record<string, any>) => string} resolveValue
+ */
+
+/**
+ * @typedef {object} AioProfileSettingsCore
+ * @property {any} defaultSettings
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(settings: any) => any} migratePostprocess
+ */
+
+/**
+ * @typedef {object} AioProfileNodeAdapter
+ * @property {(node: any) => any} getSettings
+ * @property {(node: any, settings: any) => void} applyVisibleSettings
+ * @property {(node: any, settings: any, markDirty?: boolean) => void} writeSettings
+ * @property {(node: any) => void} renderPanel
+ * @property {() => void} refreshPanels
+ * @property {(node: any) => void} markDirty
+ */
+
+/**
+ * @typedef {object} AioProfileDialogs
+ * @property {(message: string, defaultValue?: string) => string | null} prompt
+ * @property {(message: string) => void} alert
+ * @property {(message: string) => boolean} confirm
+ */
+
+/**
+ * @typedef {object} AioProfileSettingsRuntimeDependencies
+ * @property {any} document
+ * @property {(title: string, subtitle: string) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: string, control: any, tooltipKey?: string) => any} field
+ * @property {(key: string) => string} text
+ * @property {(key: string, values?: Record<string, any>) => string} format
+ * @property {AioProfileDialogs} dialogs
+ * @property {AioProfileApi} profileApi
+ * @property {AioProfileCore} profileCore
+ * @property {AioProfileSettingsCore} settingsCore
+ * @property {AioProfileNodeAdapter} nodeAdapter
+ */
+
+/**
+ * Own the AiO profile cache, CRUD, node-identity, and profile-dialog lifecycle.
+ * Extension registration, panel placement, graph traversal, and workflow
+ * serialization remain in the entry module and are supplied as adapters.
+ *
+ * @param {AioProfileSettingsRuntimeDependencies} dependencies
+ */
+export function aioCreateProfileSettingsRuntime(dependencies) {
+  const {
+    document,
+    createDialog,
+    field,
+    text,
+    format,
+    dialogs,
+    profileApi,
+    profileCore,
+    settingsCore,
+    nodeAdapter,
+  } = dependencies;
+  const {
+    customValue,
+    builtinIds,
+    builtinSettings,
+    fingerprint,
+    userValue,
+    userName,
+    findUser,
+    resolveValue,
+  } = profileCore;
+  const {
+    defaultSettings,
+    mergeDefaults,
+    migratePostprocess,
+  } = settingsCore;
+  const {
+    getSettings,
+    applyVisibleSettings,
+    writeSettings,
+    renderPanel,
+    refreshPanels,
+    markDirty,
+  } = nodeAdapter;
+
+  const state = {
+    loaded: false,
+    loading: null,
+    profiles: [],
+  };
+
+  function errorMessage(error) {
+    return error instanceof Error ? error.message : String(error || "Unknown error");
+  }
+
+  function userProfileByName(name) {
+    return findUser(state.profiles, name);
+  }
+
+  async function loadProfiles({ force = false } = {}) {
+    if (state.loaded && !force) {
+      return state.profiles;
+    }
+    if (!state.loading) {
+      state.loading = profileApi.listProfiles()
+        .then((data) => {
+          state.profiles = Array.isArray(data?.profiles)
+            ? data.profiles.filter((profile) => String(profile?.name || "").trim())
+            : [];
+          state.loaded = true;
+          return state.profiles;
+        })
+        .finally(() => {
+          state.loading = null;
+        });
+    }
+    return state.loading;
+  }
+
+  function applyProfileSettings(node, value, settings) {
+    const next = migratePostprocess(mergeDefaults(defaultSettings, settings));
+    applyVisibleSettings(node, next);
+    writeSettings(node, next, true);
+    node.__easyuseAnimaGeneratorProfileValue = value;
+    node.__easyuseAnimaGeneratorProfileFingerprint = fingerprint(getSettings(node));
+    renderPanel(node);
+    markDirty(node);
+  }
+
+  async function applyProfile(node, value) {
+    const textValue = String(value || customValue);
+    if (textValue === customValue) {
+      return;
+    }
+    if (textValue.startsWith("builtin:")) {
+      const profileId = textValue.slice(8);
+      applyProfileSettings(
+        node,
+        textValue,
+        builtinSettings(profileId, defaultSettings),
+      );
+      return;
+    }
+    const name = userName(textValue);
+    const data = await profileApi.loadProfile(name);
+    const profile = data?.profile || null;
+    if (!profile?.settings || typeof profile.settings !== "object") {
+      throw new Error("Profile settings are missing");
+    }
+    applyProfileSettings(node, userValue(profile.name || name), profile.settings);
+  }
+
+  async function saveUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
+    const selectedName = userName(selectedValue);
+    const requestedName = dialogs.prompt(text("profile.savePrompt"), selectedName || "");
+    if (requestedName == null) {
+      return;
+    }
+    const name = requestedName.trim();
+    if (!name) {
+      dialogs.alert(text("profile.nameRequired"));
+      return;
+    }
+    const existing = userProfileByName(name);
+    const overwrite = !!existing;
+    if (overwrite && !dialogs.confirm(format("profile.overwriteConfirm", { name: existing.name }))) {
+      return;
+    }
+    const settings = getSettings(node);
+    const data = await profileApi.saveProfile(name, overwrite, settings);
+    await loadProfiles({ force: true });
+    node.__easyuseAnimaGeneratorProfileValue = userValue(data?.profile?.name || name);
+    node.__easyuseAnimaGeneratorProfileFingerprint = fingerprint(settings);
+    refreshPanels();
+  }
+
+  async function renameUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
+    const oldName = userName(selectedValue);
+    if (!oldName) {
+      return;
+    }
+    const currentName = userName(syncValue(node));
+    const requestedName = dialogs.prompt(text("profile.renamePrompt"), oldName);
+    if (requestedName == null) {
+      return;
+    }
+    const newName = requestedName.trim();
+    if (!newName) {
+      dialogs.alert(text("profile.nameRequired"));
+      return;
+    }
+    const existing = userProfileByName(newName);
+    const overwrite = !!existing && existing.name.toLowerCase() !== oldName.toLowerCase();
+    if (overwrite && !dialogs.confirm(format("profile.overwriteConfirm", { name: existing.name }))) {
+      return;
+    }
+    const data = await profileApi.renameProfile(oldName, newName, overwrite);
+    await loadProfiles({ force: true });
+    if (currentName.toLowerCase() === oldName.toLowerCase()) {
+      node.__easyuseAnimaGeneratorProfileValue = userValue(data?.profile?.name || newName);
+    }
+    refreshPanels();
+  }
+
+  async function deleteUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
+    const name = userName(selectedValue);
+    if (!name || !dialogs.confirm(format("profile.deleteConfirm", { name }))) {
+      return;
+    }
+    const currentName = userName(syncValue(node));
+    await profileApi.deleteProfile(name);
+    await loadProfiles({ force: true });
+    if (currentName.toLowerCase() === name.toLowerCase()) {
+      node.__easyuseAnimaGeneratorProfileValue = customValue;
+      delete node.__easyuseAnimaGeneratorProfileFingerprint;
+    }
+    refreshPanels();
+  }
+
+  function resolvedValue(node, settings = getSettings(node)) {
+    return resolveValue({
+      settings,
+      defaultSettings,
+      selectedValue: node?.__easyuseAnimaGeneratorProfileValue,
+      selectedFingerprint: node?.__easyuseAnimaGeneratorProfileFingerprint,
+      profiles: state.profiles,
+      customValue,
+    });
+  }
+
+  function syncValue(node, settings = getSettings(node)) {
+    const value = resolvedValue(node, settings);
+    node.__easyuseAnimaGeneratorProfileValue = value;
+    if (value === customValue) {
+      delete node.__easyuseAnimaGeneratorProfileFingerprint;
+    }
+    return value;
+  }
+
+  function displayLabel(value) {
+    const textValue = String(value || customValue);
+    if (textValue === customValue) {
+      return text("profile.custom");
+    }
+    const profileName = userName(textValue);
+    if (profileName) {
+      return profileName;
+    }
+    const builtinId = textValue.startsWith("builtin:") ? textValue.slice(8) : "";
+    return builtinIds().includes(builtinId)
+      ? text(`profile.${builtinId}`)
+      : text("profile.custom");
+  }
+
+  function open(node) {
+    const currentValue = syncValue(node);
+    const { backdrop, body, actions } = createDialog(
+      text("dialog.profile.title"),
+      text("dialog.profile.subtitle"),
+    );
+    body.classList.add("easyuse-anima-aio-one-column");
+
+    const section = document.createElement("section");
+    section.className = "easyuse-anima-aio-section full";
+    const profileSelect = document.createElement("select");
+    profileSelect.title = text("profile.selectTip");
+    if (currentValue === customValue) {
+      const customOption = document.createElement("option");
+      customOption.value = customValue;
+      customOption.textContent = text("profile.custom");
+      profileSelect.append(customOption);
+    }
+    const builtInGroup = document.createElement("optgroup");
+    builtInGroup.label = text("profile.groupBuiltIn");
+    for (const profileId of builtinIds()) {
+      const option = document.createElement("option");
+      option.value = `builtin:${profileId}`;
+      option.textContent = text(`profile.${profileId}`);
+      builtInGroup.append(option);
+    }
+    profileSelect.append(builtInGroup);
+    if (state.profiles.length) {
+      const userGroup = document.createElement("optgroup");
+      userGroup.label = text("profile.groupUser");
+      for (const profile of state.profiles) {
+        const option = document.createElement("option");
+        option.value = userValue(profile.name);
+        option.textContent = profile.name;
+        userGroup.append(option);
+      }
+      profileSelect.append(userGroup);
+    }
+    profileSelect.value = currentValue;
+    field(section, "Profile", profileSelect, "profile.selectTip");
+
+    const managerActions = document.createElement("div");
+    managerActions.className = "easyuse-anima-aio-profile-manager-actions";
+    const makeActionButton = (label) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = label;
+      return button;
+    };
+    const saveProfile = makeActionButton(text("button.profileSave"));
+    const renameProfile = makeActionButton(text("button.profileRename"));
+    const deleteProfile = makeActionButton(text("button.profileDelete"));
+    managerActions.append(saveProfile, renameProfile, deleteProfile);
+    section.append(managerActions);
+    body.append(section);
+
+    const cancel = makeActionButton(text("button.cancel"));
+    const apply = makeActionButton(text("button.profileApply"));
+    apply.className = "primary";
+    actions.append(cancel, apply);
+
+    let busy = false;
+    const refreshActions = () => {
+      const isUserProfile = !!userName(profileSelect.value);
+      renameProfile.disabled = busy || !isUserProfile;
+      deleteProfile.disabled = busy || !isUserProfile;
+      saveProfile.disabled = busy;
+      cancel.disabled = busy;
+      apply.disabled = busy || profileSelect.value === customValue;
+    };
+    const run = async (callback, { reopen = false } = {}) => {
+      if (busy) {
+        return;
+      }
+      busy = true;
+      refreshActions();
+      try {
+        await callback();
+        backdrop.remove();
+        if (reopen) {
+          open(node);
+        }
+      } catch (error) {
+        dialogs.alert(format("profile.requestFailed", {
+          message: errorMessage(error),
+        }));
+      } finally {
+        busy = false;
+        if (backdrop.isConnected) {
+          refreshActions();
+        }
+      }
+    };
+    profileSelect.addEventListener("change", refreshActions);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => run(
+      () => applyProfile(node, profileSelect.value),
+    ));
+    saveProfile.addEventListener("click", () => run(
+      () => saveUserProfile(node, profileSelect.value),
+      { reopen: true },
+    ));
+    renameProfile.addEventListener("click", () => run(
+      () => renameUserProfile(node, profileSelect.value),
+      { reopen: true },
+    ));
+    deleteProfile.addEventListener("click", () => run(
+      () => deleteUserProfile(node, profileSelect.value),
+      { reopen: true },
+    ));
+    refreshActions();
+  }
+
+  return {
+    loadProfiles,
+    syncValue,
+    displayLabel,
+    open,
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -16,6 +16,8 @@ import { aioCreateDialogPrimitives } from "./aio/dialog_primitives.js";
 import { aioCreateInputSettingsDialog } from "./aio/input_settings_dialog.js";
 import { aioCreatePostprocessSettingsDialog } from "./aio/postprocess_settings_dialog.js";
 import { aioCreatePreviewSettingsDialog } from "./aio/preview_settings_dialog.js";
+import { createAioProfileApiClient } from "./aio/profile_api_client.js";
+import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -51,7 +53,6 @@ import {
 } from "./aio/preview.js";
 import { aioPanelFromWheelEvent, consumeAioPanelWheel } from "./aio/wheel.js";
 import {
-  aioBuiltinProfileIdForSettings,
   aioBuiltinProfileIds,
   aioBuiltinProfileSettings,
   aioFindUserProfileByName,
@@ -1874,11 +1875,6 @@ const generatorOptionalDependencyState = {
   errors: {},
   reportedSignature: "",
 };
-const generatorProfileState = {
-  loaded: false,
-  loading: null,
-  profiles: [],
-};
 
 function uniqueStrings(values) {
   const output = [];
@@ -2224,307 +2220,6 @@ function refreshGeneratorPanels() {
   for (const node of generatorGraphNodes()) {
     renderGeneratorPanel(node);
   }
-}
-
-function generatorProfileErrorMessage(error) {
-  return error instanceof Error ? error.message : String(error || "Unknown error");
-}
-
-function generatorUserProfileByName(name) {
-  return aioFindUserProfileByName(generatorProfileState.profiles, name);
-}
-
-async function loadGeneratorUserProfiles({ force = false } = {}) {
-  if (generatorProfileState.loaded && !force) {
-    return generatorProfileState.profiles;
-  }
-  if (!generatorProfileState.loading) {
-    generatorProfileState.loading = easyuseAnimaFetchComfyJson(api, "/easyuse_anima/aio_profiles")
-      .then((data) => {
-        generatorProfileState.profiles = Array.isArray(data?.profiles)
-          ? data.profiles.filter((profile) => String(profile?.name || "").trim())
-          : [];
-        generatorProfileState.loaded = true;
-        return generatorProfileState.profiles;
-      })
-      .finally(() => {
-        generatorProfileState.loading = null;
-      });
-  }
-  return generatorProfileState.loading;
-}
-
-async function postGeneratorProfile(path, payload) {
-  return easyuseAnimaFetchComfyJson(api, path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload || {}),
-  });
-}
-
-async function loadGeneratorUserProfile(name) {
-  const data = await easyuseAnimaFetchComfyJson(
-    api,
-    `/easyuse_anima/aio_profiles/load?name=${encodeURIComponent(name)}`,
-  );
-  return data?.profile || null;
-}
-
-function applyGeneratorProfileSettings(node, value, settings) {
-  const next = migrateGeneratorPostprocessSettings(mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings));
-  applyVisibleGeneratorSettings(node, next);
-  writeGeneratorSettingsFromState(node, next, true);
-  node.__easyuseAnimaGeneratorProfileValue = value;
-  node.__easyuseAnimaGeneratorProfileFingerprint = aioProfileSettingsFingerprint(
-    generatorSettings(node),
-  );
-  renderGeneratorPanel(node);
-  markNodeDirty(node);
-}
-
-async function applyGeneratorProfile(node, value) {
-  const textValue = String(value || GENERATOR_PROFILE_CUSTOM_VALUE);
-  if (textValue === GENERATOR_PROFILE_CUSTOM_VALUE) {
-    return;
-  }
-  if (textValue.startsWith("builtin:")) {
-    const profileId = textValue.slice(8);
-    applyGeneratorProfileSettings(
-      node,
-      textValue,
-      aioBuiltinProfileSettings(profileId, DEFAULT_GENERATION_SETTINGS),
-    );
-    return;
-  }
-  const name = aioUserProfileName(textValue);
-  const profile = await loadGeneratorUserProfile(name);
-  if (!profile?.settings || typeof profile.settings !== "object") {
-    throw new Error("Profile settings are missing");
-  }
-  applyGeneratorProfileSettings(node, aioUserProfileValue(profile.name || name), profile.settings);
-}
-
-async function saveGeneratorUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
-  const selectedName = aioUserProfileName(selectedValue);
-  const requestedName = window.prompt(aioText("profile.savePrompt"), selectedName || "");
-  if (requestedName == null) {
-    return;
-  }
-  const name = requestedName.trim();
-  if (!name) {
-    window.alert(aioText("profile.nameRequired"));
-    return;
-  }
-  const existing = generatorUserProfileByName(name);
-  const overwrite = !!existing;
-  if (overwrite && !window.confirm(aioFormat("profile.overwriteConfirm", { name: existing.name }))) {
-    return;
-  }
-  const settings = generatorSettings(node);
-  const data = await postGeneratorProfile("/easyuse_anima/aio_profiles/save", {
-    name,
-    overwrite,
-    settings,
-  });
-  await loadGeneratorUserProfiles({ force: true });
-  node.__easyuseAnimaGeneratorProfileValue = aioUserProfileValue(data?.profile?.name || name);
-  node.__easyuseAnimaGeneratorProfileFingerprint = aioProfileSettingsFingerprint(settings);
-  refreshGeneratorPanels();
-}
-
-async function renameGeneratorUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
-  const oldName = aioUserProfileName(selectedValue);
-  if (!oldName) {
-    return;
-  }
-  const currentName = aioUserProfileName(syncGeneratorProfileValue(node));
-  const requestedName = window.prompt(aioText("profile.renamePrompt"), oldName);
-  if (requestedName == null) {
-    return;
-  }
-  const newName = requestedName.trim();
-  if (!newName) {
-    window.alert(aioText("profile.nameRequired"));
-    return;
-  }
-  const existing = generatorUserProfileByName(newName);
-  const overwrite = !!existing && existing.name.toLowerCase() !== oldName.toLowerCase();
-  if (overwrite && !window.confirm(aioFormat("profile.overwriteConfirm", { name: existing.name }))) {
-    return;
-  }
-  const data = await postGeneratorProfile("/easyuse_anima/aio_profiles/rename", {
-    old_name: oldName,
-    new_name: newName,
-    overwrite,
-  });
-  await loadGeneratorUserProfiles({ force: true });
-  if (currentName.toLowerCase() === oldName.toLowerCase()) {
-    node.__easyuseAnimaGeneratorProfileValue = aioUserProfileValue(data?.profile?.name || newName);
-  }
-  refreshGeneratorPanels();
-}
-
-async function deleteGeneratorUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
-  const name = aioUserProfileName(selectedValue);
-  if (!name || !window.confirm(aioFormat("profile.deleteConfirm", { name }))) {
-    return;
-  }
-  const currentName = aioUserProfileName(syncGeneratorProfileValue(node));
-  await postGeneratorProfile("/easyuse_anima/aio_profiles/delete", { name });
-  await loadGeneratorUserProfiles({ force: true });
-  if (currentName.toLowerCase() === name.toLowerCase()) {
-    node.__easyuseAnimaGeneratorProfileValue = GENERATOR_PROFILE_CUSTOM_VALUE;
-    delete node.__easyuseAnimaGeneratorProfileFingerprint;
-  }
-  refreshGeneratorPanels();
-}
-
-function resolvedGeneratorProfileValue(node, settings = generatorSettings(node)) {
-  return aioResolvedProfileValue({
-    settings,
-    defaultSettings: DEFAULT_GENERATION_SETTINGS,
-    selectedValue: node?.__easyuseAnimaGeneratorProfileValue,
-    selectedFingerprint: node?.__easyuseAnimaGeneratorProfileFingerprint,
-    profiles: generatorProfileState.profiles,
-    customValue: GENERATOR_PROFILE_CUSTOM_VALUE,
-  });
-}
-
-function syncGeneratorProfileValue(node, settings = generatorSettings(node)) {
-  const value = resolvedGeneratorProfileValue(node, settings);
-  node.__easyuseAnimaGeneratorProfileValue = value;
-  if (value === GENERATOR_PROFILE_CUSTOM_VALUE) {
-    delete node.__easyuseAnimaGeneratorProfileFingerprint;
-  }
-  return value;
-}
-
-function generatorProfileDisplayLabel(value) {
-  const textValue = String(value || GENERATOR_PROFILE_CUSTOM_VALUE);
-  if (textValue === GENERATOR_PROFILE_CUSTOM_VALUE) {
-    return aioText("profile.custom");
-  }
-  const userName = aioUserProfileName(textValue);
-  if (userName) {
-    return userName;
-  }
-  const builtinId = textValue.startsWith("builtin:") ? textValue.slice(8) : "";
-  return aioBuiltinProfileIds().includes(builtinId)
-    ? aioText(`profile.${builtinId}`)
-    : aioText("profile.custom");
-}
-
-function openGeneratorProfileSettings(node) {
-  const currentValue = syncGeneratorProfileValue(node);
-  const { backdrop, body, actions } = createDialog(
-    aioText("dialog.profile.title"),
-    aioText("dialog.profile.subtitle"),
-  );
-  body.classList.add("easyuse-anima-aio-one-column");
-
-  const section = document.createElement("section");
-  section.className = "easyuse-anima-aio-section full";
-  const profileSelect = document.createElement("select");
-  profileSelect.title = aioText("profile.selectTip");
-  if (currentValue === GENERATOR_PROFILE_CUSTOM_VALUE) {
-    const customOption = document.createElement("option");
-    customOption.value = GENERATOR_PROFILE_CUSTOM_VALUE;
-    customOption.textContent = aioText("profile.custom");
-    profileSelect.append(customOption);
-  }
-  const builtInGroup = document.createElement("optgroup");
-  builtInGroup.label = aioText("profile.groupBuiltIn");
-  for (const profileId of aioBuiltinProfileIds()) {
-    const option = document.createElement("option");
-    option.value = `builtin:${profileId}`;
-    option.textContent = aioText(`profile.${profileId}`);
-    builtInGroup.append(option);
-  }
-  profileSelect.append(builtInGroup);
-  if (generatorProfileState.profiles.length) {
-    const userGroup = document.createElement("optgroup");
-    userGroup.label = aioText("profile.groupUser");
-    for (const profile of generatorProfileState.profiles) {
-      const option = document.createElement("option");
-      option.value = aioUserProfileValue(profile.name);
-      option.textContent = profile.name;
-      userGroup.append(option);
-    }
-    profileSelect.append(userGroup);
-  }
-  profileSelect.value = currentValue;
-  field(section, "Profile", profileSelect, "profile.selectTip");
-
-  const managerActions = document.createElement("div");
-  managerActions.className = "easyuse-anima-aio-profile-manager-actions";
-  const makeActionButton = (label) => {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.textContent = label;
-    return button;
-  };
-  const saveProfile = makeActionButton(aioText("button.profileSave"));
-  const renameProfile = makeActionButton(aioText("button.profileRename"));
-  const deleteProfile = makeActionButton(aioText("button.profileDelete"));
-  managerActions.append(saveProfile, renameProfile, deleteProfile);
-  section.append(managerActions);
-  body.append(section);
-
-  const cancel = makeActionButton(aioText("button.cancel"));
-  const apply = makeActionButton(aioText("button.profileApply"));
-  apply.className = "primary";
-  actions.append(cancel, apply);
-
-  let busy = false;
-  const refreshActions = () => {
-    const isUserProfile = !!aioUserProfileName(profileSelect.value);
-    renameProfile.disabled = busy || !isUserProfile;
-    deleteProfile.disabled = busy || !isUserProfile;
-    saveProfile.disabled = busy;
-    cancel.disabled = busy;
-    apply.disabled = busy || profileSelect.value === GENERATOR_PROFILE_CUSTOM_VALUE;
-  };
-  const run = async (callback, { reopen = false } = {}) => {
-    if (busy) {
-      return;
-    }
-    busy = true;
-    refreshActions();
-    try {
-      await callback();
-      backdrop.remove();
-      if (reopen) {
-        openGeneratorProfileSettings(node);
-      }
-    } catch (error) {
-      window.alert(aioFormat("profile.requestFailed", {
-        message: generatorProfileErrorMessage(error),
-      }));
-    } finally {
-      busy = false;
-      if (backdrop.isConnected) {
-        refreshActions();
-      }
-    }
-  };
-  profileSelect.addEventListener("change", refreshActions);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => run(
-    () => applyGeneratorProfile(node, profileSelect.value),
-  ));
-  saveProfile.addEventListener("click", () => run(
-    () => saveGeneratorUserProfile(node, profileSelect.value),
-    { reopen: true },
-  ));
-  renameProfile.addEventListener("click", () => run(
-    () => renameGeneratorUserProfile(node, profileSelect.value),
-    { reopen: true },
-  ));
-  deleteProfile.addEventListener("click", () => run(
-    () => deleteGeneratorUserProfile(node, profileSelect.value),
-    { reopen: true },
-  ));
-  refreshActions();
 }
 
 function findWidget(node, name) {
@@ -7372,6 +7067,55 @@ function ensureButton(node, key, label, callback) {
     widget.serialize = false;
   }
 }
+
+const generatorProfileApi = createAioProfileApiClient({
+  fetchJson: (url, options) => easyuseAnimaFetchComfyJson(api, url, options),
+  encodeURIComponent,
+});
+
+const generatorProfileRuntime = aioCreateProfileSettingsRuntime({
+  document,
+  createDialog,
+  field,
+  text: aioText,
+  format: aioFormat,
+  dialogs: {
+    prompt: (message, defaultValue) => window.prompt(message, defaultValue),
+    alert: (message) => window.alert(message),
+    confirm: (message) => window.confirm(message),
+  },
+  profileApi: generatorProfileApi,
+  profileCore: {
+    customValue: GENERATOR_PROFILE_CUSTOM_VALUE,
+    builtinIds: aioBuiltinProfileIds,
+    builtinSettings: aioBuiltinProfileSettings,
+    fingerprint: aioProfileSettingsFingerprint,
+    userValue: aioUserProfileValue,
+    userName: aioUserProfileName,
+    findUser: aioFindUserProfileByName,
+    resolveValue: aioResolvedProfileValue,
+  },
+  settingsCore: {
+    defaultSettings: DEFAULT_GENERATION_SETTINGS,
+    mergeDefaults,
+    migratePostprocess: migrateGeneratorPostprocessSettings,
+  },
+  nodeAdapter: {
+    getSettings: generatorSettings,
+    applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings: writeGeneratorSettingsFromState,
+    renderPanel: renderGeneratorPanel,
+    refreshPanels: refreshGeneratorPanels,
+    markDirty: markNodeDirty,
+  },
+});
+
+const {
+  loadProfiles: loadGeneratorUserProfiles,
+  syncValue: syncGeneratorProfileValue,
+  displayLabel: generatorProfileDisplayLabel,
+  open: openGeneratorProfileSettings,
+} = generatorProfileRuntime;
 
 const openInputSettings = aioCreateInputSettingsDialog({
   document,


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 profile HTTP transport를 `profile_api_client.js`로 분리했습니다.
- profile cache, built-in/user profile 적용, CRUD, profile settings dialog lifecycle을 `profile_settings_runtime.js`의 닫힌 factory 경계로 옮겼습니다.
- extension 등록, panel 배치, graph traversal, workflow 직렬화는 기존 entry에 유지했습니다.
- API route/payload, profile transient state, 적용 순서, busy/reopen/error 동작을 고정하는 focused smoke와 구조 검사를 추가했습니다.

Issue #54의 `profile API, CRUD와 profile settings dialog` 완료 경계입니다.

## 주요 파일

- `web/js/aio/profile_api_client.js`
- `web/js/aio/profile_settings_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_profile_api_client_smoke.mjs`
- `tests/frontend_aio_profile_settings_runtime_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- focused runtime smoke: 통과
- focused AIO Python 구조 검사: 38 tests 통과
- official full runner: Python 362 tests 통과
- frontend integration: 87 JavaScript files 통과
- TypeScript: 6.0.3 통과
- `git diff --check`: 통과
- 위험 기반 감사: behavior, architecture, tests 모두 Blocker/P2/P3 없음

## ComfyUI 검증 표면

- ComfyUI Codex test instance: compile/module/static/full runner
- Legacy canvas browser smoke: 미실행 — 관찰 가능한 동작 변경이 없는 기계적 lifecycle 추출
- Node 2.0 browser smoke: 미실행 — 같은 이유
- ComfyUI v0.27.0 user instance: 전체 maintenance 완료 후 1회 확인 예정

## 호환성 및 남은 범위

- node type, widget/socket 순서, serialized workflow property, API route/payload는 변경하지 않았습니다.
- #54의 generator panel/render, 나머지 settings dialogs, native preview runtime, queue/hooks/entry 경계와 final dual-canvas matrix는 후속 reviewable slice로 남습니다.

Label candidates: `type: chore`, `area: frontend`, `status: ready`