### PR TITLE
refactor: AiO Detailer 설정 대화상자 lifecycle 분리

### DIFF
--- a/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
@@ -1,0 +1,629 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+  descendants,
+} from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function find(root, predicate) {
+  return [root, ...descendants(root)].find(predicate) || null;
+}
+
+function findAll(root, predicate) {
+  return [root, ...descendants(root)].filter(predicate);
+}
+
+function findByText(root, textContent) {
+  return find(root, (element) => element.textContent === textContent);
+}
+
+function rowByLabel(root, label) {
+  return find(root, (element) => element.getAttribute?.("data-test-label") === label);
+}
+
+function controlIn(root, label) {
+  const row = rowByLabel(root, label);
+  assert.ok(row, `missing field row: ${label}`);
+  assert.ok(row.children[0], `missing field control: ${label}`);
+  return row.children[0];
+}
+
+function action(dialog, key) {
+  const button = findByText(dialog.actions, `text:${key}`);
+  assert.ok(button, `missing action: ${key}`);
+  return button;
+}
+
+function tabs(dialog) {
+  return findAll(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-tab"));
+}
+
+function tabLabel(tab) {
+  return find(tab, (element) => element.classList.contains("easyuse-anima-aio-tab-label"))?.textContent || "";
+}
+
+function tabByLabel(dialog, label) {
+  const tab = tabs(dialog).find((candidate) => tabLabel(candidate) === label);
+  assert.ok(tab, `missing detailer tab: ${label}`);
+  return tab;
+}
+
+function tabButtons(tab) {
+  return findAll(tab, (element) => element.tagName === "BUTTON");
+}
+
+function activeEditor(dialog) {
+  const panel = find(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-tab-panel"));
+  assert.ok(panel?.children[0], "missing active detailer editor");
+  return panel.children[0];
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const detailerDialogModule = await import(dataModule("../web/js/aio/detailer_settings_dialog.js"));
+const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+assert.deepEqual(
+  Object.keys(detailerDialogModule),
+  ["aioCreateDetailerSettingsDialog"],
+  "Detailer settings dialog must expose only its lifecycle factory",
+);
+
+function createFixture({ settings = {}, available = {}, deferLoads = false } = {}) {
+  let dependencyCalls = 0;
+  let currentDialog = null;
+  const trace = [];
+  const dialogs = [];
+  const loadResolvers = [];
+  const loadCalls = [];
+  const writes = [];
+  const renders = [];
+  const stageCalls = [];
+  const document = createFakeDocument();
+  const availabilityState = { ...available };
+  const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
+  const node = {
+    settings: settingsModule.aioMergeDefaults(defaultSettings, settings),
+    widgets: [{ name: "generation_settings", value: "" }],
+  };
+  node.widgets[0].value = JSON.stringify(node.settings);
+
+  function createDialog(title, subtitle) {
+    dependencyCalls += 1;
+    const dialog = {
+      title,
+      subtitle,
+      backdrop: document.createElement("div"),
+      body: document.createElement("div"),
+      actions: document.createElement("div"),
+      trace: [],
+    };
+    dialog.backdrop.remove = () => {
+      dialog.backdrop.removed = true;
+      dialog.trace.push("remove");
+      trace.push("remove");
+    };
+    dialogs.push(dialog);
+    currentDialog = dialog;
+    return dialog;
+  }
+
+  function field(section, label, element, tooltipKey = "") {
+    dependencyCalls += 1;
+    const row = document.createElement("label");
+    row.className = "easyuse-anima-aio-field";
+    row.setAttribute("data-test-label", label);
+    row.setAttribute("data-test-tooltip", tooltipKey);
+    row.append(element);
+    section.append(row);
+    return element;
+  }
+
+  function checkbox(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = !!value;
+    return input;
+  }
+
+  function textInput(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function numberInput(value, step = "1") {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "number";
+    input.step = step;
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function selectInput(options, value) {
+    dependencyCalls += 1;
+    const select = document.createElement("select");
+    select.options = [];
+    for (const optionSpec of options) {
+      const option = document.createElement("option");
+      option.value = typeof optionSpec === "object"
+        ? String(optionSpec.value ?? "")
+        : String(optionSpec ?? "");
+      option.textContent = typeof optionSpec === "object"
+        ? String(optionSpec.label ?? option.value)
+        : option.value;
+      option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
+      option.selected = option.value === String(value ?? "");
+      select.options.push(option);
+      select.append(option);
+    }
+    if (!select.options.some((option) => option.selected)) {
+      select.value = String(value ?? "");
+    }
+    return select;
+  }
+
+  function staticText(value) {
+    dependencyCalls += 1;
+    return `static:${value}`;
+  }
+
+  function text(key) {
+    dependencyCalls += 1;
+    return `text:${key}`;
+  }
+
+  function format(key, values = {}) {
+    dependencyCalls += 1;
+    return `format:${key}:${JSON.stringify(values)}`;
+  }
+
+  function applyTooltip(element, key) {
+    dependencyCalls += 1;
+    element.setAttribute("data-test-tooltip", key);
+    return element;
+  }
+
+  function mergeDefaults(defaults, current) {
+    dependencyCalls += 1;
+    return settingsModule.aioMergeDefaults(defaults, current);
+  }
+
+  function clampNumber(value, fallback, min, max) {
+    dependencyCalls += 1;
+    const parsed = Number(value);
+    const next = Number.isFinite(parsed) ? parsed : fallback;
+    return Math.max(min, Math.min(max, next));
+  }
+
+  function isDetailerTargetName(name) {
+    return name === "face" || name === "eye" || /^custom_\d+$/.test(name);
+  }
+
+  function isCustomDetailerTargetName(name) {
+    dependencyCalls += 1;
+    return /^custom_\d+$/.test(String(name || ""));
+  }
+
+  function detailerTargetDefaults(targetName) {
+    dependencyCalls += 1;
+    const defaults = targetName === "eye"
+      ? defaultSettings.detailer.eye
+      : defaultSettings.detailer.face;
+    const output = clone(defaults);
+    if (/^custom_\d+$/.test(String(targetName || ""))) {
+      output.label = `Detailer Block ${String(targetName).split("_").pop()}`;
+    }
+    return output;
+  }
+
+  function detailerTargetTitle(targetName, target, index = 0) {
+    dependencyCalls += 1;
+    if (target?.label) {
+      return String(target.label);
+    }
+    if (targetName === "face") {
+      return text("label.face");
+    }
+    if (targetName === "eye") {
+      return text("label.eye");
+    }
+    const suffix = String(targetName || "").split("_").pop();
+    return `Detailer Block ${suffix || index + 1}`;
+  }
+
+  function normalizeDetailerOrder(order, detailer = null) {
+    dependencyCalls += 1;
+    const output = [];
+    const appendTarget = (name) => {
+      const normalized = String(name || "").trim();
+      if (isDetailerTargetName(normalized) && !output.includes(normalized)) {
+        output.push(normalized);
+      }
+    };
+    for (const name of Array.isArray(order) ? order : defaultSettings.detailer.order) {
+      appendTarget(name);
+    }
+    if (detailer && typeof detailer === "object") {
+      for (const [name, value] of Object.entries(detailer)) {
+        if (["enabled", "order", "sam3"].includes(name) || !value || typeof value !== "object" || Array.isArray(value)) {
+          continue;
+        }
+        appendTarget(name);
+      }
+    }
+    for (const name of defaultSettings.detailer.order) {
+      appendTarget(name);
+    }
+    return output;
+  }
+
+  function nextDetailerTargetName(order, detailer = null) {
+    dependencyCalls += 1;
+    const used = new Set(normalizeDetailerOrder(order, detailer));
+    if (detailer && typeof detailer === "object") {
+      for (const key of Object.keys(detailer)) {
+        used.add(key);
+      }
+    }
+    for (let index = 1; index < 1000; index += 1) {
+      const candidate = `custom_${index}`;
+      if (!used.has(candidate)) {
+        return candidate;
+      }
+    }
+    return `custom_${Date.now()}`;
+  }
+
+  function createStageOptimizationEditor(title, values, defaults) {
+    dependencyCalls += 1;
+    stageCalls.push({ title, values: clone(values), defaults: clone(defaults) });
+    const section = document.createElement("section");
+    section.className = "test-stage-optimization";
+    section.append(Object.assign(document.createElement("h4"), { textContent: `optimization:${title}` }));
+    return {
+      section,
+      values() {
+        dependencyCalls += 1;
+        return {
+          spectrum: clone(values.spectrum ?? defaults.spectrum),
+          dit_corrections: clone(values.dit_corrections ?? defaults.dit_corrections),
+          optimization_marker: `optimized:${title}`,
+        };
+      },
+      setIntegratedMode() {},
+    };
+  }
+
+  function findWidget(targetNode, name) {
+    dependencyCalls += 1;
+    return targetNode.widgets?.find((widget) => widget.name === name);
+  }
+
+  function getSettings(targetNode) {
+    dependencyCalls += 1;
+    trace.push("get-settings");
+    return clone(targetNode.settings);
+  }
+
+  function widgetOptions(_targetNode, name, fallback) {
+    dependencyCalls += 1;
+    return [...new Set([...fallback, name === "sampler_name" ? "custom_sampler" : "custom_scheduler"])];
+  }
+
+  function writeSettings(targetNode, widget, nextSettings) {
+    dependencyCalls += 1;
+    const snapshot = clone(nextSettings);
+    targetNode.settings = snapshot;
+    widget.value = JSON.stringify(snapshot);
+    writes.push(snapshot);
+    currentDialog.trace.push("write");
+    trace.push("write");
+  }
+
+  function renderPanel(targetNode) {
+    dependencyCalls += 1;
+    renders.push(targetNode);
+    currentDialog.trace.push("render");
+    trace.push("render");
+  }
+
+  const openDetailerSettings = detailerDialogModule.aioCreateDetailerSettingsDialog({
+    document,
+    controls: {
+      createDialog,
+      field,
+      checkbox,
+      textInput,
+      numberInput,
+      selectInput,
+    },
+    text: {
+      staticText,
+      get: text,
+      format,
+      applyTooltip,
+    },
+    settingsCore: {
+      defaultGenerationSettings: defaultSettings,
+      fallbackSamplerNames: ["euler", "er_sde"],
+      fallbackSchedulerNames: ["simple", "sgm_uniform"],
+      mergeDefaults,
+      clampNumber,
+      normalizeDetailerOrder,
+      isCustomDetailerTargetName,
+      nextDetailerTargetName,
+      detailerTargetDefaults,
+      detailerTargetTitle,
+    },
+    stageOptimizationEditor: createStageOptimizationEditor,
+    nodeAdapter: {
+      generatorSettingsWidget: "generation_settings",
+      findWidget,
+      getSettings,
+      widgetOptions,
+      writeSettings,
+      renderPanel,
+    },
+    dependencyAdapter: {
+      available(key) {
+        dependencyCalls += 1;
+        return Object.hasOwn(availabilityState, key) ? !!availabilityState[key] : true;
+      },
+      pack(key) {
+        dependencyCalls += 1;
+        return `pack:${key}`;
+      },
+      load(options) {
+        dependencyCalls += 1;
+        loadCalls.push(options);
+        if (!deferLoads) {
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => loadResolvers.push(resolve));
+      },
+    },
+  });
+
+  return {
+    openDetailerSettings,
+    document,
+    node,
+    defaultSettings,
+    dialogs,
+    loadCalls,
+    availabilityState,
+    writes,
+    renders,
+    stageCalls,
+    trace,
+    dependencyCallCount: () => dependencyCalls,
+    resolveLoads() {
+      for (const resolve of loadResolvers.splice(0)) {
+        resolve();
+      }
+    },
+  };
+}
+
+{
+  const fixture = createFixture({
+    settings: {
+      detailer: {
+        enabled: true,
+        order: ["face", "custom_1", "eye"],
+        sam3: { checkpoint: "configured-sam3.safetensors" },
+        face: { enabled: true, preserved_face_key: "keep-face" },
+        eye: { enabled: true },
+        custom_1: {
+          ...clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS.detailer.face),
+          label: "Custom One",
+          enabled: true,
+          detect_prompt: "configured custom prompt",
+          inherit_sampler_settings: true,
+        },
+        custom_9: "obsolete-stale-custom",
+      },
+      preserved_root_key: "keep-root",
+    },
+  });
+  const originalSettings = clone(fixture.node.settings);
+  const originalWidget = fixture.node.widgets[0].value;
+  assert.equal(fixture.dependencyCallCount(), 0, "Factory composition must be side-effect free");
+  assert.equal(fixture.dialogs.length, 0);
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.equal(fixture.document.createdElements.length, 0, "Factory composition must not create DOM elements");
+  assert.equal(fixture.document.body.children.length, 0, "Factory composition must not attach DOM elements");
+
+  fixture.openDetailerSettings(fixture.node);
+  await flushPromises();
+  const cancelDialog = fixture.dialogs[0];
+  assert.equal(cancelDialog.title, "Detailer Settings");
+  assert.equal(cancelDialog.subtitle, "SAM3 detection and Impact detailer settings are saved with the node.");
+  assert.ok(cancelDialog.body.classList.contains("easyuse-anima-aio-one-column"));
+  assert.equal(controlIn(cancelDialog.body, "Enable detailer").checked, true);
+  assert.equal(controlIn(cancelDialog.body, "SAM3 checkpoint").value, "configured-sam3.safetensors");
+  assert.deepEqual(tabs(cancelDialog).map(tabLabel), ["Face Detailer", "Custom One", "Eye Detailer"]);
+  assert.ok(tabByLabel(cancelDialog, "Face Detailer").classList.contains("active"));
+  assert.equal(controlIn(activeEditor(cancelDialog), "Block name").value, "Face Detailer");
+
+  tabByLabel(cancelDialog, "Custom One").emit("click");
+  const cancelledName = controlIn(activeEditor(cancelDialog), "Block name");
+  cancelledName.value = "Cancelled Rename";
+  cancelledName.emit("input");
+  assert.ok(tabByLabel(cancelDialog, "Cancelled Rename"));
+  findByText(cancelDialog.body, "text:button.addDetailerBlock").emit("click");
+  let cancelledNewTab = tabByLabel(cancelDialog, "Detailer Block 2");
+  assert.ok(cancelledNewTab);
+  tabButtons(cancelledNewTab)[0].emit("click");
+  assert.deepEqual(
+    tabs(cancelDialog).map(tabLabel),
+    ["Face Detailer", "Cancelled Rename", "Detailer Block 2", "Eye Detailer"],
+  );
+  cancelledNewTab = tabByLabel(cancelDialog, "Detailer Block 2");
+  tabButtons(cancelledNewTab)[2].emit("click");
+  assert.equal(
+    tabs(cancelDialog).some((tab) => tabLabel(tab) === "Detailer Block 2"),
+    false,
+  );
+  controlIn(cancelDialog.body, "SAM3 checkpoint").value = "cancelled-change.safetensors";
+  action(cancelDialog, "button.cancel").emit("click");
+  assert.deepEqual(fixture.node.settings, originalSettings, "Cancel must not mutate settings");
+  assert.equal(fixture.node.widgets[0].value, originalWidget, "Cancel must not rewrite the hidden widget");
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.deepEqual(cancelDialog.trace, ["remove"]);
+
+  fixture.openDetailerSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[1];
+
+  const faceTab = tabByLabel(dialog, "Face Detailer");
+  const faceRemove = tabButtons(faceTab)[2];
+  assert.equal(faceRemove.disabled, true, "Built-in Face block removal must stay disabled");
+  faceRemove.emit("click");
+  assert.ok(tabByLabel(dialog, "Face Detailer"), "Built-in Face block must not be removable");
+
+  const eyeKeyEvent = tabByLabel(dialog, "Eye Detailer").emit("keydown", { key: "Enter" });
+  assert.equal(eyeKeyEvent.defaultPrevented, true);
+  assert.ok(tabByLabel(dialog, "Eye Detailer").classList.contains("active"));
+  const customKeyEvent = tabByLabel(dialog, "Custom One").emit("keydown", { key: " " });
+  assert.equal(customKeyEvent.defaultPrevented, true);
+  assert.ok(tabByLabel(dialog, "Custom One").classList.contains("active"));
+
+  let editor = activeEditor(dialog);
+  assert.equal(controlIn(editor, "Prompt").value, "configured custom prompt");
+  const followMain = controlIn(editor, "Follow main sampler");
+  assert.equal(followMain.checked, true);
+  assert.equal(rowByLabel(editor, "CFG").style.display, "none");
+  assert.equal(rowByLabel(editor, "Sampler").style.display, "none");
+  assert.equal(rowByLabel(editor, "Scheduler").style.display, "none");
+  followMain.checked = false;
+  followMain.emit("change");
+  assert.equal(rowByLabel(editor, "CFG").style.display, "");
+  assert.equal(rowByLabel(editor, "Sampler").style.display, "");
+  assert.equal(rowByLabel(editor, "Scheduler").style.display, "");
+
+  const addBlock = findByText(dialog.body, "text:button.addDetailerBlock");
+  assert.ok(addBlock);
+  addBlock.emit("click");
+  assert.deepEqual(tabs(dialog).map(tabLabel), ["Face Detailer", "Custom One", "Eye Detailer", "Detailer Block 2"]);
+  assert.ok(tabByLabel(dialog, "Detailer Block 2").classList.contains("active"));
+
+  editor = activeEditor(dialog);
+  const blockName = controlIn(editor, "Block name");
+  blockName.value = "Portrait Detailer";
+  blockName.emit("input");
+  assert.ok(tabByLabel(dialog, "Portrait Detailer").classList.contains("active"));
+
+  let portraitTab = tabByLabel(dialog, "Portrait Detailer");
+  let moveEvent = tabButtons(portraitTab)[0].emit("click");
+  assert.equal(moveEvent.propagationStopped, true);
+  portraitTab = tabByLabel(dialog, "Portrait Detailer");
+  moveEvent = tabButtons(portraitTab)[0].emit("click");
+  assert.equal(moveEvent.propagationStopped, true);
+  assert.deepEqual(tabs(dialog).map(tabLabel), ["Face Detailer", "Portrait Detailer", "Custom One", "Eye Detailer"]);
+
+  const customOneTab = tabByLabel(dialog, "Custom One");
+  const removeEvent = tabButtons(customOneTab)[2].emit("click");
+  assert.equal(removeEvent.propagationStopped, true);
+  assert.deepEqual(tabs(dialog).map(tabLabel), ["Face Detailer", "Portrait Detailer", "Eye Detailer"]);
+
+  tabByLabel(dialog, "Portrait Detailer").emit("click");
+  editor = activeEditor(dialog);
+  controlIn(editor, "Prompt").value = "new portrait prompt";
+  controlIn(editor, "Steps").value = "100";
+  controlIn(editor, "CFG").value = "0";
+  controlIn(editor, "Denoise").value = "2";
+  const portraitFollowMain = controlIn(editor, "Follow main sampler");
+  portraitFollowMain.checked = false;
+  portraitFollowMain.emit("change");
+  controlIn(dialog.body, "SAM3 checkpoint").value = "updated-sam3.safetensors";
+  controlIn(dialog.body, "Enable detailer").checked = true;
+
+  action(dialog, "button.apply").emit("click");
+  assert.equal(fixture.writes.length, 1);
+  assert.equal(fixture.renders.length, 1);
+  assert.deepEqual(dialog.trace.slice(-3), ["write", "render", "remove"]);
+  assert.equal(fixture.node.settings.preserved_root_key, "keep-root");
+  assert.equal(fixture.node.settings.detailer.face.preserved_face_key, "keep-face");
+  assert.equal(fixture.node.settings.detailer.enabled, true);
+  assert.equal(fixture.node.settings.detailer.sam3.context, "load_checkpoint");
+  assert.equal(fixture.node.settings.detailer.sam3.checkpoint, "updated-sam3.safetensors");
+  assert.deepEqual(fixture.node.settings.detailer.order, ["face", "custom_2", "eye"]);
+  assert.equal(Object.hasOwn(fixture.node.settings.detailer, "custom_1"), false, "Removed custom block must be deleted");
+  assert.equal(Object.hasOwn(fixture.node.settings.detailer, "custom_9"), false, "Stale custom key must be deleted");
+  assert.equal(fixture.node.settings.detailer.custom_2.label, "Portrait Detailer");
+  assert.equal(fixture.node.settings.detailer.custom_2.detect_prompt, "new portrait prompt");
+  assert.equal(fixture.node.settings.detailer.custom_2.steps, 75);
+  assert.equal(fixture.node.settings.detailer.custom_2.cfg, 1);
+  assert.equal(fixture.node.settings.detailer.custom_2.denoise, 1);
+  assert.equal(fixture.node.settings.detailer.custom_2.inherit_sampler_settings, false);
+  assert.equal(
+    fixture.node.settings.detailer.custom_2.optimization_marker,
+    "optimized:Detailer Block 2 Optimization",
+  );
+  assert.ok(fixture.node.settings.detailer.custom_2.spectrum);
+  assert.ok(fixture.node.settings.detailer.custom_2.dit_corrections);
+  assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), fixture.node.settings);
+  assert.ok(fixture.stageCalls.some(({ title }) => title === "Detailer Block 2 Optimization"));
+}
+
+{
+  const fixture = createFixture({
+    available: { impactDetailer: true, impactMaskToSegs: true },
+    deferLoads: true,
+    settings: {
+      detailer: {
+        enabled: true,
+        face: { enabled: true },
+        eye: { enabled: true },
+      },
+    },
+  });
+  assert.equal(fixture.dependencyCallCount(), 0, "Deferred fixture factory must also be side-effect free");
+  fixture.openDetailerSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const enabled = controlIn(dialog.body, "Enable detailer");
+  const warning = find(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-warning"));
+  assert.equal(enabled.disabled, false);
+  assert.equal(enabled.checked, true);
+  assert.equal(warning.hidden, true);
+  assert.equal(fixture.loadCalls.length, 1);
+
+  fixture.availabilityState.impactDetailer = false;
+  fixture.availabilityState.impactMaskToSegs = false;
+  fixture.resolveLoads();
+  await flushPromises();
+  assert.equal(enabled.disabled, true, "Missing dependencies must lock Detailer after async refresh");
+  assert.equal(enabled.checked, false, "Missing dependencies must clear an enabled Detailer toggle");
+  assert.equal(warning.hidden, false);
+  assert.equal(
+    warning.textContent,
+    'format:warning.optionalDependencyMissing:{"backend":"Detailer","pack":"pack:impactDetailer, pack:impactMaskToSegs"}',
+  );
+
+  action(dialog, "button.apply").emit("click");
+  assert.deepEqual(dialog.trace.slice(-3), ["write", "render", "remove"]);
+  assert.equal(fixture.node.settings.detailer.enabled, false);
+  assert.equal(fixture.node.settings.detailer.face.enabled, false);
+  assert.equal(fixture.node.settings.detailer.eye.enabled, false);
+}
+
+console.log("AiO Detailer settings dialog smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -21,6 +21,9 @@ AIO_GENERATOR_PANEL_RUNTIME_JS = (
 AIO_STAGE_SETTINGS_DIALOGS_JS = (
     ROOT / "web" / "js" / "aio" / "stage_settings_dialogs.js"
 )
+AIO_DETAILER_SETTINGS_DIALOG_JS = (
+    ROOT / "web" / "js" / "aio" / "detailer_settings_dialog.js"
+)
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
@@ -221,9 +224,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("aioPreviewFileSize(currentImage)", meta_parts)
 
     def test_detailer_target_editor_builds_optimization_before_visibility_refresh(self):
-        source = AIO_JS.read_text(encoding="utf-8")
+        source = AIO_DETAILER_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
         start = source.index("function createDetailerTargetEditor")
-        end = source.index("\nfunction openDetailerSettings", start)
+        end = source.index("\n  function openDetailerSettings", start)
         body = source[start:end]
 
         self.assertLess(
@@ -384,9 +387,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('"Save prompt metadata": "tip.savePromptMetadata"', source)
 
     def test_detailer_settings_support_custom_blocks(self):
-        source = AIO_JS.read_text(encoding="utf-8")
+        source = AIO_DETAILER_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
         start = source.index("function openDetailerSettings")
-        end = source.index("\nfunction normalizeImageSaverHashBundles", start)
+        end = source.index("\n\n  return openDetailerSettings", start)
         body = source[start:end]
 
         self.assertIn('addBlock.textContent = aioText("button.addDetailerBlock");', body)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -51,6 +51,10 @@ AIO_STAGE_SETTINGS_DIALOGS_JS = AIO_MODULES / "stage_settings_dialogs.js"
 AIO_STAGE_SETTINGS_DIALOGS_SMOKE = (
     ROOT / "tests" / "frontend_aio_stage_settings_dialogs_smoke.mjs"
 )
+AIO_DETAILER_SETTINGS_DIALOG_JS = AIO_MODULES / "detailer_settings_dialog.js"
+AIO_DETAILER_SETTINGS_DIALOG_SMOKE = (
+    ROOT / "tests" / "frontend_aio_detailer_settings_dialog_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -544,11 +548,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(moved_function=moved_function):
                 self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
                 self.assertNotRegex(entry_source, rf"\bfunction\s+{moved_function}\(")
-        for entry_owned_function in (
-            "createDetailerTargetEditor",
-            "openDetailerSettings",
-            "openSamplerSettings",
-        ):
+        for entry_owned_function in ("openSamplerSettings",):
             with self.subTest(entry_owned_function=entry_owned_function):
                 self.assertRegex(entry_source, rf"\bfunction\s+{entry_owned_function}\(")
                 self.assertNotRegex(source, rf"\bfunction\s+{entry_owned_function}\(")
@@ -579,7 +579,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
         composition_start = composition_match.start()
         composition_end = entry_source.index(
-            "\n\nconst generatorPanelRuntime", composition_start
+            "\n\nconst openDetailerSettings", composition_start
         )
         composition = entry_source[composition_start:composition_end]
         for expected in (
@@ -596,20 +596,73 @@ class FrontendModuleStructureTests(unittest.TestCase):
         ):
             with self.subTest(composition_dependency=expected):
                 self.assertIn(expected, composition)
-        self.assertNotIn("openDetailerSettings,", composition)
-        detailer_start = entry_source.index("function createDetailerTargetEditor")
-        detailer_end = entry_source.index("\nfunction openDetailerSettings", detailer_start)
-        self.assertIn(
-            "createStageOptimizationEditor(`${title} Optimization`, target, defaults)",
-            entry_source[detailer_start:detailer_end],
-        )
         self.assertLess(
             composition_match.start(),
-            entry_source.index("const generatorPanelRuntime"),
+            entry_source.index("const openDetailerSettings"),
         )
         self.assertTrue(AIO_STAGE_SETTINGS_DIALOGS_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_stage_settings_dialogs_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_detailer_settings_dialog_has_closed_lifecycle_boundary(self):
+        source = AIO_DETAILER_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+        stage_source = AIO_STAGE_SETTINGS_DIALOGS_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(source.startswith("// @ts-check\n"))
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotRegex(source, r"(?m)^\s*import\s")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertEqual(
+            re.findall(r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE),
+            ["aioCreateDetailerSettingsDialog"],
+        )
+        self.assertIn(
+            'import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";',
+            entry_source,
+        )
+        for moved_function in ("createDetailerTargetEditor", "openDetailerSettings"):
+            with self.subTest(moved_function=moved_function):
+                self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
+                self.assertNotRegex(entry_source, rf"\bfunction\s+{moved_function}\(")
+                self.assertNotRegex(stage_source, rf"\bfunction\s+{moved_function}\(")
+
+        composition_start = entry_source.index(
+            "const openDetailerSettings = aioCreateDetailerSettingsDialog({"
+        )
+        composition_end = entry_source.index("\n\nconst generatorPanelRuntime", composition_start)
+        composition = entry_source[composition_start:composition_end]
+        for expected in (
+            "createDialog,",
+            "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,",
+            "normalizeDetailerOrder,",
+            "stageOptimizationEditor: createStageOptimizationEditor,",
+            "getSettings: generatorSettings,",
+            "renderPanel: renderGeneratorPanel,",
+            "load: loadGeneratorOptionalDependencies,",
+        ):
+            with self.subTest(composition_dependency=expected):
+                self.assertIn(expected, composition)
+        stage_composition = entry_source.index("aioCreateStageSettingsDialogs({")
+        generator_panel_composition = entry_source.index("const generatorPanelRuntime")
+        self.assertLess(stage_composition, composition_start)
+        self.assertLess(composition_start, generator_panel_composition)
+
+        editor_start = source.index("function createDetailerTargetEditor")
+        editor_end = source.index("\n  function openDetailerSettings", editor_start)
+        editor_body = source[editor_start:editor_end]
+        self.assertIn(
+            "createStageOptimizationEditor(`${title} Optimization`, target, defaults)",
+            editor_body,
+        )
+        self.assertIn("return openDetailerSettings;", source)
+        self.assertTrue(AIO_DETAILER_SETTINGS_DIALOG_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_detailer_settings_dialog_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -64,6 +64,11 @@ try {
         throw "Frontend AiO stage settings dialogs smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_detailer_settings_dialog_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Detailer settings dialog smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_dependency_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/detailer_settings_dialog.js
+++ b/web/js/aio/detailer_settings_dialog.js
@@ -1,0 +1,466 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioDetailerDialogControls
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(value: any) => any} checkbox
+ * @property {(value: any) => any} textInput
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(options: any[], value: any) => any} selectInput
+ */
+
+/**
+ * @typedef {object} AioDetailerDialogText
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} get
+ * @property {(key: string, values?: Record<string, any>) => string} format
+ * @property {(element: any, key: string) => any} applyTooltip
+ */
+
+/**
+ * @typedef {object} AioDetailerDialogSettingsCore
+ * @property {any} defaultGenerationSettings
+ * @property {any[]} fallbackSamplerNames
+ * @property {any[]} fallbackSchedulerNames
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(value: any, fallback: number, min: number, max: number) => number} clampNumber
+ * @property {(order: any, detailer?: any) => string[]} normalizeDetailerOrder
+ * @property {(targetName: string) => boolean} isCustomDetailerTargetName
+ * @property {(order: string[], detailer: any) => string} nextDetailerTargetName
+ * @property {(targetName: string) => any} detailerTargetDefaults
+ * @property {(targetName: string, target: any, index?: number) => string} detailerTargetTitle
+ */
+
+/**
+ * @typedef {object} AioDetailerDialogNodeAdapter
+ * @property {string} generatorSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(node: any) => any} getSettings
+ * @property {(node: any, name: string, fallback: any[]) => any[]} widgetOptions
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ * @property {(node: any) => void} renderPanel
+ */
+
+/**
+ * @typedef {object} AioDetailerDialogDependencyAdapter
+ * @property {(key: string) => boolean} available
+ * @property {(key: string) => string} pack
+ * @property {(options?: Record<string, any>) => Promise<any>} load
+ */
+
+/**
+ * @typedef {object} AioDetailerSettingsDialogDependencies
+ * @property {any} document
+ * @property {AioDetailerDialogControls} controls
+ * @property {AioDetailerDialogText} text
+ * @property {AioDetailerDialogSettingsCore} settingsCore
+ * @property {(title: any, values: any, defaults: any) => {section: any, values: () => any, setIntegratedMode?: (isIntegrated: boolean) => void}} stageOptimizationEditor
+ * @property {AioDetailerDialogNodeAdapter} nodeAdapter
+ * @property {AioDetailerDialogDependencyAdapter} dependencyAdapter
+ */
+
+/**
+ * Own the Detailer settings dialog, target editor, tab order, custom-target,
+ * dependency-lock, and apply/cancel lifecycle. Stage optimization, extension
+ * registration, panel rendering, dependency discovery, and storage are adapters.
+ *
+ * @param {AioDetailerSettingsDialogDependencies} dependencies
+ * @returns {(node: any) => void}
+ */
+export function aioCreateDetailerSettingsDialog(dependencies) {
+  const {
+    document,
+    controls,
+    text,
+    settingsCore,
+    stageOptimizationEditor: createStageOptimizationEditor,
+    nodeAdapter,
+    dependencyAdapter,
+  } = dependencies;
+  const {
+    createDialog,
+    field,
+    checkbox,
+    textInput,
+    numberInput,
+    selectInput,
+  } = controls;
+  const {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+    applyTooltip,
+  } = text;
+  const {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    clampNumber: clampGeneratorNumber,
+    normalizeDetailerOrder,
+    isCustomDetailerTargetName,
+    nextDetailerTargetName,
+    detailerTargetDefaults,
+    detailerTargetTitle,
+  } = settingsCore;
+  const {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
+    widgetOptions,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  } = nodeAdapter;
+  const {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    load: loadGeneratorOptionalDependencies,
+  } = dependencyAdapter;
+
+  function createDetailerTargetEditor(node, title, values, defaults, onLabelChange = null) {
+    const target = mergeDefaults(defaults, values || {});
+    const section = document.createElement("section");
+    section.className = "easyuse-anima-aio-detailer-target-panel";
+    const header = document.createElement("div");
+    header.className = "easyuse-anima-aio-node-stage-mini-header";
+    header.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText(title) }));
+    section.append(header);
+    const labelInput = field(
+      section,
+      "Block name",
+      textInput(target.label || defaults.label || title),
+      "tip.detailerName",
+    );
+    labelInput.addEventListener("input", () => onLabelChange?.());
+    const enabled = field(section, "Enable", checkbox(target.enabled));
+
+    const detect = document.createElement("div");
+    detect.className = "easyuse-anima-aio-subsection";
+    detect.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("SAM3 Detect") }));
+    const detectPrompt = field(detect, "Prompt", textInput(target.detect_prompt));
+    const detectCount = field(detect, "Count", numberInput(target.detect_count, "1"));
+    const threshold = field(detect, "Threshold", numberInput(target.threshold, "0.01"));
+    const refine = field(detect, "Refine", numberInput(target.refine_iterations, "1"));
+    const individual = field(detect, "Individual", checkbox(target.individual_masks));
+    const combined = field(detect, "Combined", checkbox(target.combined));
+    section.append(detect);
+
+    const segs = document.createElement("div");
+    segs.className = "easyuse-anima-aio-subsection";
+    segs.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("MaskToSEGS") }));
+    const cropFactor = field(segs, "Crop factor", numberInput(target.crop_factor, "0.1"));
+    const bboxFill = field(segs, "BBox fill", checkbox(target.bbox_fill));
+    const dropSize = field(segs, "Drop size", numberInput(target.drop_size, "1"));
+    const contourFill = field(segs, "Contour fill", checkbox(target.contour_fill));
+    section.append(segs);
+
+    const detail = document.createElement("div");
+    detail.className = "easyuse-anima-aio-subsection";
+    detail.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("Impact Detailer") }));
+    const guideSize = field(detail, "Guide size", numberInput(target.guide_size, "8"));
+    const maxSize = field(detail, "Max size", numberInput(target.max_size, "8"));
+    const steps = field(detail, "Steps", numberInput(target.steps, "1"));
+    steps.min = "1";
+    steps.max = "75";
+    const inheritSampler = field(
+      detail,
+      "Follow main sampler",
+      checkbox(target.inherit_sampler_settings),
+      "tip.detailerFollow",
+    );
+    const cfg = field(detail, "CFG", numberInput(target.cfg, "0.1"));
+    cfg.min = "1";
+    cfg.max = "10";
+    const samplerName = field(detail, "Sampler", selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), target.sampler_name));
+    const scheduler = field(detail, "Scheduler", selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), target.scheduler));
+    const denoise = field(detail, "Denoise", numberInput(target.denoise, "0.01"));
+    const feather = field(detail, "Feather", numberInput(target.feather, "1"));
+    const noiseMask = field(detail, "Noise mask", checkbox(target.noise_mask));
+    const forceInpaint = field(detail, "Force inpaint", checkbox(target.force_inpaint));
+    const noiseMaskFeather = field(detail, "Mask feather", numberInput(target.noise_mask_feather, "1"));
+    const cycle = field(detail, "Cycle", numberInput(target.cycle, "1"));
+    const alignment = field(detail, "Alignment", selectInput(["impact", "none", "32", "64"], target.alignment || "32"));
+    const optimization = createStageOptimizationEditor(`${title} Optimization`, target, defaults);
+    const updateInheritedRows = () => {
+      const display = inheritSampler.checked ? "none" : "";
+      for (const control of [cfg, samplerName, scheduler]) {
+        if (control?.parentElement) {
+          control.parentElement.style.display = display;
+        }
+      }
+    };
+    inheritSampler.addEventListener("change", updateInheritedRows);
+    updateInheritedRows();
+    section.append(detail);
+
+    section.append(optimization.section);
+
+    return {
+      section,
+      label() {
+        return String(labelInput.value || defaults.label || title).trim() || title;
+      },
+      values() {
+        const optimized = optimization.values();
+        return {
+          ...target,
+          label: String(labelInput.value || defaults.label || title).trim() || title,
+          enabled: enabled.checked,
+          detect_prompt: detectPrompt.value || defaults.detect_prompt,
+          detect_count: Number(detectCount.value || defaults.detect_count),
+          threshold: Number(threshold.value || defaults.threshold),
+          refine_iterations: Number(refine.value || defaults.refine_iterations),
+          individual_masks: individual.checked,
+          combined: combined.checked,
+          crop_factor: Number(cropFactor.value || defaults.crop_factor),
+          bbox_fill: bboxFill.checked,
+          drop_size: Number(dropSize.value || defaults.drop_size),
+          contour_fill: contourFill.checked,
+          guide_size: Number(guideSize.value || defaults.guide_size),
+          guide_size_for: false,
+          max_size: Number(maxSize.value || defaults.max_size),
+          steps: Math.trunc(clampGeneratorNumber(steps.value, defaults.steps, 1, 75)),
+          inherit_sampler_settings: inheritSampler.checked,
+          cfg: clampGeneratorNumber(cfg.value, defaults.cfg, 1, 10),
+          sampler_name: samplerName.value || defaults.sampler_name,
+          scheduler: scheduler.value || defaults.scheduler,
+          denoise: clampGeneratorNumber(denoise.value, defaults.denoise, 0, 1),
+          feather: Number(feather.value || defaults.feather),
+          noise_mask: noiseMask.checked,
+          force_inpaint: forceInpaint.checked,
+          wildcard: target.wildcard || "",
+          cycle: Number(cycle.value || defaults.cycle),
+          alignment: alignment.value || "32",
+          inpaint_model: false,
+          noise_mask_feather: Number(noiseMaskFeather.value || defaults.noise_mask_feather || 0),
+          tiled_encode: false,
+          tiled_decode: false,
+          ...optimized,
+        };
+      },
+    };
+  }
+
+  function openDetailerSettings(node) {
+    const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
+    const settings = generatorSettings(node);
+    const detailer = mergeDefaults(DEFAULT_GENERATION_SETTINGS.detailer, settings.detailer || {});
+    const { backdrop, body, actions } = createDialog(
+      "Detailer Settings",
+      "SAM3 detection and Impact detailer settings are saved with the node."
+    );
+    body.classList.add("easyuse-anima-aio-one-column");
+    const main = document.createElement("section");
+    main.className = "easyuse-anima-aio-section full";
+    main.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Detailer") }));
+    const enabled = field(main, "Enable detailer", checkbox(detailer.enabled));
+    const checkpoint = field(main, "SAM3 checkpoint", textInput(detailer.sam3.checkpoint));
+    const dependencyWarning = document.createElement("div");
+    dependencyWarning.className = "easyuse-anima-aio-warning";
+    dependencyWarning.hidden = true;
+    main.append(dependencyWarning);
+    body.append(main);
+
+    const currentOrder = normalizeDetailerOrder(detailer.order, detailer);
+    let activeTargetName = currentOrder[0] || "face";
+    const tabsSection = document.createElement("section");
+    tabsSection.className = "easyuse-anima-aio-section full";
+    tabsSection.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Detailer Blocks") }));
+    const addBlock = document.createElement("button");
+    addBlock.type = "button";
+    addBlock.className = "easyuse-anima-aio-add-row";
+    addBlock.textContent = aioText("button.addDetailerBlock");
+    applyTooltip(addBlock, "tip.addDetailerBlock");
+    const tabBar = document.createElement("div");
+    tabBar.className = "easyuse-anima-aio-tabs";
+    const tabPanel = document.createElement("div");
+    tabPanel.className = "easyuse-anima-aio-tab-panel";
+    tabsSection.append(addBlock, tabBar, tabPanel);
+    body.append(tabsSection);
+
+    let editors = {};
+    const createEditor = (targetName, values = null) => {
+      const defaults = detailerTargetDefaults(targetName);
+      const targetValues = mergeDefaults(defaults, values || detailer[targetName] || {});
+      return createDetailerTargetEditor(
+        node,
+        detailerTargetTitle(targetName, targetValues),
+        targetValues,
+        defaults,
+        renderDetailerTabs,
+      );
+    };
+    const moveTarget = (targetName, delta) => {
+      const index = currentOrder.indexOf(targetName);
+      const nextIndex = index + delta;
+      if (index < 0 || nextIndex < 0 || nextIndex >= currentOrder.length) {
+        return;
+      }
+      [currentOrder[index], currentOrder[nextIndex]] = [currentOrder[nextIndex], currentOrder[index]];
+      renderDetailerTabs();
+    };
+    const selectTarget = (targetName) => {
+      activeTargetName = targetName;
+      renderDetailerTabs();
+    };
+    const removeTarget = (targetName) => {
+      if (!isCustomDetailerTargetName(targetName)) {
+        return;
+      }
+      const index = currentOrder.indexOf(targetName);
+      if (index < 0) {
+        return;
+      }
+      currentOrder.splice(index, 1);
+      delete editors[targetName];
+      if (activeTargetName === targetName) {
+        activeTargetName = currentOrder[Math.min(index, currentOrder.length - 1)] || "face";
+      }
+      renderDetailerTabs();
+    };
+    const addTarget = () => {
+      const targetName = nextDetailerTargetName(currentOrder, detailer);
+      const defaults = detailerTargetDefaults(targetName);
+      const targetValues = {
+        ...defaults,
+        enabled: true,
+      };
+      currentOrder.push(targetName);
+      editors[targetName] = createEditor(targetName, targetValues);
+      activeTargetName = targetName;
+      renderDetailerTabs();
+    };
+    addBlock.addEventListener("click", addTarget);
+    function renderDetailerTabs() {
+      tabBar.replaceChildren();
+      for (const [index, targetName] of currentOrder.entries()) {
+        const editor = editors[targetName];
+        if (!editor) {
+          continue;
+        }
+        const tab = document.createElement("div");
+        tab.className = "easyuse-anima-aio-tab";
+        tab.classList.toggle("active", targetName === activeTargetName);
+        tab.tabIndex = 0;
+        tab.setAttribute("role", "button");
+        tab.setAttribute("aria-selected", targetName === activeTargetName ? "true" : "false");
+        applyTooltip(tab, "tip.detailerBlock");
+        const label = document.createElement("span");
+        label.className = "easyuse-anima-aio-tab-label";
+        label.textContent = editor.label();
+        const tools = document.createElement("span");
+        tools.className = "easyuse-anima-aio-tab-tools";
+        const moveLeft = document.createElement("button");
+        moveLeft.type = "button";
+        moveLeft.textContent = "<";
+        moveLeft.disabled = index === 0;
+        applyTooltip(moveLeft, "tip.detailerOrder");
+        const moveRight = document.createElement("button");
+        moveRight.type = "button";
+        moveRight.textContent = ">";
+        moveRight.disabled = index === currentOrder.length - 1;
+        applyTooltip(moveRight, "tip.detailerOrder");
+        moveLeft.addEventListener("click", (event) => {
+          event.stopPropagation();
+          moveTarget(targetName, -1);
+        });
+        moveRight.addEventListener("click", (event) => {
+          event.stopPropagation();
+          moveTarget(targetName, 1);
+        });
+        const remove = document.createElement("button");
+        remove.type = "button";
+        remove.textContent = "x";
+        remove.disabled = !isCustomDetailerTargetName(targetName);
+        applyTooltip(remove, "button.remove");
+        remove.addEventListener("click", (event) => {
+          event.stopPropagation();
+          removeTarget(targetName);
+        });
+        tools.append(moveLeft, moveRight, remove);
+        tab.append(label, tools);
+        tab.addEventListener("click", () => selectTarget(targetName));
+        tab.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            selectTarget(targetName);
+          }
+        });
+        tabBar.append(tab);
+      }
+      if (!editors[activeTargetName]) {
+        activeTargetName = currentOrder[0] || "face";
+      }
+      tabPanel.replaceChildren(editors[activeTargetName]?.section || document.createElement("div"));
+    }
+    editors = Object.fromEntries(currentOrder.map((targetName) => [targetName, createEditor(targetName)]));
+    renderDetailerTabs();
+    const refreshDetailerDependencyLocks = () => {
+      const missingPacks = [];
+      if (!optionalDependencyAvailable("impactDetailer")) {
+        missingPacks.push(optionalDependencyPack("impactDetailer"));
+      }
+      if (!optionalDependencyAvailable("impactMaskToSegs")) {
+        missingPacks.push(optionalDependencyPack("impactMaskToSegs"));
+      }
+      const missing = missingPacks.length > 0;
+      enabled.disabled = missing;
+      if (missing && enabled.checked) {
+        enabled.checked = false;
+      }
+      dependencyWarning.hidden = !missing;
+      dependencyWarning.textContent = missing
+        ? aioFormat("warning.optionalDependencyMissing", {
+            backend: "Detailer",
+            pack: [...new Set(missingPacks)].join(", "),
+          })
+        : "";
+    };
+    refreshDetailerDependencyLocks();
+    loadGeneratorOptionalDependencies().then(refreshDetailerDependencyLocks);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = aioText("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = aioText("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
+      const detailerEnabled = enabled.checked && !enabled.disabled;
+      const nextDetailer = {
+        ...next.detailer,
+        enabled: detailerEnabled,
+        sam3: {
+          context: "load_checkpoint",
+          checkpoint: checkpoint.value || "sam3.1_multiplex_fp16.safetensors",
+        },
+      };
+      for (const targetName of Object.keys(nextDetailer)) {
+        if (isCustomDetailerTargetName(targetName)) {
+          delete nextDetailer[targetName];
+        }
+      }
+      for (const targetName of currentOrder) {
+        const editor = editors[targetName];
+        if (!editor) {
+          continue;
+        }
+        const values = editor.values();
+        if (!detailerEnabled) {
+          values.enabled = false;
+        }
+        nextDetailer[targetName] = values;
+      }
+      nextDetailer.order = normalizeDetailerOrder(currentOrder, nextDetailer);
+      next.detailer = nextDetailer;
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  }
+
+  return openDetailerSettings;
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -20,6 +20,7 @@ import { createAioProfileApiClient } from "./aio/profile_api_client.js";
 import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
 import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
 import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
