### PR TITLE
refactor: extract AiO generator panel runtime

### DIFF
--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -1,0 +1,699 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+  descendants,
+} from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function find(root, predicate) {
+  return [root, ...descendants(root)].find(predicate) || null;
+}
+
+function findByClass(root, className) {
+  return find(root, (element) => element.classList.contains(className));
+}
+
+function findByText(root, textContent) {
+  return find(root, (element) => element.textContent === textContent);
+}
+
+const panelModule = await import(dataModule("../web/js/aio/generator_panel_runtime.js"));
+const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+assert.deepEqual(
+  Object.keys(panelModule),
+  ["aioCreateGeneratorPanelRuntime"],
+  "Generator panel runtime must expose only its factory contract",
+);
+
+function createFixture() {
+  let dependencyCalls = 0;
+  const trace = [];
+  const animationFrames = [];
+  const actionCalls = [];
+  const document = createFakeDocument();
+  const windowListeners = new Map();
+  const window = {
+    addEventListener(type, listener) {
+      dependencyCalls += 1;
+      const listeners = windowListeners.get(type) || [];
+      listeners.push(listener);
+      windowListeners.set(type, listeners);
+    },
+    removeEventListener(type, listener) {
+      dependencyCalls += 1;
+      const listeners = windowListeners.get(type) || [];
+      windowListeners.set(type, listeners.filter((candidate) => candidate !== listener));
+    },
+  };
+
+  function numberInput(value, step = "1") {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "number";
+    input.step = step;
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function checkbox(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = !!value;
+    return input;
+  }
+
+  function selectInput(options, value) {
+    dependencyCalls += 1;
+    const select = document.createElement("select");
+    for (const optionSpec of options) {
+      const option = document.createElement("option");
+      option.value = typeof optionSpec === "object"
+        ? String(optionSpec.value ?? "")
+        : String(optionSpec ?? "");
+      option.textContent = typeof optionSpec === "object"
+        ? String(optionSpec.label ?? option.value)
+        : option.value;
+      option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
+      option.selected = option.value === String(value ?? "");
+      select.append(option);
+    }
+    return select;
+  }
+
+  function createNodeField(label, control, className = "", tooltipKey = "") {
+    dependencyCalls += 1;
+    const field = document.createElement("label");
+    field.className = ("easyuse-anima-aio-node-field " + className).trim();
+    field.setAttribute("data-test-label", label);
+    field.setAttribute("data-test-tooltip", tooltipKey);
+    field.append(control);
+    return field;
+  }
+
+  function text(key) {
+    dependencyCalls += 1;
+    return "text:" + key;
+  }
+
+  function format(key, values = {}) {
+    dependencyCalls += 1;
+    return "format:" + key + ":" + JSON.stringify(values);
+  }
+
+  function applyTooltip(element, key) {
+    dependencyCalls += 1;
+    if (key) {
+      element.title = text(key);
+    }
+    return element;
+  }
+
+  const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
+  const settingsCore = {
+    defaultGenerationSettings: defaultSettings,
+    specialSeedRandom: settingsModule.AIO_GENERATOR_SPECIAL_SEED_RANDOM,
+    fallbackSamplerNames: ["er_sde", "euler"],
+    fallbackSchedulerNames: ["simple", "karras"],
+    mergeDefaults: settingsModule.aioMergeDefaults,
+    normalizeSeedControl: settingsModule.aioNormalizeSeedControl,
+    normalizeSeedValue: settingsModule.aioNormalizeSeedValue,
+    clampNumber(value, fallback, min, max) {
+      const parsed = Number(value);
+      return Math.max(min, Math.min(max, Number.isFinite(parsed) ? parsed : fallback));
+    },
+    normalizeUsduAutoTileRange(usdu) {
+      return {
+        ...clone(defaultSettings.upscale.usdu),
+        ...clone(usdu || {}),
+      };
+    },
+    setUsduAutoTileTarget(settings, value) {
+      settings.upscale ||= {};
+      settings.upscale.usdu ||= {};
+      settings.upscale.usdu.auto_tile_target = Math.trunc(value);
+    },
+    normalizeDetailerOrder(order) {
+      return Array.isArray(order) ? [...order] : [];
+    },
+    detailerTargetDefaults(targetName) {
+      return clone(defaultSettings.detailer[targetName] || {
+        enabled: false,
+        inherit_sampler_settings: true,
+        steps: 20,
+        denoise: 0.3,
+      });
+    },
+    detailerTargetTitle(targetName, target) {
+      return String(target?.label || targetName);
+    },
+  };
+
+  const nodeAdapter = {
+    getSettings(node) {
+      dependencyCalls += 1;
+      trace.push("get-settings");
+      return clone(node.settings);
+    },
+    applyVisibleSettings(node, settings) {
+      dependencyCalls += 1;
+      trace.push("apply-visible");
+      node.visibleSettings = clone(settings);
+    },
+    writeSettings(node, settings, markDirty = true) {
+      dependencyCalls += 1;
+      trace.push("write:" + markDirty);
+      node.settings = clone(settings);
+    },
+    syncSettingsFromVisible(node) {
+      dependencyCalls += 1;
+      trace.push("sync-visible");
+      if (Object.hasOwn(node.widgetValues, "seed")) {
+        node.settings.sampler.seed = node.widgetValues.seed;
+      }
+    },
+    widgetValue(node, name, fallback) {
+      dependencyCalls += 1;
+      return Object.hasOwn(node.widgetValues, name) ? node.widgetValues[name] : fallback;
+    },
+    widgetOptions(_node, _name, fallback) {
+      dependencyCalls += 1;
+      return [...fallback];
+    },
+    setWidgetValueIfChanged(node, name, value) {
+      dependencyCalls += 1;
+      trace.push("set-widget:" + name + ":" + value);
+      node.widgetValues[name] = value;
+    },
+    markDirty(node) {
+      dependencyCalls += 1;
+      trace.push("dirty");
+      node.dirtyCount = (node.dirtyCount || 0) + 1;
+    },
+    ensureStyle() {
+      dependencyCalls += 1;
+      trace.push("ensure-style");
+    },
+    suppressDefaultPreview(_node, options) {
+      dependencyCalls += 1;
+      trace.push("suppress:" + JSON.stringify(options));
+    },
+    markNativePreviewHidden() {
+      dependencyCalls += 1;
+      trace.push("native-hidden");
+    },
+    imageUrl(image) {
+      dependencyCalls += 1;
+      return image?.filename ? "/view/" + image.filename : "";
+    },
+    randomSeed() {
+      dependencyCalls += 1;
+      trace.push("random-seed");
+      return 123456;
+    },
+    forwardPanelWheel(event) {
+      dependencyCalls += 1;
+      trace.push("forward-wheel");
+      event.preventDefault?.();
+      return true;
+    },
+  };
+
+  const profileAdapter = {
+    syncValue(node) {
+      dependencyCalls += 1;
+      trace.push("sync-profile");
+      return node.profileValue || "custom";
+    },
+    displayLabel(value) {
+      dependencyCalls += 1;
+      return String(value).startsWith("user:")
+        ? String(value).slice(5)
+        : "text:profile.custom";
+    },
+  };
+
+  function selectedIndex(node, images) {
+    dependencyCalls += 1;
+    const requested = Number(node.__easyuseAnimaSelectedPreviewIndex);
+    return Number.isInteger(requested) && requested >= 0 && requested < images.length
+      ? requested
+      : Math.max(0, images.length - 1);
+  }
+
+  const previewAdapter = {
+    selectedIndex,
+    mainImage(node, images) {
+      dependencyCalls += 1;
+      return images[selectedIndex(node, images)] || null;
+    },
+    imageLabel(image) {
+      dependencyCalls += 1;
+      return String(image?.label || image?.filename || "");
+    },
+    imageName(image) {
+      dependencyCalls += 1;
+      return String(image?.name || image?.filename || "-");
+    },
+    imageResolution(image) {
+      dependencyCalls += 1;
+      return image?.width && image?.height ? image.width + "x" + image.height : "-";
+    },
+    imageFileSize(image) {
+      dependencyCalls += 1;
+      return String(image?.fileSize || "-");
+    },
+  };
+
+  const actions = {};
+  for (const name of [
+    "openProfileSettings",
+    "openSaveSettings",
+    "openSamplerSettings",
+    "openAdvancedSettings",
+    "openHighresSettings",
+    "openDetailerSettings",
+    "openUpscaleSettings",
+    "openPostprocessSettings",
+    "openPreviewSettings",
+  ]) {
+    actions[name] = (node) => {
+      dependencyCalls += 1;
+      actionCalls.push({ name, node });
+    };
+  }
+
+  const runtime = panelModule.aioCreateGeneratorPanelRuntime({
+    document,
+    window,
+    requestAnimationFrame(callback) {
+      dependencyCalls += 1;
+      animationFrames.push(callback);
+    },
+    panelMinHeight: 430,
+    controls: {
+      numberInput,
+      checkbox,
+      selectInput,
+      createNodeField,
+    },
+    text: {
+      get: text,
+      format,
+      applyTooltip,
+    },
+    settingsCore,
+    nodeAdapter,
+    profileAdapter,
+    previewAdapter,
+    actions,
+  });
+
+  return {
+    runtime,
+    document,
+    trace,
+    animationFrames,
+    actionCalls,
+    defaultSettings,
+    dependencyCalls: () => dependencyCalls,
+  };
+}
+
+const fixture = createFixture();
+assert.deepEqual(Object.keys(fixture.runtime).sort(), [
+  "ensurePanel",
+  "refreshSeedButtons",
+  "renderPanel",
+  "scheduleLayout",
+  "updateSummary",
+]);
+assert.equal(fixture.dependencyCalls(), 0, "factory creation must have no side effects");
+
+const settings = clone(fixture.defaultSettings);
+settings.sampler.spectrum.enabled = true;
+settings.sampler.dit_corrections.enabled = true;
+settings.highres.enabled = true;
+settings.highres.inherit_sampler_settings = false;
+settings.detailer.enabled = true;
+settings.detailer.face.enabled = true;
+settings.detailer.eye.enabled = true;
+settings.upscale.enabled = true;
+settings.upscale.backend = "usdu";
+settings.upscale.usdu.auto_tile_size = true;
+settings.postprocess.enabled = true;
+settings.save.enabled = true;
+settings.preview.image_feed = true;
+settings.preview.compare_previous = true;
+
+const images = [
+  {
+    filename: "first.png",
+    name: "first",
+    label: "First image",
+    width: 512,
+    height: 768,
+    fileSize: "1 MB",
+  },
+  {
+    filename: "second.png",
+    name: "second",
+    label: "Second image",
+    width: 768,
+    height: 512,
+    fileSize: "2 MB",
+  },
+];
+const widgetCalls = [];
+const node = {
+  settings,
+  widgetValues: {
+    seed: settings.sampler.seed,
+    steps: settings.sampler.steps,
+    cfg: settings.sampler.cfg,
+    denoise: settings.sampler.denoise,
+    sampler_name: settings.sampler.sampler_name,
+    scheduler: settings.sampler.scheduler,
+  },
+  profileValue: "user:Portrait",
+  size: [500, 700],
+  minWidth: 400,
+  __easyuseAnimaGeneratorPreviewImages: images,
+  __easyuseAnimaSelectedPreviewIndex: 1,
+  addDOMWidget(name, type, element, options) {
+    widgetCalls.push({ name, type, element, options });
+  },
+};
+
+const firstEnsureStart = fixture.trace.length;
+fixture.runtime.ensurePanel(node);
+const firstEnsureTrace = fixture.trace.slice(firstEnsureStart);
+const panel = node.__easyuseAnimaGeneratorPanelEl;
+const firstMain = panel.children[0];
+const secondEnsureStart = fixture.trace.length;
+fixture.runtime.ensurePanel(node);
+const secondEnsureTrace = fixture.trace.slice(secondEnsureStart);
+const assertEnsureOrder = (runTrace) => {
+  const ensureStyleIndex = runTrace.indexOf("ensure-style");
+  const suppressIndex = runTrace.indexOf('suppress:{"markDirty":false}');
+  const firstNativeHiddenIndex = runTrace.indexOf("native-hidden");
+  const renderStartIndex = runTrace.indexOf("get-settings");
+  const lastNativeHiddenIndex = runTrace.lastIndexOf("native-hidden");
+  assert.ok(ensureStyleIndex < suppressIndex);
+  assert.ok(suppressIndex < firstNativeHiddenIndex);
+  assert.ok(firstNativeHiddenIndex < renderStartIndex);
+  assert.ok(renderStartIndex < lastNativeHiddenIndex);
+};
+assertEnsureOrder(firstEnsureTrace);
+assertEnsureOrder(secondEnsureTrace);
+assert.equal(node.__easyuseAnimaGeneratorPanelEl, panel, "panel root identity must be stable");
+assert.equal(panel.className, "easyuse-anima-aio-node-panel");
+assert.equal(firstMain.parentElement, null, "rerender must replace children without replacing the root");
+assert.equal(widgetCalls.length, 1, "repeated ensure must not add another DOM widget");
+assert.equal(node.serialize_widgets, true);
+assert.equal(node.minWidth, 560);
+assert.deepEqual(node.size, [620, 700]);
+assert.equal(widgetCalls[0].name, "easyuse_anima_generator_panel");
+assert.equal(widgetCalls[0].type, "EasyUseAnimaGeneratorPanel");
+assert.equal(widgetCalls[0].element, panel);
+assert.equal(widgetCalls[0].options.serialize, false);
+assert.equal(widgetCalls[0].options.hideOnZoom, false);
+assert.equal(widgetCalls[0].options.getMinHeight(), 430);
+assert.equal(fixture.trace.filter((value) => value === "ensure-style").length, 2);
+assert.equal(
+  fixture.trace.filter((value) => value === "suppress:{\"markDirty\":false}").length,
+  2,
+);
+assert.equal(fixture.trace.filter((value) => value === "native-hidden").length, 4);
+for (const eventName of [
+  "pointerdown",
+  "mousedown",
+  "pointerup",
+  "mouseup",
+  "click",
+  "dblclick",
+  "keydown",
+  "keyup",
+  "wheel",
+]) {
+  assert.equal(panel.listeners.get(eventName)?.length, 1, eventName + " listener must bind once");
+}
+
+assert.equal(fixture.animationFrames.length, 1, "two renders before a frame must coalesce layout");
+panel.style.height = "999px";
+panel.style["max-height"] = "999px";
+const dirtyBeforeFirstLayout = node.dirtyCount || 0;
+fixture.animationFrames.shift()();
+assert.equal(node.__easyuseAnimaGeneratorLayoutScheduled, false);
+assert.equal(panel.style.width, "600px");
+assert.equal(panel.style.maxWidth, "600px");
+assert.equal(panel.style.getPropertyValue("height"), "");
+assert.equal(panel.style.getPropertyValue("max-height"), "");
+assert.equal(node.dirtyCount, dirtyBeforeFirstLayout + 1);
+fixture.runtime.scheduleLayout(node);
+fixture.runtime.scheduleLayout(node);
+assert.equal(fixture.animationFrames.length, 1, "explicit layout requests must coalesce");
+fixture.animationFrames.shift()();
+assert.equal(node.dirtyCount, dirtyBeforeFirstLayout + 2);
+
+const controlClick = panel.emit("click", {
+  target: panel.querySelector("[data-aio-seed-input]"),
+});
+assert.equal(controlClick.propagationStopped, true);
+const backgroundClick = panel.emit("click", { target: panel });
+assert.equal(backgroundClick.propagationStopped, false);
+const backgroundPointer = panel.emit("pointerdown", { target: panel });
+assert.equal(backgroundPointer.propagationStopped, false);
+panel.emit("wheel", { target: panel });
+assert.equal(fixture.trace.includes("forward-wheel"), true);
+
+const main = panel.children[0];
+assert.equal(main.className, "easyuse-anima-aio-node-main");
+const samplerCard = main.children[0];
+const previewCard = main.children[1];
+assert.equal(samplerCard.classList.contains("easyuse-anima-aio-node-settings"), true);
+assert.equal(previewCard.classList.contains("easyuse-anima-aio-node-preview"), true);
+const samplerHeader = samplerCard.children[0];
+const samplerActions = samplerHeader.children[1];
+assert.equal(samplerActions.children[0].getAttribute("data-aio-profile-button"), "");
+assert.equal(samplerActions.children[0].textContent, "Portrait");
+assert.equal(samplerActions.children[3].getAttribute("data-aio-save-button"), "");
+assert.equal(samplerActions.children[3].classList.contains("active"), true);
+assert.equal(samplerActions.children[3].title, "text:button.saveOn");
+assert.equal(
+  panel.querySelector("[data-aio-backend-summary]").textContent,
+  "Spectrum Patch + Corrections / Comfy KSampler",
+);
+
+const settingsScroll = samplerCard.children[1];
+assert.equal(settingsScroll.className, "easyuse-anima-aio-node-settings-scroll");
+assert.equal(settingsScroll.children.length, 5);
+assert.equal(
+  settingsScroll.children.slice(1).every(
+    (block) => block.className === "easyuse-anima-aio-node-stage-block",
+  ),
+  true,
+);
+assert.deepEqual(
+  settingsScroll.children.slice(1).map((block) => block.children[0].children[0].textContent),
+  [
+    "text:title.highres",
+    "text:title.detailer",
+    "text:title.upscale",
+    "text:title.postprocess",
+  ],
+);
+assert.equal(
+  panel.querySelector("[data-aio-preview-box]").className,
+  "easyuse-anima-aio-node-preview-box",
+);
+assert.equal(
+  panel.querySelector("[data-aio-preview-feed]").className,
+  "easyuse-anima-aio-node-preview-feed",
+);
+
+node.profileValue = "custom";
+node.settings.save.enabled = false;
+node.settings.sampler.backend = "spectrum_spd_speed";
+fixture.runtime.updateSummary(node);
+assert.equal(samplerActions.children[0].textContent, "text:profile.custom");
+assert.equal(samplerActions.children[0].title, "text:profile.selectTip");
+assert.equal(samplerActions.children[3].classList.contains("active"), false);
+assert.equal(samplerActions.children[3].title, "text:button.saveOff");
+assert.equal(
+  panel.querySelector("[data-aio-backend-summary]").textContent,
+  "Spectrum SPD / SPEED",
+);
+assert.equal(
+  panel.querySelector("[data-aio-backend-summary]").title,
+  "Spectrum SPD / SPEED",
+);
+
+samplerActions.children[0].emit("click");
+samplerActions.children[1].emit("click");
+samplerActions.children[2].emit("click");
+samplerActions.children[3].emit("click");
+for (const stageBlock of settingsScroll.children.slice(1)) {
+  stageBlock.children[0].children[1].children[0].emit("click");
+}
+previewCard.children[0].children[1].children[0].emit("click");
+assert.deepEqual(
+  fixture.actionCalls.map((call) => call.name),
+  [
+    "openProfileSettings",
+    "openSamplerSettings",
+    "openAdvancedSettings",
+    "openSaveSettings",
+    "openHighresSettings",
+    "openDetailerSettings",
+    "openUpscaleSettings",
+    "openPostprocessSettings",
+    "openPreviewSettings",
+  ],
+);
+assert.equal(fixture.actionCalls.every((call) => call.node === node), true);
+
+let previewBox = panel.querySelector("[data-aio-preview-box]");
+let previewMeta = panel.querySelector("[data-aio-preview-meta]");
+let previewFeed = panel.querySelector("[data-aio-preview-feed]");
+const compare = previewBox.children[0];
+assert.equal(compare.className, "easyuse-anima-aio-node-preview-compare");
+assert.equal(compare.style.getPropertyValue("--aio-compare-x"), "50%");
+assert.equal(
+  compare.children[0].className,
+  "easyuse-anima-aio-node-preview-layer before",
+);
+assert.equal(compare.children[0].children[0].src, "/view/second.png");
+assert.equal(
+  compare.children[1].className,
+  "easyuse-anima-aio-node-preview-layer after",
+);
+assert.equal(compare.children[1].children[0].src, "/view/first.png");
+assert.equal(
+  compare.children[2].className,
+  "easyuse-anima-aio-node-preview-divider",
+);
+assert.equal(
+  compare.children[3].children[0].textContent,
+  "text:text.previewCurrent · Second image",
+);
+assert.equal(
+  compare.children[3].children[1].textContent,
+  "text:text.previewPrevious · First image",
+);
+compare.boundingClientRect = { left: 10, top: 0, width: 200, height: 100 };
+const compareDown = compare.emit("pointerdown", { clientX: 60 });
+assert.equal(compareDown.propagationStopped, true);
+assert.equal(compare.style.getPropertyValue("--aio-compare-x"), "25.00%");
+compare.emit("pointermove", { clientX: 210 });
+assert.equal(compare.style.getPropertyValue("--aio-compare-x"), "100.00%");
+assert.equal(previewMeta.textContent, "second · 768x512 · 2 MB");
+assert.equal(previewFeed.hidden, false);
+assert.equal(previewFeed.children.length, 2);
+assert.equal(previewFeed.children[0].children[0].src, "/view/first.png");
+assert.equal(previewFeed.children[1].children[0].src, "/view/second.png");
+assert.equal(previewFeed.children[1].classList.contains("active"), true);
+assert.equal(previewFeed.children[1].scrollIntoViewCalls.length, 1);
+previewFeed.children[0].emit("click");
+assert.equal(node.__easyuseAnimaSelectedPreviewIndex, 0);
+assert.equal(previewBox.children[0].tagName, "IMG");
+assert.equal(previewBox.children[0].src, "/view/first.png");
+assert.equal(previewMeta.textContent, "first · 512x768 · 1 MB");
+
+node.__easyuseAnimaGeneratorDenoisePreview = {
+  url: "blob:denoise",
+  value: 3,
+  max: 8,
+};
+fixture.runtime.updateSummary(node);
+assert.equal(
+  previewBox.children[0].className,
+  "easyuse-anima-aio-node-denoise-preview",
+);
+assert.equal(previewBox.children[0].children[0].src, "blob:denoise");
+assert.equal(previewBox.children[0].children[0].decoding, "async");
+assert.equal(
+  previewBox.children[0].children[1].textContent,
+  "text:text.previewDenoise · 3/8",
+);
+assert.equal(previewMeta.textContent, "");
+assert.equal(previewFeed.children.length, 3);
+const pendingThumb = previewFeed.children.at(-1);
+assert.equal(pendingThumb.classList.contains("pending"), true);
+assert.equal(pendingThumb.disabled, true);
+assert.equal(pendingThumb.scrollIntoViewCalls.length, 1);
+
+delete node.__easyuseAnimaGeneratorDenoisePreview;
+node.__easyuseAnimaGeneratorPreviewImages = [];
+fixture.runtime.updateSummary(node);
+assert.equal(previewFeed.hidden, true);
+assert.equal(previewMeta.textContent, "-");
+assert.equal(
+  previewBox.children[0].className,
+  "easyuse-anima-aio-node-denoise-preview",
+  "mechanical extraction must preserve the current no-image placeholder behavior",
+);
+
+node.__easyuseAnimaLastQueuedSeed = 777;
+fixture.runtime.refreshSeedButtons(node);
+let seedLast = panel.querySelector("[data-aio-seed-last]");
+assert.equal(seedLast.disabled, false);
+assert.equal(seedLast.textContent, 'format:button.useLast:{"seed":777}');
+fixture.trace.length = 0;
+findByText(panel, "text:button.newFixed").emit("click");
+assert.equal(node.widgetValues.seed, 123456);
+assert.equal(node.settings.sampler.seed, 123456);
+assert.equal(fixture.trace.includes("random-seed"), true);
+assert.ok(fixture.trace.indexOf("set-widget:seed:123456") < fixture.trace.indexOf("sync-visible"));
+assert.ok(fixture.trace.indexOf("sync-visible") < fixture.trace.indexOf("get-settings"));
+assert.ok(fixture.trace.indexOf("get-settings") < fixture.trace.lastIndexOf("dirty"));
+fixture.trace.length = 0;
+findByText(panel, "text:button.randomEach").emit("click");
+assert.equal(node.widgetValues.seed, -1);
+assert.equal(node.settings.sampler.seed, -1);
+assert.ok(fixture.trace.indexOf("set-widget:seed:-1") < fixture.trace.indexOf("sync-visible"));
+const seedInput = panel.querySelector("[data-aio-seed-input]");
+seedInput.value = "314";
+fixture.trace.length = 0;
+seedInput.emit("input");
+assert.equal(node.widgetValues.seed, 314);
+assert.equal(node.settings.sampler.seed, 314);
+assert.ok(fixture.trace.indexOf("set-widget:seed:314") < fixture.trace.indexOf("sync-visible"));
+assert.ok(fixture.trace.indexOf("sync-visible") < fixture.trace.indexOf("get-settings"));
+assert.ok(fixture.trace.indexOf("get-settings") < fixture.trace.lastIndexOf("dirty"));
+seedLast = panel.querySelector("[data-aio-seed-last]");
+seedLast.emit("click");
+assert.equal(node.widgetValues.seed, 777);
+assert.equal(node.settings.sampler.seed, 777);
+assert.equal(seedLast.disabled, true);
+
+const highresBlock = settingsScroll.children[1];
+const highresToggle = highresBlock.children[0].children[1].children[1].children[0];
+highresToggle.checked = false;
+node.settings.sampler.seed_after_generate = "invalid";
+fixture.trace.length = 0;
+highresToggle.emit("change");
+assert.equal(node.settings.highres.enabled, false);
+assert.equal(node.settings.sampler.seed_after_generate, "fixed");
+assert.deepEqual(fixture.trace.slice(0, 3), [
+  "get-settings",
+  "apply-visible",
+  "write:true",
+]);
+assert.ok(
+  fixture.trace.indexOf("write:true") < fixture.trace.indexOf("sync-profile"),
+  "settings write must complete before summary/profile refresh",
+);
+assert.notEqual(panel.children[0], main, "rerendering a stage toggle must replace panel children");
+
+assert.equal(findByClass(panel, "easyuse-anima-aio-node-main") != null, true);
+console.log("AiO generator panel runtime smoke passed.");

--- a/tests/frontend_support/fake_dom.mjs
+++ b/tests/frontend_support/fake_dom.mjs
@@ -1,12 +1,105 @@
+class FakeClassList {
+  constructor(element) {
+    this.element = element;
+  }
+
+  values() {
+    return new Set(String(this.element.className || "").split(/\s+/).filter(Boolean));
+  }
+
+  write(values) {
+    this.element.className = [...values].join(" ");
+  }
+
+  add(...names) {
+    const values = this.values();
+    for (const name of names) {
+      values.add(String(name));
+    }
+    this.write(values);
+  }
+
+  remove(...names) {
+    const values = this.values();
+    for (const name of names) {
+      values.delete(String(name));
+    }
+    this.write(values);
+  }
+
+  toggle(name, force) {
+    const values = this.values();
+    const text = String(name);
+    const enabled = force == null ? !values.has(text) : !!force;
+    if (enabled) {
+      values.add(text);
+    } else {
+      values.delete(text);
+    }
+    this.write(values);
+    return enabled;
+  }
+
+  contains(name) {
+    return this.values().has(String(name));
+  }
+}
+
+class FakeStyle {
+  constructor() {
+    this.cssText = "";
+    this.background = "";
+    this.borderColor = "";
+    this.values = new Map();
+  }
+
+  setProperty(name, value) {
+    const text = String(value);
+    this.values.set(String(name), text);
+    this[name] = text;
+  }
+
+  getPropertyValue(name) {
+    return this.values.get(String(name)) ?? this[name] ?? "";
+  }
+
+  removeProperty(name) {
+    const key = String(name);
+    const previous = this.getPropertyValue(key);
+    this.values.delete(key);
+    delete this[key];
+    return previous;
+  }
+}
+
+function matchesSelector(element, selector) {
+  return String(selector).split(",").some((candidate) => {
+    const expected = candidate.trim();
+    if (!expected) {
+      return false;
+    }
+    if (expected.startsWith(".")) {
+      return element.classList.contains(expected.slice(1));
+    }
+    const attribute = expected.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/);
+    if (attribute) {
+      const actual = element.getAttribute(attribute[1]);
+      return actual != null && (attribute[2] == null || actual === attribute[2]);
+    }
+    return element.tagName === expected.toUpperCase();
+  });
+}
+
 class FakeElement {
   constructor(tagName) {
     this.tagName = String(tagName).toUpperCase();
     this.children = [];
     this.parentElement = null;
-    this.style = { cssText: "", background: "", borderColor: "" };
+    this.style = new FakeStyle();
     this.listeners = new Map();
     this.attributes = new Map();
     this.className = "";
+    this.classList = new FakeClassList(this);
     this.textContent = "";
     this.title = "";
     this.type = "";
@@ -17,9 +110,14 @@ class FakeElement {
     this.spellcheck = true;
     this.disabled = false;
     this.selected = false;
+    this.checked = false;
+    this.hidden = false;
     this.focused = false;
     this.removed = false;
     this.onclick = null;
+    this.scrollIntoViewCalls = [];
+    this.boundingClientRect = { left: 0, top: 0, width: 100, height: 20 };
+    this.pointerCaptures = new Set();
   }
 
   append(...children) {
@@ -85,8 +183,22 @@ class FakeElement {
   }
 
   querySelector(selector) {
-    const expectedTag = String(selector).toUpperCase();
-    return descendants(this).find((element) => element.tagName === expectedTag) ?? null;
+    return descendants(this).find((element) => matchesSelector(element, selector)) ?? null;
+  }
+
+  querySelectorAll(selector) {
+    return descendants(this).filter((element) => matchesSelector(element, selector));
+  }
+
+  closest(selector) {
+    let current = this;
+    while (current) {
+      if (matchesSelector(current, selector)) {
+        return current;
+      }
+      current = current.parentElement;
+    }
+    return null;
   }
 
   focus() {
@@ -96,6 +208,22 @@ class FakeElement {
   blur() {
     this.focused = false;
     this.emit("blur");
+  }
+
+  getBoundingClientRect() {
+    return { ...this.boundingClientRect };
+  }
+
+  scrollIntoView(options) {
+    this.scrollIntoViewCalls.push(options);
+  }
+
+  setPointerCapture(pointerId) {
+    this.pointerCaptures.add(pointerId);
+  }
+
+  releasePointerCapture(pointerId) {
+    this.pointerCaptures.delete(pointerId);
   }
 
   remove() {
@@ -119,6 +247,13 @@ class FakeDocument {
 
   createElement(tagName) {
     const element = new FakeElement(tagName);
+    this.createdElements.push(element);
+    return element;
+  }
+
+  createTextNode(value) {
+    const element = new FakeElement("#text");
+    element.textContent = String(value);
     this.createdElements.push(element);
     return element;
   }

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -15,6 +15,9 @@ AIO_PROFILE_API_CLIENT_JS = (
 AIO_PROFILE_SETTINGS_RUNTIME_JS = (
     ROOT / "web" / "js" / "aio" / "profile_settings_runtime.js"
 )
+AIO_GENERATOR_PANEL_RUNTIME_JS = (
+    ROOT / "web" / "js" / "aio" / "generator_panel_runtime.js"
+)
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
@@ -37,15 +40,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         source = AIO_JS.read_text(encoding="utf-8")
         presets_source = AIO_PRESETS_JS.read_text(encoding="utf-8")
         api_client_source = AIO_PROFILE_API_CLIENT_JS.read_text(encoding="utf-8")
-        render_start = source.index("function renderGeneratorPanel")
-        render_end = source.index("\nfunction ensureGeneratorPanel", render_start)
-        render_body = source[render_start:render_end]
-        header_start = render_body.index("const samplerHeader = makeCardHeader")
-        header_end = render_body.index("const settingsScroll", header_start)
-        header_body = render_body[header_start:header_end]
-        summary_start = source.index("function updateGeneratorDomSummary")
-        summary_end = source.index("\nfunction renderGeneratorPreviewFeed", summary_start)
-        summary_body = source[summary_start:summary_end]
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         serialize_start = source.index("function syncGeneratorSerializedWidgets")
         serialize_end = source.index("\nfunction markNodeDirty", serialize_start)
         serialize_body = source[serialize_start:serialize_end]
@@ -71,16 +66,21 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('target.dit_corrections.dcw_mode = enabled ? "auto" : "off"', presets_source)
         self.assertIn('kj.sage_attention = enabled ? "auto" : "disabled"', presets_source)
         self.assertIn("compile.enabled = enabled", presets_source)
-        self.assertIn("syncGeneratorProfileValue(node, settings)", render_body)
-        self.assertIn('profileButton.setAttribute("data-aio-profile-button", "")', render_body)
-        self.assertIn('panel.querySelector("[data-aio-profile-button]")', summary_body)
-        self.assertIn("generatorProfileDisplayLabel(profileValue)", summary_body)
-        self.assertIn("profileButton,", header_body)
-        self.assertLess(header_body.index("profileButton,"), header_body.index('makeIconButton("⚙"'))
+        self.assertIn("syncGeneratorProfileValue(node, settings)", panel_source)
+        self.assertIn(
+            'profileButton.setAttribute("data-aio-profile-button", "")',
+            panel_source,
+        )
+        self.assertIn(
+            'panel.querySelector("[data-aio-profile-button]")',
+            panel_source,
+        )
+        self.assertIn("generatorProfileDisplayLabel(profileValue)", panel_source)
         self.assertNotIn("function openGeneratorProfileSettings", source)
         self.assertIn("open: openGeneratorProfileSettings,", source)
-        self.assertIn('panel.append(main)', render_body)
-        self.assertNotIn("profileBar", render_body)
+        self.assertIn("openProfileSettings: openGeneratorProfileSettings,", source)
+        self.assertIn("panel.append(main)", panel_source)
+        self.assertNotIn("profileBar", panel_source)
         for path in (
             "/easyuse_anima/aio_profiles",
             "/easyuse_anima/aio_profiles/save",
@@ -101,10 +101,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_generator_panel_height_is_owned_by_comfyui(self):
         source = AIO_JS.read_text(encoding="utf-8")
-
-        layout_start = source.index("function applyGeneratorLayout")
-        layout_end = source.index("\nfunction scheduleGeneratorLayout", layout_start)
-        layout_body = source[layout_start:layout_end]
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         panel_start = source.index("    .easyuse-anima-aio-node-panel {")
         panel_end = source.index("\n    .easyuse-anima-aio-node-panel *", panel_start)
         panel_style = source[panel_start:panel_end]
@@ -123,24 +120,19 @@ class AIOFrontendSourceTests(unittest.TestCase):
         preview_box_start = source.index("    .easyuse-anima-aio-node-preview-box {")
         preview_box_end = source.index("\n    .easyuse-anima-aio-node-preview-box img {", preview_box_start)
         preview_box_style = source[preview_box_start:preview_box_end]
-        panel_registration_start = source.index("function ensureGeneratorPanel")
-        panel_registration_end = source.index(
-            "\nfunction openSamplerSettings", panel_registration_start
-        )
-        panel_registration = source[panel_registration_start:panel_registration_end]
-
-        self.assertIn("getMinHeight: () => GENERATOR_PANEL_MIN_HEIGHT", panel_registration)
-        self.assertNotIn("getHeight:", panel_registration)
-        self.assertNotIn("computeLayoutSize", panel_registration)
-        self.assertNotIn("computedHeight =", source)
-        self.assertNotIn("generatorNodeChromeOffset", source)
-        self.assertNotIn("generatorAvailablePanelHeight", source)
-        self.assertNotIn("generatorPanelHeight", source)
-        self.assertNotIn("node.setSize?.(", layout_body)
-        self.assertNotIn("node.setSize(", layout_body)
-        self.assertNotIn("panel.style.height =", layout_body)
-        self.assertIn('panel.style.removeProperty("height")', layout_body)
-        self.assertIn('panel.style.removeProperty("max-height")', layout_body)
+        self.assertIn("getMinHeight: () => GENERATOR_PANEL_MIN_HEIGHT", panel_source)
+        self.assertNotIn("getHeight:", panel_source)
+        self.assertNotIn("computeLayoutSize", panel_source)
+        combined_source = source + panel_source
+        self.assertNotIn("computedHeight =", combined_source)
+        self.assertNotIn("generatorNodeChromeOffset", combined_source)
+        self.assertNotIn("generatorAvailablePanelHeight", combined_source)
+        self.assertNotIn("generatorPanelHeight", combined_source)
+        self.assertNotIn("node.setSize?.(", panel_source)
+        self.assertNotIn("node.setSize(", panel_source)
+        self.assertNotIn("panel.style.height =", panel_source)
+        self.assertIn('panel.style.removeProperty("height")', panel_source)
+        self.assertIn('panel.style.removeProperty("max-height")', panel_source)
 
         self.assertIn("flex: 1 1 0%;", panel_style)
         self.assertIn("contain: size;", panel_style)
@@ -161,24 +153,25 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_generator_wheel_router_decides_scroll_ownership_before_canvas(self):
         source = AIO_JS.read_text(encoding="utf-8")
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         wheel_source = AIO_WHEEL_JS.read_text(encoding="utf-8")
-        stop_start = source.index("function stopGeneratorControlPropagation")
-        stop_end = source.index("\nfunction dispatchGeneratorCanvasWheelEvent", stop_start)
-        stop_body = source[stop_start:stop_end]
         forward_start = source.index("function forwardGeneratorPanelWheel")
         forward_end = source.index("\nfunction installGeneratorWheelForwarder", forward_start)
         forward_body = source[forward_start:forward_end]
         install_start = forward_end + 1
-        install_end = source.index("\nfunction samplerModeLabel", install_start)
+        install_end = source.index("\nfunction generatorSettings", install_start)
         install_body = source[install_start:install_end]
         setup_start = source.index("  async setup() {")
         setup_end = source.index("\n  async beforeRegisterNodeDef", setup_start)
         setup_body = source[setup_start:setup_end]
 
         self.assertIn('from "./aio/wheel.js"', source)
-        self.assertIn('root.addEventListener("wheel", forwardGeneratorPanelWheel', stop_body)
-        self.assertIn("capture: true", stop_body)
-        self.assertIn("passive: false", stop_body)
+        self.assertIn(
+            'root.addEventListener("wheel", forwardGeneratorPanelWheel',
+            panel_source,
+        )
+        self.assertIn("capture: true", panel_source)
+        self.assertIn("passive: false", panel_source)
         self.assertIn("consumeAioPanelWheel(event, panel)", forward_body)
         self.assertLess(
             forward_body.index("consumeAioPanelWheel(event, panel)"),
@@ -215,13 +208,10 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("onExecuted?.apply", body)
 
     def test_generator_preview_meta_keeps_dedicated_resolution_label(self):
-        source = AIO_JS.read_text(encoding="utf-8")
-        start = source.index("function updateGeneratorDomPreview")
-        end = source.index("\nfunction cssEscape", start)
-        body = source[start:end]
-        meta_start = body.index("const parts = [")
-        meta_end = body.index("].filter", meta_start)
-        meta_parts = body[meta_start:meta_end]
+        source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
+        meta_start = source.index("const parts = [")
+        meta_end = source.index("].filter", meta_start)
+        meta_parts = source[meta_start:meta_end]
 
         self.assertIn("aioPreviewImageName(currentImage)", meta_parts)
         self.assertIn("aioPreviewResolution(currentImage)", meta_parts)
@@ -346,10 +336,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("loadGeneratorOptionalDependencies({ retryErrors: true })", queue_body)
 
     def test_generator_panel_renders_upscale_after_detailer(self):
-        source = AIO_JS.read_text(encoding="utf-8")
-        start = source.index("function renderGeneratorPanel")
-        end = source.index("\nfunction ensureGeneratorPanel", start)
-        body = source[start:end]
+        body = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
 
         self.assertLess(body.index("const detailerBlock"), body.index("const upscaleBlock"))
         self.assertLess(body.index("const upscaleBlock"), body.index("const postprocessBlock"))

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -43,6 +43,10 @@ AIO_PROFILE_SETTINGS_RUNTIME_JS = AIO_MODULES / "profile_settings_runtime.js"
 AIO_PROFILE_SETTINGS_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_profile_settings_runtime_smoke.mjs"
 )
+AIO_GENERATOR_PANEL_RUNTIME_JS = AIO_MODULES / "generator_panel_runtime.js"
+AIO_GENERATOR_PANEL_RUNTIME_SMOKE = (
+    ROOT / "tests" / "frontend_aio_generator_panel_runtime_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -304,6 +308,210 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_PROFILE_SETTINGS_RUNTIME_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_profile_settings_runtime_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_generator_panel_runtime_has_closed_view_boundary(self):
+        source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreateGeneratorPanelRuntime"],
+        )
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:app|api)\b")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotRegex(
+            source,
+            re.compile(r"^(?:window|globalThis)\.[A-Za-z_$]", re.MULTILINE),
+        )
+
+        self.assertIn(
+            'import { aioCreateGeneratorPanelRuntime } from '
+            '"./aio/generator_panel_runtime.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+generatorPanelRuntime\s*=\s*"
+            r"aioCreateGeneratorPanelRuntime\(\{(?P<dependencies>.*?)\n\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        runtime_dependencies = factory_match.group("dependencies")
+        for dependency in (
+            "document,",
+            "window,",
+            "requestAnimationFrame: (callback) => requestAnimationFrame(callback),",
+            "panelMinHeight: GENERATOR_PANEL_MIN_HEIGHT,",
+        ):
+            with self.subTest(top_level_dependency=dependency):
+                self.assertRegex(
+                    runtime_dependencies,
+                    rf"(?m)^  {re.escape(dependency)}$",
+                )
+
+        nested_dependencies = {
+            "controls": [
+                "numberInput,",
+                "checkbox,",
+                "selectInput,",
+                "createNodeField,",
+            ],
+            "text": [
+                "get: aioText,",
+                "format: aioFormat,",
+                "applyTooltip,",
+            ],
+            "settingsCore": [
+                "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,",
+                "specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,",
+                "fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,",
+                "fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,",
+                "mergeDefaults,",
+                "normalizeSeedControl,",
+                "normalizeSeedValue,",
+                "clampNumber: clampGeneratorNumber,",
+                "normalizeUsduAutoTileRange: normalizeGeneratorUsduAutoTileRange,",
+                "setUsduAutoTileTarget: setGeneratorUsduAutoTileTarget,",
+                "normalizeDetailerOrder,",
+                "detailerTargetDefaults,",
+                "detailerTargetTitle,",
+            ],
+            "nodeAdapter": [
+                "getSettings: generatorSettings,",
+                "applyVisibleSettings: applyVisibleGeneratorSettings,",
+                "writeSettings: writeGeneratorSettingsFromState,",
+                "syncSettingsFromVisible: syncGeneratorSettingsFromVisible,",
+                "widgetValue,",
+                "widgetOptions,",
+                "setWidgetValueIfChanged,",
+                "markDirty: markNodeDirty,",
+                "ensureStyle,",
+                "suppressDefaultPreview: suppressGeneratorDefaultPreview,",
+                "markNativePreviewHidden: markGeneratorNativeLivePreviewHidden,",
+                "imageUrl: generatorImageUrl,",
+                "randomSeed,",
+                "forwardPanelWheel: forwardGeneratorPanelWheel,",
+            ],
+            "profileAdapter": [
+                "syncValue: syncGeneratorProfileValue,",
+                "displayLabel: generatorProfileDisplayLabel,",
+            ],
+            "previewAdapter": [
+                "mainImage: aioMainPreviewImage,",
+                "selectedIndex: aioSelectedPreviewIndex,",
+                "imageLabel: aioPreviewImageLabel,",
+                "imageName: aioPreviewImageName,",
+                "imageResolution: aioPreviewResolution,",
+                "imageFileSize: aioPreviewFileSize,",
+            ],
+            "actions": [
+                "openProfileSettings: openGeneratorProfileSettings,",
+                "openSaveSettings,",
+                "openSamplerSettings,",
+                "openAdvancedSettings,",
+                "openHighresSettings,",
+                "openDetailerSettings,",
+                "openUpscaleSettings,",
+                "openPostprocessSettings,",
+                "openPreviewSettings,",
+            ],
+        }
+        for group_name, expected_lines in nested_dependencies.items():
+            with self.subTest(dependency_group=group_name):
+                group_match = re.search(
+                    rf"(?ms)^  {group_name}: \{{\n(?P<body>.*?)^  \}},$",
+                    runtime_dependencies,
+                )
+                self.assertIsNotNone(group_match)
+                self.assertEqual(
+                    [line.strip() for line in group_match.group("body").splitlines()],
+                    expected_lines,
+                )
+
+        wrappers = {
+            "renderGeneratorPanel": "renderPanel",
+            "ensureGeneratorPanel": "ensurePanel",
+            "updateGeneratorDomSummary": "updateSummary",
+            "scheduleGeneratorLayout": "scheduleLayout",
+            "refreshGeneratorSeedButtons": "refreshSeedButtons",
+        }
+        for wrapper, method in wrappers.items():
+            with self.subTest(public_wrapper=wrapper):
+                self.assertRegex(
+                    entry_source,
+                    rf"function {wrapper}\(node\) \{{\n"
+                    rf"  return generatorPanelRuntime\.{method}\(node\);\n\}}",
+                )
+
+        for moved_function in (
+            "generatorDenoisePreviewLabel",
+            "stopGeneratorControlPropagation",
+            "samplerModeLabel",
+            "generatorPanelWidth",
+            "applyGeneratorLayout",
+            "updateGeneratorSettings",
+            "renderGeneratorPreviewFeed",
+            "updateGeneratorDomPreview",
+            "createDomNumberControl",
+            "createDomSliderNumberControl",
+            "createDomSettingsSliderNumberControl",
+            "createDomSettingsCheckboxControl",
+            "createDomSettingsNumberControl",
+            "createDomSettingsSelectControl",
+            "createDomSelectControl",
+            "setGeneratorSeedFromUi",
+        ):
+            with self.subTest(moved_function=moved_function):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\bfunction\s+{moved_function}\(",
+                )
+                self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
+
+        for removed_function in (
+            "createDomTextControl",
+            "createDomCheckboxControl",
+            "createSeedControlSelect",
+        ):
+            with self.subTest(removed_dead_function=removed_function):
+                self.assertNotIn(removed_function, entry_source)
+                self.assertNotIn(removed_function, source)
+
+        for entry_owned_function in (
+            "syncGeneratorSerializedWidgets",
+            "installGeneratorWheelForwarder",
+            "installGeneratorQueuePromptHook",
+            "suppressGeneratorDefaultPreview",
+            "openSamplerSettings",
+            "hookGeneratorNode",
+        ):
+            with self.subTest(entry_owned_function=entry_owned_function):
+                self.assertRegex(
+                    entry_source,
+                    rf"\bfunction\s+{entry_owned_function}\(",
+                )
+                self.assertNotRegex(
+                    source,
+                    rf"\bfunction\s+{entry_owned_function}\(",
+                )
+
+        self.assertLess(
+            entry_source.index("const openPreviewSettings"),
+            entry_source.index("const generatorPanelRuntime"),
+        )
+        self.assertLess(
+            entry_source.index("const generatorPanelRuntime"),
+            entry_source.index("function hookInputNode"),
+        )
+        self.assertTrue(AIO_GENERATOR_PANEL_RUNTIME_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_generator_panel_runtime_smoke.mjs"',
             frontend_check_source,
         )
 
@@ -801,6 +1009,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
     def test_aio_postprocess_settings_dialog_has_closed_controller_boundary(self):
         source = AIO_POSTPROCESS_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
         entry_source = AIO_JS.read_text(encoding="utf-8")
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
         self.assertEqual(source.splitlines()[0], "// @ts-check")
@@ -865,11 +1074,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
         self.assertIn("const openInputSettings = aioCreateInputSettingsDialog", entry_source)
 
-        render_start = entry_source.index("function renderGeneratorPanel")
-        render_end = entry_source.index("\nfunction ensureGeneratorPanel", render_start)
-        render_body = entry_source[render_start:render_end]
-        self.assertIn("openPostprocessSettings(node)", render_body)
-        self.assertEqual(entry_source.count("openPostprocessSettings(node)"), 1)
+        self.assertIn("openPostprocessSettings(node)", panel_source)
+        self.assertEqual(panel_source.count("openPostprocessSettings(node)"), 1)
 
         self.assertIn("...postprocess", source)
         self.assertIn("...fit", source)
@@ -882,6 +1088,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
     def test_aio_preview_settings_dialog_has_closed_controller_boundary(self):
         source = AIO_PREVIEW_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
         entry_source = AIO_JS.read_text(encoding="utf-8")
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
         self.assertEqual(source.splitlines()[0], "// @ts-check")
@@ -941,11 +1148,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
 
         self.assertNotRegex(entry_source, r"\bfunction\s+openPreviewSettings\(")
-        render_start = entry_source.index("function renderGeneratorPanel")
-        render_end = entry_source.index("\nfunction ensureGeneratorPanel", render_start)
-        render_body = entry_source[render_start:render_end]
-        self.assertIn("openPreviewSettings(node)", render_body)
-        self.assertEqual(entry_source.count("openPreviewSettings(node)"), 1)
+        self.assertIn("openPreviewSettings(node)", panel_source)
+        self.assertEqual(panel_source.count("openPreviewSettings(node)"), 1)
 
         self.assertTrue(AIO_PREVIEW_SETTINGS_DIALOG_SMOKE.is_file())
         self.assertIn(

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -54,6 +54,11 @@ try {
         throw "Frontend AiO profile settings runtime smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_generator_panel_runtime_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO generator panel runtime smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_dependency_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -1,0 +1,1405 @@
+// @ts-check
+
+const GENERATOR_DOM_WIDGET = "easyuse_anima_generator_panel";
+const GENERATOR_NODE_MIN_WIDTH = 560;
+const GENERATOR_NODE_DEFAULT_WIDTH = 620;
+const GENERATOR_PANEL_CONTROL_SELECTOR = "input, select, textarea, button";
+
+/**
+ * @typedef {object} AioGeneratorPanelControls
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(value: any) => any} checkbox
+ * @property {(options: any[], value: any) => any} selectInput
+ * @property {(label: any, control: any, className?: string, tooltipKey?: string) => any} createNodeField
+ */
+
+/**
+ * @typedef {object} AioGeneratorPanelText
+ * @property {(key: string) => string} get
+ * @property {(key: string, values?: Record<string, any>) => string} format
+ * @property {(element: any, key: string) => any} applyTooltip
+ */
+
+/**
+ * @typedef {object} AioGeneratorPanelSettingsCore
+ * @property {any} defaultGenerationSettings
+ * @property {number} specialSeedRandom
+ * @property {any[]} fallbackSamplerNames
+ * @property {any[]} fallbackSchedulerNames
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(value: any) => string} normalizeSeedControl
+ * @property {(value: any, fallback?: number) => number} normalizeSeedValue
+ * @property {(value: any, fallback: number, min: number, max: number) => number} clampNumber
+ * @property {(usdu: any) => any} normalizeUsduAutoTileRange
+ * @property {(settings: any, value: number) => void} setUsduAutoTileTarget
+ * @property {(order: any, detailer?: any) => string[]} normalizeDetailerOrder
+ * @property {(targetName: string) => any} detailerTargetDefaults
+ * @property {(targetName: string, target: any, index?: number) => string} detailerTargetTitle
+ */
+
+/**
+ * @typedef {object} AioGeneratorPanelNodeAdapter
+ * @property {(node: any) => any} getSettings
+ * @property {(node: any, settings: any) => void} applyVisibleSettings
+ * @property {(node: any, settings: any, markDirty?: boolean) => void} writeSettings
+ * @property {(node: any) => void} syncSettingsFromVisible
+ * @property {(node: any, name: string, fallback: any) => any} widgetValue
+ * @property {(node: any, name: string, fallback: any[]) => any[]} widgetOptions
+ * @property {(node: any, name: string, value: any) => void} setWidgetValueIfChanged
+ * @property {(node: any) => void} markDirty
+ * @property {() => void} ensureStyle
+ * @property {(node: any, options?: Record<string, any>) => void} suppressDefaultPreview
+ * @property {(node: any) => void} markNativePreviewHidden
+ * @property {(image: any) => string} imageUrl
+ * @property {() => number} randomSeed
+ * @property {(event: any) => any} forwardPanelWheel
+ */
+
+/**
+ * @typedef {object} AioGeneratorPanelProfileAdapter
+ * @property {(node: any, settings?: any) => string} syncValue
+ * @property {(value: string) => string} displayLabel
+ */
+
+/**
+ * @typedef {object} AioGeneratorPanelPreviewAdapter
+ * @property {(node: any, images: any[]) => any} mainImage
+ * @property {(node: any, images: any[]) => number} selectedIndex
+ * @property {(image: any) => string} imageLabel
+ * @property {(image: any) => string} imageName
+ * @property {(image: any) => string} imageResolution
+ * @property {(image: any) => string} imageFileSize
+ */
+
+/**
+ * @typedef {object} AioGeneratorPanelActions
+ * @property {(node: any) => void} openProfileSettings
+ * @property {(node: any) => void} openSaveSettings
+ * @property {(node: any) => void} openSamplerSettings
+ * @property {(node: any) => void} openAdvancedSettings
+ * @property {(node: any) => void} openHighresSettings
+ * @property {(node: any) => void} openDetailerSettings
+ * @property {(node: any) => void} openUpscaleSettings
+ * @property {(node: any) => void} openPostprocessSettings
+ * @property {(node: any) => void} openPreviewSettings
+ */
+
+/**
+ * @typedef {object} AioGeneratorPanelRuntimeDependencies
+ * @property {any} document
+ * @property {any} window
+ * @property {(callback: (...args: any[]) => any) => any} requestAnimationFrame
+ * @property {number} panelMinHeight
+ * @property {AioGeneratorPanelControls} controls
+ * @property {AioGeneratorPanelText} text
+ * @property {AioGeneratorPanelSettingsCore} settingsCore
+ * @property {AioGeneratorPanelNodeAdapter} nodeAdapter
+ * @property {AioGeneratorPanelProfileAdapter} profileAdapter
+ * @property {AioGeneratorPanelPreviewAdapter} previewAdapter
+ * @property {AioGeneratorPanelActions} actions
+ */
+
+/**
+ * Own the AiO generator panel DOM, render, summary, preview, seed controls, and
+ * per-node layout lifecycle. Extension hooks, queue preparation, serialized
+ * widget ownership, dialogs, native-preview events, CSS, and the global wheel
+ * router remain in the entry module and are supplied as adapters.
+ *
+ * @param {AioGeneratorPanelRuntimeDependencies} dependencies
+ */
+export function aioCreateGeneratorPanelRuntime(dependencies) {
+  const {
+    document,
+    window,
+    requestAnimationFrame,
+    panelMinHeight: GENERATOR_PANEL_MIN_HEIGHT,
+    controls,
+    text,
+    settingsCore,
+    nodeAdapter,
+    profileAdapter,
+    previewAdapter,
+    actions,
+  } = dependencies;
+  const {
+    numberInput,
+    checkbox,
+    selectInput,
+    createNodeField,
+  } = controls;
+  const {
+    get: aioText,
+    format: aioFormat,
+    applyTooltip,
+  } = text;
+  const {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    normalizeSeedControl,
+    normalizeSeedValue,
+    clampNumber: clampGeneratorNumber,
+    normalizeUsduAutoTileRange: normalizeGeneratorUsduAutoTileRange,
+    setUsduAutoTileTarget: setGeneratorUsduAutoTileTarget,
+    normalizeDetailerOrder,
+    detailerTargetDefaults,
+    detailerTargetTitle,
+  } = settingsCore;
+  const {
+    getSettings: generatorSettings,
+    applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings: writeGeneratorSettingsFromState,
+    syncSettingsFromVisible: syncGeneratorSettingsFromVisible,
+    widgetValue,
+    widgetOptions,
+    setWidgetValueIfChanged,
+    markDirty: markNodeDirty,
+    ensureStyle,
+    suppressDefaultPreview: suppressGeneratorDefaultPreview,
+    markNativePreviewHidden: markGeneratorNativeLivePreviewHidden,
+    imageUrl: generatorImageUrl,
+    randomSeed,
+    forwardPanelWheel: forwardGeneratorPanelWheel,
+  } = nodeAdapter;
+  const {
+    syncValue: syncGeneratorProfileValue,
+    displayLabel: generatorProfileDisplayLabel,
+  } = profileAdapter;
+  const {
+    mainImage: aioMainPreviewImage,
+    selectedIndex: aioSelectedPreviewIndex,
+    imageLabel: aioPreviewImageLabel,
+    imageName: aioPreviewImageName,
+    imageResolution: aioPreviewResolution,
+    imageFileSize: aioPreviewFileSize,
+  } = previewAdapter;
+  const {
+    openProfileSettings: openGeneratorProfileSettings,
+    openSaveSettings,
+    openSamplerSettings,
+    openAdvancedSettings,
+    openHighresSettings,
+    openDetailerSettings,
+    openUpscaleSettings,
+    openPostprocessSettings,
+    openPreviewSettings,
+  } = actions;
+
+  function generatorDenoisePreviewLabel(preview) {
+    const base = aioText("text.previewDenoise");
+    const value = Number(preview?.value);
+    const max = Number(preview?.max);
+    if (Number.isFinite(value) && Number.isFinite(max) && max > 0) {
+      const current = Math.max(0, Math.min(max, Math.round(value)));
+      return `${base} · ${current}/${Math.round(max)}`;
+    }
+    return base;
+  }
+
+  function stopGeneratorControlPropagation(root) {
+    if (!root || root.__easyuseAnimaAioStopPropagation) {
+      return;
+    }
+    const stop = (event) => {
+      if (event.target?.closest?.(GENERATOR_PANEL_CONTROL_SELECTOR)) {
+        event.stopPropagation();
+      }
+    };
+    for (const eventName of [
+      "pointerdown",
+      "mousedown",
+      "pointerup",
+      "mouseup",
+      "click",
+      "dblclick",
+      "keydown",
+      "keyup",
+    ]) {
+      root.addEventListener(eventName, stop);
+    }
+    // Legacy canvas bubbles DOM-widget wheel events through the panel. Keep this
+    // local guard as a fallback; Node 2.0 still needs the window capture router
+    // installed below because its Vue ancestor can handle wheel first.
+    root.addEventListener("wheel", forwardGeneratorPanelWheel, {
+      capture: true,
+      passive: false,
+    });
+    root.__easyuseAnimaAioStopPropagation = true;
+  }
+
+  function samplerModeLabel(settingsOrBackend) {
+    const settings = typeof settingsOrBackend === "object" && settingsOrBackend
+      ? settingsOrBackend
+      : null;
+    const sampler = settings?.sampler || {};
+    const backend = String(settings ? sampler.backend : settingsOrBackend || "comfy_ksampler");
+    const corrections = !!sampler?.dit_corrections?.enabled;
+    const spectrum = !!sampler?.spectrum?.enabled;
+    switch (backend) {
+      case "spectrum_mod_guidance_advanced":
+        return corrections ? "Spectrum Mod Guidance + Corrections" : "Spectrum Mod Guidance";
+      case "spectrum_spd_speed":
+        return "Spectrum SPD / SPEED";
+      case "comfy_ksampler": {
+        const extras = [];
+        if (spectrum) {
+          extras.push("Spectrum Patch");
+        }
+        if (corrections) {
+          extras.push("Corrections");
+        }
+        return extras.length ? `${extras.join(" + ")} / Comfy KSampler` : "Standard Comfy KSampler";
+      }
+      default:
+        return "Standard Comfy KSampler";
+    }
+  }
+
+  function generatorPanelWidth(node) {
+    return Math.max(240, Math.floor((Number(node?.size?.[0]) || GENERATOR_NODE_DEFAULT_WIDTH) - 20));
+  }
+
+  function applyGeneratorLayout(node) {
+    const panel = node?.__easyuseAnimaGeneratorPanelEl;
+    if (!panel) {
+      return;
+    }
+    const width = generatorPanelWidth(node);
+    panel.style.width = `${width}px`;
+    panel.style.maxWidth = `${width}px`;
+    // ComfyUI owns the node and DOM-widget viewport height. AiO owns only child
+    // content: the settings column scrolls while the preview stays in that host
+    // viewport. Never derive height from node.size or write node.setSize here.
+    panel.style.removeProperty("height");
+    panel.style.removeProperty("max-height");
+    markNodeDirty(node);
+  }
+
+  function scheduleGeneratorLayout(node) {
+    if (!node?.__easyuseAnimaGeneratorPanelEl || node.__easyuseAnimaGeneratorLayoutScheduled) {
+      return;
+    }
+    node.__easyuseAnimaGeneratorLayoutScheduled = true;
+    requestAnimationFrame(() => {
+      node.__easyuseAnimaGeneratorLayoutScheduled = false;
+      applyGeneratorLayout(node);
+    });
+  }
+
+  function updateGeneratorSettings(node, updater, markDirty = true) {
+    const settings = generatorSettings(node);
+    updater?.(settings);
+    settings.sampler.seed_after_generate = normalizeSeedControl(settings.sampler.seed_after_generate);
+    applyVisibleGeneratorSettings(node, settings);
+    writeGeneratorSettingsFromState(node, settings, markDirty);
+    updateGeneratorDomSummary(node);
+    return settings;
+  }
+
+  function updateGeneratorDomSummary(node) {
+    const panel = node?.__easyuseAnimaGeneratorPanelEl;
+    if (!panel) {
+      return;
+    }
+    const settings = generatorSettings(node);
+    const profileValue = syncGeneratorProfileValue(node, settings);
+    const profileButtonEl = panel.querySelector("[data-aio-profile-button]");
+    if (profileButtonEl) {
+      profileButtonEl.textContent = generatorProfileDisplayLabel(profileValue);
+      profileButtonEl.title = aioText("profile.selectTip");
+    }
+    const backendSummaryEl = panel.querySelector("[data-aio-backend-summary]");
+    const saveButtonEl = panel.querySelector("[data-aio-save-button]");
+    if (saveButtonEl) {
+      saveButtonEl.classList.toggle("active", !!settings.save.enabled);
+      saveButtonEl.title = settings.save.enabled ? aioText("button.saveOn") : aioText("button.saveOff");
+    }
+    if (backendSummaryEl) {
+      backendSummaryEl.textContent = samplerModeLabel(settings);
+      backendSummaryEl.title = samplerModeLabel(settings);
+    }
+    updateGeneratorDomPreview(node);
+  }
+
+  function renderGeneratorPreviewFeed(node, panel, images, settings, selectedIndex, options = {}) {
+    const feed = panel?.querySelector?.("[data-aio-preview-feed]");
+    if (!feed) {
+      return;
+    }
+    const showPending = !!options.showPending;
+    feed.replaceChildren();
+    feed.hidden = !settings.preview.image_feed || (!images.length && !showPending);
+    if (feed.hidden) {
+      return;
+    }
+    let selectedThumb = null;
+    let pendingThumb = null;
+    for (const [index, image] of images.entries()) {
+      const thumbUrl = generatorImageUrl(image);
+      if (!thumbUrl) {
+        continue;
+      }
+      const thumb = document.createElement("button");
+      thumb.type = "button";
+      thumb.className = "easyuse-anima-aio-node-preview-thumb";
+      if (index === selectedIndex) {
+        thumb.classList.add("active");
+        selectedThumb = thumb;
+      }
+      thumb.title = aioPreviewImageLabel(image);
+      const thumbImage = document.createElement("img");
+      thumbImage.src = thumbUrl;
+      thumbImage.alt = "";
+      thumbImage.loading = "lazy";
+      const label = document.createElement("span");
+      label.textContent = aioPreviewImageLabel(image);
+      thumb.append(thumbImage, label);
+      thumb.addEventListener("click", () => {
+        node.__easyuseAnimaSelectedPreviewIndex = index;
+        updateGeneratorDomPreview(node);
+      });
+      feed.append(thumb);
+    }
+    if (showPending) {
+      const pendingLabel = aioText("text.previewGenerating");
+      pendingThumb = document.createElement("button");
+      pendingThumb.type = "button";
+      pendingThumb.className = "easyuse-anima-aio-node-preview-thumb pending";
+      pendingThumb.disabled = true;
+      pendingThumb.title = pendingLabel;
+      pendingThumb.setAttribute("aria-label", pendingLabel);
+      const label = document.createElement("span");
+      label.textContent = pendingLabel;
+      pendingThumb.append(label);
+      feed.append(pendingThumb);
+    }
+    (pendingThumb || selectedThumb)?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+  }
+
+  function updateGeneratorDomPreview(node) {
+    const panel = node?.__easyuseAnimaGeneratorPanelEl;
+    const previewBox = panel?.querySelector?.("[data-aio-preview-box]");
+    if (!previewBox) {
+      return;
+    }
+    const settings = generatorSettings(node);
+    const denoisePreview = node.__easyuseAnimaGeneratorDenoisePreview;
+    if (denoisePreview?.url) {
+      const label = generatorDenoisePreviewLabel(denoisePreview);
+      const preview = document.createElement("div");
+      preview.className = "easyuse-anima-aio-node-denoise-preview";
+      const img = document.createElement("img");
+      img.src = denoisePreview.url;
+      img.alt = "";
+      img.decoding = "async";
+      const labelEl = document.createElement("div");
+      labelEl.className = "easyuse-anima-aio-node-denoise-preview-label";
+      labelEl.textContent = label;
+      labelEl.title = label;
+      preview.append(img, labelEl);
+      previewBox.replaceChildren(preview);
+      const feedImages = Array.isArray(node.__easyuseAnimaGeneratorPreviewImages)
+        ? node.__easyuseAnimaGeneratorPreviewImages
+        : [];
+      renderGeneratorPreviewFeed(
+        node,
+        panel,
+        feedImages,
+        settings,
+        aioSelectedPreviewIndex(node, feedImages),
+        { showPending: true },
+      );
+      const metaEl = panel.querySelector("[data-aio-preview-meta]");
+      if (metaEl) {
+        metaEl.textContent = "";
+        metaEl.title = "";
+      }
+      return;
+    }
+    const images = Array.isArray(node.__easyuseAnimaGeneratorPreviewImages)
+      ? node.__easyuseAnimaGeneratorPreviewImages
+      : [];
+    if (!images.length) {
+      const feed = panel?.querySelector?.("[data-aio-preview-feed]");
+      if (feed) {
+        feed.hidden = true;
+        feed.replaceChildren();
+      }
+      const metaEl = panel.querySelector("[data-aio-preview-meta]");
+      if (metaEl) {
+        metaEl.textContent = "-";
+        metaEl.title = "";
+      }
+      return;
+    }
+    const currentImage = aioMainPreviewImage(node, images);
+    const imageUrl = generatorImageUrl(currentImage);
+    if (!currentImage || !imageUrl) {
+      return;
+    }
+    const selectedIndex = aioSelectedPreviewIndex(node, images);
+    const metaEl = panel.querySelector("[data-aio-preview-meta]");
+    if (metaEl) {
+      const parts = [
+        aioPreviewImageName(currentImage),
+        aioPreviewResolution(currentImage),
+        aioPreviewFileSize(currentImage),
+      ].filter((part) => part && part !== "-");
+      const metaText = parts.length ? parts.join(" · ") : "-";
+      metaEl.textContent = metaText;
+      metaEl.title = metaText === "-" ? "" : metaText;
+    }
+
+    const makeImage = (image) => {
+      const img = document.createElement("img");
+      img.src = generatorImageUrl(image);
+      img.alt = "";
+      img.loading = "lazy";
+      return img;
+    };
+    const makeLayer = (className, image) => {
+      const pane = document.createElement("div");
+      pane.className = `easyuse-anima-aio-node-preview-layer ${className}`.trim();
+      pane.append(makeImage(image));
+      return pane;
+    };
+    const makeCompareLabel = (className, label) => {
+      const labelEl = document.createElement("div");
+      labelEl.className = `easyuse-anima-aio-node-preview-pane-label ${className}`.trim();
+      labelEl.textContent = label;
+      labelEl.title = label;
+      return labelEl;
+    };
+    const previousImage = selectedIndex > 0 ? images[selectedIndex - 1] : null;
+    const canCompare = (
+      settings.preview.compare_previous
+      && previousImage
+      && generatorImageUrl(previousImage)
+    );
+    if (canCompare) {
+      const compare = document.createElement("div");
+      compare.className = "easyuse-anima-aio-node-preview-compare";
+      compare.style.setProperty("--aio-compare-x", "50%");
+      const updateCompareX = (event) => {
+        const rect = compare.getBoundingClientRect();
+        const x = Math.max(0, Math.min(rect.width, event.clientX - rect.left));
+        const percent = rect.width > 0 ? (x / rect.width) * 100 : 50;
+        compare.style.setProperty("--aio-compare-x", `${percent.toFixed(2)}%`);
+      };
+      for (const eventName of ["pointerdown", "pointermove"]) {
+        compare.addEventListener(eventName, (event) => {
+          event.stopPropagation();
+          updateCompareX(event);
+        });
+      }
+      const labels = document.createElement("div");
+      labels.className = "easyuse-anima-aio-node-preview-compare-labels";
+      labels.append(
+        makeCompareLabel("current", `${aioText("text.previewCurrent")} · ${aioPreviewImageLabel(currentImage)}`),
+        makeCompareLabel("previous", `${aioText("text.previewPrevious")} · ${aioPreviewImageLabel(previousImage)}`),
+      );
+      compare.append(
+        makeLayer("before", currentImage),
+        makeLayer("after", previousImage),
+        Object.assign(document.createElement("div"), { className: "easyuse-anima-aio-node-preview-divider" }),
+        labels,
+      );
+      previewBox.replaceChildren(compare);
+    } else {
+      previewBox.replaceChildren(makeImage(currentImage));
+    }
+
+    renderGeneratorPreviewFeed(node, panel, images, settings, selectedIndex);
+  }
+
+  function createDomNumberControl(node, name, value, step = "1") {
+    const input = numberInput(value, step);
+    input.addEventListener("input", () => {
+      const nextValue = name === "seed"
+        ? normalizeSeedValue(input.value, GENERATOR_SPECIAL_SEED_RANDOM)
+        : Number(input.value || 0);
+      setWidgetValueIfChanged(node, name, nextValue);
+      syncGeneratorSettingsFromVisible(node);
+      updateGeneratorDomSummary(node);
+      if (name === "seed") {
+        refreshGeneratorSeedButtons(node);
+      }
+      markNodeDirty(node);
+    });
+    return input;
+  }
+
+  function createDomSliderNumberControl(node, name, value, options = {}) {
+    const min = Number(options.min ?? 0);
+    const max = Number(options.max ?? 100);
+    const step = Number(options.step ?? 1);
+    const decimals = Number(options.decimals ?? 0);
+    const clamp = (next) => Math.max(min, Math.min(max, Number(next)));
+    const snap = (next) => {
+      const clamped = clamp(next);
+      if (!Number.isFinite(step) || step <= 0) {
+        return clamped;
+      }
+      return min + Math.round((clamped - min) / step) * step;
+    };
+    const round = (next) => {
+      const factor = 10 ** decimals;
+      return Math.round(clamp(snap(next)) * factor) / factor;
+    };
+    const currentValue = round(value);
+    const wrapper = document.createElement("div");
+    wrapper.className = "easyuse-anima-aio-node-slider-control";
+    const input = numberInput(currentValue, String(step));
+    input.min = String(min);
+    input.max = String(max);
+    const track = document.createElement("div");
+    track.className = "easyuse-anima-aio-node-slider-track";
+    const rail = document.createElement("div");
+    rail.className = "easyuse-anima-aio-node-slider-rail";
+    const fill = document.createElement("div");
+    fill.className = "easyuse-anima-aio-node-slider-fill";
+    const thumb = document.createElement("div");
+    thumb.className = "easyuse-anima-aio-node-slider-thumb";
+    track.append(rail, fill, thumb);
+
+    const normalizeValue = typeof options.normalize === "function"
+      ? options.normalize
+      : (next) => (name === "steps" ? Math.trunc(next) : next);
+    const commit = (nextValue) => {
+      const next = round(nextValue);
+      input.value = String(next);
+      const normalized = normalizeValue(next);
+      if (typeof options.onCommit === "function") {
+        options.onCommit(normalized);
+      } else {
+        setWidgetValueIfChanged(node, name, normalized);
+        syncGeneratorSettingsFromVisible(node);
+      }
+      updateGeneratorDomSummary(node);
+      updateSlider();
+      markNodeDirty(node);
+    };
+    const updateSlider = () => {
+      const next = round(input.value || currentValue);
+      const percent = max <= min ? 0 : ((next - min) / (max - min)) * 100;
+      const clampedPercent = Math.max(0, Math.min(100, percent));
+      fill.style.width = `${clampedPercent}%`;
+      thumb.style.left = `${clampedPercent}%`;
+    };
+    const valueFromPointer = (pointerEvent) => {
+      const rect = track.getBoundingClientRect();
+      const relative = rect.width > 0 ? (pointerEvent.clientX - rect.left) / rect.width : 0;
+      return round(min + Math.max(0, Math.min(1, relative)) * (max - min));
+    };
+
+    input.addEventListener("input", () => commit(input.value));
+    track.addEventListener("pointerdown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const pointerId = event.pointerId;
+      track.setPointerCapture?.(pointerId);
+      commit(valueFromPointer(event));
+      const move = (moveEvent) => {
+        moveEvent.preventDefault();
+        moveEvent.stopPropagation();
+        commit(valueFromPointer(moveEvent));
+      };
+      const up = (upEvent) => {
+        upEvent.stopPropagation();
+        track.releasePointerCapture?.(pointerId);
+        window.removeEventListener("pointermove", move, true);
+        window.removeEventListener("pointerup", up, true);
+      };
+      window.addEventListener("pointermove", move, true);
+      window.addEventListener("pointerup", up, true);
+    });
+    wrapper.append(input, track);
+    updateSlider();
+    return wrapper;
+  }
+
+  function createDomSettingsSliderNumberControl(node, value, options, updater) {
+    return createDomSliderNumberControl(node, "__settings__", value, {
+      ...options,
+      onCommit(nextValue) {
+        updateGeneratorSettings(node, (settings) => {
+          updater?.(settings, nextValue);
+        });
+      },
+    });
+  }
+
+  function createDomSettingsCheckboxControl(node, value, updater, options = {}) {
+    const input = checkbox(value);
+    input.addEventListener("change", () => {
+      updateGeneratorSettings(node, (settings) => {
+        updater?.(settings, input.checked);
+      });
+      if (options.rerender) {
+        renderGeneratorPanel(node);
+      } else {
+        updateGeneratorDomSummary(node);
+        scheduleGeneratorLayout(node);
+        markNodeDirty(node);
+      }
+    });
+    return input;
+  }
+
+  function createDomSettingsNumberControl(node, value, step, updater, options = {}) {
+    const input = numberInput(value, step);
+    if (options.min != null) {
+      input.min = String(options.min);
+    }
+    if (options.max != null) {
+      input.max = String(options.max);
+    }
+    const decimals = Number(options.decimals ?? 0);
+    const commit = () => {
+      const fallback = Number(value) || 0;
+      const min = Number(options.min ?? -Infinity);
+      const max = Number(options.max ?? Infinity);
+      const factor = 10 ** decimals;
+      const clamped = clampGeneratorNumber(input.value, fallback, min, max);
+      const nextValue = decimals > 0 ? Math.round(clamped * factor) / factor : Math.trunc(clamped);
+      input.value = nextValue;
+      updateGeneratorSettings(node, (settings) => {
+        updater?.(settings, nextValue);
+      });
+      if (options.rerender) {
+        renderGeneratorPanel(node);
+      } else {
+        updateGeneratorDomSummary(node);
+        scheduleGeneratorLayout(node);
+        markNodeDirty(node);
+      }
+    };
+    input.addEventListener("input", commit);
+    return input;
+  }
+
+  function createDomSettingsSelectControl(node, value, options, updater, settings = {}) {
+    const select = selectInput(options, String(value ?? ""));
+    select.addEventListener("change", () => {
+      updateGeneratorSettings(node, (nextSettings) => {
+        updater?.(nextSettings, select.value);
+      });
+      if (settings.rerender) {
+        renderGeneratorPanel(node);
+      } else {
+        updateGeneratorDomSummary(node);
+        scheduleGeneratorLayout(node);
+        markNodeDirty(node);
+      }
+    });
+    return select;
+  }
+
+  function createDomSelectControl(node, name, value, fallbackOptions = []) {
+    const select = selectInput(widgetOptions(node, name, fallbackOptions), String(value ?? ""));
+    select.addEventListener("change", () => {
+      setWidgetValueIfChanged(node, name, select.value);
+      syncGeneratorSettingsFromVisible(node);
+      updateGeneratorDomSummary(node);
+      markNodeDirty(node);
+    });
+    return select;
+  }
+
+  function setGeneratorSeedFromUi(node, value) {
+    const seed = normalizeSeedValue(value, GENERATOR_SPECIAL_SEED_RANDOM);
+    const panel = node?.__easyuseAnimaGeneratorPanelEl;
+    const seedInput = panel?.querySelector?.("[data-aio-seed-input]");
+    if (seedInput) {
+      seedInput.value = seed;
+    }
+    setWidgetValueIfChanged(node, "seed", seed);
+    syncGeneratorSettingsFromVisible(node);
+    updateGeneratorDomSummary(node);
+    refreshGeneratorSeedButtons(node);
+    markNodeDirty(node);
+  }
+
+  function refreshGeneratorSeedButtons(node) {
+    const panel = node?.__easyuseAnimaGeneratorPanelEl;
+    if (!panel) {
+      return;
+    }
+    const lastSeed = node.__easyuseAnimaLastQueuedSeed;
+    const currentSeed = normalizeSeedValue(widgetValue(node, "seed", GENERATOR_SPECIAL_SEED_RANDOM));
+    const lastButton = panel.querySelector("[data-aio-seed-last]");
+    if (lastButton) {
+      const hasLastSeed = lastSeed != null;
+      lastButton.disabled = !hasLastSeed || Number(lastSeed) === currentSeed;
+      lastButton.textContent = hasLastSeed
+        ? aioFormat("button.useLast", { seed: lastSeed })
+        : aioText("button.useLastNone");
+      lastButton.title = aioText("tip.useLast");
+    }
+  }
+
+  function renderGeneratorPanel(node) {
+    const panel = node?.__easyuseAnimaGeneratorPanelEl;
+    if (!panel) {
+      return;
+    }
+    const settings = generatorSettings(node);
+    panel.replaceChildren();
+
+    const makeButton = (label, callback, className = "", tooltipKey = "") => {
+      const button = document.createElement("button");
+      button.className = `easyuse-anima-aio-node-button ${className}`.trim();
+      button.type = "button";
+      button.textContent = label;
+      applyTooltip(button, tooltipKey);
+      button.addEventListener("click", callback);
+      return button;
+    };
+    const makeIconButton = (label, callback, tooltipKey = "") => {
+      const button = document.createElement("button");
+      button.className = "easyuse-anima-aio-node-icon-button";
+      button.type = "button";
+      button.textContent = label;
+      applyTooltip(button, tooltipKey);
+      button.addEventListener("click", callback);
+      return button;
+    };
+    const makeCardHeader = (title, actions = []) => {
+      const header = document.createElement("div");
+      header.className = "easyuse-anima-aio-node-card-header";
+      const titleEl = document.createElement("div");
+      titleEl.className = "easyuse-anima-aio-node-card-title";
+      titleEl.textContent = title;
+      const actionBox = document.createElement("div");
+      actionBox.className = "easyuse-anima-aio-node-card-actions";
+      actionBox.append(...actions.filter(Boolean));
+      header.append(titleEl, actionBox);
+      return header;
+    };
+    const makeStageHeader = (title, toggle, tooltipKey = "", actions = []) => {
+      const header = document.createElement("div");
+      header.className = "easyuse-anima-aio-node-stage-header";
+      const titleEl = document.createElement("div");
+      titleEl.className = "easyuse-anima-aio-node-stage-title";
+      titleEl.textContent = title;
+      applyTooltip(titleEl, tooltipKey);
+      const toggleLabel = document.createElement("label");
+      toggleLabel.className = "easyuse-anima-aio-node-stage-toggle";
+      toggleLabel.append(toggle, document.createTextNode(aioText("label.enabled")));
+      applyTooltip(toggleLabel, tooltipKey);
+      const actionBox = document.createElement("div");
+      actionBox.className = "easyuse-anima-aio-node-stage-tools";
+      actionBox.append(...actions.filter(Boolean), toggleLabel);
+      header.append(titleEl, actionBox);
+      return header;
+    };
+    const makeNote = (textKey, tooltipKey = "") => {
+      const note = document.createElement("div");
+      note.className = "easyuse-anima-aio-node-stage-note";
+      note.textContent = aioText(textKey);
+      applyTooltip(note, tooltipKey);
+      return note;
+    };
+    const moveDetailerTarget = (targetName, delta) => {
+      updateGeneratorSettings(node, (nextSettings) => {
+        const order = normalizeDetailerOrder(nextSettings.detailer?.order, nextSettings.detailer);
+        const currentIndex = order.indexOf(targetName);
+        const nextIndex = currentIndex + delta;
+        if (currentIndex < 0 || nextIndex < 0 || nextIndex >= order.length) {
+          return;
+        }
+        [order[currentIndex], order[nextIndex]] = [order[nextIndex], order[currentIndex]];
+        nextSettings.detailer ||= {};
+        nextSettings.detailer.order = order;
+      });
+      renderGeneratorPanel(node);
+    };
+
+    const main = document.createElement("div");
+    main.className = "easyuse-anima-aio-node-main";
+
+    const samplerCard = document.createElement("section");
+    samplerCard.className = "easyuse-anima-aio-node-card easyuse-anima-aio-node-settings";
+    const profileValue = syncGeneratorProfileValue(node, settings);
+    const profileButton = makeButton(
+      generatorProfileDisplayLabel(profileValue),
+      () => openGeneratorProfileSettings(node),
+      "easyuse-anima-aio-node-profile-button",
+      "profile.selectTip",
+    );
+    profileButton.setAttribute("data-aio-profile-button", "");
+    const saveIcon = makeIconButton("💾", () => openSaveSettings(node), "tip.saveOptions");
+    saveIcon.setAttribute("data-aio-save-button", "");
+    const samplerHeader = makeCardHeader(aioText("title.sampler"), [
+      profileButton,
+      makeIconButton("⚙", () => openSamplerSettings(node), "tip.samplerDetails"),
+      makeIconButton("⋯", () => openAdvancedSettings(node), "tip.advancedOptions"),
+      saveIcon,
+    ]);
+    const settingsScroll = document.createElement("div");
+    settingsScroll.className = "easyuse-anima-aio-node-settings-scroll";
+
+    const samplerGrid = document.createElement("div");
+    samplerGrid.className = "easyuse-anima-aio-node-sampler-grid";
+
+    const seedBlock = document.createElement("div");
+    const seedInput = createDomNumberControl(node, "seed", settings.sampler.seed);
+    seedInput.setAttribute("data-aio-seed-input", "");
+    applyTooltip(seedInput, "tip.seed");
+    const seedActions = document.createElement("div");
+    seedActions.className = "easyuse-anima-aio-node-seed-actions";
+    const seedRandomEach = makeButton(
+      aioText("button.randomEach"),
+      () => setGeneratorSeedFromUi(node, GENERATOR_SPECIAL_SEED_RANDOM),
+      "",
+      "tip.randomEach",
+    );
+    const seedNewFixed = makeButton(
+      aioText("button.newFixed"),
+      () => setGeneratorSeedFromUi(node, randomSeed()),
+      "",
+      "tip.newFixed",
+    );
+    const seedLast = makeButton(
+      aioText("button.useLastNone"),
+      () => {
+        if (node.__easyuseAnimaLastQueuedSeed == null) {
+          return;
+        }
+        setGeneratorSeedFromUi(node, node.__easyuseAnimaLastQueuedSeed);
+      },
+      "",
+      "tip.useLast",
+    );
+    seedLast.setAttribute("data-aio-seed-last", "");
+    seedActions.append(seedRandomEach, seedNewFixed, seedLast);
+    seedBlock.append(seedInput, seedActions);
+
+    const modeBadge = Object.assign(document.createElement("div"), {
+      className: "easyuse-anima-aio-node-mode-badge",
+    });
+    modeBadge.setAttribute("data-aio-backend-summary", "");
+    samplerGrid.append(
+      createNodeField(aioText("label.mode"), modeBadge, "wide", "tip.mode"),
+      createNodeField(aioText("label.seed"), seedBlock, "seed", "tip.seed"),
+      createNodeField(
+        aioText("label.steps"),
+        createDomSliderNumberControl(node, "steps", settings.sampler.steps, {
+          min: 1,
+          max: 75,
+          step: 1,
+          decimals: 0,
+        }),
+        "wide",
+        "tip.steps",
+      ),
+      createNodeField(
+        aioText("label.cfg"),
+        createDomSliderNumberControl(node, "cfg", settings.sampler.cfg, {
+          min: 1,
+          max: 10,
+          step: 0.1,
+          decimals: 1,
+        }),
+        "wide",
+        "tip.cfg",
+      ),
+      createNodeField(
+        aioText("label.shift"),
+        createDomSettingsSliderNumberControl(
+          node,
+          settings.model_patches.aura_flow.shift ?? DEFAULT_GENERATION_SETTINGS.model_patches.aura_flow.shift,
+          {
+            min: 1,
+            max: 10,
+            step: 0.5,
+            decimals: 1,
+          },
+          (nextSettings, value) => {
+            nextSettings.model_patches.aura_flow ||= {};
+            delete nextSettings.model_patches.aura_flow.enabled;
+            nextSettings.model_patches.aura_flow.shift = value;
+          },
+        ),
+        "wide",
+        "tip.shift",
+      ),
+      createNodeField(
+        aioText("label.denoise"),
+        createDomNumberControl(node, "denoise", settings.sampler.denoise, "0.01"),
+        "",
+        "tip.denoise",
+      ),
+      createNodeField(
+        aioText("label.sampler"),
+        createDomSelectControl(node, "sampler_name", settings.sampler.sampler_name, GENERATOR_FALLBACK_SAMPLER_NAMES),
+        "wide",
+        "tip.sampler",
+      ),
+      createNodeField(
+        aioText("label.scheduler"),
+        createDomSelectControl(node, "scheduler", settings.sampler.scheduler, GENERATOR_FALLBACK_SCHEDULER_NAMES),
+        "wide",
+        "tip.scheduler",
+      ),
+    );
+
+    const highresBlock = document.createElement("div");
+    highresBlock.className = "easyuse-anima-aio-node-stage-block";
+    const highresEnabled = createDomSettingsCheckboxControl(
+      node,
+      settings.highres.enabled,
+      (nextSettings, value) => {
+        nextSettings.highres ||= {};
+        nextSettings.highres.enabled = value;
+      },
+      { rerender: true },
+    );
+    highresBlock.append(makeStageHeader(
+      aioText("title.highres"),
+      highresEnabled,
+      "tip.highresEnabled",
+      [makeIconButton("⚙", () => openHighresSettings(node), "tip.highresSettings")],
+    ));
+    const highresBody = document.createElement("div");
+    highresBody.className = "easyuse-anima-aio-node-stage-body";
+    if (settings.highres.enabled) {
+      const mainBackendIsSpd = settings.sampler.backend === "spectrum_spd_speed";
+      const highresFollowsMain = !!settings.highres.inherit_sampler_settings;
+      const followMain = createDomSettingsCheckboxControl(
+        node,
+        highresFollowsMain,
+        (nextSettings, value) => {
+          nextSettings.highres ||= {};
+          nextSettings.highres.inherit_sampler_settings = value;
+        },
+        { rerender: true },
+      );
+      const stageMode = Object.assign(document.createElement("div"), {
+        className: "easyuse-anima-aio-node-mode-badge",
+        textContent: samplerModeLabel({
+          sampler: {
+            backend: settings.highres.backend || "comfy_ksampler",
+            spectrum: settings.highres.spectrum || {},
+            dit_corrections: settings.highres.dit_corrections || {},
+          },
+        }),
+      });
+      const noteKey = mainBackendIsSpd && highresFollowsMain
+        ? "text.highresSpdManualRequired"
+        : (highresFollowsMain ? "text.inheritsMainSampler" : "text.usesStageSamplerOverride");
+      highresBody.append(
+        createNodeField(aioText("label.followMainSampler"), followMain, "wide", "tip.highresFollow"),
+        makeNote(noteKey, "tip.highresFollow"),
+        ...(highresFollowsMain ? [] : [
+          createNodeField(aioText("label.mode"), stageMode, "wide", "tip.highresBackend"),
+        ]),
+        createNodeField(
+          aioText("label.scaleBy"),
+          createDomSettingsSliderNumberControl(
+            node,
+            settings.highres.scale_by,
+            { min: 1, max: 4, step: 0.05, decimals: 2 },
+            (nextSettings, value) => {
+              nextSettings.highres ||= {};
+              nextSettings.highres.scale_by = value;
+            },
+          ),
+          "wide",
+          "tip.highresScale",
+        ),
+        createNodeField(
+          aioText("label.steps"),
+          createDomSettingsSliderNumberControl(
+            node,
+            settings.highres.steps,
+            { min: 1, max: 75, step: 1, decimals: 0 },
+            (nextSettings, value) => {
+              nextSettings.highres ||= {};
+              nextSettings.highres.steps = Math.trunc(value);
+            },
+          ),
+          "wide",
+          "tip.highresSteps",
+        ),
+        createNodeField(
+          aioText("label.denoise"),
+          createDomSettingsSliderNumberControl(
+            node,
+            settings.highres.denoise,
+            { min: 0, max: 1, step: 0.01, decimals: 2 },
+            (nextSettings, value) => {
+              nextSettings.highres ||= {};
+              nextSettings.highres.denoise = value;
+            },
+          ),
+          "wide",
+          "tip.highresDenoise",
+        ),
+        createNodeField(
+          aioText("label.maxLongEdge"),
+          createDomSettingsNumberControl(
+            node,
+            settings.highres.max_long_edge,
+            "32",
+            (nextSettings, value) => {
+              nextSettings.highres ||= {};
+              nextSettings.highres.max_long_edge = Math.trunc(value);
+            },
+            { min: 0, max: 16384, decimals: 0 },
+          ),
+          "wide",
+          "tip.highresMaxEdge",
+        ),
+      );
+    } else {
+      highresBody.append(makeNote("text.highresDisabled", "tip.highresEnabled"));
+    }
+    highresBlock.append(highresBody);
+
+    const detailerBlock = document.createElement("div");
+    detailerBlock.className = "easyuse-anima-aio-node-stage-block";
+    const detailerEnabled = createDomSettingsCheckboxControl(
+      node,
+      settings.detailer.enabled,
+      (nextSettings, value) => {
+        nextSettings.detailer ||= {};
+        nextSettings.detailer.enabled = value;
+      },
+      { rerender: true },
+    );
+    detailerBlock.append(makeStageHeader(
+      aioText("title.detailer"),
+      detailerEnabled,
+      "tip.detailerEnabled",
+      [makeIconButton("⚙", () => openDetailerSettings(node), "tip.detailerSettings")],
+    ));
+    const detailerBody = document.createElement("div");
+    detailerBody.className = "easyuse-anima-aio-node-stage-body";
+    if (settings.detailer.enabled) {
+      const order = normalizeDetailerOrder(settings.detailer.order, settings.detailer);
+      for (const [index, targetName] of order.entries()) {
+        const defaults = detailerTargetDefaults(targetName);
+        const target = mergeDefaults(defaults, settings.detailer[targetName] || {});
+        const targetBlock = document.createElement("div");
+        targetBlock.className = "easyuse-anima-aio-node-stage-mini";
+        applyTooltip(targetBlock, "tip.detailerBlock");
+        const targetHeader = document.createElement("div");
+        targetHeader.className = "easyuse-anima-aio-node-stage-mini-header";
+        const targetTitle = document.createElement("div");
+        targetTitle.className = "easyuse-anima-aio-node-stage-mini-title";
+        targetTitle.textContent = `${index + 1}. ${detailerTargetTitle(targetName, target, index)}`;
+        applyTooltip(targetTitle, "tip.detailerBlock");
+        const targetTools = document.createElement("div");
+        targetTools.className = "easyuse-anima-aio-node-stage-tools";
+        const moveUp = makeIconButton("↑", () => moveDetailerTarget(targetName, -1), "tip.detailerOrder");
+        const moveDown = makeIconButton("↓", () => moveDetailerTarget(targetName, 1), "tip.detailerOrder");
+        moveUp.disabled = index === 0;
+        moveDown.disabled = index === order.length - 1;
+        targetTools.append(moveUp, moveDown);
+        targetHeader.append(targetTitle, targetTools);
+        targetBlock.append(targetHeader);
+
+        const targetGrid = document.createElement("div");
+        targetGrid.className = "easyuse-anima-aio-node-stage-body";
+        const targetEnabled = createDomSettingsCheckboxControl(
+          node,
+          target.enabled,
+          (nextSettings, value) => {
+            nextSettings.detailer ||= {};
+            nextSettings.detailer[targetName] ||= {};
+            nextSettings.detailer[targetName].enabled = value;
+          },
+          { rerender: true },
+        );
+        targetGrid.append(createNodeField(aioText("label.enabled"), targetEnabled, "wide", "tip.detailerBlock"));
+        if (target.enabled) {
+          const followMain = createDomSettingsCheckboxControl(
+            node,
+            target.inherit_sampler_settings,
+            (nextSettings, value) => {
+              nextSettings.detailer ||= {};
+              nextSettings.detailer[targetName] ||= {};
+              nextSettings.detailer[targetName].inherit_sampler_settings = value;
+            },
+            { rerender: true },
+          );
+          targetGrid.append(
+            createNodeField(aioText("label.followMainSampler"), followMain, "wide", "tip.detailerFollow"),
+            makeNote(
+              target.inherit_sampler_settings ? "text.inheritsMainSampler" : "text.usesStageSamplerOverride",
+              "tip.detailerFollow",
+            ),
+            createNodeField(
+              aioText("label.steps"),
+              createDomSettingsSliderNumberControl(
+                node,
+                target.steps,
+                { min: 1, max: 75, step: 1, decimals: 0 },
+                (nextSettings, value) => {
+                  nextSettings.detailer ||= {};
+                  nextSettings.detailer[targetName] ||= {};
+                  nextSettings.detailer[targetName].steps = Math.trunc(value);
+                },
+              ),
+              "wide",
+              "tip.detailerSteps",
+            ),
+            createNodeField(
+              aioText("label.denoise"),
+              createDomSettingsSliderNumberControl(
+                node,
+                target.denoise,
+                { min: 0, max: 1, step: 0.01, decimals: 2 },
+                (nextSettings, value) => {
+                  nextSettings.detailer ||= {};
+                  nextSettings.detailer[targetName] ||= {};
+                  nextSettings.detailer[targetName].denoise = value;
+                },
+              ),
+              "wide",
+              "tip.detailerDenoise",
+            ),
+          );
+        }
+        targetBlock.append(targetGrid);
+        detailerBody.append(targetBlock);
+      }
+    } else {
+      detailerBody.append(makeNote("text.detailerDisabled", "tip.detailerEnabled"));
+    }
+    detailerBlock.append(detailerBody);
+
+    const upscaleBlock = document.createElement("div");
+    upscaleBlock.className = "easyuse-anima-aio-node-stage-block";
+    const upscaleEnabled = createDomSettingsCheckboxControl(
+      node,
+      settings.upscale.enabled,
+      (nextSettings, value) => {
+        nextSettings.upscale ||= {};
+        nextSettings.upscale.enabled = value;
+      },
+      { rerender: true },
+    );
+    upscaleBlock.append(makeStageHeader(
+      aioText("title.upscale"),
+      upscaleEnabled,
+      "tip.upscaleEnabled",
+      [makeIconButton("⚙", () => openUpscaleSettings(node), "tip.upscaleSettings")],
+    ));
+    const upscaleBody = document.createElement("div");
+    upscaleBody.className = "easyuse-anima-aio-node-stage-body";
+    if (settings.upscale.enabled) {
+      const backend = createDomSettingsSelectControl(
+        node,
+        settings.upscale.backend || "usdu",
+        ["usdu", "resshift"],
+        (nextSettings, value) => {
+          nextSettings.upscale ||= {};
+          nextSettings.upscale.backend = value || "usdu";
+        },
+        { rerender: true },
+      );
+      upscaleBody.append(
+        createNodeField(aioText("label.mode"), backend, "wide", "tip.upscaleBackend"),
+      );
+      if (settings.upscale.backend === "usdu") {
+        const usdu = normalizeGeneratorUsduAutoTileRange(
+          mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale.usdu, settings.upscale.usdu || {}),
+        );
+        upscaleBody.append(
+          createNodeField(
+            aioText("label.scaleBy"),
+            createDomSettingsSliderNumberControl(
+              node,
+              settings.upscale.scale_by,
+              { min: 1, max: 4, step: 0.05, decimals: 2 },
+              (nextSettings, value) => {
+                nextSettings.upscale ||= {};
+                nextSettings.upscale.scale_by = value;
+              },
+            ),
+            "wide",
+            "tip.upscaleScale",
+          ),
+          createNodeField(
+            aioText("label.steps"),
+            createDomSettingsSliderNumberControl(
+              node,
+              settings.upscale.steps,
+              { min: 1, max: 75, step: 1, decimals: 0 },
+              (nextSettings, value) => {
+                nextSettings.upscale ||= {};
+                nextSettings.upscale.steps = Math.trunc(value);
+              },
+            ),
+            "wide",
+            "tip.steps",
+          ),
+          createNodeField(
+            aioText("label.denoise"),
+            createDomSettingsSliderNumberControl(
+              node,
+              settings.upscale.denoise,
+              { min: 0, max: 1, step: 0.01, decimals: 2 },
+              (nextSettings, value) => {
+                nextSettings.upscale ||= {};
+                nextSettings.upscale.denoise = value;
+              },
+            ),
+            "wide",
+            "tip.denoise",
+          ),
+          createNodeField(
+            aioText("field.autoTileSize"),
+            createDomSettingsCheckboxControl(
+              node,
+              usdu.auto_tile_size,
+              (nextSettings, value) => {
+                nextSettings.upscale ||= {};
+                nextSettings.upscale.usdu ||= {};
+                nextSettings.upscale.usdu.auto_tile_size = value;
+              },
+              { rerender: true },
+            ),
+            "wide",
+            "tip.usduAutoTile",
+          ),
+        );
+        if (usdu.auto_tile_size) {
+          upscaleBody.append(
+            createNodeField(
+              aioText("field.autoTileTarget"),
+              createDomSettingsSliderNumberControl(
+                node,
+                usdu.auto_tile_target,
+                { min: 256, max: 2048, step: 64, decimals: 0 },
+                (nextSettings, value) => {
+                  setGeneratorUsduAutoTileTarget(nextSettings, value);
+                },
+              ),
+              "wide",
+              "tip.usduAutoTile",
+            ),
+          );
+        }
+        upscaleBody.append(
+          makeNote(
+            usdu.auto_tile_size ? "text.usduAutoTile" : "text.usduManualTile",
+            usdu.auto_tile_size ? "tip.usduAutoTile" : "tip.usduTile",
+          ),
+        );
+      } else {
+        upscaleBody.append(makeNote(`ResShift ${settings.upscale.resshift?.scale || "x2"}`, "tip.resshiftScale"));
+      }
+    } else {
+      upscaleBody.append(makeNote("text.upscaleDisabled", "tip.upscaleEnabled"));
+    }
+    upscaleBlock.append(upscaleBody);
+
+    const postprocess = mergeDefaults(DEFAULT_GENERATION_SETTINGS.postprocess, settings.postprocess || {});
+    const postprocessBlock = document.createElement("div");
+    postprocessBlock.className = "easyuse-anima-aio-node-stage-block";
+    const postprocessEnabled = createDomSettingsCheckboxControl(
+      node,
+      postprocess.enabled,
+      (nextSettings, value) => {
+        nextSettings.postprocess ||= {};
+        nextSettings.postprocess.enabled = value;
+      },
+      { rerender: true },
+    );
+    postprocessBlock.append(makeStageHeader(
+      aioText("title.postprocess"),
+      postprocessEnabled,
+      "tip.postprocessEnabled",
+      [makeIconButton("⚙", () => openPostprocessSettings(node), "tip.postprocessSettings")],
+    ));
+    const postprocessBody = document.createElement("div");
+    postprocessBody.className = "easyuse-anima-aio-node-stage-body";
+    if (postprocess.enabled) {
+      const fit = mergeDefaults(DEFAULT_GENERATION_SETTINGS.postprocess.fit, postprocess.fit || {});
+      const fitText = fit.mode === "megapixels"
+        ? `Fit <= ${fit.max_megapixels || 4}MP`
+        : `Fit <= ${fit.max_long_edge || 2048}px`;
+      postprocessBody.append(makeNote(fitText, "tip.finalFit"));
+    } else {
+      postprocessBody.append(makeNote("text.postprocessDisabled", "tip.postprocessEnabled"));
+    }
+    postprocessBlock.append(postprocessBody);
+
+    settingsScroll.append(samplerGrid, highresBlock, detailerBlock, upscaleBlock, postprocessBlock);
+
+    samplerCard.append(samplerHeader, settingsScroll);
+
+    const previewCard = document.createElement("section");
+    previewCard.className = "easyuse-anima-aio-node-card easyuse-anima-aio-node-preview";
+    const previewHeader = makeCardHeader(aioText("title.preview"), [
+      makeIconButton("⚙", () => openPreviewSettings(node), "tip.previewOptions"),
+    ]);
+    const previewBox = document.createElement("div");
+    previewBox.className = "easyuse-anima-aio-node-preview-box";
+    previewBox.setAttribute("data-aio-preview-box", "");
+    const previewPlaceholder = document.createElement("div");
+    previewPlaceholder.className = "easyuse-anima-aio-node-preview-placeholder";
+    const previewStrong = document.createElement("strong");
+    previewStrong.textContent = aioText("text.previewTitle");
+    const previewText = document.createElement("span");
+    previewText.textContent = aioText("text.previewSubtitle");
+    previewPlaceholder.append(previewStrong, previewText);
+    previewBox.append(previewPlaceholder);
+
+    const previewMeta = document.createElement("div");
+    previewMeta.className = "easyuse-anima-aio-node-preview-meta";
+    previewMeta.setAttribute("data-aio-preview-meta", "");
+    previewMeta.textContent = "-";
+    applyTooltip(previewMeta, "tip.size");
+
+    const previewFeed = document.createElement("div");
+    previewFeed.className = "easyuse-anima-aio-node-preview-feed";
+    previewFeed.setAttribute("data-aio-preview-feed", "");
+    previewFeed.hidden = true;
+
+    previewCard.append(previewHeader, previewBox, previewMeta, previewFeed);
+
+    main.append(samplerCard, previewCard);
+    panel.append(main);
+    stopGeneratorControlPropagation(panel);
+    updateGeneratorDomSummary(node);
+    refreshGeneratorSeedButtons(node);
+    scheduleGeneratorLayout(node);
+  }
+
+  function ensureGeneratorPanel(node) {
+    ensureStyle();
+    node.serialize_widgets = true;
+    suppressGeneratorDefaultPreview(node, { markDirty: false });
+    node.minWidth = Math.max(Number(node.minWidth) || 0, GENERATOR_NODE_MIN_WIDTH);
+    if (Array.isArray(node.size)) {
+      node.size[0] = Math.max(Number(node.size[0]) || 0, GENERATOR_NODE_DEFAULT_WIDTH);
+    }
+    if (!node.__easyuseAnimaGeneratorPanelEl) {
+      const panel = document.createElement("div");
+      panel.className = "easyuse-anima-aio-node-panel";
+      node.__easyuseAnimaGeneratorPanelEl = panel;
+      node.addDOMWidget?.(GENERATOR_DOM_WIDGET, "EasyUseAnimaGeneratorPanel", panel, {
+        serialize: false,
+        hideOnZoom: false,
+        getMinHeight: () => GENERATOR_PANEL_MIN_HEIGHT,
+      });
+    }
+    markGeneratorNativeLivePreviewHidden(node);
+    renderGeneratorPanel(node);
+    markGeneratorNativeLivePreviewHidden(node);
+  }
+
+  return {
+    ensurePanel: ensureGeneratorPanel,
+    renderPanel: renderGeneratorPanel,
+    updateSummary: updateGeneratorDomSummary,
+    scheduleLayout: scheduleGeneratorLayout,
+    refreshSeedButtons: refreshGeneratorSeedButtons,
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -18,6 +18,7 @@ import { aioCreatePostprocessSettingsDialog } from "./aio/postprocess_settings_d
 import { aioCreatePreviewSettingsDialog } from "./aio/preview_settings_dialog.js";
 import { createAioProfileApiClient } from "./aio/profile_api_client.js";
 import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
+import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -85,17 +86,13 @@ const GENERATOR_NODE_TYPE = "EasyUseAnimaAIOGenerator";
 const INPUT_SETTINGS_WIDGET = "input_settings";
 const GENERATOR_SETTINGS_WIDGET = "generation_settings";
 const GENERATOR_PROFILE_CUSTOM_VALUE = "custom";
-const GENERATOR_DOM_WIDGET = "easyuse_anima_generator_panel";
 const GENERATOR_PREVIEW_EVENT = "easyuse-anima-aio-preview";
+const GENERATOR_PANEL_MIN_HEIGHT = 430;
 const GENERATOR_SPECIAL_SEEDS = [
   GENERATOR_SPECIAL_SEED_RANDOM,
   GENERATOR_SPECIAL_SEED_INCREMENT,
   GENERATOR_SPECIAL_SEED_DECREMENT,
 ];
-const GENERATOR_NODE_MIN_WIDTH = 560;
-const GENERATOR_NODE_DEFAULT_WIDTH = 620;
-const GENERATOR_PANEL_MIN_HEIGHT = 430;
-const GENERATOR_PANEL_CONTROL_SELECTOR = "input, select, textarea, button";
 const GENERATOR_VUE_NODE_CLASS = "easyuse-anima-aio-hide-native-live-preview";
 const GENERATOR_FALLBACK_SAMPLER_NAMES = [
   "er_sde",
@@ -3254,16 +3251,6 @@ const {
   clear: clearGeneratorPreviewProgress,
 } = aioCreatePreviewProgressTracker();
 
-function generatorDenoisePreviewLabel(preview) {
-  const base = aioText("text.previewDenoise");
-  const value = Number(preview?.value);
-  const max = Number(preview?.max);
-  if (Number.isFinite(value) && Number.isFinite(max) && max > 0) {
-    const current = Math.max(0, Math.min(max, Math.round(value)));
-    return `${base} · ${current}/${Math.round(max)}`;
-  }
-  return base;
-}
 
 function clearGeneratorDenoisePreview(node, update = false) {
   const preview = node?.__easyuseAnimaGeneratorDenoisePreview;
@@ -3558,36 +3545,6 @@ function markNodeDirty(node) {
   app.graph?.setDirtyCanvas?.(true, true);
 }
 
-function stopGeneratorControlPropagation(root) {
-  if (!root || root.__easyuseAnimaAioStopPropagation) {
-    return;
-  }
-  const stop = (event) => {
-    if (event.target?.closest?.(GENERATOR_PANEL_CONTROL_SELECTOR)) {
-      event.stopPropagation();
-    }
-  };
-  for (const eventName of [
-    "pointerdown",
-    "mousedown",
-    "pointerup",
-    "mouseup",
-    "click",
-    "dblclick",
-    "keydown",
-    "keyup",
-  ]) {
-    root.addEventListener(eventName, stop);
-  }
-  // Legacy canvas bubbles DOM-widget wheel events through the panel. Keep this
-  // local guard as a fallback; Node 2.0 still needs the window capture router
-  // installed below because its Vue ancestor can handle wheel first.
-  root.addEventListener("wheel", forwardGeneratorPanelWheel, {
-    capture: true,
-    passive: false,
-  });
-  root.__easyuseAnimaAioStopPropagation = true;
-}
 
 function dispatchGeneratorCanvasWheelEvent(sourceEvent) {
   const canvas = app?.canvas?.canvas;
@@ -3646,65 +3603,6 @@ function installGeneratorWheelForwarder() {
   });
 }
 
-function samplerModeLabel(settingsOrBackend) {
-  const settings = typeof settingsOrBackend === "object" && settingsOrBackend
-    ? settingsOrBackend
-    : null;
-  const sampler = settings?.sampler || {};
-  const backend = String(settings ? sampler.backend : settingsOrBackend || "comfy_ksampler");
-  const corrections = !!sampler?.dit_corrections?.enabled;
-  const spectrum = !!sampler?.spectrum?.enabled;
-  switch (backend) {
-    case "spectrum_mod_guidance_advanced":
-      return corrections ? "Spectrum Mod Guidance + Corrections" : "Spectrum Mod Guidance";
-    case "spectrum_spd_speed":
-      return "Spectrum SPD / SPEED";
-    case "comfy_ksampler": {
-      const extras = [];
-      if (spectrum) {
-        extras.push("Spectrum Patch");
-      }
-      if (corrections) {
-        extras.push("Corrections");
-      }
-      return extras.length ? `${extras.join(" + ")} / Comfy KSampler` : "Standard Comfy KSampler";
-    }
-    default:
-      return "Standard Comfy KSampler";
-  }
-}
-
-function generatorPanelWidth(node) {
-  return Math.max(240, Math.floor((Number(node?.size?.[0]) || GENERATOR_NODE_DEFAULT_WIDTH) - 20));
-}
-
-function applyGeneratorLayout(node) {
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  if (!panel) {
-    return;
-  }
-  const width = generatorPanelWidth(node);
-  panel.style.width = `${width}px`;
-  panel.style.maxWidth = `${width}px`;
-  // ComfyUI owns the node and DOM-widget viewport height. AiO owns only child
-  // content: the settings column scrolls while the preview stays in that host
-  // viewport. Never derive height from node.size or write node.setSize here.
-  panel.style.removeProperty("height");
-  panel.style.removeProperty("max-height");
-  markNodeDirty(node);
-}
-
-function scheduleGeneratorLayout(node) {
-  if (!node?.__easyuseAnimaGeneratorPanelEl || node.__easyuseAnimaGeneratorLayoutScheduled) {
-    return;
-  }
-  node.__easyuseAnimaGeneratorLayoutScheduled = true;
-  requestAnimationFrame(() => {
-    node.__easyuseAnimaGeneratorLayoutScheduled = false;
-    applyGeneratorLayout(node);
-  });
-}
-
 function generatorSettings(node) {
   const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
   return mergeVisibleGeneratorSettings(node, parseSettings(widget, DEFAULT_GENERATION_SETTINGS));
@@ -3715,231 +3613,24 @@ function writeGeneratorSettingsFromState(node, settings, markDirty = true) {
   writeSettings(node, widget, settings, markDirty);
 }
 
-function updateGeneratorSettings(node, updater, markDirty = true) {
-  const settings = generatorSettings(node);
-  updater?.(settings);
-  settings.sampler.seed_after_generate = normalizeSeedControl(settings.sampler.seed_after_generate);
-  applyVisibleGeneratorSettings(node, settings);
-  writeGeneratorSettingsFromState(node, settings, markDirty);
-  updateGeneratorDomSummary(node);
-  return settings;
+function renderGeneratorPanel(node) {
+  return generatorPanelRuntime.renderPanel(node);
+}
+
+function ensureGeneratorPanel(node) {
+  return generatorPanelRuntime.ensurePanel(node);
 }
 
 function updateGeneratorDomSummary(node) {
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  if (!panel) {
-    return;
-  }
-  const status = node.__easyuseAnimaGeneratorStatus || {};
-  const settings = generatorSettings(node);
-  const profileValue = syncGeneratorProfileValue(node, settings);
-  const profileButtonEl = panel.querySelector("[data-aio-profile-button]");
-  if (profileButtonEl) {
-    profileButtonEl.textContent = generatorProfileDisplayLabel(profileValue);
-    profileButtonEl.title = aioText("profile.selectTip");
-  }
-  const backendSummaryEl = panel.querySelector("[data-aio-backend-summary]");
-  const saveButtonEl = panel.querySelector("[data-aio-save-button]");
-  if (saveButtonEl) {
-    saveButtonEl.classList.toggle("active", !!settings.save.enabled);
-    saveButtonEl.title = settings.save.enabled ? aioText("button.saveOn") : aioText("button.saveOff");
-  }
-  if (backendSummaryEl) {
-    backendSummaryEl.textContent = samplerModeLabel(settings);
-    backendSummaryEl.title = samplerModeLabel(settings);
-  }
-  updateGeneratorDomPreview(node);
+  return generatorPanelRuntime.updateSummary(node);
 }
 
-function renderGeneratorPreviewFeed(node, panel, images, settings, selectedIndex, options = {}) {
-  const feed = panel?.querySelector?.("[data-aio-preview-feed]");
-  if (!feed) {
-    return;
-  }
-  const showPending = !!options.showPending;
-  feed.replaceChildren();
-  feed.hidden = !settings.preview.image_feed || (!images.length && !showPending);
-  if (feed.hidden) {
-    return;
-  }
-  let selectedThumb = null;
-  let pendingThumb = null;
-  for (const [index, image] of images.entries()) {
-    const thumbUrl = generatorImageUrl(image);
-    if (!thumbUrl) {
-      continue;
-    }
-    const thumb = document.createElement("button");
-    thumb.type = "button";
-    thumb.className = "easyuse-anima-aio-node-preview-thumb";
-    if (index === selectedIndex) {
-      thumb.classList.add("active");
-      selectedThumb = thumb;
-    }
-    thumb.title = aioPreviewImageLabel(image);
-    const thumbImage = document.createElement("img");
-    thumbImage.src = thumbUrl;
-    thumbImage.alt = "";
-    thumbImage.loading = "lazy";
-    const label = document.createElement("span");
-    label.textContent = aioPreviewImageLabel(image);
-    thumb.append(thumbImage, label);
-    thumb.addEventListener("click", () => {
-      node.__easyuseAnimaSelectedPreviewIndex = index;
-      updateGeneratorDomPreview(node);
-    });
-    feed.append(thumb);
-  }
-  if (showPending) {
-    const pendingLabel = aioText("text.previewGenerating");
-    pendingThumb = document.createElement("button");
-    pendingThumb.type = "button";
-    pendingThumb.className = "easyuse-anima-aio-node-preview-thumb pending";
-    pendingThumb.disabled = true;
-    pendingThumb.title = pendingLabel;
-    pendingThumb.setAttribute("aria-label", pendingLabel);
-    const label = document.createElement("span");
-    label.textContent = pendingLabel;
-    pendingThumb.append(label);
-    feed.append(pendingThumb);
-  }
-  (pendingThumb || selectedThumb)?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+function scheduleGeneratorLayout(node) {
+  return generatorPanelRuntime.scheduleLayout(node);
 }
 
-function updateGeneratorDomPreview(node) {
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  const previewBox = panel?.querySelector?.("[data-aio-preview-box]");
-  if (!previewBox) {
-    return;
-  }
-  const settings = generatorSettings(node);
-  const denoisePreview = node.__easyuseAnimaGeneratorDenoisePreview;
-  if (denoisePreview?.url) {
-    const label = generatorDenoisePreviewLabel(denoisePreview);
-    const preview = document.createElement("div");
-    preview.className = "easyuse-anima-aio-node-denoise-preview";
-    const img = document.createElement("img");
-    img.src = denoisePreview.url;
-    img.alt = "";
-    img.decoding = "async";
-    const labelEl = document.createElement("div");
-    labelEl.className = "easyuse-anima-aio-node-denoise-preview-label";
-    labelEl.textContent = label;
-    labelEl.title = label;
-    preview.append(img, labelEl);
-    previewBox.replaceChildren(preview);
-    const feedImages = Array.isArray(node.__easyuseAnimaGeneratorPreviewImages)
-      ? node.__easyuseAnimaGeneratorPreviewImages
-      : [];
-    renderGeneratorPreviewFeed(
-      node,
-      panel,
-      feedImages,
-      settings,
-      aioSelectedPreviewIndex(node, feedImages),
-      { showPending: true },
-    );
-    const metaEl = panel.querySelector("[data-aio-preview-meta]");
-    if (metaEl) {
-      metaEl.textContent = "";
-      metaEl.title = "";
-    }
-    return;
-  }
-  const images = Array.isArray(node.__easyuseAnimaGeneratorPreviewImages)
-    ? node.__easyuseAnimaGeneratorPreviewImages
-    : [];
-  if (!images.length) {
-    const feed = panel?.querySelector?.("[data-aio-preview-feed]");
-    if (feed) {
-      feed.hidden = true;
-      feed.replaceChildren();
-    }
-    const metaEl = panel.querySelector("[data-aio-preview-meta]");
-    if (metaEl) {
-      metaEl.textContent = "-";
-      metaEl.title = "";
-    }
-    return;
-  }
-  const currentImage = aioMainPreviewImage(node, images);
-  const imageUrl = generatorImageUrl(currentImage);
-  if (!currentImage || !imageUrl) {
-    return;
-  }
-  const selectedIndex = aioSelectedPreviewIndex(node, images);
-  const metaEl = panel.querySelector("[data-aio-preview-meta]");
-  if (metaEl) {
-    const parts = [
-      aioPreviewImageName(currentImage),
-      aioPreviewResolution(currentImage),
-      aioPreviewFileSize(currentImage),
-    ].filter((part) => part && part !== "-");
-    const metaText = parts.length ? parts.join(" · ") : "-";
-    metaEl.textContent = metaText;
-    metaEl.title = metaText === "-" ? "" : metaText;
-  }
-
-  const makeImage = (image) => {
-    const img = document.createElement("img");
-    img.src = generatorImageUrl(image);
-    img.alt = "";
-    img.loading = "lazy";
-    return img;
-  };
-  const makeLayer = (className, image) => {
-    const pane = document.createElement("div");
-    pane.className = `easyuse-anima-aio-node-preview-layer ${className}`.trim();
-    pane.append(makeImage(image));
-    return pane;
-  };
-  const makeCompareLabel = (className, label) => {
-    const labelEl = document.createElement("div");
-    labelEl.className = `easyuse-anima-aio-node-preview-pane-label ${className}`.trim();
-    labelEl.textContent = label;
-    labelEl.title = label;
-    return labelEl;
-  };
-  const previousImage = selectedIndex > 0 ? images[selectedIndex - 1] : null;
-  const canCompare = (
-    settings.preview.compare_previous
-    && previousImage
-    && generatorImageUrl(previousImage)
-  );
-  if (canCompare) {
-    const compare = document.createElement("div");
-    compare.className = "easyuse-anima-aio-node-preview-compare";
-    compare.style.setProperty("--aio-compare-x", "50%");
-    const updateCompareX = (event) => {
-      const rect = compare.getBoundingClientRect();
-      const x = Math.max(0, Math.min(rect.width, event.clientX - rect.left));
-      const percent = rect.width > 0 ? (x / rect.width) * 100 : 50;
-      compare.style.setProperty("--aio-compare-x", `${percent.toFixed(2)}%`);
-    };
-    for (const eventName of ["pointerdown", "pointermove"]) {
-      compare.addEventListener(eventName, (event) => {
-        event.stopPropagation();
-        updateCompareX(event);
-      });
-    }
-    const labels = document.createElement("div");
-    labels.className = "easyuse-anima-aio-node-preview-compare-labels";
-    labels.append(
-      makeCompareLabel("current", `${aioText("text.previewCurrent")} · ${aioPreviewImageLabel(currentImage)}`),
-      makeCompareLabel("previous", `${aioText("text.previewPrevious")} · ${aioPreviewImageLabel(previousImage)}`),
-    );
-    compare.append(
-      makeLayer("before", currentImage),
-      makeLayer("after", previousImage),
-      Object.assign(document.createElement("div"), { className: "easyuse-anima-aio-node-preview-divider" }),
-      labels,
-    );
-    previewBox.replaceChildren(compare);
-  } else {
-    previewBox.replaceChildren(makeImage(currentImage));
-  }
-
-  renderGeneratorPreviewFeed(node, panel, images, settings, selectedIndex);
+function refreshGeneratorSeedButtons(node) {
+  return generatorPanelRuntime.refreshSeedButtons(node);
 }
 
 function cssEscape(value) {
@@ -4332,233 +4023,6 @@ function scheduleGeneratorDefaultPreviewSuppression(node, options = {}) {
   }, 360);
 }
 
-function createDomNumberControl(node, name, value, step = "1") {
-  const input = numberInput(value, step);
-  input.addEventListener("input", () => {
-    const nextValue = name === "seed"
-      ? normalizeSeedValue(input.value, GENERATOR_SPECIAL_SEED_RANDOM)
-      : Number(input.value || 0);
-    setWidgetValueIfChanged(node, name, nextValue);
-    syncGeneratorSettingsFromVisible(node);
-    updateGeneratorDomSummary(node);
-    if (name === "seed") {
-      refreshGeneratorSeedButtons(node);
-    }
-    markNodeDirty(node);
-  });
-  return input;
-}
-
-function createDomSliderNumberControl(node, name, value, options = {}) {
-  const min = Number(options.min ?? 0);
-  const max = Number(options.max ?? 100);
-  const step = Number(options.step ?? 1);
-  const decimals = Number(options.decimals ?? 0);
-  const clamp = (next) => Math.max(min, Math.min(max, Number(next)));
-  const snap = (next) => {
-    const clamped = clamp(next);
-    if (!Number.isFinite(step) || step <= 0) {
-      return clamped;
-    }
-    return min + Math.round((clamped - min) / step) * step;
-  };
-  const round = (next) => {
-    const factor = 10 ** decimals;
-    return Math.round(clamp(snap(next)) * factor) / factor;
-  };
-  const currentValue = round(value);
-  const wrapper = document.createElement("div");
-  wrapper.className = "easyuse-anima-aio-node-slider-control";
-  const input = numberInput(currentValue, String(step));
-  input.min = String(min);
-  input.max = String(max);
-  const track = document.createElement("div");
-  track.className = "easyuse-anima-aio-node-slider-track";
-  const rail = document.createElement("div");
-  rail.className = "easyuse-anima-aio-node-slider-rail";
-  const fill = document.createElement("div");
-  fill.className = "easyuse-anima-aio-node-slider-fill";
-  const thumb = document.createElement("div");
-  thumb.className = "easyuse-anima-aio-node-slider-thumb";
-  track.append(rail, fill, thumb);
-
-  const normalizeValue = typeof options.normalize === "function"
-    ? options.normalize
-    : (next) => (name === "steps" ? Math.trunc(next) : next);
-  const commit = (nextValue) => {
-    const next = round(nextValue);
-    input.value = String(next);
-    const normalized = normalizeValue(next);
-    if (typeof options.onCommit === "function") {
-      options.onCommit(normalized);
-    } else {
-      setWidgetValueIfChanged(node, name, normalized);
-      syncGeneratorSettingsFromVisible(node);
-    }
-    updateGeneratorDomSummary(node);
-    updateSlider();
-    markNodeDirty(node);
-  };
-  const updateSlider = () => {
-    const next = round(input.value || currentValue);
-    const percent = max <= min ? 0 : ((next - min) / (max - min)) * 100;
-    const clampedPercent = Math.max(0, Math.min(100, percent));
-    fill.style.width = `${clampedPercent}%`;
-    thumb.style.left = `${clampedPercent}%`;
-  };
-  const valueFromPointer = (pointerEvent) => {
-    const rect = track.getBoundingClientRect();
-    const relative = rect.width > 0 ? (pointerEvent.clientX - rect.left) / rect.width : 0;
-    return round(min + Math.max(0, Math.min(1, relative)) * (max - min));
-  };
-
-  input.addEventListener("input", () => commit(input.value));
-  track.addEventListener("pointerdown", (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const pointerId = event.pointerId;
-    track.setPointerCapture?.(pointerId);
-    commit(valueFromPointer(event));
-    const move = (moveEvent) => {
-      moveEvent.preventDefault();
-      moveEvent.stopPropagation();
-      commit(valueFromPointer(moveEvent));
-    };
-    const up = (upEvent) => {
-      upEvent.stopPropagation();
-      track.releasePointerCapture?.(pointerId);
-      window.removeEventListener("pointermove", move, true);
-      window.removeEventListener("pointerup", up, true);
-    };
-    window.addEventListener("pointermove", move, true);
-    window.addEventListener("pointerup", up, true);
-  });
-  wrapper.append(input, track);
-  updateSlider();
-  return wrapper;
-}
-
-function createDomSettingsSliderNumberControl(node, value, options, updater) {
-  return createDomSliderNumberControl(node, "__settings__", value, {
-    ...options,
-    onCommit(nextValue) {
-      updateGeneratorSettings(node, (settings) => {
-        updater?.(settings, nextValue);
-      });
-    },
-  });
-}
-
-function createDomTextControl(node, name, value) {
-  const input = textInput(value);
-  input.addEventListener("input", () => {
-    setWidgetValueIfChanged(node, name, input.value);
-    syncGeneratorSettingsFromVisible(node);
-    updateGeneratorDomSummary(node);
-    markNodeDirty(node);
-  });
-  return input;
-}
-
-function createDomCheckboxControl(node, name, value) {
-  const input = checkbox(value);
-  input.addEventListener("change", () => {
-    setWidgetValueIfChanged(node, name, input.checked);
-    syncGeneratorSettingsFromVisible(node);
-    updateGeneratorDomSummary(node);
-    markNodeDirty(node);
-  });
-  return input;
-}
-
-function createDomSettingsCheckboxControl(node, value, updater, options = {}) {
-  const input = checkbox(value);
-  input.addEventListener("change", () => {
-    updateGeneratorSettings(node, (settings) => {
-      updater?.(settings, input.checked);
-    });
-    if (options.rerender) {
-      renderGeneratorPanel(node);
-    } else {
-      updateGeneratorDomSummary(node);
-      scheduleGeneratorLayout(node);
-      markNodeDirty(node);
-    }
-  });
-  return input;
-}
-
-function createDomSettingsNumberControl(node, value, step, updater, options = {}) {
-  const input = numberInput(value, step);
-  if (options.min != null) {
-    input.min = String(options.min);
-  }
-  if (options.max != null) {
-    input.max = String(options.max);
-  }
-  const decimals = Number(options.decimals ?? 0);
-  const commit = () => {
-    const fallback = Number(value) || 0;
-    const min = Number(options.min ?? -Infinity);
-    const max = Number(options.max ?? Infinity);
-    const factor = 10 ** decimals;
-    const clamped = clampGeneratorNumber(input.value, fallback, min, max);
-    const nextValue = decimals > 0 ? Math.round(clamped * factor) / factor : Math.trunc(clamped);
-    input.value = nextValue;
-    updateGeneratorSettings(node, (settings) => {
-      updater?.(settings, nextValue);
-    });
-    if (options.rerender) {
-      renderGeneratorPanel(node);
-    } else {
-      updateGeneratorDomSummary(node);
-      scheduleGeneratorLayout(node);
-      markNodeDirty(node);
-    }
-  };
-  input.addEventListener("input", commit);
-  return input;
-}
-
-function createDomSettingsSelectControl(node, value, options, updater, settings = {}) {
-  const select = selectInput(options, String(value ?? ""));
-  select.addEventListener("change", () => {
-    updateGeneratorSettings(node, (nextSettings) => {
-      updater?.(nextSettings, select.value);
-    });
-    if (settings.rerender) {
-      renderGeneratorPanel(node);
-    } else {
-      updateGeneratorDomSummary(node);
-      scheduleGeneratorLayout(node);
-      markNodeDirty(node);
-    }
-  });
-  return select;
-}
-
-function createDomSelectControl(node, name, value, fallbackOptions = []) {
-  const select = selectInput(widgetOptions(node, name, fallbackOptions), String(value ?? ""));
-  select.addEventListener("change", () => {
-    setWidgetValueIfChanged(node, name, select.value);
-    syncGeneratorSettingsFromVisible(node);
-    updateGeneratorDomSummary(node);
-    markNodeDirty(node);
-  });
-  return select;
-}
-
-function createSeedControlSelect(node, value) {
-  const select = selectInput(GENERATOR_SEED_CONTROLS, normalizeSeedControl(value));
-  select.addEventListener("change", () => {
-    updateGeneratorSettings(node, (settings) => {
-      settings.sampler.seed_after_generate = normalizeSeedControl(select.value);
-    });
-    markNodeDirty(node);
-  });
-  return select;
-}
-
 function syncGeneratorStateFromDom(node) {
   const settings = generatorSettings(node);
   writeGeneratorSettingsFromState(node, settings, false);
@@ -4575,693 +4039,6 @@ function randomSeed() {
     seed = Math.floor(Math.random() * limit);
   }
   return isSpecialSeed(seed) ? 0 : seed;
-}
-
-function setGeneratorSeedFromUi(node, value) {
-  const seed = normalizeSeedValue(value, GENERATOR_SPECIAL_SEED_RANDOM);
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  const seedInput = panel?.querySelector?.("[data-aio-seed-input]");
-  if (seedInput) {
-    seedInput.value = seed;
-  }
-  setWidgetValueIfChanged(node, "seed", seed);
-  syncGeneratorSettingsFromVisible(node);
-  updateGeneratorDomSummary(node);
-  refreshGeneratorSeedButtons(node);
-  markNodeDirty(node);
-}
-
-function refreshGeneratorSeedButtons(node) {
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  if (!panel) {
-    return;
-  }
-  const lastSeed = node.__easyuseAnimaLastQueuedSeed;
-  const currentSeed = normalizeSeedValue(widgetValue(node, "seed", GENERATOR_SPECIAL_SEED_RANDOM));
-  const lastButton = panel.querySelector("[data-aio-seed-last]");
-  if (lastButton) {
-    const hasLastSeed = lastSeed != null;
-    lastButton.disabled = !hasLastSeed || Number(lastSeed) === currentSeed;
-    lastButton.textContent = hasLastSeed
-      ? aioFormat("button.useLast", { seed: lastSeed })
-      : aioText("button.useLastNone");
-    lastButton.title = aioText("tip.useLast");
-  }
-}
-
-function renderGeneratorPanel(node) {
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  if (!panel) {
-    return;
-  }
-  const settings = generatorSettings(node);
-  panel.replaceChildren();
-
-  const makeButton = (label, callback, className = "", tooltipKey = "") => {
-    const button = document.createElement("button");
-    button.className = `easyuse-anima-aio-node-button ${className}`.trim();
-    button.type = "button";
-    button.textContent = label;
-    applyTooltip(button, tooltipKey);
-    button.addEventListener("click", callback);
-    return button;
-  };
-  const makeIconButton = (label, callback, tooltipKey = "") => {
-    const button = document.createElement("button");
-    button.className = "easyuse-anima-aio-node-icon-button";
-    button.type = "button";
-    button.textContent = label;
-    applyTooltip(button, tooltipKey);
-    button.addEventListener("click", callback);
-    return button;
-  };
-  const makeCardHeader = (title, actions = []) => {
-    const header = document.createElement("div");
-    header.className = "easyuse-anima-aio-node-card-header";
-    const titleEl = document.createElement("div");
-    titleEl.className = "easyuse-anima-aio-node-card-title";
-    titleEl.textContent = title;
-    const actionBox = document.createElement("div");
-    actionBox.className = "easyuse-anima-aio-node-card-actions";
-    actionBox.append(...actions.filter(Boolean));
-    header.append(titleEl, actionBox);
-    return header;
-  };
-  const makeStageHeader = (title, toggle, tooltipKey = "", actions = []) => {
-    const header = document.createElement("div");
-    header.className = "easyuse-anima-aio-node-stage-header";
-    const titleEl = document.createElement("div");
-    titleEl.className = "easyuse-anima-aio-node-stage-title";
-    titleEl.textContent = title;
-    applyTooltip(titleEl, tooltipKey);
-    const toggleLabel = document.createElement("label");
-    toggleLabel.className = "easyuse-anima-aio-node-stage-toggle";
-    toggleLabel.append(toggle, document.createTextNode(aioText("label.enabled")));
-    applyTooltip(toggleLabel, tooltipKey);
-    const actionBox = document.createElement("div");
-    actionBox.className = "easyuse-anima-aio-node-stage-tools";
-    actionBox.append(...actions.filter(Boolean), toggleLabel);
-    header.append(titleEl, actionBox);
-    return header;
-  };
-  const makeNote = (textKey, tooltipKey = "") => {
-    const note = document.createElement("div");
-    note.className = "easyuse-anima-aio-node-stage-note";
-    note.textContent = aioText(textKey);
-    applyTooltip(note, tooltipKey);
-    return note;
-  };
-  const moveDetailerTarget = (targetName, delta) => {
-    updateGeneratorSettings(node, (nextSettings) => {
-      const order = normalizeDetailerOrder(nextSettings.detailer?.order, nextSettings.detailer);
-      const currentIndex = order.indexOf(targetName);
-      const nextIndex = currentIndex + delta;
-      if (currentIndex < 0 || nextIndex < 0 || nextIndex >= order.length) {
-        return;
-      }
-      [order[currentIndex], order[nextIndex]] = [order[nextIndex], order[currentIndex]];
-      nextSettings.detailer ||= {};
-      nextSettings.detailer.order = order;
-    });
-    renderGeneratorPanel(node);
-  };
-
-  const main = document.createElement("div");
-  main.className = "easyuse-anima-aio-node-main";
-
-  const samplerCard = document.createElement("section");
-  samplerCard.className = "easyuse-anima-aio-node-card easyuse-anima-aio-node-settings";
-  const profileValue = syncGeneratorProfileValue(node, settings);
-  const profileButton = makeButton(
-    generatorProfileDisplayLabel(profileValue),
-    () => openGeneratorProfileSettings(node),
-    "easyuse-anima-aio-node-profile-button",
-    "profile.selectTip",
-  );
-  profileButton.setAttribute("data-aio-profile-button", "");
-  const saveIcon = makeIconButton("💾", () => openSaveSettings(node), "tip.saveOptions");
-  saveIcon.setAttribute("data-aio-save-button", "");
-  const samplerHeader = makeCardHeader(aioText("title.sampler"), [
-    profileButton,
-    makeIconButton("⚙", () => openSamplerSettings(node), "tip.samplerDetails"),
-    makeIconButton("⋯", () => openAdvancedSettings(node), "tip.advancedOptions"),
-    saveIcon,
-  ]);
-  const settingsScroll = document.createElement("div");
-  settingsScroll.className = "easyuse-anima-aio-node-settings-scroll";
-
-  const samplerGrid = document.createElement("div");
-  samplerGrid.className = "easyuse-anima-aio-node-sampler-grid";
-
-  const seedBlock = document.createElement("div");
-  const seedInput = createDomNumberControl(node, "seed", settings.sampler.seed);
-  seedInput.setAttribute("data-aio-seed-input", "");
-  applyTooltip(seedInput, "tip.seed");
-  const seedActions = document.createElement("div");
-  seedActions.className = "easyuse-anima-aio-node-seed-actions";
-  const seedRandomEach = makeButton(
-    aioText("button.randomEach"),
-    () => setGeneratorSeedFromUi(node, GENERATOR_SPECIAL_SEED_RANDOM),
-    "",
-    "tip.randomEach",
-  );
-  const seedNewFixed = makeButton(
-    aioText("button.newFixed"),
-    () => setGeneratorSeedFromUi(node, randomSeed()),
-    "",
-    "tip.newFixed",
-  );
-  const seedLast = makeButton(
-    aioText("button.useLastNone"),
-    () => {
-      if (node.__easyuseAnimaLastQueuedSeed == null) {
-        return;
-      }
-      setGeneratorSeedFromUi(node, node.__easyuseAnimaLastQueuedSeed);
-    },
-    "",
-    "tip.useLast",
-  );
-  seedLast.setAttribute("data-aio-seed-last", "");
-  seedActions.append(seedRandomEach, seedNewFixed, seedLast);
-  seedBlock.append(seedInput, seedActions);
-
-  const modeBadge = Object.assign(document.createElement("div"), {
-    className: "easyuse-anima-aio-node-mode-badge",
-  });
-  modeBadge.setAttribute("data-aio-backend-summary", "");
-  samplerGrid.append(
-    createNodeField(aioText("label.mode"), modeBadge, "wide", "tip.mode"),
-    createNodeField(aioText("label.seed"), seedBlock, "seed", "tip.seed"),
-    createNodeField(
-      aioText("label.steps"),
-      createDomSliderNumberControl(node, "steps", settings.sampler.steps, {
-        min: 1,
-        max: 75,
-        step: 1,
-        decimals: 0,
-      }),
-      "wide",
-      "tip.steps",
-    ),
-    createNodeField(
-      aioText("label.cfg"),
-      createDomSliderNumberControl(node, "cfg", settings.sampler.cfg, {
-        min: 1,
-        max: 10,
-        step: 0.1,
-        decimals: 1,
-      }),
-      "wide",
-      "tip.cfg",
-    ),
-    createNodeField(
-      aioText("label.shift"),
-      createDomSettingsSliderNumberControl(
-        node,
-        settings.model_patches.aura_flow.shift ?? DEFAULT_GENERATION_SETTINGS.model_patches.aura_flow.shift,
-        {
-          min: 1,
-          max: 10,
-          step: 0.5,
-          decimals: 1,
-        },
-        (nextSettings, value) => {
-          nextSettings.model_patches.aura_flow ||= {};
-          delete nextSettings.model_patches.aura_flow.enabled;
-          nextSettings.model_patches.aura_flow.shift = value;
-        },
-      ),
-      "wide",
-      "tip.shift",
-    ),
-    createNodeField(
-      aioText("label.denoise"),
-      createDomNumberControl(node, "denoise", settings.sampler.denoise, "0.01"),
-      "",
-      "tip.denoise",
-    ),
-    createNodeField(
-      aioText("label.sampler"),
-      createDomSelectControl(node, "sampler_name", settings.sampler.sampler_name, GENERATOR_FALLBACK_SAMPLER_NAMES),
-      "wide",
-      "tip.sampler",
-    ),
-    createNodeField(
-      aioText("label.scheduler"),
-      createDomSelectControl(node, "scheduler", settings.sampler.scheduler, GENERATOR_FALLBACK_SCHEDULER_NAMES),
-      "wide",
-      "tip.scheduler",
-    ),
-  );
-
-  const highresBlock = document.createElement("div");
-  highresBlock.className = "easyuse-anima-aio-node-stage-block";
-  const highresEnabled = createDomSettingsCheckboxControl(
-    node,
-    settings.highres.enabled,
-    (nextSettings, value) => {
-      nextSettings.highres ||= {};
-      nextSettings.highres.enabled = value;
-    },
-    { rerender: true },
-  );
-  highresBlock.append(makeStageHeader(
-    aioText("title.highres"),
-    highresEnabled,
-    "tip.highresEnabled",
-    [makeIconButton("⚙", () => openHighresSettings(node), "tip.highresSettings")],
-  ));
-  const highresBody = document.createElement("div");
-  highresBody.className = "easyuse-anima-aio-node-stage-body";
-  if (settings.highres.enabled) {
-    const mainBackendIsSpd = settings.sampler.backend === "spectrum_spd_speed";
-    const highresFollowsMain = !!settings.highres.inherit_sampler_settings;
-    const followMain = createDomSettingsCheckboxControl(
-      node,
-      highresFollowsMain,
-      (nextSettings, value) => {
-        nextSettings.highres ||= {};
-        nextSettings.highres.inherit_sampler_settings = value;
-      },
-      { rerender: true },
-    );
-    const stageMode = Object.assign(document.createElement("div"), {
-      className: "easyuse-anima-aio-node-mode-badge",
-      textContent: samplerModeLabel({
-        sampler: {
-          backend: settings.highres.backend || "comfy_ksampler",
-          spectrum: settings.highres.spectrum || {},
-          dit_corrections: settings.highres.dit_corrections || {},
-        },
-      }),
-    });
-    const noteKey = mainBackendIsSpd && highresFollowsMain
-      ? "text.highresSpdManualRequired"
-      : (highresFollowsMain ? "text.inheritsMainSampler" : "text.usesStageSamplerOverride");
-    highresBody.append(
-      createNodeField(aioText("label.followMainSampler"), followMain, "wide", "tip.highresFollow"),
-      makeNote(noteKey, "tip.highresFollow"),
-      ...(highresFollowsMain ? [] : [
-        createNodeField(aioText("label.mode"), stageMode, "wide", "tip.highresBackend"),
-      ]),
-      createNodeField(
-        aioText("label.scaleBy"),
-        createDomSettingsSliderNumberControl(
-          node,
-          settings.highres.scale_by,
-          { min: 1, max: 4, step: 0.05, decimals: 2 },
-          (nextSettings, value) => {
-            nextSettings.highres ||= {};
-            nextSettings.highres.scale_by = value;
-          },
-        ),
-        "wide",
-        "tip.highresScale",
-      ),
-      createNodeField(
-        aioText("label.steps"),
-        createDomSettingsSliderNumberControl(
-          node,
-          settings.highres.steps,
-          { min: 1, max: 75, step: 1, decimals: 0 },
-          (nextSettings, value) => {
-            nextSettings.highres ||= {};
-            nextSettings.highres.steps = Math.trunc(value);
-          },
-        ),
-        "wide",
-        "tip.highresSteps",
-      ),
-      createNodeField(
-        aioText("label.denoise"),
-        createDomSettingsSliderNumberControl(
-          node,
-          settings.highres.denoise,
-          { min: 0, max: 1, step: 0.01, decimals: 2 },
-          (nextSettings, value) => {
-            nextSettings.highres ||= {};
-            nextSettings.highres.denoise = value;
-          },
-        ),
-        "wide",
-        "tip.highresDenoise",
-      ),
-      createNodeField(
-        aioText("label.maxLongEdge"),
-        createDomSettingsNumberControl(
-          node,
-          settings.highres.max_long_edge,
-          "32",
-          (nextSettings, value) => {
-            nextSettings.highres ||= {};
-            nextSettings.highres.max_long_edge = Math.trunc(value);
-          },
-          { min: 0, max: 16384, decimals: 0 },
-        ),
-        "wide",
-        "tip.highresMaxEdge",
-      ),
-    );
-  } else {
-    highresBody.append(makeNote("text.highresDisabled", "tip.highresEnabled"));
-  }
-  highresBlock.append(highresBody);
-
-  const detailerBlock = document.createElement("div");
-  detailerBlock.className = "easyuse-anima-aio-node-stage-block";
-  const detailerEnabled = createDomSettingsCheckboxControl(
-    node,
-    settings.detailer.enabled,
-    (nextSettings, value) => {
-      nextSettings.detailer ||= {};
-      nextSettings.detailer.enabled = value;
-    },
-    { rerender: true },
-  );
-  detailerBlock.append(makeStageHeader(
-    aioText("title.detailer"),
-    detailerEnabled,
-    "tip.detailerEnabled",
-    [makeIconButton("⚙", () => openDetailerSettings(node), "tip.detailerSettings")],
-  ));
-  const detailerBody = document.createElement("div");
-  detailerBody.className = "easyuse-anima-aio-node-stage-body";
-  if (settings.detailer.enabled) {
-    const order = normalizeDetailerOrder(settings.detailer.order, settings.detailer);
-    for (const [index, targetName] of order.entries()) {
-      const defaults = detailerTargetDefaults(targetName);
-      const target = mergeDefaults(defaults, settings.detailer[targetName] || {});
-      const targetBlock = document.createElement("div");
-      targetBlock.className = "easyuse-anima-aio-node-stage-mini";
-      applyTooltip(targetBlock, "tip.detailerBlock");
-      const targetHeader = document.createElement("div");
-      targetHeader.className = "easyuse-anima-aio-node-stage-mini-header";
-      const targetTitle = document.createElement("div");
-      targetTitle.className = "easyuse-anima-aio-node-stage-mini-title";
-      targetTitle.textContent = `${index + 1}. ${detailerTargetTitle(targetName, target, index)}`;
-      applyTooltip(targetTitle, "tip.detailerBlock");
-      const targetTools = document.createElement("div");
-      targetTools.className = "easyuse-anima-aio-node-stage-tools";
-      const moveUp = makeIconButton("↑", () => moveDetailerTarget(targetName, -1), "tip.detailerOrder");
-      const moveDown = makeIconButton("↓", () => moveDetailerTarget(targetName, 1), "tip.detailerOrder");
-      moveUp.disabled = index === 0;
-      moveDown.disabled = index === order.length - 1;
-      targetTools.append(moveUp, moveDown);
-      targetHeader.append(targetTitle, targetTools);
-      targetBlock.append(targetHeader);
-
-      const targetGrid = document.createElement("div");
-      targetGrid.className = "easyuse-anima-aio-node-stage-body";
-      const targetEnabled = createDomSettingsCheckboxControl(
-        node,
-        target.enabled,
-        (nextSettings, value) => {
-          nextSettings.detailer ||= {};
-          nextSettings.detailer[targetName] ||= {};
-          nextSettings.detailer[targetName].enabled = value;
-        },
-        { rerender: true },
-      );
-      targetGrid.append(createNodeField(aioText("label.enabled"), targetEnabled, "wide", "tip.detailerBlock"));
-      if (target.enabled) {
-        const followMain = createDomSettingsCheckboxControl(
-          node,
-          target.inherit_sampler_settings,
-          (nextSettings, value) => {
-            nextSettings.detailer ||= {};
-            nextSettings.detailer[targetName] ||= {};
-            nextSettings.detailer[targetName].inherit_sampler_settings = value;
-          },
-          { rerender: true },
-        );
-        targetGrid.append(
-          createNodeField(aioText("label.followMainSampler"), followMain, "wide", "tip.detailerFollow"),
-          makeNote(
-            target.inherit_sampler_settings ? "text.inheritsMainSampler" : "text.usesStageSamplerOverride",
-            "tip.detailerFollow",
-          ),
-          createNodeField(
-            aioText("label.steps"),
-            createDomSettingsSliderNumberControl(
-              node,
-              target.steps,
-              { min: 1, max: 75, step: 1, decimals: 0 },
-              (nextSettings, value) => {
-                nextSettings.detailer ||= {};
-                nextSettings.detailer[targetName] ||= {};
-                nextSettings.detailer[targetName].steps = Math.trunc(value);
-              },
-            ),
-            "wide",
-            "tip.detailerSteps",
-          ),
-          createNodeField(
-            aioText("label.denoise"),
-            createDomSettingsSliderNumberControl(
-              node,
-              target.denoise,
-              { min: 0, max: 1, step: 0.01, decimals: 2 },
-              (nextSettings, value) => {
-                nextSettings.detailer ||= {};
-                nextSettings.detailer[targetName] ||= {};
-                nextSettings.detailer[targetName].denoise = value;
-              },
-            ),
-            "wide",
-            "tip.detailerDenoise",
-          ),
-        );
-      }
-      targetBlock.append(targetGrid);
-      detailerBody.append(targetBlock);
-    }
-  } else {
-    detailerBody.append(makeNote("text.detailerDisabled", "tip.detailerEnabled"));
-  }
-  detailerBlock.append(detailerBody);
-
-  const upscaleBlock = document.createElement("div");
-  upscaleBlock.className = "easyuse-anima-aio-node-stage-block";
-  const upscaleEnabled = createDomSettingsCheckboxControl(
-    node,
-    settings.upscale.enabled,
-    (nextSettings, value) => {
-      nextSettings.upscale ||= {};
-      nextSettings.upscale.enabled = value;
-    },
-    { rerender: true },
-  );
-  upscaleBlock.append(makeStageHeader(
-    aioText("title.upscale"),
-    upscaleEnabled,
-    "tip.upscaleEnabled",
-    [makeIconButton("⚙", () => openUpscaleSettings(node), "tip.upscaleSettings")],
-  ));
-  const upscaleBody = document.createElement("div");
-  upscaleBody.className = "easyuse-anima-aio-node-stage-body";
-  if (settings.upscale.enabled) {
-    const backend = createDomSettingsSelectControl(
-      node,
-      settings.upscale.backend || "usdu",
-      ["usdu", "resshift"],
-      (nextSettings, value) => {
-        nextSettings.upscale ||= {};
-        nextSettings.upscale.backend = value || "usdu";
-      },
-      { rerender: true },
-    );
-    upscaleBody.append(
-      createNodeField(aioText("label.mode"), backend, "wide", "tip.upscaleBackend"),
-    );
-    if (settings.upscale.backend === "usdu") {
-      const usdu = normalizeGeneratorUsduAutoTileRange(
-        mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale.usdu, settings.upscale.usdu || {}),
-      );
-      upscaleBody.append(
-        createNodeField(
-          aioText("label.scaleBy"),
-          createDomSettingsSliderNumberControl(
-            node,
-            settings.upscale.scale_by,
-            { min: 1, max: 4, step: 0.05, decimals: 2 },
-            (nextSettings, value) => {
-              nextSettings.upscale ||= {};
-              nextSettings.upscale.scale_by = value;
-            },
-          ),
-          "wide",
-          "tip.upscaleScale",
-        ),
-        createNodeField(
-          aioText("label.steps"),
-          createDomSettingsSliderNumberControl(
-            node,
-            settings.upscale.steps,
-            { min: 1, max: 75, step: 1, decimals: 0 },
-            (nextSettings, value) => {
-              nextSettings.upscale ||= {};
-              nextSettings.upscale.steps = Math.trunc(value);
-            },
-          ),
-          "wide",
-          "tip.steps",
-        ),
-        createNodeField(
-          aioText("label.denoise"),
-          createDomSettingsSliderNumberControl(
-            node,
-            settings.upscale.denoise,
-            { min: 0, max: 1, step: 0.01, decimals: 2 },
-            (nextSettings, value) => {
-              nextSettings.upscale ||= {};
-              nextSettings.upscale.denoise = value;
-            },
-          ),
-          "wide",
-          "tip.denoise",
-        ),
-        createNodeField(
-          aioText("field.autoTileSize"),
-          createDomSettingsCheckboxControl(
-            node,
-            usdu.auto_tile_size,
-            (nextSettings, value) => {
-              nextSettings.upscale ||= {};
-              nextSettings.upscale.usdu ||= {};
-              nextSettings.upscale.usdu.auto_tile_size = value;
-            },
-            { rerender: true },
-          ),
-          "wide",
-          "tip.usduAutoTile",
-        ),
-      );
-      if (usdu.auto_tile_size) {
-        upscaleBody.append(
-          createNodeField(
-            aioText("field.autoTileTarget"),
-            createDomSettingsSliderNumberControl(
-              node,
-              usdu.auto_tile_target,
-              { min: 256, max: 2048, step: 64, decimals: 0 },
-              (nextSettings, value) => {
-                setGeneratorUsduAutoTileTarget(nextSettings, value);
-              },
-            ),
-            "wide",
-            "tip.usduAutoTile",
-          ),
-        );
-      }
-      upscaleBody.append(
-        makeNote(
-          usdu.auto_tile_size ? "text.usduAutoTile" : "text.usduManualTile",
-          usdu.auto_tile_size ? "tip.usduAutoTile" : "tip.usduTile",
-        ),
-      );
-    } else {
-      upscaleBody.append(makeNote(`ResShift ${settings.upscale.resshift?.scale || "x2"}`, "tip.resshiftScale"));
-    }
-  } else {
-    upscaleBody.append(makeNote("text.upscaleDisabled", "tip.upscaleEnabled"));
-  }
-  upscaleBlock.append(upscaleBody);
-
-  const postprocess = mergeDefaults(DEFAULT_GENERATION_SETTINGS.postprocess, settings.postprocess || {});
-  const postprocessBlock = document.createElement("div");
-  postprocessBlock.className = "easyuse-anima-aio-node-stage-block";
-  const postprocessEnabled = createDomSettingsCheckboxControl(
-    node,
-    postprocess.enabled,
-    (nextSettings, value) => {
-      nextSettings.postprocess ||= {};
-      nextSettings.postprocess.enabled = value;
-    },
-    { rerender: true },
-  );
-  postprocessBlock.append(makeStageHeader(
-    aioText("title.postprocess"),
-    postprocessEnabled,
-    "tip.postprocessEnabled",
-    [makeIconButton("⚙", () => openPostprocessSettings(node), "tip.postprocessSettings")],
-  ));
-  const postprocessBody = document.createElement("div");
-  postprocessBody.className = "easyuse-anima-aio-node-stage-body";
-  if (postprocess.enabled) {
-    const fit = mergeDefaults(DEFAULT_GENERATION_SETTINGS.postprocess.fit, postprocess.fit || {});
-    const fitText = fit.mode === "megapixels"
-      ? `Fit <= ${fit.max_megapixels || 4}MP`
-      : `Fit <= ${fit.max_long_edge || 2048}px`;
-    postprocessBody.append(makeNote(fitText, "tip.finalFit"));
-  } else {
-    postprocessBody.append(makeNote("text.postprocessDisabled", "tip.postprocessEnabled"));
-  }
-  postprocessBlock.append(postprocessBody);
-
-  settingsScroll.append(samplerGrid, highresBlock, detailerBlock, upscaleBlock, postprocessBlock);
-
-  samplerCard.append(samplerHeader, settingsScroll);
-
-  const previewCard = document.createElement("section");
-  previewCard.className = "easyuse-anima-aio-node-card easyuse-anima-aio-node-preview";
-  const previewHeader = makeCardHeader(aioText("title.preview"), [
-    makeIconButton("⚙", () => openPreviewSettings(node), "tip.previewOptions"),
-  ]);
-  const previewBox = document.createElement("div");
-  previewBox.className = "easyuse-anima-aio-node-preview-box";
-  previewBox.setAttribute("data-aio-preview-box", "");
-  const previewPlaceholder = document.createElement("div");
-  previewPlaceholder.className = "easyuse-anima-aio-node-preview-placeholder";
-  const previewStrong = document.createElement("strong");
-  previewStrong.textContent = aioText("text.previewTitle");
-  const previewText = document.createElement("span");
-  previewText.textContent = aioText("text.previewSubtitle");
-  previewPlaceholder.append(previewStrong, previewText);
-  previewBox.append(previewPlaceholder);
-
-  const previewMeta = document.createElement("div");
-  previewMeta.className = "easyuse-anima-aio-node-preview-meta";
-  previewMeta.setAttribute("data-aio-preview-meta", "");
-  previewMeta.textContent = "-";
-  applyTooltip(previewMeta, "tip.size");
-
-  const previewFeed = document.createElement("div");
-  previewFeed.className = "easyuse-anima-aio-node-preview-feed";
-  previewFeed.setAttribute("data-aio-preview-feed", "");
-  previewFeed.hidden = true;
-
-  previewCard.append(previewHeader, previewBox, previewMeta, previewFeed);
-
-  main.append(samplerCard, previewCard);
-  panel.append(main);
-  stopGeneratorControlPropagation(panel);
-  updateGeneratorDomSummary(node);
-  refreshGeneratorSeedButtons(node);
-  scheduleGeneratorLayout(node);
-}
-
-function ensureGeneratorPanel(node) {
-  ensureStyle();
-  node.serialize_widgets = true;
-  suppressGeneratorDefaultPreview(node, { markDirty: false });
-  node.minWidth = Math.max(Number(node.minWidth) || 0, GENERATOR_NODE_MIN_WIDTH);
-  if (Array.isArray(node.size)) {
-    node.size[0] = Math.max(Number(node.size[0]) || 0, GENERATOR_NODE_DEFAULT_WIDTH);
-  }
-  if (!node.__easyuseAnimaGeneratorPanelEl) {
-    const panel = document.createElement("div");
-    panel.className = "easyuse-anima-aio-node-panel";
-    node.__easyuseAnimaGeneratorPanelEl = panel;
-    node.addDOMWidget?.(GENERATOR_DOM_WIDGET, "EasyUseAnimaGeneratorPanel", panel, {
-      serialize: false,
-      hideOnZoom: false,
-      getMinHeight: () => GENERATOR_PANEL_MIN_HEIGHT,
-    });
-  }
-  markGeneratorNativeLivePreviewHidden(node);
-  renderGeneratorPanel(node);
-  markGeneratorNativeLivePreviewHidden(node);
 }
 
 function openSamplerSettings(node) {
@@ -7169,6 +5946,78 @@ const openPreviewSettings = aioCreatePreviewSettingsDialog({
   applyVisibleSettings: applyVisibleGeneratorSettings,
   writeSettings,
   renderGeneratorPanel,
+});
+
+const generatorPanelRuntime = aioCreateGeneratorPanelRuntime({
+  document,
+  window,
+  requestAnimationFrame: (callback) => requestAnimationFrame(callback),
+  panelMinHeight: GENERATOR_PANEL_MIN_HEIGHT,
+  controls: {
+    numberInput,
+    checkbox,
+    selectInput,
+    createNodeField,
+  },
+  text: {
+    get: aioText,
+    format: aioFormat,
+    applyTooltip,
+  },
+  settingsCore: {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    normalizeSeedControl,
+    normalizeSeedValue,
+    clampNumber: clampGeneratorNumber,
+    normalizeUsduAutoTileRange: normalizeGeneratorUsduAutoTileRange,
+    setUsduAutoTileTarget: setGeneratorUsduAutoTileTarget,
+    normalizeDetailerOrder,
+    detailerTargetDefaults,
+    detailerTargetTitle,
+  },
+  nodeAdapter: {
+    getSettings: generatorSettings,
+    applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings: writeGeneratorSettingsFromState,
+    syncSettingsFromVisible: syncGeneratorSettingsFromVisible,
+    widgetValue,
+    widgetOptions,
+    setWidgetValueIfChanged,
+    markDirty: markNodeDirty,
+    ensureStyle,
+    suppressDefaultPreview: suppressGeneratorDefaultPreview,
+    markNativePreviewHidden: markGeneratorNativeLivePreviewHidden,
+    imageUrl: generatorImageUrl,
+    randomSeed,
+    forwardPanelWheel: forwardGeneratorPanelWheel,
+  },
+  profileAdapter: {
+    syncValue: syncGeneratorProfileValue,
+    displayLabel: generatorProfileDisplayLabel,
+  },
+  previewAdapter: {
+    mainImage: aioMainPreviewImage,
+    selectedIndex: aioSelectedPreviewIndex,
+    imageLabel: aioPreviewImageLabel,
+    imageName: aioPreviewImageName,
+    imageResolution: aioPreviewResolution,
+    imageFileSize: aioPreviewFileSize,
+  },
+  actions: {
+    openProfileSettings: openGeneratorProfileSettings,
+    openSaveSettings,
+    openSamplerSettings,
+    openAdvancedSettings,
+    openHighresSettings,
+    openDetailerSettings,
+    openUpscaleSettings,
+    openPostprocessSettings,
+    openPreviewSettings,
+  },
 });
 
 function hookInputNode(node) {


### PR DESCRIPTION
## 변경 요약

- AiO generator panel의 렌더링, 요약, preview/feed/compare, layout, seed UI lifecycle을 `aio/generator_panel_runtime.js`로 분리했습니다.
- 기존 entry는 안정적인 5개 facade(`ensurePanel`, `renderPanel`, `updateSummary`, `scheduleLayout`, `refreshSeedButtons`)를 통해 새 runtime에 위임합니다.
- 직렬화, queue/hooks, dialog, native preview/event 책임은 이번 조각의 경계 밖에 그대로 유지했습니다.
- panel smoke가 사용하는 공용 Fake DOM harness에 필요한 최소 DOM 기능을 보강하고, panel lifecycle 전용 회귀 smoke를 추가했습니다.
- 이동 과정에서 실제 호출되지 않던 기존 local helper 3개와 정적 검사에서 확인된 미사용 지역 변수 1개를 정리했습니다.

## 주요 파일

- `web/js/aio/generator_panel_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_generator_panel_runtime_smoke.mjs`
- `tests/frontend_support/fake_dom.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 호환성 경계

- panel 생성 순서, DOM widget 옵션, layout scheduling, control event 전파, summary/preview 갱신, seed 설정 동기화의 기존 동작을 유지했습니다.
- serialization, queue 동작, dialog 동작, native preview 연결은 변경하지 않았습니다.
- #54에 기록된 seed/denoise/rerender/cleanup 관련 동작 finding은 이번 기계적 추출에서 수정하지 않고 후속 behavior 조각으로 유지합니다.

## 검증

- Focused panel runtime smoke: 통과
- Focused TypeScript 6.0.3: 통과
- 기존 공용 Fake DOM 사용 smoke 및 관련 Python 구조 검사: 통과
- 공식 full runner 최종 결과:
  - Python unittest: 363 tests 통과
  - Frontend: 88 JavaScript files 통과
  - TypeScript: 6.0.3 통과
  - Git diff check: 통과
- 첫 full 실행은 새 모듈의 미사용 지역 변수 1건으로 TypeScript 검사만 실패했습니다. 해당 변수 제거 후 focused 검사와 최종 full runner를 재실행해 통과했습니다.
- 행동/구조/테스트 3중 감사: Blocker/P2/P3 없음
- Legacy canvas browser smoke: 미실행 (기계적 lifecycle 이동, 동작 변경 없음)
- Node 2.0 browser smoke: 미실행 (기계적 lifecycle 이동, 동작 변경 없음)
- Live ComfyUI smoke: 미실행

## 남은 범위

- #54의 dialog/native-preview/queue/hooks/entry 경계와 별도 behavior finding은 후속 reviewable slice로 계속 진행합니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`