### PR TITLE
refactor: extract AiO stage settings dialogs

### DIFF
--- a/tests/frontend_aio_stage_settings_dialogs_smoke.mjs
+++ b/tests/frontend_aio_stage_settings_dialogs_smoke.mjs
@@ -1,0 +1,592 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+  descendants,
+} from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function find(root, predicate) {
+  return [root, ...descendants(root)].find(predicate) || null;
+}
+
+function findAll(root, predicate) {
+  return [root, ...descendants(root)].filter(predicate);
+}
+
+function findByText(root, textContent) {
+  return find(root, (element) => element.textContent === textContent);
+}
+
+function sectionByHeading(dialog, heading) {
+  return findByText(dialog.body, `static:${heading}`)?.parentElement || null;
+}
+
+function rowByLabel(root, label) {
+  return find(root, (element) => element.getAttribute?.("data-test-label") === label);
+}
+
+function control(dialog, label, index = 0) {
+  const values = dialog.controls.get(label) || [];
+  assert.ok(values[index], `missing control: ${label}[${index}]`);
+  return values[index];
+}
+
+function action(dialog, key) {
+  const button = findByText(dialog.actions, `text:${key}`);
+  assert.ok(button, `missing action: ${key}`);
+  return button;
+}
+
+function setSelectValue(select, value) {
+  select.value = String(value);
+  for (const option of select.options || []) {
+    option.selected = option.value === select.value;
+  }
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const stageDialogModule = await import(dataModule("../web/js/aio/stage_settings_dialogs.js"));
+const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+assert.deepEqual(
+  Object.keys(stageDialogModule),
+  ["aioCreateStageSettingsDialogs"],
+  "Stage settings dialogs must expose only their factory contract",
+);
+
+function createFixture({
+  settings = {},
+  available = {},
+  missingByBackend = {},
+  deferLoads = false,
+} = {}) {
+  let dependencyCalls = 0;
+  let currentDialog = null;
+  const trace = [];
+  const dialogs = [];
+  const loadCalls = [];
+  const loadResolvers = [];
+  const optionCalls = [];
+  const choiceCalls = [];
+  const writes = [];
+  const renders = [];
+  const document = createFakeDocument();
+  const availabilityState = { ...available };
+  const missingByBackendState = Object.fromEntries(
+    Object.entries(missingByBackend).map(([backend, packs]) => [backend, [...packs]]),
+  );
+  const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
+  const node = {
+    settings: settingsModule.aioMergeDefaults(defaultSettings, settings),
+    widgets: [{ name: "generation_settings", value: "" }],
+  };
+  node.widgets[0].value = JSON.stringify(node.settings);
+
+  function createDialog(title, subtitle) {
+    dependencyCalls += 1;
+    const dialog = {
+      title,
+      subtitle,
+      backdrop: document.createElement("div"),
+      body: document.createElement("div"),
+      actions: document.createElement("div"),
+      controls: new Map(),
+      tooltips: new Map(),
+      trace: [],
+    };
+    dialog.backdrop.remove = () => {
+      dialog.backdrop.removed = true;
+      dialog.trace.push("remove");
+      trace.push("remove");
+    };
+    dialogs.push(dialog);
+    currentDialog = dialog;
+    return dialog;
+  }
+
+  function field(section, label, element, tooltipKey = "") {
+    dependencyCalls += 1;
+    const row = document.createElement("label");
+    row.className = "easyuse-anima-aio-field";
+    row.setAttribute("data-test-label", label);
+    row.append(element);
+    section.append(row);
+    if (currentDialog) {
+      const values = currentDialog.controls.get(label) || [];
+      values.push(element);
+      currentDialog.controls.set(label, values);
+      currentDialog.tooltips.set(label, tooltipKey);
+    }
+    return element;
+  }
+
+  function numberInput(value, step = "1") {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "number";
+    input.step = step;
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function checkbox(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = !!value;
+    return input;
+  }
+
+  function selectInput(options, value) {
+    dependencyCalls += 1;
+    const select = document.createElement("select");
+    select.options = [];
+    for (const optionSpec of options) {
+      const option = document.createElement("option");
+      option.value = typeof optionSpec === "object"
+        ? String(optionSpec.value ?? "")
+        : String(optionSpec ?? "");
+      option.textContent = typeof optionSpec === "object"
+        ? String(optionSpec.label ?? option.value)
+        : option.value;
+      option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
+      option.selected = option.value === String(value ?? "");
+      select.options.push(option);
+      select.append(option);
+    }
+    if (!select.options.some((option) => option.selected)) {
+      select.value = String(value ?? "");
+    }
+    return select;
+  }
+
+  function staticText(value) {
+    dependencyCalls += 1;
+    return `static:${value}`;
+  }
+
+  function text(key) {
+    dependencyCalls += 1;
+    return `text:${key}`;
+  }
+
+  function format(key, values = {}) {
+    dependencyCalls += 1;
+    return `format:${key}:${JSON.stringify(values)}`;
+  }
+
+  function clampNumber(value, fallback, min, max) {
+    dependencyCalls += 1;
+    const parsed = Number(value);
+    const next = Number.isFinite(parsed) ? parsed : fallback;
+    return Math.max(min, Math.min(max, next));
+  }
+
+  function normalizeUsduAutoTileRange(usdu) {
+    dependencyCalls += 1;
+    const defaults = defaultSettings.upscale.usdu;
+    const target = Math.trunc(clampNumber(usdu.auto_tile_target, defaults.auto_tile_target, 64, 16384));
+    let min = Math.trunc(clampNumber(usdu.auto_tile_min, defaults.auto_tile_min, 64, 16384));
+    let max = Math.trunc(clampNumber(usdu.auto_tile_max, defaults.auto_tile_max, 64, 16384));
+    max = Math.max(min, max);
+    if (target < min) {
+      min = target;
+    }
+    if (target > max) {
+      max = target;
+    }
+    usdu.auto_tile_target = target;
+    usdu.auto_tile_min = min;
+    usdu.auto_tile_max = Math.max(min, max);
+    return usdu;
+  }
+
+  function findWidget(targetNode, name) {
+    dependencyCalls += 1;
+    return targetNode.widgets?.find((widget) => widget.name === name);
+  }
+
+  function getSettings(targetNode) {
+    dependencyCalls += 1;
+    trace.push("get-settings");
+    return clone(targetNode.settings);
+  }
+
+  function widgetOptions(_targetNode, name, fallback) {
+    dependencyCalls += 1;
+    optionCalls.push(name);
+    return [...new Set([...fallback, name === "sampler_name" ? "custom_sampler" : "custom_scheduler"])];
+  }
+
+  function nodeInputChoiceOptions(dependencyKey, inputName, current, fallback = []) {
+    dependencyCalls += 1;
+    choiceCalls.push({ dependencyKey, inputName, current, fallback: [...fallback] });
+    return [...new Set([...fallback, current].filter(Boolean))];
+  }
+
+  function writeSettings(targetNode, widget, nextSettings) {
+    dependencyCalls += 1;
+    const snapshot = clone(nextSettings);
+    targetNode.settings = snapshot;
+    widget.value = JSON.stringify(snapshot);
+    writes.push(snapshot);
+    currentDialog.trace.push("write");
+    trace.push("write");
+  }
+
+  function renderPanel(targetNode) {
+    dependencyCalls += 1;
+    renders.push(targetNode);
+    currentDialog.trace.push("render");
+    trace.push("render");
+  }
+
+  const runtime = stageDialogModule.aioCreateStageSettingsDialogs({
+    document,
+    controls: {
+      createDialog,
+      field,
+      numberInput,
+      checkbox,
+      selectInput,
+    },
+    text: {
+      staticText,
+      get: text,
+      format,
+    },
+    settingsCore: {
+      defaultGenerationSettings: defaultSettings,
+      fallbackSamplerNames: ["euler", "er_sde"],
+      fallbackSchedulerNames: ["simple", "karras"],
+      mergeDefaults: settingsModule.aioMergeDefaults,
+      clampNumber,
+      normalizeUsduAutoTileRange,
+    },
+    nodeAdapter: {
+      generatorSettingsWidget: "generation_settings",
+      findWidget,
+      getSettings,
+      widgetOptions,
+      nodeInputChoiceOptions,
+      writeSettings,
+      renderPanel,
+    },
+    dependencyAdapter: {
+      available(key) {
+        dependencyCalls += 1;
+        return Object.hasOwn(availabilityState, key) ? !!availabilityState[key] : true;
+      },
+      pack(key) {
+        dependencyCalls += 1;
+        return `pack:${key}`;
+      },
+      upscaleBackendMissingPacks(backend) {
+        dependencyCalls += 1;
+        return [...(missingByBackendState[backend] || [])];
+      },
+      load(options) {
+        dependencyCalls += 1;
+        loadCalls.push(options);
+        if (!deferLoads) {
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => loadResolvers.push(resolve));
+      },
+    },
+  });
+
+  return {
+    runtime,
+    node,
+    document,
+    defaultSettings,
+    dialogs,
+    loadCalls,
+    availabilityState,
+    missingByBackendState,
+    optionCalls,
+    choiceCalls,
+    writes,
+    renders,
+    trace,
+    resolveLoads() {
+      for (const resolve of loadResolvers.splice(0)) {
+        resolve();
+      }
+    },
+    dependencyCallCount: () => dependencyCalls,
+  };
+}
+
+{
+  const fixture = createFixture();
+  assert.equal(fixture.dependencyCallCount(), 0, "Factory composition must be side-effect free");
+  const editor = fixture.runtime.createStageOptimizationEditor(
+    "Standalone Optimization",
+    fixture.defaultSettings.highres,
+    fixture.defaultSettings.highres,
+  );
+  await flushPromises();
+  assert.equal(findByText(editor.section, "static:Standalone Optimization")?.tagName, "H3");
+  assert.equal(typeof editor.values, "function");
+  assert.equal(typeof editor.setIntegratedMode, "function");
+  assert.equal(editor.values().spectrum.window_size, fixture.defaultSettings.highres.spectrum.window_size);
+  editor.setIntegratedMode(true);
+  assert.equal(rowByLabel(editor.section, "Spectrum patch").style.display, "none");
+  assert.equal(rowByLabel(editor.section, "Compat").style.display, "none");
+  assert.equal(fixture.dialogs.length, 0);
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+}
+
+{
+  const fixture = createFixture({
+    available: { spectrumPatch: true },
+    deferLoads: true,
+    settings: {
+      sampler: { backend: "spectrum_spd_speed" },
+      highres: {
+        enabled: true,
+        scale_by: 1.75,
+        upscale_method: "lanczos",
+        multiple: "64",
+        max_long_edge: 4096,
+        steps: 33,
+        inherit_sampler_settings: true,
+        cfg: 7.5,
+        sampler_name: "custom_sampler",
+        scheduler: "custom_scheduler",
+        denoise: 0.44,
+        spectrum: { enabled: true },
+        dit_corrections: { enabled: true },
+        preserved_highres_key: "keep-highres",
+      },
+      preserved_root_key: "keep-root",
+    },
+  });
+  assert.deepEqual(
+    Object.keys(fixture.runtime).sort(),
+    ["createStageOptimizationEditor", "openHighresSettings", "openUpscaleSettings"].sort(),
+    "Stage dialog runtime must expose the shared editor and two opener facades",
+  );
+
+  fixture.runtime.openHighresSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  assert.equal(control(dialog, "Spectrum patch").disabled, false);
+  assert.equal(control(dialog, "Spectrum patch").checked, true);
+  assert.equal(control(dialog, "Use corrections").disabled, false);
+  assert.equal(control(dialog, "Use corrections").checked, true);
+  fixture.availabilityState.spectrumPatch = false;
+  fixture.resolveLoads();
+  await flushPromises();
+  assert.equal(dialog.title, "Highres Settings");
+  assert.equal(dialog.subtitle, "Image scaling and Highres resampling settings are saved with the node.");
+  assert.ok(dialog.body.classList.contains("easyuse-anima-aio-one-column"));
+  assert.ok(fixture.loadCalls.length > 0, "Highres optimization must refresh dependencies asynchronously");
+  assert.equal(control(dialog, "Enable highres").checked, true);
+  assert.equal(control(dialog, "Scale by").value, "1.75");
+  assert.equal(control(dialog, "Method").value, "lanczos");
+  assert.equal(control(dialog, "Multiple").value, "64");
+  assert.equal(control(dialog, "Max long edge").value, "4096");
+  assert.equal(control(dialog, "Steps").value, "33");
+  assert.equal(control(dialog, "Follow main sampler").checked, true);
+  assert.equal(control(dialog, "CFG").value, "7.5");
+  assert.equal(control(dialog, "Sampler").value, "custom_sampler");
+  assert.equal(control(dialog, "Scheduler").value, "custom_scheduler");
+  assert.equal(control(dialog, "Denoise").value, "0.44");
+  assert.equal(control(dialog, "CFG").parentElement.style.display, "none");
+  assert.equal(control(dialog, "Sampler").parentElement.style.display, "none");
+  assert.equal(control(dialog, "Scheduler").parentElement.style.display, "none");
+  assert.equal(control(dialog, "Spectrum patch").disabled, true);
+  assert.equal(control(dialog, "Spectrum patch").checked, false);
+  assert.equal(control(dialog, "Use corrections").disabled, true);
+  assert.equal(control(dialog, "Use corrections").checked, false);
+  const warnings = findAll(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-warning"));
+  const spdWarning = warnings.find((element) => element.textContent === "text:text.highresSpdManualRequired");
+  assert.ok(spdWarning);
+  assert.ok(warnings.some((element) => element.textContent.includes("pack:spectrumPatch")));
+
+  const inheritSampler = control(dialog, "Follow main sampler");
+  inheritSampler.checked = false;
+  inheritSampler.emit("change");
+  assert.equal(control(dialog, "CFG").parentElement.style.display, "");
+  assert.equal(control(dialog, "Sampler").parentElement.style.display, "");
+  assert.equal(control(dialog, "Scheduler").parentElement.style.display, "");
+  assert.equal(spdWarning.textContent, "");
+  assert.equal(spdWarning.hidden, true);
+
+  const beforeCancel = clone(fixture.node.settings);
+  action(dialog, "button.cancel").emit("click");
+  assert.deepEqual(fixture.node.settings, beforeCancel, "Cancel must not mutate Highres settings");
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.deepEqual(dialog.trace, ["remove"]);
+
+  fixture.runtime.openHighresSettings(fixture.node);
+  fixture.resolveLoads();
+  await flushPromises();
+  const applyDialog = fixture.dialogs[1];
+  control(applyDialog, "Scale by").value = "9";
+  control(applyDialog, "Steps").value = "0";
+  control(applyDialog, "CFG").value = "20";
+  control(applyDialog, "Denoise").value = "-1";
+  control(applyDialog, "Follow main sampler").checked = false;
+  action(applyDialog, "button.apply").emit("click");
+  assert.equal(fixture.writes.length, 1);
+  assert.equal(fixture.renders.length, 1);
+  assert.deepEqual(applyDialog.trace.slice(-3), ["write", "render", "remove"]);
+  assert.equal(fixture.node.settings.highres.scale_by, 8);
+  assert.equal(fixture.node.settings.highres.steps, 1);
+  assert.equal(fixture.node.settings.highres.cfg, 10);
+  assert.equal(fixture.node.settings.highres.denoise, 0);
+  assert.equal(fixture.node.settings.highres.inherit_sampler_settings, false);
+  assert.equal(fixture.node.settings.highres.spectrum.enabled, false);
+  assert.equal(fixture.node.settings.highres.dit_corrections.enabled, false);
+  assert.equal(fixture.node.settings.highres.preserved_highres_key, "keep-highres");
+  assert.equal(fixture.node.settings.preserved_root_key, "keep-root");
+  assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), fixture.node.settings);
+}
+
+{
+  const fixture = createFixture({
+    missingByBackend: { resshift: [] },
+    deferLoads: true,
+    settings: {
+      upscale: {
+        enabled: true,
+        backend: "resshift",
+        scale_by: 2.5,
+        inherit_sampler_settings: false,
+        prompt_mode: "ignored-legacy-root",
+        usdu: {
+          auto_tile_size: false,
+          prompt_mode: "quality_tags_only",
+          auto_tile_target: 900,
+          auto_tile_min: 500,
+          auto_tile_max: 1500,
+        },
+        resshift: {
+          scale: "x4",
+          student_name: "student.safetensors",
+          dtype: "fp32",
+          chop: 768,
+          overlap: 96,
+          tile_batch: 3,
+        },
+        preserved_upscale_key: "keep-upscale",
+      },
+    },
+  });
+  assert.equal(fixture.dependencyCallCount(), 0, "Second factory composition must also be side-effect free");
+  fixture.runtime.openUpscaleSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const backend = control(dialog, "Upscale backend");
+  const resshiftOption = backend.options.find((option) => option.value === "resshift");
+  assert.equal(resshiftOption.disabled, false);
+  assert.equal(control(dialog, "Enable upscale").checked, true);
+  fixture.missingByBackendState.resshift = ["ComfyUI-ResShift"];
+  fixture.resolveLoads();
+  await flushPromises();
+  assert.equal(dialog.title, "Upscale Settings");
+  assert.ok(fixture.loadCalls.length > 0, "Upscale must refresh dependencies asynchronously");
+  assert.deepEqual(new Set(fixture.optionCalls), new Set(["sampler_name", "scheduler"]));
+  assert.deepEqual(
+    new Set(fixture.choiceCalls.map(({ dependencyKey, inputName }) => `${dependencyKey}:${inputName}`)),
+    new Set(["upscaleModelLoader:model_name", "resShiftLoader:student_name"]),
+  );
+  assert.equal(resshiftOption.disabled, true);
+  assert.ok(resshiftOption.textContent.includes("ComfyUI-ResShift"));
+  assert.equal(control(dialog, "Enable upscale").checked, false, "Missing selected backend must disable upscale");
+  assert.ok(findAll(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-warning"))
+    .some((element) => element.textContent.includes("ComfyUI-ResShift")));
+  assert.ok(sectionByHeading(dialog, "USDU Upscale").classList.contains("hidden"));
+  assert.ok(sectionByHeading(dialog, "USDU Sampler").classList.contains("hidden"));
+  assert.ok(!sectionByHeading(dialog, "ResShift Upscale").classList.contains("hidden"));
+  assert.equal(control(dialog, "Auto tile target").parentElement.style.display, "none");
+  assert.equal(control(dialog, "Tile width").parentElement.style.display, "");
+  assert.equal(control(dialog, "CFG").parentElement.style.display, "");
+  assert.equal(control(dialog, "Scale by").value, "2.5");
+  assert.equal(control(dialog, "USDU prompt").value, "no_general");
+  assert.equal(control(dialog, "Auto tile size").checked, false);
+  assert.equal(control(dialog, "Auto tile target").value, "900");
+  assert.equal(control(dialog, "Auto tile min").value, "500");
+  assert.equal(control(dialog, "Auto tile max").value, "1500");
+  assert.equal(control(dialog, "Scale").value, "x4");
+  assert.equal(control(dialog, "Student").value, "student.safetensors");
+  assert.equal(control(dialog, "Dtype").value, "fp32");
+  assert.equal(control(dialog, "Chop").value, "768");
+  assert.equal(control(dialog, "Overlap").value, "96");
+  assert.equal(control(dialog, "Tile batch", 1).value, "3");
+
+  setSelectValue(backend, "usdu");
+  backend.emit("change");
+  control(dialog, "Enable upscale").checked = true;
+  assert.ok(!sectionByHeading(dialog, "USDU Upscale").classList.contains("hidden"));
+  assert.ok(!sectionByHeading(dialog, "USDU Sampler").classList.contains("hidden"));
+  assert.ok(sectionByHeading(dialog, "ResShift Upscale").classList.contains("hidden"));
+  const autoTile = control(dialog, "Auto tile size");
+  autoTile.checked = true;
+  autoTile.emit("change");
+  assert.equal(control(dialog, "Auto tile target").parentElement.style.display, "");
+  assert.equal(control(dialog, "Auto tile min").parentElement.style.display, "");
+  assert.equal(control(dialog, "Auto tile max").parentElement.style.display, "");
+  assert.equal(control(dialog, "Tile width").parentElement.style.display, "none");
+  const inheritSampler = control(dialog, "Follow main sampler");
+  inheritSampler.checked = true;
+  inheritSampler.emit("change");
+  assert.equal(control(dialog, "CFG").parentElement.style.display, "none");
+  assert.equal(control(dialog, "Sampler").parentElement.style.display, "none");
+  assert.equal(control(dialog, "Scheduler").parentElement.style.display, "none");
+
+  control(dialog, "Scale by").value = "5";
+  control(dialog, "Steps").value = "2000";
+  control(dialog, "Denoise").value = "2";
+  control(dialog, "Auto tile target").value = "300";
+  control(dialog, "Auto tile min").value = "500";
+  control(dialog, "Auto tile max").value = "100";
+  setSelectValue(control(dialog, "USDU prompt"), "no_general");
+  action(dialog, "button.apply").emit("click");
+  assert.deepEqual(dialog.trace.slice(-3), ["write", "render", "remove"]);
+  assert.equal(fixture.node.settings.upscale.enabled, true);
+  assert.equal(fixture.node.settings.upscale.backend, "usdu");
+  assert.equal(fixture.node.settings.upscale.scale_by, 4);
+  assert.equal(fixture.node.settings.upscale.steps, 1000);
+  assert.equal(fixture.node.settings.upscale.denoise, 1);
+  assert.equal(fixture.node.settings.upscale.inherit_sampler_settings, true);
+  assert.equal(fixture.node.settings.upscale.usdu.prompt_mode, "no_general");
+  assert.equal(fixture.node.settings.upscale.usdu.auto_tile_target, 300);
+  assert.equal(fixture.node.settings.upscale.usdu.auto_tile_min, 300);
+  assert.equal(fixture.node.settings.upscale.usdu.auto_tile_max, 500);
+  assert.equal(fixture.node.settings.upscale.resshift.student_name, "student.safetensors");
+  assert.equal(fixture.node.settings.upscale.preserved_upscale_key, "keep-upscale");
+
+  const writesAfterApply = fixture.writes.length;
+  const rendersAfterApply = fixture.renders.length;
+  const settingsBeforeCancel = clone(fixture.node.settings);
+  const widgetBeforeCancel = fixture.node.widgets[0].value;
+  fixture.runtime.openUpscaleSettings(fixture.node);
+  fixture.resolveLoads();
+  await flushPromises();
+  const cancelDialog = fixture.dialogs[1];
+  action(cancelDialog, "button.cancel").emit("click");
+  assert.equal(fixture.writes.length, writesAfterApply, "Upscale Cancel must not add a write");
+  assert.equal(fixture.renders.length, rendersAfterApply, "Upscale Cancel must not render");
+  assert.deepEqual(fixture.node.settings, settingsBeforeCancel, "Upscale Cancel must not mutate settings");
+  assert.equal(fixture.node.widgets[0].value, widgetBeforeCancel, "Upscale Cancel must not rewrite the hidden widget");
+  assert.deepEqual(cancelDialog.trace, ["remove"]);
+}
+
+console.log("AiO stage settings dialogs smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -18,6 +18,9 @@ AIO_PROFILE_SETTINGS_RUNTIME_JS = (
 AIO_GENERATOR_PANEL_RUNTIME_JS = (
     ROOT / "web" / "js" / "aio" / "generator_panel_runtime.js"
 )
+AIO_STAGE_SETTINGS_DIALOGS_JS = (
+    ROOT / "web" / "js" / "aio" / "stage_settings_dialogs.js"
+)
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
@@ -230,9 +233,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn('optimization.section.classList.toggle("hidden"', body)
 
     def test_highres_settings_save_stage_optimization(self):
-        source = AIO_JS.read_text(encoding="utf-8")
+        source = AIO_STAGE_SETTINGS_DIALOGS_JS.read_text(encoding="utf-8")
         start = source.index("function openHighresSettings")
-        end = source.index("\nfunction createDetailerTargetEditor", start)
+        end = source.index("\n  function openUpscaleSettings", start)
         body = source[start:end]
 
         self.assertIn('createStageOptimizationEditor("Highres Optimization"', body)
@@ -242,9 +245,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("next.highres.dit_corrections = mergeDefaults", body)
 
     def test_upscale_settings_offer_single_backend_and_usdu_helpers(self):
-        source = AIO_JS.read_text(encoding="utf-8")
+        source = AIO_STAGE_SETTINGS_DIALOGS_JS.read_text(encoding="utf-8")
         start = source.index("function openUpscaleSettings")
-        end = source.index("\nfunction createDetailerTargetEditor", start)
+        end = source.index("\n\n  return {", start)
         body = source[start:end]
 
         self.assertIn('selectInput(["usdu", "resshift"]', body)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -47,6 +47,10 @@ AIO_GENERATOR_PANEL_RUNTIME_JS = AIO_MODULES / "generator_panel_runtime.js"
 AIO_GENERATOR_PANEL_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_generator_panel_runtime_smoke.mjs"
 )
+AIO_STAGE_SETTINGS_DIALOGS_JS = AIO_MODULES / "stage_settings_dialogs.js"
+AIO_STAGE_SETTINGS_DIALOGS_SMOKE = (
+    ROOT / "tests" / "frontend_aio_stage_settings_dialogs_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -512,6 +516,100 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_GENERATOR_PANEL_RUNTIME_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_generator_panel_runtime_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_stage_settings_dialogs_have_closed_lifecycle_boundary(self):
+        source = AIO_STAGE_SETTINGS_DIALOGS_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(source.startswith("// @ts-check\n"))
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertEqual(
+            re.findall(r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE),
+            ["aioCreateStageSettingsDialogs"],
+        )
+        self.assertIn(
+            'import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";',
+            entry_source,
+        )
+        for moved_function in (
+            "createStageOptimizationEditor",
+            "openHighresSettings",
+            "openUpscaleSettings",
+        ):
+            with self.subTest(moved_function=moved_function):
+                self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
+                self.assertNotRegex(entry_source, rf"\bfunction\s+{moved_function}\(")
+        for entry_owned_function in (
+            "createDetailerTargetEditor",
+            "openDetailerSettings",
+            "openSamplerSettings",
+        ):
+            with self.subTest(entry_owned_function=entry_owned_function):
+                self.assertRegex(entry_source, rf"\bfunction\s+{entry_owned_function}\(")
+                self.assertNotRegex(source, rf"\bfunction\s+{entry_owned_function}\(")
+
+        return_match = re.search(
+            r"(?ms)^  return \{(?P<facades>[A-Za-z0-9_,\s]+)\};\s*\}\s*$",
+            source,
+        )
+        self.assertIsNotNone(return_match)
+        expected_facades = {
+            "createStageOptimizationEditor",
+            "openHighresSettings",
+            "openUpscaleSettings",
+        }
+        self.assertEqual(
+            set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", return_match.group("facades"))),
+            expected_facades,
+        )
+        composition_match = re.search(
+            r"(?ms)const\s*\{(?P<facades>[A-Za-z0-9_,\s]+?)\}\s*=\s*"
+            r"aioCreateStageSettingsDialogs\(\{",
+            entry_source,
+        )
+        self.assertIsNotNone(composition_match)
+        self.assertEqual(
+            set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", composition_match.group("facades"))),
+            expected_facades,
+        )
+        composition_start = composition_match.start()
+        composition_end = entry_source.index(
+            "\n\nconst generatorPanelRuntime", composition_start
+        )
+        composition = entry_source[composition_start:composition_end]
+        for expected in (
+            "createStageOptimizationEditor,",
+            "openHighresSettings,",
+            "openUpscaleSettings,",
+            "createDialog,",
+            "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,",
+            "normalizeUsduAutoTileRange: normalizeGeneratorUsduAutoTileRange,",
+            "getSettings: generatorSettings,",
+            "renderPanel: renderGeneratorPanel,",
+            "upscaleBackendMissingPacks,",
+            "load: loadGeneratorOptionalDependencies,",
+        ):
+            with self.subTest(composition_dependency=expected):
+                self.assertIn(expected, composition)
+        self.assertNotIn("openDetailerSettings,", composition)
+        detailer_start = entry_source.index("function createDetailerTargetEditor")
+        detailer_end = entry_source.index("\nfunction openDetailerSettings", detailer_start)
+        self.assertIn(
+            "createStageOptimizationEditor(`${title} Optimization`, target, defaults)",
+            entry_source[detailer_start:detailer_end],
+        )
+        self.assertLess(
+            composition_match.start(),
+            entry_source.index("const generatorPanelRuntime"),
+        )
+        self.assertTrue(AIO_STAGE_SETTINGS_DIALOGS_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_stage_settings_dialogs_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -59,6 +59,11 @@ try {
         throw "Frontend AiO generator panel runtime smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_stage_settings_dialogs_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO stage settings dialogs smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_dependency_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/stage_settings_dialogs.js
+++ b/web/js/aio/stage_settings_dialogs.js
@@ -1,0 +1,557 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioStageDialogControls
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(value: any) => any} checkbox
+ * @property {(options: any[], value: any) => any} selectInput
+ */
+
+/**
+ * @typedef {object} AioStageDialogText
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} get
+ * @property {(key: string, values?: Record<string, any>) => string} format
+ */
+
+/**
+ * @typedef {object} AioStageDialogSettingsCore
+ * @property {any} defaultGenerationSettings
+ * @property {any[]} fallbackSamplerNames
+ * @property {any[]} fallbackSchedulerNames
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(value: any, fallback: number, min: number, max: number) => number} clampNumber
+ * @property {(value: any) => any} normalizeUsduAutoTileRange
+ */
+
+/**
+ * @typedef {object} AioStageDialogNodeAdapter
+ * @property {string} generatorSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(node: any) => any} getSettings
+ * @property {(node: any, name: string, fallback: any[]) => any[]} widgetOptions
+ * @property {(dependencyKey: string, inputName: string, current: any, fallback?: any[]) => any[]} nodeInputChoiceOptions
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ * @property {(node: any) => void} renderPanel
+ */
+
+/**
+ * @typedef {object} AioStageDialogDependencyAdapter
+ * @property {(key: string) => boolean} available
+ * @property {(key: string) => string} pack
+ * @property {(backend: string) => string[]} upscaleBackendMissingPacks
+ * @property {(options?: Record<string, any>) => Promise<any>} load
+ */
+
+/**
+ * @typedef {object} AioStageSettingsDialogDependencies
+ * @property {any} document
+ * @property {AioStageDialogControls} controls
+ * @property {AioStageDialogText} text
+ * @property {AioStageDialogSettingsCore} settingsCore
+ * @property {AioStageDialogNodeAdapter} nodeAdapter
+ * @property {AioStageDialogDependencyAdapter} dependencyAdapter
+ */
+
+/**
+ * Own the Highres and Upscale settings dialog lifecycles plus their shared
+ * stage-optimization editor. Extension registration, panel rendering,
+ * optional-dependency discovery, and durable settings storage remain adapters.
+ *
+ * @param {AioStageSettingsDialogDependencies} dependencies
+ * @returns {{
+ *   createStageOptimizationEditor: (title: any, values: any, defaults: any) => any,
+ *   openHighresSettings: (node: any) => void,
+ *   openUpscaleSettings: (node: any) => void,
+ * }}
+ */
+export function aioCreateStageSettingsDialogs(dependencies) {
+  const {
+    document,
+    controls,
+    text,
+    settingsCore,
+    nodeAdapter,
+    dependencyAdapter,
+  } = dependencies;
+  const {
+    createDialog,
+    field,
+    numberInput,
+    checkbox,
+    selectInput,
+  } = controls;
+  const {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+  } = text;
+  const {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    clampNumber: clampGeneratorNumber,
+    normalizeUsduAutoTileRange: normalizeGeneratorUsduAutoTileRange,
+  } = settingsCore;
+  const {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
+    widgetOptions,
+    nodeInputChoiceOptions,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  } = nodeAdapter;
+  const {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    upscaleBackendMissingPacks,
+    load: loadGeneratorOptionalDependencies,
+  } = dependencyAdapter;
+
+  function createStageOptimizationEditor(title, values, defaults) {
+    const section = document.createElement("section");
+    section.className = "easyuse-anima-aio-section";
+    section.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText(title) }));
+    const spectrumValues = mergeDefaults(defaults.spectrum || {}, values.spectrum || {});
+    const correctionValues = mergeDefaults(defaults.dit_corrections || {}, values.dit_corrections || {});
+
+    const spectrumEnabled = field(section, "Spectrum patch", checkbox(spectrumValues.enabled));
+    const windowSize = field(section, "Window size", numberInput(spectrumValues.window_size, "0.25"));
+    const flexWindow = field(section, "Flex window", numberInput(spectrumValues.flex_window, "0.05"));
+    const warmupSteps = field(section, "Warmup", numberInput(spectrumValues.warmup_steps, "1"));
+    const tailSteps = field(section, "Tail actual", numberInput(spectrumValues.tail_actual_steps, "1"));
+    const blendW = field(section, "Blend W", numberInput(spectrumValues.blend_w, "0.05"));
+    const chebyDegree = field(section, "Cheby", numberInput(spectrumValues.cheby_degree, "1"));
+    const ridgeLambda = field(section, "Ridge lambda", numberInput(spectrumValues.ridge_lambda, "0.01"));
+    const compatPolicy = field(
+      section,
+      "Compat",
+      selectInput(["conservative", "legacy", "strict"], spectrumValues.compat_policy || "conservative")
+    );
+
+    const corrections = document.createElement("div");
+    corrections.className = "easyuse-anima-aio-subsection";
+    corrections.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("Spectrum DCW / Corrections") }));
+    const correctionsEnabled = field(corrections, "Use corrections", checkbox(correctionValues.enabled));
+    const dcwMode = field(corrections, "DCW mode", selectInput(["off", "manual", "auto"], correctionValues.dcw_mode || "off"));
+    const dcwLambda = field(corrections, "DCW lambda", numberInput(correctionValues.dcw_lambda, "0.001"));
+    const dcwBand = field(corrections, "DCW band", selectInput(["LL", "all", "HH", "LH+HL+HH"], correctionValues.dcw_band_mask || "LL"));
+    const smcCfg = field(corrections, "SMC-CFG", checkbox(correctionValues.smc_cfg));
+    const smcAlpha = field(corrections, "SMC alpha", numberInput(correctionValues.adaptive_smc_alpha, "0.01"));
+    const smcLambda = field(corrections, "SMC lambda", numberInput(correctionValues.smc_cfg_lambda, "0.1"));
+    const cfgpp = field(corrections, "CFG++", checkbox(correctionValues.cfgpp));
+    const cfgppLambda = field(corrections, "CFG++ lambda", numberInput(correctionValues.cfgpp_lambda, "0.1"));
+    const fsg = field(corrections, "FSG", checkbox(correctionValues.fsg));
+    section.append(corrections);
+    const dependencyWarning = document.createElement("div");
+    dependencyWarning.className = "easyuse-anima-aio-warning";
+    dependencyWarning.hidden = true;
+    section.append(dependencyWarning);
+    const refreshDependencyLocks = () => {
+      const spectrumPatchMissing = !optionalDependencyAvailable("spectrumPatch");
+      spectrumEnabled.disabled = spectrumPatchMissing;
+      correctionsEnabled.disabled = spectrumPatchMissing;
+      if (spectrumPatchMissing) {
+        spectrumEnabled.checked = false;
+        correctionsEnabled.checked = false;
+        dependencyWarning.hidden = false;
+        dependencyWarning.textContent = aioFormat("warning.optionalDependencyMissing", {
+          backend: title,
+          pack: optionalDependencyPack("spectrumPatch"),
+        });
+      } else {
+        dependencyWarning.hidden = true;
+        dependencyWarning.textContent = "";
+      }
+    };
+    refreshDependencyLocks();
+    loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
+
+    return {
+      section,
+      setIntegratedMode(isIntegrated) {
+        if (spectrumEnabled?.parentElement) {
+          spectrumEnabled.parentElement.style.display = isIntegrated ? "none" : "";
+        }
+        if (compatPolicy?.parentElement) {
+          compatPolicy.parentElement.style.display = isIntegrated ? "none" : "";
+        }
+      },
+      values() {
+        return {
+          spectrum: {
+            enabled: spectrumEnabled.checked && !spectrumEnabled.disabled,
+            window_size: Number(windowSize.value || defaults.spectrum.window_size || 2),
+            flex_window: Number(flexWindow.value || defaults.spectrum.flex_window || 0.25),
+            warmup_steps: Number(warmupSteps.value || defaults.spectrum.warmup_steps || 6),
+            tail_actual_steps: Number(tailSteps.value || defaults.spectrum.tail_actual_steps || 3),
+            blend_w: Number(blendW.value || defaults.spectrum.blend_w || 0.3),
+            cheby_degree: Number(chebyDegree.value || defaults.spectrum.cheby_degree || 3),
+            ridge_lambda: Number(ridgeLambda.value || defaults.spectrum.ridge_lambda || 0.1),
+            history_size: Number(spectrumValues.history_size || defaults.spectrum.history_size || 100),
+            one_sampler_only: !!spectrumValues.one_sampler_only,
+            verbose: !!spectrumValues.verbose,
+            compat_policy: compatPolicy.value || "conservative",
+          },
+          dit_corrections: {
+            enabled: correctionsEnabled.checked && !correctionsEnabled.disabled,
+            dcw_mode: dcwMode.value || "off",
+            dcw_lambda: Number(dcwLambda.value || defaults.dit_corrections.dcw_lambda || 0.01),
+            dcw_band_mask: dcwBand.value || "LL",
+            dcw_calibrator: correctionValues.dcw_calibrator || "(auto-download default)",
+            smc_cfg: smcCfg.checked,
+            adaptive_smc_alpha: Number(smcAlpha.value || defaults.dit_corrections.adaptive_smc_alpha || 0),
+            smc_cfg_lambda: Number(smcLambda.value || defaults.dit_corrections.smc_cfg_lambda || 6),
+            cfgpp: cfgpp.checked,
+            cfgpp_lambda: Number(cfgppLambda.value || defaults.dit_corrections.cfgpp_lambda || 0),
+            fsg: fsg.checked,
+            fsg_band_lo: Number(correctionValues.fsg_band_lo || defaults.dit_corrections.fsg_band_lo || 0.59),
+            fsg_band_hi: Number(correctionValues.fsg_band_hi || defaults.dit_corrections.fsg_band_hi || 0.75),
+            fsg_k: Number(correctionValues.fsg_k || defaults.dit_corrections.fsg_k || 3),
+            fsg_d_sigma: Number(correctionValues.fsg_d_sigma || defaults.dit_corrections.fsg_d_sigma || 0.1),
+            fsg_gamma: Number(correctionValues.fsg_gamma || defaults.dit_corrections.fsg_gamma || 0),
+            replace_existing_cfg: !!correctionValues.replace_existing_cfg,
+          },
+        };
+      },
+    };
+  }
+
+  function openHighresSettings(node) {
+    const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
+    const settings = generatorSettings(node);
+    const highres = mergeDefaults(DEFAULT_GENERATION_SETTINGS.highres, settings.highres || {});
+    const mainBackendIsSpd = settings.sampler?.backend === "spectrum_spd_speed";
+    const { backdrop, body, actions } = createDialog(
+      "Highres Settings",
+      "Image scaling and Highres resampling settings are saved with the node."
+    );
+    body.classList.add("easyuse-anima-aio-one-column");
+
+    const image = document.createElement("section");
+    image.className = "easyuse-anima-aio-section";
+    image.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Scale") }));
+    const enabled = field(image, "Enable highres", checkbox(highres.enabled));
+    const scaleBy = field(image, "Scale by", numberInput(highres.scale_by, "0.01"));
+    const upscaleMethod = field(image, "Method", selectInput(["bicubic", "nearest-exact", "bilinear", "area", "lanczos"], highres.upscale_method));
+    const multiple = field(image, "Multiple", selectInput(["8", "16", "32", "64"], highres.multiple));
+    const maxLongEdge = field(image, "Max long edge", numberInput(highres.max_long_edge, "32"));
+
+    const sampler = document.createElement("section");
+    sampler.className = "easyuse-anima-aio-section";
+    sampler.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Highres Sampler") }));
+    const steps = field(sampler, "Steps", numberInput(highres.steps, "1"));
+    steps.min = "1";
+    steps.max = "75";
+    const effectiveInherit = !!highres.inherit_sampler_settings;
+    const inheritSampler = field(
+      sampler,
+      "Follow main sampler",
+      checkbox(effectiveInherit),
+      "tip.highresFollow",
+    );
+    const dependencyWarning = document.createElement("div");
+    dependencyWarning.className = "easyuse-anima-aio-warning";
+    dependencyWarning.hidden = true;
+    sampler.append(dependencyWarning);
+    const cfg = field(sampler, "CFG", numberInput(highres.cfg, "0.1"));
+    cfg.min = "1";
+    cfg.max = "10";
+    const samplerName = field(
+      sampler,
+      "Sampler",
+      selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), highres.sampler_name)
+    );
+    const scheduler = field(
+      sampler,
+      "Scheduler",
+      selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), highres.scheduler)
+    );
+    const denoise = field(sampler, "Denoise", numberInput(highres.denoise, "0.01"));
+    const optimization = createStageOptimizationEditor("Highres Optimization", highres, DEFAULT_GENERATION_SETTINGS.highres);
+    const updateInheritedRows = () => {
+      const usesMain = inheritSampler.checked;
+      const display = usesMain ? "none" : "";
+      for (const control of [cfg, samplerName, scheduler]) {
+        if (control?.parentElement) {
+          control.parentElement.style.display = display;
+        }
+      }
+    };
+    const refreshDependencyLocks = () => {
+      const messages = [];
+      if (mainBackendIsSpd && inheritSampler.checked) {
+        messages.push(aioText("text.highresSpdManualRequired"));
+      }
+      dependencyWarning.hidden = messages.length === 0;
+      dependencyWarning.textContent = messages.join(" ");
+      updateInheritedRows();
+    };
+    inheritSampler.addEventListener("change", refreshDependencyLocks);
+    updateInheritedRows();
+    refreshDependencyLocks();
+    body.append(image, sampler, optimization.section);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = aioText("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = aioText("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
+      const optimized = optimization.values();
+      next.highres = {
+        ...next.highres,
+        enabled: enabled.checked,
+        scale_by: clampGeneratorNumber(scaleBy.value, DEFAULT_GENERATION_SETTINGS.highres.scale_by, 0.01, 8),
+        upscale_method: upscaleMethod.value || "bicubic",
+        multiple: multiple.value || "32",
+        max_long_edge: Math.trunc(clampGeneratorNumber(maxLongEdge.value, 2560, 0, 16384)),
+        steps: Math.trunc(clampGeneratorNumber(steps.value, 20, 1, 75)),
+        inherit_sampler_settings: inheritSampler.checked,
+        cfg: clampGeneratorNumber(cfg.value, 8, 1, 10),
+        sampler_name: samplerName.value || "euler",
+        scheduler: scheduler.value || "simple",
+        denoise: clampGeneratorNumber(denoise.value, DEFAULT_GENERATION_SETTINGS.highres.denoise, 0, 1),
+        ...optimized,
+      };
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  }
+
+  function openUpscaleSettings(node) {
+    const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
+    const settings = generatorSettings(node);
+    const upscale = mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale, settings.upscale || {});
+    const usdu = mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale.usdu, upscale.usdu || {});
+    const resshift = mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale.resshift, upscale.resshift || {});
+    const { backdrop, body, actions } = createDialog(
+      "Upscale Settings",
+      "Final-stage upscale runs after Detailer and before Save. Choose USDU or ResShift."
+    );
+    body.classList.add("easyuse-anima-aio-one-column");
+
+    const main = document.createElement("section");
+    main.className = "easyuse-anima-aio-section";
+    main.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Scale") }));
+    const enabled = field(main, "Enable upscale", checkbox(upscale.enabled), "tip.upscaleEnabled");
+    const backend = field(
+      main,
+      "Upscale backend",
+      selectInput(["usdu", "resshift"], upscale.backend || "usdu"),
+      "tip.upscaleBackend",
+    );
+    const dependencyWarning = document.createElement("div");
+    dependencyWarning.className = "easyuse-anima-aio-warning";
+    dependencyWarning.hidden = true;
+    main.append(dependencyWarning);
+
+    const usduSection = document.createElement("section");
+    usduSection.className = "easyuse-anima-aio-section";
+    usduSection.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("USDU Upscale") }));
+    const scaleBy = field(usduSection, "Scale by", numberInput(upscale.scale_by, "0.05"), "tip.upscaleScale");
+    scaleBy.min = "0.05";
+    scaleBy.max = "4";
+    const upscaleModel = field(
+      usduSection,
+      "Upscale model",
+      selectInput(
+        nodeInputChoiceOptions("upscaleModelLoader", "model_name", usdu.upscale_model_name, [usdu.upscale_model_name]),
+        usdu.upscale_model_name,
+      ),
+      "tip.usduUpscaleModel",
+    );
+    const promptMode = field(
+      usduSection,
+      "USDU prompt",
+      selectInput(["full", "no_general"], usdu.prompt_mode === "quality_tags_only" ? "no_general" : usdu.prompt_mode || "full"),
+      "tip.usduPrompt",
+    );
+    const autoTile = field(usduSection, "Auto tile size", checkbox(usdu.auto_tile_size), "tip.usduAutoTile");
+    const autoTileTarget = field(usduSection, "Auto tile target", numberInput(usdu.auto_tile_target, "64"), "tip.usduAutoTile");
+    const autoTileMin = field(usduSection, "Auto tile min", numberInput(usdu.auto_tile_min, "64"), "tip.usduAutoTile");
+    const autoTileMax = field(usduSection, "Auto tile max", numberInput(usdu.auto_tile_max, "64"), "tip.usduAutoTile");
+    const modeType = field(usduSection, "Mode", selectInput(["Linear", "Chess", "None"], usdu.mode_type || "Linear"), "tip.usduMode");
+    const tileWidth = field(usduSection, "Tile width", numberInput(usdu.tile_width, "8"), "tip.usduTile");
+    const tileHeight = field(usduSection, "Tile height", numberInput(usdu.tile_height, "8"), "tip.usduTile");
+    const maskBlur = field(usduSection, "Mask blur", numberInput(usdu.mask_blur, "1"), "tip.usduTile");
+    const tilePadding = field(usduSection, "Tile padding", numberInput(usdu.tile_padding, "8"), "tip.usduTile");
+    const forceUniformTiles = field(usduSection, "Force uniform tiles", checkbox(usdu.force_uniform_tiles), "tip.usduTile");
+    const tiledDecode = field(usduSection, "Tiled decode", checkbox(usdu.tiled_decode), "tip.usduTile");
+    const batchSize = field(usduSection, "Tile batch", numberInput(usdu.batch_size, "1"), "tip.usduTile");
+    const seamFix = field(
+      usduSection,
+      "Seam fix",
+      selectInput(["None", "Band Pass", "Half Tile", "Half Tile + Intersections"], usdu.seam_fix_mode || "None"),
+      "tip.usduSeam",
+    );
+    const seamDenoise = field(usduSection, "Seam denoise", numberInput(usdu.seam_fix_denoise, "0.01"), "tip.usduSeam");
+    const seamWidth = field(usduSection, "Seam width", numberInput(usdu.seam_fix_width, "8"), "tip.usduSeam");
+    const seamMaskBlur = field(usduSection, "Seam mask blur", numberInput(usdu.seam_fix_mask_blur, "1"), "tip.usduSeam");
+    const seamPadding = field(usduSection, "Seam padding", numberInput(usdu.seam_fix_padding, "8"), "tip.usduSeam");
+
+    const usduSampler = document.createElement("section");
+    usduSampler.className = "easyuse-anima-aio-section";
+    usduSampler.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("USDU Sampler") }));
+    const inheritSampler = field(usduSampler, "Follow main sampler", checkbox(upscale.inherit_sampler_settings), "tip.highresFollow");
+    const steps = field(usduSampler, "Steps", numberInput(upscale.steps, "1"), "tip.steps");
+    const cfg = field(usduSampler, "CFG", numberInput(upscale.cfg, "0.1"), "tip.cfg");
+    const samplerName = field(
+      usduSampler,
+      "Sampler",
+      selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), upscale.sampler_name),
+      "tip.sampler",
+    );
+    const scheduler = field(
+      usduSampler,
+      "Scheduler",
+      selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), upscale.scheduler),
+      "tip.scheduler",
+    );
+    const denoise = field(usduSampler, "Denoise", numberInput(upscale.denoise, "0.01"), "tip.denoise");
+    const optimization = createStageOptimizationEditor("USDU Spectrum/DCW", upscale, DEFAULT_GENERATION_SETTINGS.upscale);
+
+    const resshiftSection = document.createElement("section");
+    resshiftSection.className = "easyuse-anima-aio-section";
+    resshiftSection.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("ResShift Upscale") }));
+    const resshiftScale = field(resshiftSection, "Scale", selectInput(["x2", "x4"], resshift.scale || "x2"), "tip.resshiftScale");
+    const student = field(
+      resshiftSection,
+      "Student",
+      selectInput(
+        nodeInputChoiceOptions("resShiftLoader", "student_name", resshift.student_name, ["(auto-download)"]),
+        resshift.student_name || "(auto-download)",
+      ),
+      "tip.resshiftStudent",
+    );
+    const dtype = field(resshiftSection, "Dtype", selectInput(["bf16", "fp32"], resshift.dtype || "bf16"), "tip.resshiftDtype");
+    const chop = field(resshiftSection, "Chop", numberInput(resshift.chop, "256"), "tip.resshiftTiling");
+    const overlap = field(resshiftSection, "Overlap", numberInput(resshift.overlap, "16"), "tip.resshiftTiling");
+    const tileBatch = field(resshiftSection, "Tile batch", numberInput(resshift.tile_batch, "1"), "tip.resshiftTiling");
+
+    const updateVisibility = () => {
+      const isUsdu = backend.value === "usdu";
+      usduSection.classList.toggle("hidden", !isUsdu);
+      usduSampler.classList.toggle("hidden", !isUsdu);
+      optimization.section.classList.toggle("hidden", !isUsdu);
+      resshiftSection.classList.toggle("hidden", isUsdu);
+      const autoTileDisplay = autoTile.checked ? "" : "none";
+      for (const control of [autoTileTarget, autoTileMin, autoTileMax]) {
+        if (control?.parentElement) {
+          control.parentElement.style.display = autoTileDisplay;
+        }
+      }
+      const manualTileDisplay = autoTile.checked ? "none" : "";
+      for (const control of [tileWidth, tileHeight]) {
+        if (control?.parentElement) {
+          control.parentElement.style.display = manualTileDisplay;
+        }
+      }
+      const samplerOverrideDisplay = inheritSampler.checked ? "none" : "";
+      for (const control of [cfg, samplerName, scheduler]) {
+        if (control?.parentElement) {
+          control.parentElement.style.display = samplerOverrideDisplay;
+        }
+      }
+    };
+    const refreshDependencyLocks = () => {
+      const messages = [];
+      for (const option of Array.from(backend.options)) {
+        const missingPacks = upscaleBackendMissingPacks(option.value);
+        option.disabled = missingPacks.length > 0;
+        option.textContent = missingPacks.length
+          ? `${option.value} (${missingPacks.join(", ")} missing)`
+          : option.value;
+        if (option.selected && missingPacks.length) {
+          messages.push(aioFormat("warning.optionalDependencyMissing", {
+            backend: option.value,
+            pack: missingPacks.join(", "),
+          }));
+          enabled.checked = false;
+        }
+      }
+      dependencyWarning.hidden = messages.length === 0;
+      dependencyWarning.textContent = messages.join(" ");
+      updateVisibility();
+    };
+    backend.addEventListener("change", refreshDependencyLocks);
+    autoTile.addEventListener("change", updateVisibility);
+    inheritSampler.addEventListener("change", updateVisibility);
+    body.append(main, usduSection, usduSampler, optimization.section, resshiftSection);
+    updateVisibility();
+    refreshDependencyLocks();
+    loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = aioText("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = aioText("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
+      const missingPacks = upscaleBackendMissingPacks(backend.value);
+      const optimized = optimization.values();
+      next.upscale = {
+        ...next.upscale,
+        enabled: enabled.checked && missingPacks.length === 0,
+        backend: backend.value || "usdu",
+        scale_by: clampGeneratorNumber(scaleBy.value, DEFAULT_GENERATION_SETTINGS.upscale.scale_by, 0.05, 4),
+        steps: Math.trunc(clampGeneratorNumber(steps.value, DEFAULT_GENERATION_SETTINGS.upscale.steps, 1, 1000)),
+        inherit_sampler_settings: inheritSampler.checked,
+        cfg: clampGeneratorNumber(cfg.value, DEFAULT_GENERATION_SETTINGS.upscale.cfg, 0, 100),
+        sampler_name: samplerName.value || "euler",
+        scheduler: scheduler.value || "simple",
+        denoise: clampGeneratorNumber(denoise.value, DEFAULT_GENERATION_SETTINGS.upscale.denoise, 0, 1),
+        ...optimized,
+        usdu: normalizeGeneratorUsduAutoTileRange({
+          upscale_model_name: upscaleModel.value || DEFAULT_GENERATION_SETTINGS.upscale.usdu.upscale_model_name,
+          auto_tile_size: autoTile.checked,
+          prompt_mode: promptMode.value || "full",
+          mode_type: modeType.value || "Linear",
+          auto_tile_target: Math.trunc(clampGeneratorNumber(autoTileTarget.value, 1024, 64, 16384)),
+          auto_tile_min: Math.trunc(clampGeneratorNumber(autoTileMin.value, 512, 64, 16384)),
+          auto_tile_max: Math.trunc(clampGeneratorNumber(autoTileMax.value, 2048, 64, 16384)),
+          tile_width: Math.trunc(clampGeneratorNumber(tileWidth.value, 512, 64, 16384)),
+          tile_height: Math.trunc(clampGeneratorNumber(tileHeight.value, 512, 64, 16384)),
+          mask_blur: Math.trunc(clampGeneratorNumber(maskBlur.value, 8, 0, 64)),
+          tile_padding: Math.trunc(clampGeneratorNumber(tilePadding.value, 32, 0, 16384)),
+          seam_fix_mode: seamFix.value || "None",
+          seam_fix_denoise: clampGeneratorNumber(seamDenoise.value, 1, 0, 1),
+          seam_fix_width: Math.trunc(clampGeneratorNumber(seamWidth.value, 64, 0, 16384)),
+          seam_fix_mask_blur: Math.trunc(clampGeneratorNumber(seamMaskBlur.value, 8, 0, 64)),
+          seam_fix_padding: Math.trunc(clampGeneratorNumber(seamPadding.value, 16, 0, 16384)),
+          force_uniform_tiles: forceUniformTiles.checked,
+          tiled_decode: tiledDecode.checked,
+          batch_size: Math.trunc(clampGeneratorNumber(batchSize.value, 1, 1, 4096)),
+        }),
+        resshift: {
+          scale: resshiftScale.value || "x2",
+          student_name: student.value || "(auto-download)",
+          dtype: dtype.value || "bf16",
+          chop: Math.trunc(clampGeneratorNumber(chop.value, 512, 256, 4096)),
+          overlap: Math.trunc(clampGeneratorNumber(overlap.value, 64, 0, 512)),
+          tile_batch: Math.trunc(clampGeneratorNumber(tileBatch.value, 4, 1, 32)),
+        },
+      };
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  }
+
+  return {
+    createStageOptimizationEditor,
+    openHighresSettings,
+    openUpscaleSettings,
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -19,6 +19,7 @@ import { aioCreatePreviewSettingsDialog } from "./aio/preview_settings_dialog.js
 import { createAioProfileApiClient } from "./aio/profile_api_client.js";
 import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
 import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
+import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -4310,443 +4311,6 @@ function openSamplerSettings(node) {
   });
 }
 