+import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -4311,350 +4312,6 @@ function openSamplerSettings(node) {
   });
 }
 
-function createDetailerTargetEditor(node, title, values, defaults, onLabelChange = null) {
-  const target = mergeDefaults(defaults, values || {});
-  const section = document.createElement("section");
-  section.className = "easyuse-anima-aio-detailer-target-panel";
-  const header = document.createElement("div");
-  header.className = "easyuse-anima-aio-node-stage-mini-header";
-  header.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText(title) }));
-  section.append(header);
-  const labelInput = field(
-    section,
-    "Block name",
-    textInput(target.label || defaults.label || title),
-    "tip.detailerName",
-  );
-  labelInput.addEventListener("input", () => onLabelChange?.());
-  const enabled = field(section, "Enable", checkbox(target.enabled));
-
-  const detect = document.createElement("div");
-  detect.className = "easyuse-anima-aio-subsection";
-  detect.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("SAM3 Detect") }));
-  const detectPrompt = field(detect, "Prompt", textInput(target.detect_prompt));
-  const detectCount = field(detect, "Count", numberInput(target.detect_count, "1"));
-  const threshold = field(detect, "Threshold", numberInput(target.threshold, "0.01"));
-  const refine = field(detect, "Refine", numberInput(target.refine_iterations, "1"));
-  const individual = field(detect, "Individual", checkbox(target.individual_masks));
-  const combined = field(detect, "Combined", checkbox(target.combined));
-  section.append(detect);
-
-  const segs = document.createElement("div");
-  segs.className = "easyuse-anima-aio-subsection";
-  segs.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("MaskToSEGS") }));
-  const cropFactor = field(segs, "Crop factor", numberInput(target.crop_factor, "0.1"));
-  const bboxFill = field(segs, "BBox fill", checkbox(target.bbox_fill));
-  const dropSize = field(segs, "Drop size", numberInput(target.drop_size, "1"));
-  const contourFill = field(segs, "Contour fill", checkbox(target.contour_fill));
-  section.append(segs);
-
-  const detail = document.createElement("div");
-  detail.className = "easyuse-anima-aio-subsection";
-  detail.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("Impact Detailer") }));
-  const guideSize = field(detail, "Guide size", numberInput(target.guide_size, "8"));
-  const maxSize = field(detail, "Max size", numberInput(target.max_size, "8"));
-  const steps = field(detail, "Steps", numberInput(target.steps, "1"));
-  steps.min = "1";
-  steps.max = "75";
-  const inheritSampler = field(
-    detail,
-    "Follow main sampler",
-    checkbox(target.inherit_sampler_settings),
-    "tip.detailerFollow",
-  );
-  const cfg = field(detail, "CFG", numberInput(target.cfg, "0.1"));
-  cfg.min = "1";
-  cfg.max = "10";
-  const samplerName = field(detail, "Sampler", selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), target.sampler_name));
-  const scheduler = field(detail, "Scheduler", selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), target.scheduler));
-  const denoise = field(detail, "Denoise", numberInput(target.denoise, "0.01"));
-  const feather = field(detail, "Feather", numberInput(target.feather, "1"));
-  const noiseMask = field(detail, "Noise mask", checkbox(target.noise_mask));
-  const forceInpaint = field(detail, "Force inpaint", checkbox(target.force_inpaint));
-  const noiseMaskFeather = field(detail, "Mask feather", numberInput(target.noise_mask_feather, "1"));
-  const cycle = field(detail, "Cycle", numberInput(target.cycle, "1"));
-  const alignment = field(detail, "Alignment", selectInput(["impact", "none", "32", "64"], target.alignment || "32"));
-  const optimization = createStageOptimizationEditor(`${title} Optimization`, target, defaults);
-  const updateInheritedRows = () => {
-    const display = inheritSampler.checked ? "none" : "";
-    for (const control of [cfg, samplerName, scheduler]) {
-      if (control?.parentElement) {
-        control.parentElement.style.display = display;
-      }
-    }
-  };
-  inheritSampler.addEventListener("change", updateInheritedRows);
-  updateInheritedRows();
-  section.append(detail);
-
-  section.append(optimization.section);
-
-  return {
-    section,
-    label() {
-      return String(labelInput.value || defaults.label || title).trim() || title;
-    },
-    values() {
-      const optimized = optimization.values();
-      return {
-        ...target,
-        label: String(labelInput.value || defaults.label || title).trim() || title,
-        enabled: enabled.checked,
-        detect_prompt: detectPrompt.value || defaults.detect_prompt,
-        detect_count: Number(detectCount.value || defaults.detect_count),
-        threshold: Number(threshold.value || defaults.threshold),
-        refine_iterations: Number(refine.value || defaults.refine_iterations),
-        individual_masks: individual.checked,
-        combined: combined.checked,
-        crop_factor: Number(cropFactor.value || defaults.crop_factor),
-        bbox_fill: bboxFill.checked,
-        drop_size: Number(dropSize.value || defaults.drop_size),
-        contour_fill: contourFill.checked,
-        guide_size: Number(guideSize.value || defaults.guide_size),
-        guide_size_for: false,
-        max_size: Number(maxSize.value || defaults.max_size),
-        steps: Math.trunc(clampGeneratorNumber(steps.value, defaults.steps, 1, 75)),
-        inherit_sampler_settings: inheritSampler.checked,
-        cfg: clampGeneratorNumber(cfg.value, defaults.cfg, 1, 10),
-        sampler_name: samplerName.value || defaults.sampler_name,
-        scheduler: scheduler.value || defaults.scheduler,
-        denoise: clampGeneratorNumber(denoise.value, defaults.denoise, 0, 1),
-        feather: Number(feather.value || defaults.feather),
-        noise_mask: noiseMask.checked,
-        force_inpaint: forceInpaint.checked,
-        wildcard: target.wildcard || "",
-        cycle: Number(cycle.value || defaults.cycle),
-        alignment: alignment.value || "32",
-        inpaint_model: false,
-        noise_mask_feather: Number(noiseMaskFeather.value || defaults.noise_mask_feather || 0),
-        tiled_encode: false,
-        tiled_decode: false,
-        ...optimized,
-      };
-    },
-  };
-}
-
-function openDetailerSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = generatorSettings(node);
-  const detailer = mergeDefaults(DEFAULT_GENERATION_SETTINGS.detailer, settings.detailer || {});
-  const { backdrop, body, actions } = createDialog(
-    "Detailer Settings",
-    "SAM3 detection and Impact detailer settings are saved with the node."
-  );
-  body.classList.add("easyuse-anima-aio-one-column");
-  const main = document.createElement("section");
-  main.className = "easyuse-anima-aio-section full";
-  main.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Detailer") }));
-  const enabled = field(main, "Enable detailer", checkbox(detailer.enabled));
-  const checkpoint = field(main, "SAM3 checkpoint", textInput(detailer.sam3.checkpoint));
-  const dependencyWarning = document.createElement("div");
-  dependencyWarning.className = "easyuse-anima-aio-warning";
-  dependencyWarning.hidden = true;
-  main.append(dependencyWarning);
-  body.append(main);
-
-  const currentOrder = normalizeDetailerOrder(detailer.order, detailer);
-  let activeTargetName = currentOrder[0] || "face";
-  const tabsSection = document.createElement("section");
-  tabsSection.className = "easyuse-anima-aio-section full";
-  tabsSection.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Detailer Blocks") }));
-  const addBlock = document.createElement("button");
-  addBlock.type = "button";
-  addBlock.className = "easyuse-anima-aio-add-row";
-  addBlock.textContent = aioText("button.addDetailerBlock");
-  applyTooltip(addBlock, "tip.addDetailerBlock");
-  const tabBar = document.createElement("div");
-  tabBar.className = "easyuse-anima-aio-tabs";
-  const tabPanel = document.createElement("div");
-  tabPanel.className = "easyuse-anima-aio-tab-panel";
-  tabsSection.append(addBlock, tabBar, tabPanel);
-  body.append(tabsSection);
-
-  let editors = {};
-  const createEditor = (targetName, values = null) => {
-    const defaults = detailerTargetDefaults(targetName);
-    const targetValues = mergeDefaults(defaults, values || detailer[targetName] || {});
-    return createDetailerTargetEditor(
-      node,
-      detailerTargetTitle(targetName, targetValues),
-      targetValues,
-      defaults,
-      renderDetailerTabs,
-    );
-  };
-  const moveTarget = (targetName, delta) => {
-    const index = currentOrder.indexOf(targetName);
-    const nextIndex = index + delta;
-    if (index < 0 || nextIndex < 0 || nextIndex >= currentOrder.length) {
-      return;
-    }
-    [currentOrder[index], currentOrder[nextIndex]] = [currentOrder[nextIndex], currentOrder[index]];
-    renderDetailerTabs();
-  };
-  const selectTarget = (targetName) => {
-    activeTargetName = targetName;
-    renderDetailerTabs();
-  };
-  const removeTarget = (targetName) => {
-    if (!isCustomDetailerTargetName(targetName)) {
-      return;
-    }
-    const index = currentOrder.indexOf(targetName);
-    if (index < 0) {
-      return;
-    }
-    currentOrder.splice(index, 1);
-    delete editors[targetName];
-    if (activeTargetName === targetName) {
-      activeTargetName = currentOrder[Math.min(index, currentOrder.length - 1)] || "face";
-    }
-    renderDetailerTabs();
-  };
-  const addTarget = () => {
-    const targetName = nextDetailerTargetName(currentOrder, detailer);
-    const defaults = detailerTargetDefaults(targetName);
-    const targetValues = {
-      ...defaults,
-      enabled: true,
-    };
-    currentOrder.push(targetName);
-    editors[targetName] = createEditor(targetName, targetValues);
-    activeTargetName = targetName;
-    renderDetailerTabs();
-  };
-  addBlock.addEventListener("click", addTarget);
-  function renderDetailerTabs() {
-    tabBar.replaceChildren();
-    for (const [index, targetName] of currentOrder.entries()) {
-      const editor = editors[targetName];
-      if (!editor) {
-        continue;
-      }
-      const tab = document.createElement("div");
-      tab.className = "easyuse-anima-aio-tab";
-      tab.classList.toggle("active", targetName === activeTargetName);
-      tab.tabIndex = 0;
-      tab.setAttribute("role", "button");
-      tab.setAttribute("aria-selected", targetName === activeTargetName ? "true" : "false");
-      applyTooltip(tab, "tip.detailerBlock");
-      const label = document.createElement("span");
-      label.className = "easyuse-anima-aio-tab-label";
-      label.textContent = editor.label();
-      const tools = document.createElement("span");
-      tools.className = "easyuse-anima-aio-tab-tools";
-      const moveLeft = document.createElement("button");
-      moveLeft.type = "button";
-      moveLeft.textContent = "<";
-      moveLeft.disabled = index === 0;
-      applyTooltip(moveLeft, "tip.detailerOrder");
-      const moveRight = document.createElement("button");
-      moveRight.type = "button";
-      moveRight.textContent = ">";
-      moveRight.disabled = index === currentOrder.length - 1;
-      applyTooltip(moveRight, "tip.detailerOrder");
-      moveLeft.addEventListener("click", (event) => {
-        event.stopPropagation();
-        moveTarget(targetName, -1);
-      });
-      moveRight.addEventListener("click", (event) => {
-        event.stopPropagation();
-        moveTarget(targetName, 1);
-      });
-      const remove = document.createElement("button");
-      remove.type = "button";
-      remove.textContent = "x";
-      remove.disabled = !isCustomDetailerTargetName(targetName);
-      applyTooltip(remove, "button.remove");
-      remove.addEventListener("click", (event) => {
-        event.stopPropagation();
-        removeTarget(targetName);
-      });
-      tools.append(moveLeft, moveRight, remove);
-      tab.append(label, tools);
-      tab.addEventListener("click", () => selectTarget(targetName));
-      tab.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          selectTarget(targetName);
-        }
-      });
-      tabBar.append(tab);
-    }
-    if (!editors[activeTargetName]) {
-      activeTargetName = currentOrder[0] || "face";
-    }
-    tabPanel.replaceChildren(editors[activeTargetName]?.section || document.createElement("div"));
-  }
-  editors = Object.fromEntries(currentOrder.map((targetName) => [targetName, createEditor(targetName)]));
-  renderDetailerTabs();
-  const refreshDetailerDependencyLocks = () => {
-    const missingPacks = [];
-    if (!optionalDependencyAvailable("impactDetailer")) {
-      missingPacks.push(optionalDependencyPack("impactDetailer"));
-    }
-    if (!optionalDependencyAvailable("impactMaskToSegs")) {
-      missingPacks.push(optionalDependencyPack("impactMaskToSegs"));
-    }
-    const missing = missingPacks.length > 0;
-    enabled.disabled = missing;
-    if (missing && enabled.checked) {
-      enabled.checked = false;
-    }
-    dependencyWarning.hidden = !missing;
-    dependencyWarning.textContent = missing
-      ? aioFormat("warning.optionalDependencyMissing", {
-          backend: "Detailer",
-          pack: [...new Set(missingPacks)].join(", "),
-        })
-      : "";
-  };
-  refreshDetailerDependencyLocks();
-  loadGeneratorOptionalDependencies().then(refreshDetailerDependencyLocks);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    const detailerEnabled = enabled.checked && !enabled.disabled;
-    const nextDetailer = {
-      ...next.detailer,
-      enabled: detailerEnabled,
-      sam3: {
-        context: "load_checkpoint",
-        checkpoint: checkpoint.value || "sam3.1_multiplex_fp16.safetensors",
-      },
-    };
-    for (const targetName of Object.keys(nextDetailer)) {
-      if (isCustomDetailerTargetName(targetName)) {
-        delete nextDetailer[targetName];
-      }
-    }
-    for (const targetName of currentOrder) {
-      const editor = editors[targetName];
-      if (!editor) {
-        continue;
-      }
-      const values = editor.values();
-      if (!detailerEnabled) {
-        values.enabled = false;
-      }
-      nextDetailer[targetName] = values;
-    }
-    nextDetailer.order = normalizeDetailerOrder(currentOrder, nextDetailer);
-    next.detailer = nextDetailer;
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
-
 function normalizeImageSaverHashBundles(value) {
   if (typeof value === "string") {
     try {
@@ -5551,6 +5208,50 @@ const {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
     upscaleBackendMissingPacks,
+    load: loadGeneratorOptionalDependencies,
+  },
+});
+
+const openDetailerSettings = aioCreateDetailerSettingsDialog({
+  document,
+  controls: {
+    createDialog,
+    field,
+    checkbox,
+    textInput,
+    numberInput,
+    selectInput,
+  },
+  text: {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+    applyTooltip,
+  },
+  settingsCore: {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    clampNumber: clampGeneratorNumber,
+    normalizeDetailerOrder,
+    isCustomDetailerTargetName,
+    nextDetailerTargetName,
+    detailerTargetDefaults,
+    detailerTargetTitle,
+  },
+  stageOptimizationEditor: createStageOptimizationEditor,
+  nodeAdapter: {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
+    widgetOptions,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  },
+  dependencyAdapter: {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
     load: loadGeneratorOptionalDependencies,
   },
 });


### PR DESCRIPTION
## 변경 요약

- AiO Detailer 대상 편집기와 설정 대화상자 lifecycle을 `web/js/aio/detailer_settings_dialog.js`의 단일 factory 경계로 분리했습니다.
- 기존 stage optimization editor는 주입 adapter로 재사용하며, entry는 composition과 generator panel action 연결만 담당합니다.
- 공용 Fake DOM harness 기반 Detailer smoke를 추가해 탭 순서, custom block lifecycle, dependency lock, Cancel/Apply 직렬화를 검증합니다.
- 사용자 동작은 변경하지 않는 기계적 추출입니다.

## 주요 파일

- `web/js/aio/detailer_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_detailer_settings_dialog_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- focused Detailer smoke: 통과
- 관련 Python source/ownership tests: 66개 통과
- JavaScript syntax 검사: 통과
- TypeScript 6.0.3: 통과
- official full runner: Python 365 tests, frontend 90 JavaScript files 통과
- `git diff --check`: 통과
- 행동 보존 / 아키텍처·DI / 테스트 적정성 3중 감사: Blocker, P2, P3 없음

## ComfyUI 표면

- ComfyUI Codex test surface: official full project validation
- Legacy canvas / Node 2.0 browser smoke: 미실행 (동작 변경 없는 lifecycle extraction)
- ComfyUI v0.27.0 user instance: 전체 유지보수 완료 후 최종 수동 확인 예정

## 위험 및 후속

- 이 PR은 Issue #54의 Detailer lifecycle 경계 조각이며 Issue #54 전체를 닫지 않습니다.
- 실제 UI 동작 변경은 별도 PR과 dual-canvas browser smoke로 검증합니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`