-function createStageOptimizationEditor(title, values, defaults) {
-  const section = document.createElement("section");
-  section.className = "easyuse-anima-aio-section";
-  section.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText(title) }));
-  const spectrumValues = mergeDefaults(defaults.spectrum || {}, values.spectrum || {});
-  const correctionValues = mergeDefaults(defaults.dit_corrections || {}, values.dit_corrections || {});
-
-  const spectrumEnabled = field(section, "Spectrum patch", checkbox(spectrumValues.enabled));
-  const windowSize = field(section, "Window size", numberInput(spectrumValues.window_size, "0.25"));
-  const flexWindow = field(section, "Flex window", numberInput(spectrumValues.flex_window, "0.05"));
-  const warmupSteps = field(section, "Warmup", numberInput(spectrumValues.warmup_steps, "1"));
-  const tailSteps = field(section, "Tail actual", numberInput(spectrumValues.tail_actual_steps, "1"));
-  const blendW = field(section, "Blend W", numberInput(spectrumValues.blend_w, "0.05"));
-  const chebyDegree = field(section, "Cheby", numberInput(spectrumValues.cheby_degree, "1"));
-  const ridgeLambda = field(section, "Ridge lambda", numberInput(spectrumValues.ridge_lambda, "0.01"));
-  const compatPolicy = field(
-    section,
-    "Compat",
-    selectInput(["conservative", "legacy", "strict"], spectrumValues.compat_policy || "conservative")
-  );
-
-  const corrections = document.createElement("div");
-  corrections.className = "easyuse-anima-aio-subsection";
-  corrections.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("Spectrum DCW / Corrections") }));
-  const correctionsEnabled = field(corrections, "Use corrections", checkbox(correctionValues.enabled));
-  const dcwMode = field(corrections, "DCW mode", selectInput(["off", "manual", "auto"], correctionValues.dcw_mode || "off"));
-  const dcwLambda = field(corrections, "DCW lambda", numberInput(correctionValues.dcw_lambda, "0.001"));
-  const dcwBand = field(corrections, "DCW band", selectInput(["LL", "all", "HH", "LH+HL+HH"], correctionValues.dcw_band_mask || "LL"));
-  const smcCfg = field(corrections, "SMC-CFG", checkbox(correctionValues.smc_cfg));
-  const smcAlpha = field(corrections, "SMC alpha", numberInput(correctionValues.adaptive_smc_alpha, "0.01"));
-  const smcLambda = field(corrections, "SMC lambda", numberInput(correctionValues.smc_cfg_lambda, "0.1"));
-  const cfgpp = field(corrections, "CFG++", checkbox(correctionValues.cfgpp));
-  const cfgppLambda = field(corrections, "CFG++ lambda", numberInput(correctionValues.cfgpp_lambda, "0.1"));
-  const fsg = field(corrections, "FSG", checkbox(correctionValues.fsg));
-  section.append(corrections);
-  const dependencyWarning = document.createElement("div");
-  dependencyWarning.className = "easyuse-anima-aio-warning";
-  dependencyWarning.hidden = true;
-  section.append(dependencyWarning);
-  const refreshDependencyLocks = () => {
-    const spectrumPatchMissing = !optionalDependencyAvailable("spectrumPatch");
-    spectrumEnabled.disabled = spectrumPatchMissing;
-    correctionsEnabled.disabled = spectrumPatchMissing;
-    if (spectrumPatchMissing) {
-      spectrumEnabled.checked = false;
-      correctionsEnabled.checked = false;
-      dependencyWarning.hidden = false;
-      dependencyWarning.textContent = aioFormat("warning.optionalDependencyMissing", {
-        backend: title,
-        pack: optionalDependencyPack("spectrumPatch"),
-      });
-    } else {
-      dependencyWarning.hidden = true;
-      dependencyWarning.textContent = "";
-    }
-  };
-  refreshDependencyLocks();
-  loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
-
-  return {
-    section,
-    setIntegratedMode(isIntegrated) {
-      if (spectrumEnabled?.parentElement) {
-        spectrumEnabled.parentElement.style.display = isIntegrated ? "none" : "";
-      }
-      if (compatPolicy?.parentElement) {
-        compatPolicy.parentElement.style.display = isIntegrated ? "none" : "";
-      }
-    },
-    values() {
-      return {
-        spectrum: {
-          enabled: spectrumEnabled.checked && !spectrumEnabled.disabled,
-          window_size: Number(windowSize.value || defaults.spectrum.window_size || 2),
-          flex_window: Number(flexWindow.value || defaults.spectrum.flex_window || 0.25),
-          warmup_steps: Number(warmupSteps.value || defaults.spectrum.warmup_steps || 6),
-          tail_actual_steps: Number(tailSteps.value || defaults.spectrum.tail_actual_steps || 3),
-          blend_w: Number(blendW.value || defaults.spectrum.blend_w || 0.3),
-          cheby_degree: Number(chebyDegree.value || defaults.spectrum.cheby_degree || 3),
-          ridge_lambda: Number(ridgeLambda.value || defaults.spectrum.ridge_lambda || 0.1),
-          history_size: Number(spectrumValues.history_size || defaults.spectrum.history_size || 100),
-          one_sampler_only: !!spectrumValues.one_sampler_only,
-          verbose: !!spectrumValues.verbose,
-          compat_policy: compatPolicy.value || "conservative",
-        },
-        dit_corrections: {
-          enabled: correctionsEnabled.checked && !correctionsEnabled.disabled,
-          dcw_mode: dcwMode.value || "off",
-          dcw_lambda: Number(dcwLambda.value || defaults.dit_corrections.dcw_lambda || 0.01),
-          dcw_band_mask: dcwBand.value || "LL",
-          dcw_calibrator: correctionValues.dcw_calibrator || "(auto-download default)",
-          smc_cfg: smcCfg.checked,
-          adaptive_smc_alpha: Number(smcAlpha.value || defaults.dit_corrections.adaptive_smc_alpha || 0),
-          smc_cfg_lambda: Number(smcLambda.value || defaults.dit_corrections.smc_cfg_lambda || 6),
-          cfgpp: cfgpp.checked,
-          cfgpp_lambda: Number(cfgppLambda.value || defaults.dit_corrections.cfgpp_lambda || 0),
-          fsg: fsg.checked,
-          fsg_band_lo: Number(correctionValues.fsg_band_lo || defaults.dit_corrections.fsg_band_lo || 0.59),
-          fsg_band_hi: Number(correctionValues.fsg_band_hi || defaults.dit_corrections.fsg_band_hi || 0.75),
-          fsg_k: Number(correctionValues.fsg_k || defaults.dit_corrections.fsg_k || 3),
-          fsg_d_sigma: Number(correctionValues.fsg_d_sigma || defaults.dit_corrections.fsg_d_sigma || 0.1),
-          fsg_gamma: Number(correctionValues.fsg_gamma || defaults.dit_corrections.fsg_gamma || 0),
-          replace_existing_cfg: !!correctionValues.replace_existing_cfg,
-        },
-      };
-    },
-  };
-}
-
-function openHighresSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = generatorSettings(node);
-  const highres = mergeDefaults(DEFAULT_GENERATION_SETTINGS.highres, settings.highres || {});
-  const mainBackendIsSpd = settings.sampler?.backend === "spectrum_spd_speed";
-  const { backdrop, body, actions } = createDialog(
-    "Highres Settings",
-    "Image scaling and Highres resampling settings are saved with the node."
-  );
-  body.classList.add("easyuse-anima-aio-one-column");
-
-  const image = document.createElement("section");
-  image.className = "easyuse-anima-aio-section";
-  image.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Scale") }));
-  const enabled = field(image, "Enable highres", checkbox(highres.enabled));
-  const scaleBy = field(image, "Scale by", numberInput(highres.scale_by, "0.01"));
-  const upscaleMethod = field(image, "Method", selectInput(["bicubic", "nearest-exact", "bilinear", "area", "lanczos"], highres.upscale_method));
-  const multiple = field(image, "Multiple", selectInput(["8", "16", "32", "64"], highres.multiple));
-  const maxLongEdge = field(image, "Max long edge", numberInput(highres.max_long_edge, "32"));
-
-  const sampler = document.createElement("section");
-  sampler.className = "easyuse-anima-aio-section";
-  sampler.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Highres Sampler") }));
-  const steps = field(sampler, "Steps", numberInput(highres.steps, "1"));
-  steps.min = "1";
-  steps.max = "75";
-  const effectiveInherit = !!highres.inherit_sampler_settings;
-  const inheritSampler = field(
-    sampler,
-    "Follow main sampler",
-    checkbox(effectiveInherit),
-    "tip.highresFollow",
-  );
-  const dependencyWarning = document.createElement("div");
-  dependencyWarning.className = "easyuse-anima-aio-warning";
-  dependencyWarning.hidden = true;
-  sampler.append(dependencyWarning);
-  const cfg = field(sampler, "CFG", numberInput(highres.cfg, "0.1"));
-  cfg.min = "1";
-  cfg.max = "10";
-  const samplerName = field(
-    sampler,
-    "Sampler",
-    selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), highres.sampler_name)
-  );
-  const scheduler = field(
-    sampler,
-    "Scheduler",
-    selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), highres.scheduler)
-  );
-  const denoise = field(sampler, "Denoise", numberInput(highres.denoise, "0.01"));
-  const optimization = createStageOptimizationEditor("Highres Optimization", highres, DEFAULT_GENERATION_SETTINGS.highres);
-  const updateInheritedRows = () => {
-    const usesMain = inheritSampler.checked;
-    const display = usesMain ? "none" : "";
-    for (const control of [cfg, samplerName, scheduler]) {
-      if (control?.parentElement) {
-        control.parentElement.style.display = display;
-      }
-    }
-  };
-  const refreshDependencyLocks = () => {
-    const messages = [];
-    if (mainBackendIsSpd && inheritSampler.checked) {
-      messages.push(aioText("text.highresSpdManualRequired"));
-    }
-    dependencyWarning.hidden = messages.length === 0;
-    dependencyWarning.textContent = messages.join(" ");
-    updateInheritedRows();
-  };
-  inheritSampler.addEventListener("change", refreshDependencyLocks);
-  updateInheritedRows();
-  refreshDependencyLocks();
-  body.append(image, sampler, optimization.section);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    const optimized = optimization.values();
-    next.highres = {
-      ...next.highres,
-      enabled: enabled.checked,
-      scale_by: clampGeneratorNumber(scaleBy.value, DEFAULT_GENERATION_SETTINGS.highres.scale_by, 0.01, 8),
-      upscale_method: upscaleMethod.value || "bicubic",
-      multiple: multiple.value || "32",
-      max_long_edge: Math.trunc(clampGeneratorNumber(maxLongEdge.value, 2560, 0, 16384)),
-      steps: Math.trunc(clampGeneratorNumber(steps.value, 20, 1, 75)),
-      inherit_sampler_settings: inheritSampler.checked,
-      cfg: clampGeneratorNumber(cfg.value, 8, 1, 10),
-      sampler_name: samplerName.value || "euler",
-      scheduler: scheduler.value || "simple",
-      denoise: clampGeneratorNumber(denoise.value, DEFAULT_GENERATION_SETTINGS.highres.denoise, 0, 1),
-      ...optimized,
-    };
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
-
-function openUpscaleSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = generatorSettings(node);
-  const upscale = mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale, settings.upscale || {});
-  const usdu = mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale.usdu, upscale.usdu || {});
-  const resshift = mergeDefaults(DEFAULT_GENERATION_SETTINGS.upscale.resshift, upscale.resshift || {});
-  const { backdrop, body, actions } = createDialog(
-    "Upscale Settings",
-    "Final-stage upscale runs after Detailer and before Save. Choose USDU or ResShift."
-  );
-  body.classList.add("easyuse-anima-aio-one-column");
-
-  const main = document.createElement("section");
-  main.className = "easyuse-anima-aio-section";
-  main.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Scale") }));
-  const enabled = field(main, "Enable upscale", checkbox(upscale.enabled), "tip.upscaleEnabled");
-  const backend = field(
-    main,
-    "Upscale backend",
-    selectInput(["usdu", "resshift"], upscale.backend || "usdu"),
-    "tip.upscaleBackend",
-  );
-  const dependencyWarning = document.createElement("div");
-  dependencyWarning.className = "easyuse-anima-aio-warning";
-  dependencyWarning.hidden = true;
-  main.append(dependencyWarning);
-
-  const usduSection = document.createElement("section");
-  usduSection.className = "easyuse-anima-aio-section";
-  usduSection.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("USDU Upscale") }));
-  const scaleBy = field(usduSection, "Scale by", numberInput(upscale.scale_by, "0.05"), "tip.upscaleScale");
-  scaleBy.min = "0.05";
-  scaleBy.max = "4";
-  const upscaleModel = field(
-    usduSection,
-    "Upscale model",
-    selectInput(
-      nodeInputChoiceOptions("upscaleModelLoader", "model_name", usdu.upscale_model_name, [usdu.upscale_model_name]),
-      usdu.upscale_model_name,
-    ),
-    "tip.usduUpscaleModel",
-  );
-  const promptMode = field(
-    usduSection,
-    "USDU prompt",
-    selectInput(["full", "no_general"], usdu.prompt_mode === "quality_tags_only" ? "no_general" : usdu.prompt_mode || "full"),
-    "tip.usduPrompt",
-  );
-  const autoTile = field(usduSection, "Auto tile size", checkbox(usdu.auto_tile_size), "tip.usduAutoTile");
-  const autoTileTarget = field(usduSection, "Auto tile target", numberInput(usdu.auto_tile_target, "64"), "tip.usduAutoTile");
-  const autoTileMin = field(usduSection, "Auto tile min", numberInput(usdu.auto_tile_min, "64"), "tip.usduAutoTile");
-  const autoTileMax = field(usduSection, "Auto tile max", numberInput(usdu.auto_tile_max, "64"), "tip.usduAutoTile");
-  const modeType = field(usduSection, "Mode", selectInput(["Linear", "Chess", "None"], usdu.mode_type || "Linear"), "tip.usduMode");
-  const tileWidth = field(usduSection, "Tile width", numberInput(usdu.tile_width, "8"), "tip.usduTile");
-  const tileHeight = field(usduSection, "Tile height", numberInput(usdu.tile_height, "8"), "tip.usduTile");
-  const maskBlur = field(usduSection, "Mask blur", numberInput(usdu.mask_blur, "1"), "tip.usduTile");
-  const tilePadding = field(usduSection, "Tile padding", numberInput(usdu.tile_padding, "8"), "tip.usduTile");
-  const forceUniformTiles = field(usduSection, "Force uniform tiles", checkbox(usdu.force_uniform_tiles), "tip.usduTile");
-  const tiledDecode = field(usduSection, "Tiled decode", checkbox(usdu.tiled_decode), "tip.usduTile");
-  const batchSize = field(usduSection, "Tile batch", numberInput(usdu.batch_size, "1"), "tip.usduTile");
-  const seamFix = field(
-    usduSection,
-    "Seam fix",
-    selectInput(["None", "Band Pass", "Half Tile", "Half Tile + Intersections"], usdu.seam_fix_mode || "None"),
-    "tip.usduSeam",
-  );
-  const seamDenoise = field(usduSection, "Seam denoise", numberInput(usdu.seam_fix_denoise, "0.01"), "tip.usduSeam");
-  const seamWidth = field(usduSection, "Seam width", numberInput(usdu.seam_fix_width, "8"), "tip.usduSeam");
-  const seamMaskBlur = field(usduSection, "Seam mask blur", numberInput(usdu.seam_fix_mask_blur, "1"), "tip.usduSeam");
-  const seamPadding = field(usduSection, "Seam padding", numberInput(usdu.seam_fix_padding, "8"), "tip.usduSeam");
-
-  const usduSampler = document.createElement("section");
-  usduSampler.className = "easyuse-anima-aio-section";
-  usduSampler.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("USDU Sampler") }));
-  const inheritSampler = field(usduSampler, "Follow main sampler", checkbox(upscale.inherit_sampler_settings), "tip.highresFollow");
-  const steps = field(usduSampler, "Steps", numberInput(upscale.steps, "1"), "tip.steps");
-  const cfg = field(usduSampler, "CFG", numberInput(upscale.cfg, "0.1"), "tip.cfg");
-  const samplerName = field(
-    usduSampler,
-    "Sampler",
-    selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), upscale.sampler_name),
-    "tip.sampler",
-  );
-  const scheduler = field(
-    usduSampler,
-    "Scheduler",
-    selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), upscale.scheduler),
-    "tip.scheduler",
-  );
-  const denoise = field(usduSampler, "Denoise", numberInput(upscale.denoise, "0.01"), "tip.denoise");
-  const optimization = createStageOptimizationEditor("USDU Spectrum/DCW", upscale, DEFAULT_GENERATION_SETTINGS.upscale);
-
-  const resshiftSection = document.createElement("section");
-  resshiftSection.className = "easyuse-anima-aio-section";
-  resshiftSection.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("ResShift Upscale") }));
-  const resshiftScale = field(resshiftSection, "Scale", selectInput(["x2", "x4"], resshift.scale || "x2"), "tip.resshiftScale");
-  const student = field(
-    resshiftSection,
-    "Student",
-    selectInput(
-      nodeInputChoiceOptions("resShiftLoader", "student_name", resshift.student_name, ["(auto-download)"]),
-      resshift.student_name || "(auto-download)",
-    ),
-    "tip.resshiftStudent",
-  );
-  const dtype = field(resshiftSection, "Dtype", selectInput(["bf16", "fp32"], resshift.dtype || "bf16"), "tip.resshiftDtype");
-  const chop = field(resshiftSection, "Chop", numberInput(resshift.chop, "256"), "tip.resshiftTiling");
-  const overlap = field(resshiftSection, "Overlap", numberInput(resshift.overlap, "16"), "tip.resshiftTiling");
-  const tileBatch = field(resshiftSection, "Tile batch", numberInput(resshift.tile_batch, "1"), "tip.resshiftTiling");
-
-  const updateVisibility = () => {
-    const isUsdu = backend.value === "usdu";
-    usduSection.classList.toggle("hidden", !isUsdu);
-    usduSampler.classList.toggle("hidden", !isUsdu);
-    optimization.section.classList.toggle("hidden", !isUsdu);
-    resshiftSection.classList.toggle("hidden", isUsdu);
-    const autoTileDisplay = autoTile.checked ? "" : "none";
-    for (const control of [autoTileTarget, autoTileMin, autoTileMax]) {
-      if (control?.parentElement) {
-        control.parentElement.style.display = autoTileDisplay;
-      }
-    }
-    const manualTileDisplay = autoTile.checked ? "none" : "";
-    for (const control of [tileWidth, tileHeight]) {
-      if (control?.parentElement) {
-        control.parentElement.style.display = manualTileDisplay;
-      }
-    }
-    const samplerOverrideDisplay = inheritSampler.checked ? "none" : "";
-    for (const control of [cfg, samplerName, scheduler]) {
-      if (control?.parentElement) {
-        control.parentElement.style.display = samplerOverrideDisplay;
-      }
-    }
-  };
-  const refreshDependencyLocks = () => {
-    const messages = [];
-    for (const option of Array.from(backend.options)) {
-      const missingPacks = upscaleBackendMissingPacks(option.value);
-      option.disabled = missingPacks.length > 0;
-      option.textContent = missingPacks.length
-        ? `${option.value} (${missingPacks.join(", ")} missing)`
-        : option.value;
-      if (option.selected && missingPacks.length) {
-        messages.push(aioFormat("warning.optionalDependencyMissing", {
-          backend: option.value,
-          pack: missingPacks.join(", "),
-        }));
-        enabled.checked = false;
-      }
-    }
-    dependencyWarning.hidden = messages.length === 0;
-    dependencyWarning.textContent = messages.join(" ");
-    updateVisibility();
-  };
-  backend.addEventListener("change", refreshDependencyLocks);
-  autoTile.addEventListener("change", updateVisibility);
-  inheritSampler.addEventListener("change", updateVisibility);
-  body.append(main, usduSection, usduSampler, optimization.section, resshiftSection);
-  updateVisibility();
-  refreshDependencyLocks();
-  loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    const missingPacks = upscaleBackendMissingPacks(backend.value);
-    const optimized = optimization.values();
-    next.upscale = {
-      ...next.upscale,
-      enabled: enabled.checked && missingPacks.length === 0,
-      backend: backend.value || "usdu",
-      scale_by: clampGeneratorNumber(scaleBy.value, DEFAULT_GENERATION_SETTINGS.upscale.scale_by, 0.05, 4),
-      steps: Math.trunc(clampGeneratorNumber(steps.value, DEFAULT_GENERATION_SETTINGS.upscale.steps, 1, 1000)),
-      inherit_sampler_settings: inheritSampler.checked,
-      cfg: clampGeneratorNumber(cfg.value, DEFAULT_GENERATION_SETTINGS.upscale.cfg, 0, 100),
-      sampler_name: samplerName.value || "euler",
-      scheduler: scheduler.value || "simple",
-      denoise: clampGeneratorNumber(denoise.value, DEFAULT_GENERATION_SETTINGS.upscale.denoise, 0, 1),
-      ...optimized,
-      usdu: normalizeGeneratorUsduAutoTileRange({
-        upscale_model_name: upscaleModel.value || DEFAULT_GENERATION_SETTINGS.upscale.usdu.upscale_model_name,
-        auto_tile_size: autoTile.checked,
-        prompt_mode: promptMode.value || "full",
-        mode_type: modeType.value || "Linear",
-        auto_tile_target: Math.trunc(clampGeneratorNumber(autoTileTarget.value, 1024, 64, 16384)),
-        auto_tile_min: Math.trunc(clampGeneratorNumber(autoTileMin.value, 512, 64, 16384)),
-        auto_tile_max: Math.trunc(clampGeneratorNumber(autoTileMax.value, 2048, 64, 16384)),
-        tile_width: Math.trunc(clampGeneratorNumber(tileWidth.value, 512, 64, 16384)),
-        tile_height: Math.trunc(clampGeneratorNumber(tileHeight.value, 512, 64, 16384)),
-        mask_blur: Math.trunc(clampGeneratorNumber(maskBlur.value, 8, 0, 64)),
-        tile_padding: Math.trunc(clampGeneratorNumber(tilePadding.value, 32, 0, 16384)),
-        seam_fix_mode: seamFix.value || "None",
-        seam_fix_denoise: clampGeneratorNumber(seamDenoise.value, 1, 0, 1),
-        seam_fix_width: Math.trunc(clampGeneratorNumber(seamWidth.value, 64, 0, 16384)),
-        seam_fix_mask_blur: Math.trunc(clampGeneratorNumber(seamMaskBlur.value, 8, 0, 64)),
-        seam_fix_padding: Math.trunc(clampGeneratorNumber(seamPadding.value, 16, 0, 16384)),
-        force_uniform_tiles: forceUniformTiles.checked,
-        tiled_decode: tiledDecode.checked,
-        batch_size: Math.trunc(clampGeneratorNumber(batchSize.value, 1, 1, 4096)),
-      }),
-      resshift: {
-        scale: resshiftScale.value || "x2",
-        student_name: student.value || "(auto-download)",
-        dtype: dtype.value || "bf16",
-        chop: Math.trunc(clampGeneratorNumber(chop.value, 512, 256, 4096)),
-        overlap: Math.trunc(clampGeneratorNumber(overlap.value, 64, 0, 512)),
-        tile_batch: Math.trunc(clampGeneratorNumber(tileBatch.value, 4, 1, 32)),
-      },
-    };
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
-
 function createDetailerTargetEditor(node, title, values, defaults, onLabelChange = null) {
   const target = mergeDefaults(defaults, values || {});
   const section = document.createElement("section");
@@ -5946,6 +5510,49 @@ const openPreviewSettings = aioCreatePreviewSettingsDialog({
   applyVisibleSettings: applyVisibleGeneratorSettings,
   writeSettings,
   renderGeneratorPanel,
+});
+
+const {
+  createStageOptimizationEditor,
+  openHighresSettings,
+  openUpscaleSettings,
+} = aioCreateStageSettingsDialogs({
+  document,
+  controls: {
+    createDialog,
+    field,
+    numberInput,
+    checkbox,
+    selectInput,
+  },
+  text: {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+  },
+  settingsCore: {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    clampNumber: clampGeneratorNumber,
+    normalizeUsduAutoTileRange: normalizeGeneratorUsduAutoTileRange,
+  },
+  nodeAdapter: {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
+    widgetOptions,
+    nodeInputChoiceOptions,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  },
+  dependencyAdapter: {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    upscaleBackendMissingPacks,
+    load: loadGeneratorOptionalDependencies,
+  },
 });
 
 const generatorPanelRuntime = aioCreateGeneratorPanelRuntime({


### PR DESCRIPTION
## 변경 요약

- Highres와 Upscale 설정 dialog lifecycle을 `aio/stage_settings_dialogs.js`로 분리했습니다.
- 두 dialog가 공유하는 `createStageOptimizationEditor`도 같은 module이 소유하며, 아직 entry에 남은 Detailer가 계속 사용할 수 있도록 명시적 facade로 제공합니다.
- 기존 entry는 DOM/control/settings/dependency adapter를 조립하고 opener를 generator panel에 전달하는 역할만 유지합니다.
- 실제 함수 body는 기준 `dev`와 동일하게 이동했으며 Detailer, Sampler, Save, Advanced dialog 동작은 변경하지 않았습니다.

## 주요 파일

- `web/js/aio/stage_settings_dialogs.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_stage_settings_dialogs_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 호환성 경계

- Highres/Upscale hydrate, Cancel, Apply, visibility, optional dependency lock, stage optimization 저장 구조를 유지합니다.
- node/widget 이름, workflow 직렬화, API payload, raw ES module 배포 계약은 변경하지 않습니다.
- shared editor facade를 entry에서 destructure해 후속 Detailer 분리 전에도 기존 호출 경로를 유지합니다.

## 검증

- Focused stage settings dialog Fake DOM smoke: 통과
  - factory/import side effect 없음
  - shared editor facade와 integrated-mode visibility
  - Highres/Upscale hydrate
  - 비동기 dependency load 후 lock 재평가
  - Cancel 무기록 및 Apply의 write → render → remove 순서
  - USDU/ResShift visibility와 auto-tile normalization
- 관련 AiO/frontend module unittest: 65 tests 통과
- Focused TypeScript 6.0.3: 통과
- 행동/경계 감사 + 테스트 감사: Blocker/P2/P3 없음
- 공식 full runner:
  - Python unittest: 364 tests 통과
  - Frontend: 89 JavaScript files 통과
  - TypeScript: 6.0.3 통과
  - Git diff check: 통과
- Legacy canvas browser smoke: 미실행 (기계적 lifecycle 이동, 동작 변경 없음)
- Node 2.0 browser smoke: 미실행 (기계적 lifecycle 이동, 동작 변경 없음)
- Live ComfyUI smoke: 미실행

## 남은 범위

- #54 후속 조각에서 Detailer, Sampler, Save, Advanced dialog lifecycle을 각각 응집된 경계로 계속 분리합니다.
- 실제 seed/cleanup 동작 finding은 별도 behavior PR에서 dual-canvas 검증과 함께 처리합니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`