### PR TITLE
refactor: AiO Sampler 설정 dialog lifecycle 분리

### DIFF
--- a/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
@@ -1,0 +1,797 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+  descendants,
+} from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function find(root, predicate) {
+  return [root, ...descendants(root)].find(predicate) || null;
+}
+
+function findAll(root, predicate) {
+  return [root, ...descendants(root)].filter(predicate);
+}
+
+function findByText(root, textContent) {
+  return find(root, (element) => element.textContent === textContent);
+}
+
+function sectionByHeading(dialog, heading) {
+  const title = findByText(dialog.body, `static:${heading}`);
+  assert.ok(title?.parentElement, `missing section: ${heading}`);
+  return title.parentElement;
+}
+
+function rowByLabel(root, label, index = 0) {
+  return findAll(root, (element) => element.getAttribute?.("data-test-label") === label)[index] || null;
+}
+
+function controlIn(root, label, index = 0) {
+  const row = rowByLabel(root, label, index);
+  assert.ok(row, `missing field row: ${label}[${index}]`);
+  assert.ok(row.children[0], `missing field control: ${label}[${index}]`);
+  return row.children[0];
+}
+
+function action(dialog, key) {
+  const button = findByText(dialog.actions, `text:${key}`);
+  assert.ok(button, `missing action: ${key}`);
+  return button;
+}
+
+function warningIn(dialog) {
+  const warning = find(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-warning"));
+  assert.ok(warning, "missing dependency warning");
+  return warning;
+}
+
+function setSelectValue(select, value) {
+  select.value = String(value);
+  for (const option of select.options || []) {
+    option.selected = option.value === select.value;
+  }
+}
+
+function assertBackendVisibility(dialog, backendValue) {
+  const spectrum = sectionByHeading(dialog, "Spectrum Patch / Advanced Sampler");
+  const spd = sectionByHeading(dialog, "Spectrum + SPD / SPEED");
+  const modGuidance = sectionByHeading(dialog, "Mod Guidance");
+  const modAdvanced = rowByLabel(modGuidance, "Adapter")?.parentElement;
+  assert.ok(modAdvanced, "missing Mod Guidance advanced container");
+  const isComfy = backendValue === "comfy_ksampler";
+  const isAdvanced = backendValue === "spectrum_mod_guidance_advanced";
+  assert.equal(spectrum.classList.contains("hidden"), !(isComfy || isAdvanced));
+  assert.equal(rowByLabel(spectrum, "Use Spectrum patch").style.display, isComfy ? "" : "none");
+  assert.equal(rowByLabel(spectrum, "Compat policy").style.display, isComfy ? "" : "none");
+  assert.equal(modAdvanced.style.display, isAdvanced ? "" : "none");
+  assert.equal(spd.classList.contains("hidden"), backendValue !== "spectrum_spd_speed");
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const samplerDialogModule = await import(dataModule("../web/js/aio/sampler_settings_dialog.js"));
+const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+assert.deepEqual(
+  Object.keys(samplerDialogModule),
+  ["aioCreateSamplerSettingsDialog"],
+  "Sampler settings dialog must expose only its lifecycle factory",
+);
+
+function createFixture({
+  settings = {},
+  available = {},
+  loaded = true,
+  nodeInputs = {},
+  supported = {},
+  deferLoads = false,
+} = {}) {
+  let dependencyCalls = 0;
+  let currentDialog = null;
+  const trace = [];
+  const dialogs = [];
+  const loadCalls = [];
+  const loadResolvers = [];
+  const parseCalls = [];
+  const mergeVisibleCalls = [];
+  const optionCalls = [];
+  const supportedCalls = [];
+  const writes = [];
+  const renders = [];
+  const applyVisibleCalls = [];
+  const document = createFakeDocument();
+  const availabilityState = { ...available };
+  const supportedState = clone(supported);
+  const nodeInputMaps = clone(nodeInputs);
+  const dependencyState = { loaded: !!loaded };
+  const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
+  const node = {
+    settings: settingsModule.aioMergeDefaults(defaultSettings, settings),
+    visible: {},
+    widgets: [{ name: "generation_settings", value: "" }],
+  };
+  node.widgets[0].value = JSON.stringify(node.settings);
+
+  function createDialog(title, subtitle) {
+    dependencyCalls += 1;
+    const dialog = {
+      title,
+      subtitle,
+      backdrop: document.createElement("div"),
+      body: document.createElement("div"),
+      actions: document.createElement("div"),
+      trace: [],
+    };
+    dialog.backdrop.remove = () => {
+      dialog.backdrop.removed = true;
+      dialog.trace.push("remove");
+      trace.push("remove");
+    };
+    dialogs.push(dialog);
+    currentDialog = dialog;
+    return dialog;
+  }
+
+  function field(section, label, element, tooltipKey = "") {
+    dependencyCalls += 1;
+    const row = document.createElement("label");
+    row.className = "easyuse-anima-aio-field";
+    row.setAttribute("data-test-label", label);
+    row.setAttribute("data-test-tooltip", tooltipKey);
+    row.append(element);
+    section.append(row);
+    return element;
+  }
+
+  function numberInput(value, step = "1") {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "number";
+    input.step = step;
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function textInput(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function checkbox(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = !!value;
+    return input;
+  }
+
+  function selectInput(options, value) {
+    dependencyCalls += 1;
+    const select = document.createElement("select");
+    select.options = [];
+    for (const optionSpec of options) {
+      const option = document.createElement("option");
+      option.value = typeof optionSpec === "object"
+        ? String(optionSpec.value ?? "")
+        : String(optionSpec ?? "");
+      option.textContent = typeof optionSpec === "object"
+        ? String(optionSpec.label ?? option.value)
+        : option.value;
+      option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
+      option.selected = option.value === String(value ?? "");
+      select.options.push(option);
+      select.append(option);
+    }
+    if (!select.options.some((option) => option.selected)) {
+      select.value = String(value ?? "");
+    }
+    return select;
+  }
+
+  function nodeInputControlForSpec(spec, current) {
+    dependencyCalls += 1;
+    if (!Array.isArray(spec)) {
+      return null;
+    }
+    const type = spec[0];
+    const options = spec[1] && typeof spec[1] === "object" ? spec[1] : {};
+    const value = current ?? (Object.hasOwn(options, "default") ? options.default : undefined);
+    if (Array.isArray(type)) {
+      return selectInput(type, value ?? type[0] ?? "");
+    }
+    const normalized = String(type || "").toUpperCase();
+    if (normalized === "BOOLEAN") {
+      return checkbox(value ?? false);
+    }
+    if (normalized === "INT") {
+      return numberInput(value ?? 0, "1");
+    }
+    if (normalized === "FLOAT") {
+      return numberInput(value ?? 0, "0.01");
+    }
+    if (normalized === "STRING") {
+      return textInput(value ?? "");
+    }
+    return null;
+  }
+
+  function valueFromNodeInputControl(control) {
+    dependencyCalls += 1;
+    if (!control) {
+      return null;
+    }
+    if (control.type === "checkbox") {
+      return !!control.checked;
+    }
+    if (control.type === "number") {
+      return Number(control.value || 0);
+    }
+    return control.value;
+  }
+
+  function staticText(value) {
+    dependencyCalls += 1;
+    return `static:${value}`;
+  }
+
+  function text(key) {
+    dependencyCalls += 1;
+    return `text:${key}`;
+  }
+
+  function format(key, values = {}) {
+    dependencyCalls += 1;
+    return `format:${key}:${JSON.stringify(values)}`;
+  }
+
+  function applyTooltipText(element, value) {
+    dependencyCalls += 1;
+    element.title = String(value || "");
+    return element;
+  }
+
+  function mergeDefaults(defaults, current) {
+    dependencyCalls += 1;
+    currentDialog?.trace.push("merge");
+    return settingsModule.aioMergeDefaults(defaults, current);
+  }
+
+  function clampNumber(value, fallback, min, max) {
+    dependencyCalls += 1;
+    const parsed = Number(value);
+    const next = Number.isFinite(parsed) ? parsed : fallback;
+    return Math.max(min, Math.min(max, next));
+  }
+
+  function findWidget(targetNode, name) {
+    dependencyCalls += 1;
+    return targetNode.widgets?.find((widget) => widget.name === name);
+  }
+
+  function parseSettings(widget, defaults) {
+    dependencyCalls += 1;
+    parseCalls.push({ widget, defaults });
+    let current = {};
+    try {
+      current = JSON.parse(widget?.value || "{}");
+    } catch (_error) {
+      current = {};
+    }
+    return settingsModule.aioMergeDefaults(defaults, current);
+  }
+
+  function mergeVisibleSettings(targetNode, parsed) {
+    dependencyCalls += 1;
+    mergeVisibleCalls.push({ node: targetNode, parsed: clone(parsed) });
+    const next = clone(parsed);
+    Object.assign(next.sampler, targetNode.visible || {});
+    return next;
+  }
+
+  function widgetOptions(_targetNode, name, fallback) {
+    dependencyCalls += 1;
+    optionCalls.push(name);
+    return [...new Set([...fallback, name === "sampler_name" ? "custom_sampler" : "custom_scheduler"])];
+  }
+
+  function applyVisibleSettings(targetNode, nextSettings) {
+    dependencyCalls += 1;
+    const snapshot = clone(nextSettings);
+    targetNode.visible = {
+      seed: snapshot.sampler.seed,
+      steps: snapshot.sampler.steps,
+      cfg: snapshot.sampler.cfg,
+      sampler_name: snapshot.sampler.sampler_name,
+      scheduler: snapshot.sampler.scheduler,
+      denoise: snapshot.sampler.denoise,
+    };
+    applyVisibleCalls.push(snapshot);
+    currentDialog.trace.push("apply-visible");
+    trace.push("apply-visible");
+  }
+
+  function writeSettings(targetNode, widget, nextSettings) {
+    dependencyCalls += 1;
+    const snapshot = clone(nextSettings);
+    targetNode.settings = snapshot;
+    widget.value = JSON.stringify(snapshot);
+    writes.push(snapshot);
+    currentDialog.trace.push("write");
+    trace.push("write");
+  }
+
+  function renderPanel(targetNode) {
+    dependencyCalls += 1;
+    renders.push(targetNode);
+    currentDialog.trace.push("render");
+    trace.push("render");
+  }
+
+  const openSamplerSettings = samplerDialogModule.aioCreateSamplerSettingsDialog({
+    document,
+    controls: {
+      createDialog,
+      field,
+      numberInput,
+      selectInput,
+      checkbox,
+      textInput,
+      nodeInputControlForSpec,
+      valueFromNodeInputControl,
+    },
+    text: {
+      staticText,
+      get: text,
+      format,
+      applyTooltipText,
+    },
+    settingsCore: {
+      defaultGenerationSettings: defaultSettings,
+      seedControls: settingsModule.AIO_GENERATOR_SEED_CONTROLS,
+      specialSeedRandom: settingsModule.AIO_GENERATOR_SPECIAL_SEED_RANDOM,
+      fallbackSamplerNames: ["euler", "er_sde"],
+      fallbackSchedulerNames: ["simple", "sgm_uniform"],
+      mergeDefaults,
+      normalizeSeedControl: settingsModule.aioNormalizeSeedControl,
+      normalizeSeedValue: settingsModule.aioNormalizeSeedValue,
+      clampNumber,
+    },
+    nodeAdapter: {
+      generatorSettingsWidget: "generation_settings",
+      findWidget,
+      parseSettings,
+      mergeVisibleSettings,
+      widgetOptions,
+      applyVisibleSettings,
+      writeSettings,
+      renderPanel,
+    },
+    dependencyAdapter: {
+      backendDependencies: {
+        spectrum_mod_guidance_advanced: "spectrumAdvanced",
+        spectrum_spd_speed: "spectrumSpd",
+      },
+      isLoaded() {
+        dependencyCalls += 1;
+        return dependencyState.loaded;
+      },
+      available(key) {
+        dependencyCalls += 1;
+        return Object.hasOwn(availabilityState, key) ? !!availabilityState[key] : true;
+      },
+      pack(key) {
+        dependencyCalls += 1;
+        return `pack:${key}`;
+      },
+      nodeInputMap(key) {
+        dependencyCalls += 1;
+        return nodeInputMaps[key] || {};
+      },
+      nodeInputTooltip(key, inputName) {
+        dependencyCalls += 1;
+        const spec = nodeInputMaps[key]?.[inputName];
+        const options = Array.isArray(spec) && spec[1] && typeof spec[1] === "object" ? spec[1] : {};
+        return String(options.tooltip || `tooltip:${key}:${inputName}`);
+      },
+      nodeInputSupported(key, inputName) {
+        dependencyCalls += 1;
+        supportedCalls.push({ key, inputName });
+        if (Object.hasOwn(supportedState[key] || {}, inputName)) {
+          return !!supportedState[key][inputName];
+        }
+        return !Object.hasOwn(availabilityState, key) || !!availabilityState[key];
+      },
+      load(options) {
+        dependencyCalls += 1;
+        loadCalls.push(options);
+        if (!deferLoads) {
+          return Promise.resolve(dependencyState);
+        }
+        return new Promise((resolve) => loadResolvers.push(resolve));
+      },
+    },
+  });
+
+  return {
+    openSamplerSettings,
+    document,
+    node,
+    defaultSettings,
+    dialogs,
+    loadCalls,
+    parseCalls,
+    mergeVisibleCalls,
+    optionCalls,
+    supportedCalls,
+    writes,
+    renders,
+    applyVisibleCalls,
+    trace,
+    availabilityState,
+    dependencyState,
+    nodeInputMaps,
+    dependencyCallCount: () => dependencyCalls,
+    resolveLoads() {
+      for (const resolve of loadResolvers.splice(0)) {
+        resolve(dependencyState);
+      }
+    },
+  };
+}
+
+{
+  const fixture = createFixture({
+    deferLoads: true,
+    settings: {
+      sampler: {
+        backend: "spectrum_mod_guidance_advanced",
+        seed: 1234,
+        seed_after_generate: "increment",
+        steps: 47,
+        cfg: 6.5,
+        sampler_name: "custom_sampler",
+        scheduler: "custom_scheduler",
+        denoise: 0.55,
+        spectrum: {
+          enabled: false,
+          window_size: 2.75,
+          compat_policy: "strict",
+        },
+        spectrum_extra: {
+          future_gain: 1.25,
+          future_mode: "quality",
+        },
+        spd_extra: {
+          future_flag: true,
+        },
+      },
+      mod_guidance: {
+        mode: "enabled",
+        profile: "uniform_w3",
+        advanced: {
+          adapter: "custom-adapter.safetensors",
+          mod_w: 4.5,
+        },
+      },
+      preserved_root_key: "cancel-keep-root",
+    },
+    nodeInputs: {
+      spectrumAdvanced: {
+        window_size: ["FLOAT", { default: 2 }],
+        future_gain: ["FLOAT", { default: 1, tooltip: "Future gain" }],
+        future_mode: [["speed", "quality"], { default: "speed" }],
+      },
+      spectrumSpd: {
+        spd_scale: ["FLOAT", { default: 0.5 }],
+        future_flag: ["BOOLEAN", { default: false }],
+      },
+    },
+  });
+  const originalSettings = clone(fixture.node.settings);
+  const originalWidget = fixture.node.widgets[0].value;
+  assert.equal(fixture.dependencyCallCount(), 0, "Factory composition must be side-effect free");
+  assert.equal(fixture.dialogs.length, 0);
+  assert.equal(fixture.loadCalls.length, 0);
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.equal(fixture.applyVisibleCalls.length, 0);
+  assert.equal(fixture.document.createdElements.length, 0, "Factory composition must not create DOM elements");
+  assert.equal(fixture.document.body.children.length, 0, "Factory composition must not attach DOM elements");
+
+  fixture.openSamplerSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  assert.equal(dialog.title, "Sampler Details");
+  assert.equal(
+    dialog.subtitle,
+    "Choose one of three sampler paths. Missing optional node packs are locked before queue execution.",
+  );
+  const base = sectionByHeading(dialog, "Base Parameters");
+  const sampler = sectionByHeading(dialog, "Sampler Backend");
+  const modGuidance = sectionByHeading(dialog, "Mod Guidance");
+  const spectrum = sectionByHeading(dialog, "Spectrum Patch / Advanced Sampler");
+  assert.equal(controlIn(base, "Seed").value, "1234");
+  assert.equal(controlIn(base, "Seed mode").value, "increment");
+  assert.equal(controlIn(base, "Steps").value, "47");
+  assert.equal(controlIn(base, "CFG").value, "6.5");
+  assert.equal(controlIn(base, "Denoise").value, "0.55");
+  assert.equal(controlIn(sampler, "Mode").value, "spectrum_mod_guidance_advanced");
+  assert.equal(controlIn(sampler, "Sampler").value, "custom_sampler");
+  assert.equal(controlIn(sampler, "Scheduler").value, "custom_scheduler");
+  assert.equal(controlIn(modGuidance, "Mode").value, "enabled");
+  assert.equal(controlIn(modGuidance, "Profile").value, "uniform_w3");
+  assert.equal(controlIn(modGuidance, "Adapter").value, "custom-adapter.safetensors");
+  assert.equal(controlIn(modGuidance, "Mod W").value, "4.5");
+  assert.equal(controlIn(spectrum, "Window size").value, "2.75");
+  assert.equal(controlIn(spectrum, "Compat policy").value, "strict");
+  assertBackendVisibility(dialog, "spectrum_mod_guidance_advanced");
+  assert.deepEqual(new Set(fixture.optionCalls), new Set(["sampler_name", "scheduler"]));
+  assert.equal(fixture.loadCalls.length, 3, "Two dynamic editors and dependency locks must refresh asynchronously");
+
+  let dynamicSpectrum = sectionByHeading(dialog, "Detected Spectrum Inputs");
+  assert.equal(dynamicSpectrum.classList.contains("hidden"), false);
+  assert.equal(rowByLabel(dynamicSpectrum, "window_size"), null, "Known inputs must not be duplicated dynamically");
+  assert.equal(controlIn(dynamicSpectrum, "future_gain").value, "1.25");
+  assert.equal(controlIn(dynamicSpectrum, "future_mode").value, "quality");
+  controlIn(dynamicSpectrum, "future_gain").value = "2.75";
+  fixture.resolveLoads();
+  await flushPromises();
+  dynamicSpectrum = sectionByHeading(dialog, "Detected Spectrum Inputs");
+  assert.equal(
+    controlIn(dynamicSpectrum, "future_gain").value,
+    "2.75",
+    "Async dynamic-editor rerender must preserve an in-progress control value",
+  );
+
+  const backend = controlIn(sampler, "Mode");
+  setSelectValue(backend, "spectrum_spd_speed");
+  backend.emit("change");
+  assertBackendVisibility(dialog, "spectrum_spd_speed");
+  const dynamicSpd = sectionByHeading(dialog, "Detected SPD Inputs");
+  assert.equal(rowByLabel(dynamicSpd, "spd_scale"), null, "Known SPD inputs must not be duplicated dynamically");
+  assert.equal(controlIn(dynamicSpd, "future_flag").checked, true);
+  controlIn(dynamicSpd, "future_flag").checked = false;
+  controlIn(base, "Seed").value = "999";
+  action(dialog, "button.cancel").emit("click");
+  assert.deepEqual(fixture.node.settings, originalSettings, "Cancel must not mutate Sampler settings");
+  assert.equal(fixture.node.widgets[0].value, originalWidget, "Cancel must not rewrite the hidden widget");
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.equal(fixture.applyVisibleCalls.length, 0);
+  assert.deepEqual(dialog.trace, ["remove"]);
+}
+
+for (const testCase of [
+  {
+    name: "advanced forces Spectrum",
+    backend: "spectrum_mod_guidance_advanced",
+    checked: false,
+    patchAvailable: true,
+    expected: true,
+  },
+  {
+    name: "Comfy enables available Spectrum patch",
+    backend: "comfy_ksampler",
+    checked: true,
+    patchAvailable: true,
+    expected: true,
+  },
+  {
+    name: "Comfy disables missing Spectrum patch",
+    backend: "comfy_ksampler",
+    checked: true,
+    patchAvailable: false,
+    expected: false,
+  },
+  {
+    name: "SPD does not serialize Spectrum patch",
+    backend: "spectrum_spd_speed",
+    checked: true,
+    patchAvailable: true,
+    expected: false,
+  },
+]) {
+  const fixture = createFixture({
+    available: {
+      spectrumAdvanced: true,
+      spectrumSpd: true,
+      spectrumPatch: testCase.patchAvailable,
+    },
+    settings: {
+      sampler: {
+        backend: testCase.backend,
+        spectrum: { enabled: testCase.checked },
+      },
+    },
+  });
+  fixture.openSamplerSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[0];
+  assertBackendVisibility(dialog, testCase.backend);
+  action(dialog, "button.apply").emit("click");
+  assert.equal(fixture.node.settings.sampler.spectrum.enabled, testCase.expected, testCase.name);
+  assert.deepEqual(dialog.trace.slice(-5), ["merge", "apply-visible", "write", "render", "remove"]);
+  assert.equal(fixture.writes.length, 1);
+  assert.equal(fixture.renders.length, 1);
+  assert.equal(fixture.applyVisibleCalls.length, 1);
+}
+
+{
+  const fixture = createFixture({
+    loaded: false,
+    deferLoads: true,
+    available: {
+      spectrumAdvanced: true,
+      spectrumSpd: true,
+      spectrumPatch: true,
+      spectrumCorrections: true,
+    },
+    settings: {
+      sampler: {
+        backend: "spectrum_mod_guidance_advanced",
+        spectrum: { enabled: true },
+        dit_corrections: { enabled: true },
+        spectrum_extra: {
+          future_gain: 1.5,
+          retired_spectrum_input: "tracked-separately",
+        },
+        spd_extra: {
+          future_variant: "single",
+          future_strength: 1.25,
+          retired_spd_input: "remove-on-render",
+        },
+        dave: { legacy: true },
+        preserved_sampler_key: "keep-sampler",
+      },
+      preserved_root_key: "keep-root",
+    },
+  });
+  fixture.openSamplerSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const base = sectionByHeading(dialog, "Base Parameters");
+  const sampler = sectionByHeading(dialog, "Sampler Backend");
+  const modGuidance = sectionByHeading(dialog, "Mod Guidance");
+  const spectrum = sectionByHeading(dialog, "Spectrum Patch / Advanced Sampler");
+  const corrections = sectionByHeading(dialog, "Spectrum Advanced Corrections");
+  const spd = sectionByHeading(dialog, "Spectrum + SPD / SPEED");
+  const backend = controlIn(sampler, "Mode");
+  const advancedOption = backend.options.find((option) => option.value === "spectrum_mod_guidance_advanced");
+  assert.equal(backend.value, "spectrum_mod_guidance_advanced");
+  assert.equal(advancedOption.disabled, false);
+  assert.equal(controlIn(spectrum, "Use Spectrum patch").checked, true);
+  assert.equal(controlIn(corrections, "Use corrections").checked, true);
+  assert.equal(sectionByHeading(dialog, "Detected Spectrum Inputs").classList.contains("hidden"), true);
+  assert.equal(sectionByHeading(dialog, "Detected SPD Inputs").classList.contains("hidden"), true);
+
+  fixture.availabilityState.spectrumAdvanced = false;
+  fixture.availabilityState.spectrumPatch = false;
+  fixture.dependencyState.loaded = true;
+  fixture.nodeInputMaps.spectrumAdvanced = {
+    window_size: ["FLOAT", { default: 2 }],
+    future_gain: ["FLOAT", { default: 1, tooltip: "Future gain" }],
+  };
+  fixture.nodeInputMaps.spectrumSpd = {
+    spd_scale: ["FLOAT", { default: 0.5 }],
+    future_variant: [["single", "dual"], { default: "single", tooltip: "Future variant" }],
+    future_strength: ["FLOAT", { default: 1, tooltip: "Future strength" }],
+    unsupported_image: ["IMAGE"],
+  };
+  fixture.resolveLoads();
+  await flushPromises();
+
+  assert.equal(advancedOption.disabled, true);
+  assert.equal(advancedOption.textContent, "spectrum_mod_guidance_advanced (pack:spectrumAdvanced missing)");
+  assert.equal(backend.value, "comfy_ksampler", "Missing selected backend must fall back to Comfy KSampler");
+  assert.equal(controlIn(spectrum, "Use Spectrum patch").disabled, true);
+  assert.equal(controlIn(spectrum, "Use Spectrum patch").checked, false);
+  assert.equal(controlIn(corrections, "Use corrections").disabled, true);
+  assert.equal(controlIn(corrections, "Use corrections").checked, false);
+  assert.equal(
+    warningIn(dialog).textContent,
+    'format:warning.optionalDependencyMissing:{"backend":"spectrum_mod_guidance_advanced","pack":"pack:spectrumAdvanced"} '
+      + 'format:warning.optionalDependencyMissing:{"backend":"Spectrum Patch","pack":"pack:spectrumPatch"}',
+  );
+  assertBackendVisibility(dialog, "comfy_ksampler");
+  const latestInputInfo = fixture.supportedCalls.slice(-17);
+  assert.deepEqual(
+    latestInputInfo.slice(0, 7).map(({ key }) => key),
+    Array(7).fill("spectrumPatch"),
+    "Comfy Spectrum controls must use Spectrum patch capabilities",
+  );
+  assert.deepEqual(
+    latestInputInfo.slice(7, 14).map(({ key }) => key),
+    Array(7).fill("spectrumCorrections"),
+    "Comfy correction controls must use correction capabilities",
+  );
+  assert.deepEqual(
+    latestInputInfo.slice(14).map(({ key }) => key),
+    Array(3).fill("spectrumSpd"),
+    "SPD controls must keep SPD capability metadata",
+  );
+
+  const dynamicSpd = sectionByHeading(dialog, "Detected SPD Inputs");
+  assert.equal(dynamicSpd.classList.contains("hidden"), false);
+  assert.equal(rowByLabel(dynamicSpd, "spd_scale"), null);
+  assert.equal(rowByLabel(dynamicSpd, "unsupported_image"), null);
+  assert.equal(controlIn(dynamicSpd, "future_variant").value, "single");
+  assert.equal(controlIn(dynamicSpd, "future_strength").value, "1.25");
+
+  setSelectValue(backend, "spectrum_spd_speed");
+  backend.emit("change");
+  assertBackendVisibility(dialog, "spectrum_spd_speed");
+  assert.equal(warningIn(dialog).hidden, true, "Unselected missing dependencies must not keep a warning visible");
+
+  controlIn(base, "Seed").value = String(settingsModule.AIO_GENERATOR_MAX_SEED + 100);
+  setSelectValue(controlIn(base, "Seed mode"), "");
+  controlIn(base, "Steps").value = "0";
+  controlIn(base, "CFG").value = "99";
+  controlIn(base, "Denoise").value = "-1";
+  setSelectValue(controlIn(sampler, "Sampler"), "");
+  setSelectValue(controlIn(sampler, "Scheduler"), "");
+  controlIn(spd, "Scale").value = "0";
+  controlIn(spd, "Sigma").value = "";
+  controlIn(spd, "SMC alpha").value = "0.4";
+  setSelectValue(controlIn(modGuidance, "Mode"), "");
+  setSelectValue(controlIn(modGuidance, "Profile"), "");
+  controlIn(modGuidance, "Adapter").value = "";
+  controlIn(modGuidance, "Mod W").value = "";
+  setSelectValue(controlIn(dynamicSpd, "future_variant"), "dual");
+  controlIn(dynamicSpd, "future_strength").value = "2.5";
+
+  action(dialog, "button.apply").emit("click");
+  assert.deepEqual(dialog.trace.slice(-5), ["merge", "apply-visible", "write", "render", "remove"]);
+  assert.equal(fixture.writes.length, 1);
+  assert.equal(fixture.renders.length, 1);
+  assert.equal(fixture.applyVisibleCalls.length, 1);
+  const written = fixture.node.settings;
+  assert.equal(written.sampler.backend, "spectrum_spd_speed");
+  assert.equal(written.sampler.seed, settingsModule.AIO_GENERATOR_MAX_SEED);
+  assert.equal(written.sampler.seed_after_generate, "fixed");
+  assert.equal(written.sampler.steps, 1);
+  assert.equal(written.sampler.cfg, 10);
+  assert.equal(written.sampler.denoise, 0);
+  assert.equal(written.sampler.sampler_name, fixture.defaultSettings.sampler.sampler_name);
+  assert.equal(written.sampler.scheduler, fixture.defaultSettings.sampler.scheduler);
+  assert.equal(written.sampler.spectrum.enabled, false);
+  assert.equal(written.sampler.dit_corrections.enabled, false);
+  assert.equal(written.sampler.spd.scale, 0);
+  assert.equal(written.sampler.spd.sigma, 0.7);
+  assert.equal(written.sampler.spd.adaptive_smc_alpha, 0.4);
+  assert.equal(written.mod_guidance.mode, "prompt_data");
+  assert.equal(written.mod_guidance.profile, "step_i8_skip27");
+  assert.equal(written.mod_guidance.advanced.adapter, "(auto-download default)");
+  assert.equal(written.mod_guidance.advanced.mod_w, 3);
+  assert.equal(Object.hasOwn(written.sampler, "dave"), false);
+  assert.equal(written.sampler.preserved_sampler_key, "keep-sampler");
+  assert.equal(written.preserved_root_key, "keep-root");
+  assert.deepEqual(
+    written.sampler.spectrum_extra,
+    {},
+    "Unavailable dynamic Spectrum controls retain the existing rendered-controls-only serialization behavior",
+  );
+  assert.deepEqual(written.sampler.spd_extra, {
+    future_variant: "dual",
+    future_strength: 2.5,
+  });
+  assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), written);
+  assert.equal(fixture.applyVisibleCalls[0].sampler.seed, settingsModule.AIO_GENERATOR_MAX_SEED);
+  assert.equal(fixture.node.visible.steps, 1);
+  assert.equal(fixture.node.visible.cfg, 10);
+  assert.equal(fixture.node.visible.denoise, 0);
+}
+
+console.log("AiO Sampler settings dialog smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -55,6 +55,10 @@ AIO_DETAILER_SETTINGS_DIALOG_JS = AIO_MODULES / "detailer_settings_dialog.js"
 AIO_DETAILER_SETTINGS_DIALOG_SMOKE = (
     ROOT / "tests" / "frontend_aio_detailer_settings_dialog_smoke.mjs"
 )
+AIO_SAMPLER_SETTINGS_DIALOG_JS = AIO_MODULES / "sampler_settings_dialog.js"
+AIO_SAMPLER_SETTINGS_DIALOG_SMOKE = (
+    ROOT / "tests" / "frontend_aio_sampler_settings_dialog_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -496,7 +500,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "installGeneratorWheelForwarder",
             "installGeneratorQueuePromptHook",
             "suppressGeneratorDefaultPreview",
-            "openSamplerSettings",
             "hookGeneratorNode",
         ):
             with self.subTest(entry_owned_function=entry_owned_function):
@@ -548,11 +551,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(moved_function=moved_function):
                 self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
                 self.assertNotRegex(entry_source, rf"\bfunction\s+{moved_function}\(")
-        for entry_owned_function in ("openSamplerSettings",):
-            with self.subTest(entry_owned_function=entry_owned_function):
-                self.assertRegex(entry_source, rf"\bfunction\s+{entry_owned_function}\(")
-                self.assertNotRegex(source, rf"\bfunction\s+{entry_owned_function}\(")
-
         return_match = re.search(
             r"(?ms)^  return \{(?P<facades>[A-Za-z0-9_,\s]+)\};\s*\}\s*$",
             source,
@@ -634,7 +632,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         composition_start = entry_source.index(
             "const openDetailerSettings = aioCreateDetailerSettingsDialog({"
         )
-        composition_end = entry_source.index("\n\nconst generatorPanelRuntime", composition_start)
+        composition_end = entry_source.index("\n\nconst openSamplerSettings", composition_start)
         composition = entry_source[composition_start:composition_end]
         for expected in (
             "createDialog,",
@@ -648,9 +646,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(composition_dependency=expected):
                 self.assertIn(expected, composition)
         stage_composition = entry_source.index("aioCreateStageSettingsDialogs({")
-        generator_panel_composition = entry_source.index("const generatorPanelRuntime")
+        sampler_composition = entry_source.index("const openSamplerSettings")
         self.assertLess(stage_composition, composition_start)
-        self.assertLess(composition_start, generator_panel_composition)
+        self.assertLess(composition_start, sampler_composition)
 
         editor_start = source.index("function createDetailerTargetEditor")
         editor_end = source.index("\n  function openDetailerSettings", editor_start)
@@ -663,6 +661,77 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_DETAILER_SETTINGS_DIALOG_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_detailer_settings_dialog_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_sampler_settings_dialog_has_closed_lifecycle_boundary(self):
+        source = AIO_SAMPLER_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(source.startswith("// @ts-check\n"))
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotRegex(source, r"(?m)^\s*import\s")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertEqual(
+            re.findall(r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE),
+            ["aioCreateSamplerSettingsDialog"],
+        )
+        self.assertEqual(len(re.findall(r"(?m)^export\s+", source)), 1)
+        self.assertIn(
+            'import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";',
+            entry_source,
+        )
+        for moved_function in (
+            "applyNodeInputInfo",
+            "createDynamicNodeInputEditor",
+            "openSamplerSettings",
+        ):
+            with self.subTest(moved_function=moved_function):
+                self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
+                self.assertNotRegex(entry_source, rf"\bfunction\s+{moved_function}\(")
+        for moved_constant in (
+            "SPECTRUM_ADVANCED_KNOWN_INPUTS",
+            "SPECTRUM_SPD_KNOWN_INPUTS",
+        ):
+            with self.subTest(moved_constant=moved_constant):
+                self.assertRegex(source, rf"\bconst\s+{moved_constant}\s*=")
+                self.assertNotRegex(entry_source, rf"\bconst\s+{moved_constant}\s*=")
+
+        composition_start = entry_source.index(
+            "const openSamplerSettings = aioCreateSamplerSettingsDialog({"
+        )
+        composition_end = entry_source.index("\n\nconst generatorPanelRuntime", composition_start)
+        composition = entry_source[composition_start:composition_end]
+        for expected in (
+            "createDialog,",
+            "nodeInputControlForSpec,",
+            "valueFromNodeInputControl,",
+            "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,",
+            "seedControls: GENERATOR_SEED_CONTROLS,",
+            "specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,",
+            "mergeVisibleSettings: mergeVisibleGeneratorSettings,",
+            "applyVisibleSettings: applyVisibleGeneratorSettings,",
+            "writeSettings,",
+            "renderPanel: renderGeneratorPanel,",
+            "backendDependencies: AIO_BACKEND_DEPENDENCIES,",
+            "isLoaded: () => generatorOptionalDependencyState.loaded,",
+            "nodeInputMap,",
+            "nodeInputTooltip,",
+            "nodeInputSupported,",
+            "load: loadGeneratorOptionalDependencies,",
+        ):
+            with self.subTest(composition_dependency=expected):
+                self.assertIn(expected, composition)
+        detailer_composition = entry_source.index("const openDetailerSettings")
+        generator_panel_composition = entry_source.index("const generatorPanelRuntime")
+        self.assertLess(detailer_composition, composition_start)
+        self.assertLess(composition_start, generator_panel_composition)
+        self.assertIn("return openSamplerSettings;", source)
+        self.assertTrue(AIO_SAMPLER_SETTINGS_DIALOG_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_sampler_settings_dialog_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -69,6 +69,11 @@ try {
         throw "Frontend AiO Detailer settings dialog smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_sampler_settings_dialog_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Sampler settings dialog smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_dependency_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/sampler_settings_dialog.js
+++ b/web/js/aio/sampler_settings_dialog.js
@@ -1,0 +1,540 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioSamplerDialogControls
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(options: any[], value: any) => any} selectInput
+ * @property {(value: any) => any} checkbox
+ * @property {(value: any) => any} textInput
+ * @property {(spec: any, current: any) => any} nodeInputControlForSpec
+ * @property {(control: any) => any} valueFromNodeInputControl
+ */
+
+/**
+ * @typedef {object} AioSamplerDialogText
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} get
+ * @property {(key: string, values?: Record<string, any>) => string} format
+ * @property {(element: any, value: any) => any} applyTooltipText
+ */
+
+/**
+ * @typedef {object} AioSamplerDialogSettingsCore
+ * @property {any} defaultGenerationSettings
+ * @property {any[]} seedControls
+ * @property {number} specialSeedRandom
+ * @property {any[]} fallbackSamplerNames
+ * @property {any[]} fallbackSchedulerNames
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(value: any) => string} normalizeSeedControl
+ * @property {(value: any, fallback: number) => number} normalizeSeedValue
+ * @property {(value: any, fallback: number, min: number, max: number) => number} clampNumber
+ */
+
+/**
+ * @typedef {object} AioSamplerDialogNodeAdapter
+ * @property {string} generatorSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(widget: any, defaults: any) => any} parseSettings
+ * @property {(node: any, settings: any) => any} mergeVisibleSettings
+ * @property {(node: any, name: string, fallback: any[]) => any[]} widgetOptions
+ * @property {(node: any, settings: any) => void} applyVisibleSettings
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ * @property {(node: any) => void} renderPanel
+ */
+
+/**
+ * @typedef {object} AioSamplerDialogDependencyAdapter
+ * @property {Record<string, string>} backendDependencies
+ * @property {() => boolean} isLoaded
+ * @property {(key: string) => boolean} available
+ * @property {(key: string) => string} pack
+ * @property {(key: string) => Record<string, any>} nodeInputMap
+ * @property {(key: string, inputName: string) => string} nodeInputTooltip
+ * @property {(key: string, inputName: string) => boolean} nodeInputSupported
+ * @property {(options?: Record<string, any>) => Promise<any>} load
+ */
+
+/**
+ * @typedef {object} AioSamplerSettingsDialogDependencies
+ * @property {any} document
+ * @property {AioSamplerDialogControls} controls
+ * @property {AioSamplerDialogText} text
+ * @property {AioSamplerDialogSettingsCore} settingsCore
+ * @property {AioSamplerDialogNodeAdapter} nodeAdapter
+ * @property {AioSamplerDialogDependencyAdapter} dependencyAdapter
+ */
+
+const SPECTRUM_ADVANCED_KNOWN_INPUTS = new Set([
+  "model",
+  "clip",
+  "seed",
+  "steps",
+  "cfg",
+  "sampler_name",
+  "scheduler",
+  "positive",
+  "negative",
+  "latent_image",
+  "adapter",
+  "quality_tags",
+  "mod_w",
+  "quality_neg",
+  "mod_start_layer",
+  "mod_end_layer",
+  "mod_taper",
+  "mod_taper_scale",
+  "mod_final_w",
+  "denoise",
+  "window_size",
+  "flex_window",
+  "warmup_steps",
+  "blend_w",
+  "cheby_degree",
+  "ridge_lambda",
+  "dcw_mode",
+  "dcw_lambda",
+  "dcw_band_mask",
+  "dcw_calibrator",
+  "cfgpp_lambda",
+  "fsg",
+  "fsg_band_lo",
+  "fsg_band_hi",
+  "fsg_k",
+  "fsg_d_sigma",
+  "fsg_gamma",
+  "adaptive_smc_alpha",
+  "smc_cfg_lambda",
+]);
+const SPECTRUM_SPD_KNOWN_INPUTS = new Set([
+  "model",
+  "seed",
+  "steps",
+  "cfg",
+  "sampler_name",
+  "scheduler",
+  "positive",
+  "negative",
+  "latent_image",
+  "split_mode",
+  "spd_scale",
+  "spd_sigma",
+  "denoise",
+  "adaptive_smc_alpha",
+]);
+
+/**
+ * Own the Sampler settings dialog, dynamic optional-node inputs, dependency
+ * locks, and Apply/Cancel lifecycle. Extension registration, dependency
+ * discovery, generator-panel rendering, and durable storage remain adapters.
+ *
+ * @param {AioSamplerSettingsDialogDependencies} dependencies
+ * @returns {(node: any) => void}
+ */
+export function aioCreateSamplerSettingsDialog(dependencies) {
+  const {
+    document,
+    controls,
+    text,
+    settingsCore,
+    nodeAdapter,
+    dependencyAdapter,
+  } = dependencies;
+  const {
+    createDialog,
+    field,
+    numberInput,
+    selectInput,
+    checkbox,
+    textInput,
+    nodeInputControlForSpec,
+    valueFromNodeInputControl,
+  } = controls;
+  const {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+    applyTooltipText,
+  } = text;
+  const {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    seedControls: GENERATOR_SEED_CONTROLS,
+    specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    normalizeSeedControl,
+    normalizeSeedValue,
+    clampNumber: clampGeneratorNumber,
+  } = settingsCore;
+  const {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    parseSettings,
+    mergeVisibleSettings: mergeVisibleGeneratorSettings,
+    widgetOptions,
+    applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  } = nodeAdapter;
+  const {
+    backendDependencies: AIO_BACKEND_DEPENDENCIES,
+    isLoaded: optionalDependenciesLoaded,
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    nodeInputMap,
+    nodeInputTooltip,
+    nodeInputSupported,
+    load: loadGeneratorOptionalDependencies,
+  } = dependencyAdapter;
+
+  function applyNodeInputInfo(control, dependencyKey, inputName, fallbackTooltipKey = "") {
+    if (!control) {
+      return control;
+    }
+    const objectTooltip = nodeInputTooltip(dependencyKey, inputName);
+    const fallback = fallbackTooltipKey ? aioText(fallbackTooltipKey) : "";
+    const supported = nodeInputSupported(dependencyKey, inputName);
+    control.disabled = !supported;
+    control.title = supported
+      ? (objectTooltip || fallback || control.title || "")
+      : aioFormat("warning.optionalDependencyMissing", {
+        backend: inputName,
+        pack: optionalDependencyPack(dependencyKey),
+      });
+    const row = control.parentElement?.classList?.contains("easyuse-anima-aio-field")
+      ? control.parentElement
+      : null;
+    if (row) {
+      row.title = control.title;
+      row.classList.toggle("easyuse-anima-aio-unsupported", !supported);
+    }
+    return control;
+  }
+
+  function createDynamicNodeInputEditor(title, dependencyKey, knownInputs, values = {}) {
+    const section = document.createElement("div");
+    section.className = "easyuse-anima-aio-subsection";
+    section.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
+    const controls = new Map();
+    const render = () => {
+      const currentValues = { ...(values || {}) };
+      for (const [name, control] of controls.entries()) {
+        currentValues[name] = valueFromNodeInputControl(control);
+      }
+      controls.clear();
+      section.replaceChildren(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
+      if (!optionalDependenciesLoaded() || !optionalDependencyAvailable(dependencyKey)) {
+        section.classList.add("hidden");
+        return;
+      }
+      const inputMap = nodeInputMap(dependencyKey);
+      const dynamicNames = Object.keys(inputMap).filter((name) => !knownInputs.has(name));
+      if (!dynamicNames.length) {
+        section.classList.add("hidden");
+        return;
+      }
+      section.classList.remove("hidden");
+      for (const name of dynamicNames) {
+        const spec = inputMap[name];
+        const control = nodeInputControlForSpec(spec, currentValues[name]);
+        if (!control) {
+          continue;
+        }
+        controls.set(name, control);
+        field(section, name, control);
+        applyTooltipText(control, nodeInputTooltip(dependencyKey, name));
+      }
+      if (!controls.size) {
+        section.classList.add("hidden");
+      }
+    };
+    render();
+    loadGeneratorOptionalDependencies().then(render);
+    return {
+      section,
+      values() {
+        const output = {};
+        for (const [name, control] of controls.entries()) {
+          output[name] = valueFromNodeInputControl(control);
+        }
+        return output;
+      },
+    };
+  }
+
+
+  function openSamplerSettings(node) {
+    const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
+    const settings = mergeVisibleGeneratorSettings(node, parseSettings(widget, DEFAULT_GENERATION_SETTINGS));
+    const { backdrop, body, actions } = createDialog(
+      "Sampler Details",
+      "Choose one of three sampler paths. Missing optional node packs are locked before queue execution."
+    );
+
+    const makeSection = (title, className = "easyuse-anima-aio-section full") => {
+      const section = document.createElement("section");
+      section.className = className;
+      section.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText(title) }));
+      return section;
+    };
+    const makeSubsection = (title) => {
+      const section = document.createElement("div");
+      section.className = "easyuse-anima-aio-subsection";
+      section.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
+      return section;
+    };
+
+    const base = makeSection("Base Parameters");
+    const seed = field(base, "Seed", numberInput(settings.sampler.seed));
+    const seedControl = field(
+      base,
+      "Seed mode",
+      selectInput(GENERATOR_SEED_CONTROLS, normalizeSeedControl(settings.sampler.seed_after_generate))
+    );
+    const steps = field(base, "Steps", numberInput(settings.sampler.steps));
+    steps.min = "1";
+    steps.max = "75";
+    const cfg = field(base, "CFG", numberInput(settings.sampler.cfg, "0.1"));
+    cfg.min = "1";
+    cfg.max = "10";
+    const denoise = field(base, "Denoise", numberInput(settings.sampler.denoise, "0.01"));
+
+    const sampler = makeSection("Sampler Backend");
+    const backendValues = [
+      "comfy_ksampler",
+      "spectrum_mod_guidance_advanced",
+      "spectrum_spd_speed",
+    ];
+    const backend = field(
+      sampler,
+      "Mode",
+      selectInput(backendValues, settings.sampler.backend || "comfy_ksampler")
+    );
+    const dependencyWarning = document.createElement("div");
+    dependencyWarning.className = "easyuse-anima-aio-warning";
+    dependencyWarning.hidden = true;
+    sampler.append(dependencyWarning);
+    const samplerName = field(
+      sampler,
+      "Sampler",
+      selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), settings.sampler.sampler_name)
+    );
+    const scheduler = field(
+      sampler,
+      "Scheduler",
+      selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), settings.sampler.scheduler)
+    );
+
+    const modGuidance = makeSubsection("Mod Guidance");
+    const modMode = field(
+      modGuidance,
+      "Mode",
+      selectInput(["prompt_data", "enabled", "disabled"], settings.mod_guidance.mode),
+      "tip.modMode",
+    );
+    const modProfile = field(
+      modGuidance,
+      "Profile",
+      selectInput(["off", "step_i8_skip27", "step_i14", "uniform_w3"], settings.mod_guidance.profile)
+    );
+    const modAdvanced = document.createElement("div");
+    modGuidance.append(modAdvanced);
+    const modAdapter = field(modAdvanced, "Adapter", textInput(settings.mod_guidance.advanced.adapter));
+    const modW = field(modAdvanced, "Mod W", numberInput(settings.mod_guidance.advanced.mod_w, "0.1"));
+    const modStart = field(modAdvanced, "Start layer", numberInput(settings.mod_guidance.advanced.mod_start_layer));
+    const modEnd = field(modAdvanced, "End layer", numberInput(settings.mod_guidance.advanced.mod_end_layer));
+    const modTaper = field(modAdvanced, "Taper", numberInput(settings.mod_guidance.advanced.mod_taper));
+    const modTaperScale = field(modAdvanced, "Taper scale", numberInput(settings.mod_guidance.advanced.mod_taper_scale, "0.05"));
+    const modFinalW = field(modAdvanced, "Final W", numberInput(settings.mod_guidance.advanced.mod_final_w, "0.1"));
+    sampler.append(modGuidance);
+
+    const backendDetails = document.createElement("div");
+    const spectrum = makeSubsection("Spectrum Patch / Advanced Sampler");
+    const spectrumPatchEnabled = field(spectrum, "Use Spectrum patch", checkbox(settings.sampler.spectrum.enabled));
+    const windowSize = field(spectrum, "Window size", numberInput(settings.sampler.spectrum.window_size, "0.25"));
+    const flexWindow = field(spectrum, "Flex window", numberInput(settings.sampler.spectrum.flex_window, "0.05"));
+    const warmupSteps = field(spectrum, "Warmup steps", numberInput(settings.sampler.spectrum.warmup_steps));
+    const tailSteps = field(spectrum, "Tail actual", numberInput(settings.sampler.spectrum.tail_actual_steps));
+    const blendW = field(spectrum, "Blend W", numberInput(settings.sampler.spectrum.blend_w, "0.05"));
+    const chebyDegree = field(spectrum, "Cheby degree", numberInput(settings.sampler.spectrum.cheby_degree));
+    const ridgeLambda = field(spectrum, "Ridge lambda", numberInput(settings.sampler.spectrum.ridge_lambda, "0.01"));
+    const spectrumCompat = field(
+      spectrum,
+      "Compat policy",
+      selectInput(["conservative", "legacy", "strict"], settings.sampler.spectrum.compat_policy || "conservative")
+    );
+
+    const corrections = makeSubsection("Spectrum Advanced Corrections");
+    const correctionsEnabled = field(corrections, "Use corrections", checkbox(settings.sampler.dit_corrections.enabled));
+    const dcwMode = field(corrections, "DCW mode", selectInput(["off", "manual", "auto"], settings.sampler.dit_corrections.dcw_mode));
+    const dcwLambda = field(corrections, "DCW lambda", numberInput(settings.sampler.dit_corrections.dcw_lambda, "0.001"));
+    const dcwBand = field(corrections, "DCW band", selectInput(["LL", "all", "HH", "LH+HL+HH"], settings.sampler.dit_corrections.dcw_band_mask));
+    const smcCfg = field(corrections, "SMC-CFG", checkbox(settings.sampler.dit_corrections.smc_cfg));
+    const smcAlpha = field(corrections, "SMC alpha", numberInput(settings.sampler.dit_corrections.adaptive_smc_alpha, "0.01"));
+    const smcLambda = field(corrections, "SMC lambda", numberInput(settings.sampler.dit_corrections.smc_cfg_lambda, "0.1"));
+    const cfgpp = field(corrections, "CFG++", checkbox(settings.sampler.dit_corrections.cfgpp));
+    const cfgppLambda = field(corrections, "CFG++ lambda", numberInput(settings.sampler.dit_corrections.cfgpp_lambda, "0.1"));
+    const fsg = field(corrections, "FSG", checkbox(settings.sampler.dit_corrections.fsg));
+    spectrum.append(corrections);
+    const spectrumExtra = createDynamicNodeInputEditor(
+      "Detected Spectrum Inputs",
+      "spectrumAdvanced",
+      SPECTRUM_ADVANCED_KNOWN_INPUTS,
+      settings.sampler.spectrum_extra || {},
+    );
+    spectrum.append(spectrumExtra.section);
+
+    const spd = makeSubsection("Spectrum + SPD / SPEED");
+    const spdScale = field(spd, "Scale", numberInput(settings.sampler.spd.scale, "0.05"));
+    const spdSigma = field(spd, "Sigma", numberInput(settings.sampler.spd.sigma, "0.01"));
+    const spdSmc = field(spd, "SMC alpha", numberInput(settings.sampler.spd.adaptive_smc_alpha, "0.01"));
+    const spdExtra = createDynamicNodeInputEditor(
+      "Detected SPD Inputs",
+      "spectrumSpd",
+      SPECTRUM_SPD_KNOWN_INPUTS,
+      settings.sampler.spd_extra || {},
+    );
+    spd.append(spdExtra.section);
+    backendDetails.append(spectrum, spd);
+    sampler.append(backendDetails);
+    body.append(base, sampler);
+
+    const refreshBackendDetails = () => {
+      const isComfy = backend.value === "comfy_ksampler";
+      const isSpectrumAdvanced = backend.value === "spectrum_mod_guidance_advanced";
+      spectrum.classList.toggle("hidden", !(isComfy || isSpectrumAdvanced));
+      spectrumPatchEnabled.parentElement.style.display = isComfy ? "" : "none";
+      spectrumCompat.parentElement.style.display = isComfy ? "" : "none";
+      modAdvanced.style.display = isSpectrumAdvanced ? "" : "none";
+      spd.classList.toggle("hidden", backend.value !== "spectrum_spd_speed");
+    };
+    const refreshDependencyLocks = () => {
+      const messages = [];
+      for (const option of Array.from(backend.options)) {
+        const dependencyKey = AIO_BACKEND_DEPENDENCIES[option.value];
+        const pack = optionalDependencyPack(dependencyKey);
+        const missing = !!dependencyKey && !optionalDependencyAvailable(dependencyKey);
+        option.disabled = missing;
+        option.textContent = missing ? `${option.value} (${pack} missing)` : option.value;
+        if (missing && option.selected) {
+          messages.push(aioFormat("warning.optionalDependencyMissing", {
+            backend: option.value,
+            pack,
+          }));
+          backend.value = "comfy_ksampler";
+        }
+      }
+      const spectrumPatchMissing = !optionalDependencyAvailable("spectrumPatch");
+      spectrumPatchEnabled.disabled = spectrumPatchMissing;
+      correctionsEnabled.disabled = spectrumPatchMissing;
+      const spectrumInputDependency = backend.value === "comfy_ksampler" ? "spectrumPatch" : "spectrumAdvanced";
+      const correctionInputDependency = backend.value === "comfy_ksampler" ? "spectrumCorrections" : "spectrumAdvanced";
+      const spectrumControls = [
+        [windowSize, "window_size", "tip.spectrumWindow"],
+        [flexWindow, "flex_window", "tip.spectrumFlex"],
+        [warmupSteps, "warmup_steps", "tip.spectrumWarmup"],
+        [tailSteps, "tail_actual_steps", "tip.spectrumTail"],
+        [blendW, "blend_w", "tip.spectrumBlend"],
+        [chebyDegree, "cheby_degree", "tip.spectrumCheby"],
+        [ridgeLambda, "ridge_lambda", "tip.spectrumRidge"],
+        [dcwMode, "dcw_mode", "tip.dcwMode"],
+        [dcwLambda, "dcw_lambda", "tip.dcwLambda"],
+        [dcwBand, "dcw_band_mask", "tip.dcwBand"],
+        [cfgppLambda, "cfgpp_lambda", "tip.cfgppLambda"],
+        [fsg, "fsg", "tip.fsg"],
+        [smcAlpha, "adaptive_smc_alpha", "tip.smcAlpha"],
+        [smcLambda, "smc_cfg_lambda", "tip.smcLambda"],
+      ];
+      for (const [control, inputName, tooltipKey] of spectrumControls.slice(0, 7)) {
+        applyNodeInputInfo(control, spectrumInputDependency, inputName, tooltipKey);
+      }
+      for (const [control, inputName, tooltipKey] of spectrumControls.slice(7)) {
+        applyNodeInputInfo(control, correctionInputDependency, inputName, tooltipKey);
+      }
+      applyNodeInputInfo(spdScale, "spectrumSpd", "spd_scale", "tip.spdScale");
+      applyNodeInputInfo(spdSigma, "spectrumSpd", "spd_sigma", "tip.spdSigma");
+      applyNodeInputInfo(spdSmc, "spectrumSpd", "adaptive_smc_alpha", "tip.smcAlpha");
+      if (spectrumPatchMissing && (spectrumPatchEnabled.checked || correctionsEnabled.checked)) {
+        messages.push(aioFormat("warning.optionalDependencyMissing", {
+          backend: "Spectrum Patch",
+          pack: optionalDependencyPack("spectrumPatch"),
+        }));
+        spectrumPatchEnabled.checked = false;
+        correctionsEnabled.checked = false;
+      }
+      dependencyWarning.hidden = messages.length === 0;
+      dependencyWarning.textContent = messages.join(" ");
+      refreshBackendDetails();
+    };
+    backend.addEventListener("change", refreshDependencyLocks);
+    refreshBackendDetails();
+    refreshDependencyLocks();
+    loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = aioText("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = aioText("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
+      delete next.sampler.dave;
+      next.sampler.backend = backend.value || "comfy_ksampler";
+      next.sampler.seed = normalizeSeedValue(seed.value, GENERATOR_SPECIAL_SEED_RANDOM);
+      next.sampler.seed_after_generate = normalizeSeedControl(seedControl.value);
+      next.sampler.steps = Math.trunc(clampGeneratorNumber(steps.value, DEFAULT_GENERATION_SETTINGS.sampler.steps, 1, 75));
+      next.sampler.cfg = clampGeneratorNumber(cfg.value, DEFAULT_GENERATION_SETTINGS.sampler.cfg, 1, 10);
+      next.sampler.denoise = clampGeneratorNumber(denoise.value, DEFAULT_GENERATION_SETTINGS.sampler.denoise, 0, 1);
+      next.sampler.sampler_name = samplerName.value || DEFAULT_GENERATION_SETTINGS.sampler.sampler_name;
+      next.sampler.scheduler = scheduler.value || DEFAULT_GENERATION_SETTINGS.sampler.scheduler;
+      next.sampler.spectrum.enabled = (
+        next.sampler.backend === "spectrum_mod_guidance_advanced"
+        || (next.sampler.backend === "comfy_ksampler" && spectrumPatchEnabled.checked && !spectrumPatchEnabled.disabled)
+      );
+      next.sampler.spectrum.window_size = Number(windowSize.value || 2);
+      next.sampler.spectrum.flex_window = Number(flexWindow.value || 0.25);
+      next.sampler.spectrum.warmup_steps = Number(warmupSteps.value || 6);
+      next.sampler.spectrum.tail_actual_steps = Number(tailSteps.value || 3);
+      next.sampler.spectrum.blend_w = Number(blendW.value || 0.3);
+      next.sampler.spectrum.cheby_degree = Number(chebyDegree.value || 3);
+      next.sampler.spectrum.ridge_lambda = Number(ridgeLambda.value || 0.1);
+      next.sampler.spectrum.compat_policy = spectrumCompat.value || "conservative";
+      next.sampler.spd.scale = Number(spdScale.value || 0.5);
+      next.sampler.spd.sigma = Number(spdSigma.value || 0.7);
+      next.sampler.spd.adaptive_smc_alpha = Number(spdSmc.value || 0);
+      next.sampler.spectrum_extra = spectrumExtra.values();
+      next.sampler.spd_extra = spdExtra.values();
+      next.sampler.dit_corrections.enabled = correctionsEnabled.checked && !correctionsEnabled.disabled;
+      next.sampler.dit_corrections.dcw_mode = dcwMode.value || "off";
+      next.sampler.dit_corrections.dcw_lambda = Number(dcwLambda.value || 0.01);
+      next.sampler.dit_corrections.dcw_band_mask = dcwBand.value || "LL";
+      next.sampler.dit_corrections.smc_cfg = smcCfg.checked;
+      next.sampler.dit_corrections.adaptive_smc_alpha = Number(smcAlpha.value || 0);
+      next.sampler.dit_corrections.smc_cfg_lambda = Number(smcLambda.value || 6);
+      next.sampler.dit_corrections.cfgpp = cfgpp.checked;
+      next.sampler.dit_corrections.cfgpp_lambda = Number(cfgppLambda.value || 0);
+      next.sampler.dit_corrections.fsg = fsg.checked;
+      next.mod_guidance.mode = modMode.value || "prompt_data";
+      next.mod_guidance.profile = modProfile.value || "step_i8_skip27";
+      next.mod_guidance.advanced.adapter = modAdapter.value || "(auto-download default)";
+      next.mod_guidance.advanced.mod_w = Number(modW.value || 3);
+      next.mod_guidance.advanced.mod_start_layer = Number(modStart.value || 8);
+      next.mod_guidance.advanced.mod_end_layer = Number(modEnd.value || 27);
+      next.mod_guidance.advanced.mod_taper = Number(modTaper.value || 0);
+      next.mod_guidance.advanced.mod_taper_scale = Number(modTaperScale.value || 0.25);
+      next.mod_guidance.advanced.mod_final_w = Number(modFinalW.value || 0);
+      applyVisibleGeneratorSettings(node, next);
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  }
+
+
+  return openSamplerSettings;
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -21,6 +21,7 @@ import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.
 import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
 import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
 import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";
+import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -126,63 +127,7 @@ const GENERATOR_FALLBACK_SCHEDULER_NAMES = [
   "OSS Wan",
   "OSS Chroma",
 ];
-const SPECTRUM_ADVANCED_KNOWN_INPUTS = new Set([
-  "model",
-  "clip",
-  "seed",
-  "steps",
-  "cfg",
-  "sampler_name",
-  "scheduler",
-  "positive",
-  "negative",
-  "latent_image",
-  "adapter",
-  "quality_tags",
-  "mod_w",
-  "quality_neg",
-  "mod_start_layer",
-  "mod_end_layer",
-  "mod_taper",
-  "mod_taper_scale",
-  "mod_final_w",
-  "denoise",
-  "window_size",
-  "flex_window",
-  "warmup_steps",
-  "blend_w",
-  "cheby_degree",
-  "ridge_lambda",
-  "dcw_mode",
-  "dcw_lambda",
-  "dcw_band_mask",
-  "dcw_calibrator",
-  "cfgpp_lambda",
-  "fsg",
-  "fsg_band_lo",
-  "fsg_band_hi",
-  "fsg_k",
-  "fsg_d_sigma",
-  "fsg_gamma",
-  "adaptive_smc_alpha",
-  "smc_cfg_lambda",
-]);
-const SPECTRUM_SPD_KNOWN_INPUTS = new Set([
-  "model",
-  "seed",
-  "steps",
-  "cfg",
-  "sampler_name",
-  "scheduler",
-  "positive",
-  "negative",
-  "latent_image",
-  "split_mode",
-  "spd_scale",
-  "spd_sigma",
-  "denoise",
-  "adaptive_smc_alpha",
-]);
+
 
 
 const AIO_TEXT = {
@@ -2069,80 +2014,6 @@ function nodeInputSupported(dependencyKey, inputName) {
   return aioNodeInputSupported(generatorOptionalDependencyState, dependencyKey, inputName);
 }
 
-function applyNodeInputInfo(control, dependencyKey, inputName, fallbackTooltipKey = "") {
-  if (!control) {
-    return control;
-  }
-  const objectTooltip = nodeInputTooltip(dependencyKey, inputName);
-  const fallback = fallbackTooltipKey ? aioText(fallbackTooltipKey) : "";
-  const supported = nodeInputSupported(dependencyKey, inputName);
-  control.disabled = !supported;
-  control.title = supported
-    ? (objectTooltip || fallback || control.title || "")
-    : aioFormat("warning.optionalDependencyMissing", {
-      backend: inputName,
-      pack: optionalDependencyPack(dependencyKey),
-    });
-  const row = control.parentElement?.classList?.contains("easyuse-anima-aio-field")
-    ? control.parentElement
-    : null;
-  if (row) {
-    row.title = control.title;
-    row.classList.toggle("easyuse-anima-aio-unsupported", !supported);
-  }
-  return control;
-}
-
-function createDynamicNodeInputEditor(title, dependencyKey, knownInputs, values = {}) {
-  const section = document.createElement("div");
-  section.className = "easyuse-anima-aio-subsection";
-  section.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
-  const controls = new Map();
-  const render = () => {
-    const currentValues = { ...(values || {}) };
-    for (const [name, control] of controls.entries()) {
-      currentValues[name] = valueFromNodeInputControl(control);
-    }
-    controls.clear();
-    section.replaceChildren(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
-    if (!generatorOptionalDependencyState.loaded || !optionalDependencyAvailable(dependencyKey)) {
-      section.classList.add("hidden");
-      return;
-    }
-    const inputMap = nodeInputMap(dependencyKey);
-    const dynamicNames = Object.keys(inputMap).filter((name) => !knownInputs.has(name));
-    if (!dynamicNames.length) {
-      section.classList.add("hidden");
-      return;
-    }
-    section.classList.remove("hidden");
-    for (const name of dynamicNames) {
-      const spec = inputMap[name];
-      const control = nodeInputControlForSpec(spec, currentValues[name]);
-      if (!control) {
-        continue;
-      }
-      controls.set(name, control);
-      field(section, name, control);
-      applyTooltipText(control, nodeInputTooltip(dependencyKey, name));
-    }
-    if (!controls.size) {
-      section.classList.add("hidden");
-    }
-  };
-  render();
-  loadGeneratorOptionalDependencies().then(render);
-  return {
-    section,
-    values() {
-      const output = {};
-      for (const [name, control] of controls.entries()) {
-        output[name] = valueFromNodeInputControl(control);
-      }
-      return output;
-    },
-  };
-}
 
 function disableGeneratorSpectrumOptions(target) {
   if (!target || typeof target !== "object") {
@@ -4043,274 +3914,6 @@ function randomSeed() {
   return isSpecialSeed(seed) ? 0 : seed;
 }
 
-function openSamplerSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = mergeVisibleGeneratorSettings(node, parseSettings(widget, DEFAULT_GENERATION_SETTINGS));
-  const { backdrop, body, actions } = createDialog(
-    "Sampler Details",
-    "Choose one of three sampler paths. Missing optional node packs are locked before queue execution."
-  );
-
-  const makeSection = (title, className = "easyuse-anima-aio-section full") => {
-    const section = document.createElement("section");
-    section.className = className;
-    section.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText(title) }));
-    return section;
-  };
-  const makeSubsection = (title) => {
-    const section = document.createElement("div");
-    section.className = "easyuse-anima-aio-subsection";
-    section.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
-    return section;
-  };
-
-  const base = makeSection("Base Parameters");
-  const seed = field(base, "Seed", numberInput(settings.sampler.seed));
-  const seedControl = field(
-    base,
-    "Seed mode",
-    selectInput(GENERATOR_SEED_CONTROLS, normalizeSeedControl(settings.sampler.seed_after_generate))
-  );
-  const steps = field(base, "Steps", numberInput(settings.sampler.steps));
-  steps.min = "1";
-  steps.max = "75";
-  const cfg = field(base, "CFG", numberInput(settings.sampler.cfg, "0.1"));
-  cfg.min = "1";
-  cfg.max = "10";
-  const denoise = field(base, "Denoise", numberInput(settings.sampler.denoise, "0.01"));
-
-  const sampler = makeSection("Sampler Backend");
-  const backendValues = [
-    "comfy_ksampler",
-    "spectrum_mod_guidance_advanced",
-    "spectrum_spd_speed",
-  ];
-  const backend = field(
-    sampler,
-    "Mode",
-    selectInput(backendValues, settings.sampler.backend || "comfy_ksampler")
-  );
-  const dependencyWarning = document.createElement("div");
-  dependencyWarning.className = "easyuse-anima-aio-warning";
-  dependencyWarning.hidden = true;
-  sampler.append(dependencyWarning);
-  const samplerName = field(
-    sampler,
-    "Sampler",
-    selectInput(widgetOptions(node, "sampler_name", GENERATOR_FALLBACK_SAMPLER_NAMES), settings.sampler.sampler_name)
-  );
-  const scheduler = field(
-    sampler,
-    "Scheduler",
-    selectInput(widgetOptions(node, "scheduler", GENERATOR_FALLBACK_SCHEDULER_NAMES), settings.sampler.scheduler)
-  );
-
-  const modGuidance = makeSubsection("Mod Guidance");
-  const modMode = field(
-    modGuidance,
-    "Mode",
-    selectInput(["prompt_data", "enabled", "disabled"], settings.mod_guidance.mode),
-    "tip.modMode",
-  );
-  const modProfile = field(
-    modGuidance,
-    "Profile",
-    selectInput(["off", "step_i8_skip27", "step_i14", "uniform_w3"], settings.mod_guidance.profile)
-  );
-  const modAdvanced = document.createElement("div");
-  modGuidance.append(modAdvanced);
-  const modAdapter = field(modAdvanced, "Adapter", textInput(settings.mod_guidance.advanced.adapter));
-  const modW = field(modAdvanced, "Mod W", numberInput(settings.mod_guidance.advanced.mod_w, "0.1"));
-  const modStart = field(modAdvanced, "Start layer", numberInput(settings.mod_guidance.advanced.mod_start_layer));
-  const modEnd = field(modAdvanced, "End layer", numberInput(settings.mod_guidance.advanced.mod_end_layer));
-  const modTaper = field(modAdvanced, "Taper", numberInput(settings.mod_guidance.advanced.mod_taper));
-  const modTaperScale = field(modAdvanced, "Taper scale", numberInput(settings.mod_guidance.advanced.mod_taper_scale, "0.05"));
-  const modFinalW = field(modAdvanced, "Final W", numberInput(settings.mod_guidance.advanced.mod_final_w, "0.1"));
-  sampler.append(modGuidance);
-
-  const backendDetails = document.createElement("div");
-  const spectrum = makeSubsection("Spectrum Patch / Advanced Sampler");
-  const spectrumPatchEnabled = field(spectrum, "Use Spectrum patch", checkbox(settings.sampler.spectrum.enabled));
-  const windowSize = field(spectrum, "Window size", numberInput(settings.sampler.spectrum.window_size, "0.25"));
-  const flexWindow = field(spectrum, "Flex window", numberInput(settings.sampler.spectrum.flex_window, "0.05"));
-  const warmupSteps = field(spectrum, "Warmup steps", numberInput(settings.sampler.spectrum.warmup_steps));
-  const tailSteps = field(spectrum, "Tail actual", numberInput(settings.sampler.spectrum.tail_actual_steps));
-  const blendW = field(spectrum, "Blend W", numberInput(settings.sampler.spectrum.blend_w, "0.05"));
-  const chebyDegree = field(spectrum, "Cheby degree", numberInput(settings.sampler.spectrum.cheby_degree));
-  const ridgeLambda = field(spectrum, "Ridge lambda", numberInput(settings.sampler.spectrum.ridge_lambda, "0.01"));
-  const spectrumCompat = field(
-    spectrum,
-    "Compat policy",
-    selectInput(["conservative", "legacy", "strict"], settings.sampler.spectrum.compat_policy || "conservative")
-  );
-
-  const corrections = makeSubsection("Spectrum Advanced Corrections");
-  const correctionsEnabled = field(corrections, "Use corrections", checkbox(settings.sampler.dit_corrections.enabled));
-  const dcwMode = field(corrections, "DCW mode", selectInput(["off", "manual", "auto"], settings.sampler.dit_corrections.dcw_mode));
-  const dcwLambda = field(corrections, "DCW lambda", numberInput(settings.sampler.dit_corrections.dcw_lambda, "0.001"));
-  const dcwBand = field(corrections, "DCW band", selectInput(["LL", "all", "HH", "LH+HL+HH"], settings.sampler.dit_corrections.dcw_band_mask));
-  const smcCfg = field(corrections, "SMC-CFG", checkbox(settings.sampler.dit_corrections.smc_cfg));
-  const smcAlpha = field(corrections, "SMC alpha", numberInput(settings.sampler.dit_corrections.adaptive_smc_alpha, "0.01"));
-  const smcLambda = field(corrections, "SMC lambda", numberInput(settings.sampler.dit_corrections.smc_cfg_lambda, "0.1"));
-  const cfgpp = field(corrections, "CFG++", checkbox(settings.sampler.dit_corrections.cfgpp));
-  const cfgppLambda = field(corrections, "CFG++ lambda", numberInput(settings.sampler.dit_corrections.cfgpp_lambda, "0.1"));
-  const fsg = field(corrections, "FSG", checkbox(settings.sampler.dit_corrections.fsg));
-  spectrum.append(corrections);
-  const spectrumExtra = createDynamicNodeInputEditor(
-    "Detected Spectrum Inputs",
-    "spectrumAdvanced",
-    SPECTRUM_ADVANCED_KNOWN_INPUTS,
-    settings.sampler.spectrum_extra || {},
-  );
-  spectrum.append(spectrumExtra.section);
-
-  const spd = makeSubsection("Spectrum + SPD / SPEED");
-  const spdScale = field(spd, "Scale", numberInput(settings.sampler.spd.scale, "0.05"));
-  const spdSigma = field(spd, "Sigma", numberInput(settings.sampler.spd.sigma, "0.01"));
-  const spdSmc = field(spd, "SMC alpha", numberInput(settings.sampler.spd.adaptive_smc_alpha, "0.01"));
-  const spdExtra = createDynamicNodeInputEditor(
-    "Detected SPD Inputs",
-    "spectrumSpd",
-    SPECTRUM_SPD_KNOWN_INPUTS,
-    settings.sampler.spd_extra || {},
-  );
-  spd.append(spdExtra.section);
-  backendDetails.append(spectrum, spd);
-  sampler.append(backendDetails);
-  body.append(base, sampler);
-
-  const refreshBackendDetails = () => {
-    const isComfy = backend.value === "comfy_ksampler";
-    const isSpectrumAdvanced = backend.value === "spectrum_mod_guidance_advanced";
-    spectrum.classList.toggle("hidden", !(isComfy || isSpectrumAdvanced));
-    spectrumPatchEnabled.parentElement.style.display = isComfy ? "" : "none";
-    spectrumCompat.parentElement.style.display = isComfy ? "" : "none";
-    modAdvanced.style.display = isSpectrumAdvanced ? "" : "none";
-    spd.classList.toggle("hidden", backend.value !== "spectrum_spd_speed");
-  };
-  const refreshDependencyLocks = () => {
-    const messages = [];
-    for (const option of Array.from(backend.options)) {
-      const dependencyKey = AIO_BACKEND_DEPENDENCIES[option.value];
-      const pack = optionalDependencyPack(dependencyKey);
-      const missing = !!dependencyKey && !optionalDependencyAvailable(dependencyKey);
-      option.disabled = missing;
-      option.textContent = missing ? `${option.value} (${pack} missing)` : option.value;
-      if (missing && option.selected) {
-        messages.push(aioFormat("warning.optionalDependencyMissing", {
-          backend: option.value,
-          pack,
-        }));
-        backend.value = "comfy_ksampler";
-      }
-    }
-    const spectrumPatchMissing = !optionalDependencyAvailable("spectrumPatch");
-    spectrumPatchEnabled.disabled = spectrumPatchMissing;
-    correctionsEnabled.disabled = spectrumPatchMissing;
-    const spectrumInputDependency = backend.value === "comfy_ksampler" ? "spectrumPatch" : "spectrumAdvanced";
-    const correctionInputDependency = backend.value === "comfy_ksampler" ? "spectrumCorrections" : "spectrumAdvanced";
-    const spectrumControls = [
-      [windowSize, "window_size", "tip.spectrumWindow"],
-      [flexWindow, "flex_window", "tip.spectrumFlex"],
-      [warmupSteps, "warmup_steps", "tip.spectrumWarmup"],
-      [tailSteps, "tail_actual_steps", "tip.spectrumTail"],
-      [blendW, "blend_w", "tip.spectrumBlend"],
-      [chebyDegree, "cheby_degree", "tip.spectrumCheby"],
-      [ridgeLambda, "ridge_lambda", "tip.spectrumRidge"],
-      [dcwMode, "dcw_mode", "tip.dcwMode"],
-      [dcwLambda, "dcw_lambda", "tip.dcwLambda"],
-      [dcwBand, "dcw_band_mask", "tip.dcwBand"],
-      [cfgppLambda, "cfgpp_lambda", "tip.cfgppLambda"],
-      [fsg, "fsg", "tip.fsg"],
-      [smcAlpha, "adaptive_smc_alpha", "tip.smcAlpha"],
-      [smcLambda, "smc_cfg_lambda", "tip.smcLambda"],
-    ];
-    for (const [control, inputName, tooltipKey] of spectrumControls.slice(0, 7)) {
-      applyNodeInputInfo(control, spectrumInputDependency, inputName, tooltipKey);
-    }
-    for (const [control, inputName, tooltipKey] of spectrumControls.slice(7)) {
-      applyNodeInputInfo(control, correctionInputDependency, inputName, tooltipKey);
-    }
-    applyNodeInputInfo(spdScale, "spectrumSpd", "spd_scale", "tip.spdScale");
-    applyNodeInputInfo(spdSigma, "spectrumSpd", "spd_sigma", "tip.spdSigma");
-    applyNodeInputInfo(spdSmc, "spectrumSpd", "adaptive_smc_alpha", "tip.smcAlpha");
-    if (spectrumPatchMissing && (spectrumPatchEnabled.checked || correctionsEnabled.checked)) {
-      messages.push(aioFormat("warning.optionalDependencyMissing", {
-        backend: "Spectrum Patch",
-        pack: optionalDependencyPack("spectrumPatch"),
-      }));
-      spectrumPatchEnabled.checked = false;
-      correctionsEnabled.checked = false;
-    }
-    dependencyWarning.hidden = messages.length === 0;
-    dependencyWarning.textContent = messages.join(" ");
-    refreshBackendDetails();
-  };
-  backend.addEventListener("change", refreshDependencyLocks);
-  refreshBackendDetails();
-  refreshDependencyLocks();
-  loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    delete next.sampler.dave;
-    next.sampler.backend = backend.value || "comfy_ksampler";
-    next.sampler.seed = normalizeSeedValue(seed.value, GENERATOR_SPECIAL_SEED_RANDOM);
-    next.sampler.seed_after_generate = normalizeSeedControl(seedControl.value);
-    next.sampler.steps = Math.trunc(clampGeneratorNumber(steps.value, DEFAULT_GENERATION_SETTINGS.sampler.steps, 1, 75));
-    next.sampler.cfg = clampGeneratorNumber(cfg.value, DEFAULT_GENERATION_SETTINGS.sampler.cfg, 1, 10);
-    next.sampler.denoise = clampGeneratorNumber(denoise.value, DEFAULT_GENERATION_SETTINGS.sampler.denoise, 0, 1);
-    next.sampler.sampler_name = samplerName.value || DEFAULT_GENERATION_SETTINGS.sampler.sampler_name;
-    next.sampler.scheduler = scheduler.value || DEFAULT_GENERATION_SETTINGS.sampler.scheduler;
-    next.sampler.spectrum.enabled = (
-      next.sampler.backend === "spectrum_mod_guidance_advanced"
-      || (next.sampler.backend === "comfy_ksampler" && spectrumPatchEnabled.checked && !spectrumPatchEnabled.disabled)
-    );
-    next.sampler.spectrum.window_size = Number(windowSize.value || 2);
-    next.sampler.spectrum.flex_window = Number(flexWindow.value || 0.25);
-    next.sampler.spectrum.warmup_steps = Number(warmupSteps.value || 6);
-    next.sampler.spectrum.tail_actual_steps = Number(tailSteps.value || 3);
-    next.sampler.spectrum.blend_w = Number(blendW.value || 0.3);
-    next.sampler.spectrum.cheby_degree = Number(chebyDegree.value || 3);
-    next.sampler.spectrum.ridge_lambda = Number(ridgeLambda.value || 0.1);
-    next.sampler.spectrum.compat_policy = spectrumCompat.value || "conservative";
-    next.sampler.spd.scale = Number(spdScale.value || 0.5);
-    next.sampler.spd.sigma = Number(spdSigma.value || 0.7);
-    next.sampler.spd.adaptive_smc_alpha = Number(spdSmc.value || 0);
-    next.sampler.spectrum_extra = spectrumExtra.values();
-    next.sampler.spd_extra = spdExtra.values();
-    next.sampler.dit_corrections.enabled = correctionsEnabled.checked && !correctionsEnabled.disabled;
-    next.sampler.dit_corrections.dcw_mode = dcwMode.value || "off";
-    next.sampler.dit_corrections.dcw_lambda = Number(dcwLambda.value || 0.01);
-    next.sampler.dit_corrections.dcw_band_mask = dcwBand.value || "LL";
-    next.sampler.dit_corrections.smc_cfg = smcCfg.checked;
-    next.sampler.dit_corrections.adaptive_smc_alpha = Number(smcAlpha.value || 0);
-    next.sampler.dit_corrections.smc_cfg_lambda = Number(smcLambda.value || 6);
-    next.sampler.dit_corrections.cfgpp = cfgpp.checked;
-    next.sampler.dit_corrections.cfgpp_lambda = Number(cfgppLambda.value || 0);
-    next.sampler.dit_corrections.fsg = fsg.checked;
-    next.mod_guidance.mode = modMode.value || "prompt_data";
-    next.mod_guidance.profile = modProfile.value || "step_i8_skip27";
-    next.mod_guidance.advanced.adapter = modAdapter.value || "(auto-download default)";
-    next.mod_guidance.advanced.mod_w = Number(modW.value || 3);
-    next.mod_guidance.advanced.mod_start_layer = Number(modStart.value || 8);
-    next.mod_guidance.advanced.mod_end_layer = Number(modEnd.value || 27);
-    next.mod_guidance.advanced.mod_taper = Number(modTaper.value || 0);
-    next.mod_guidance.advanced.mod_taper_scale = Number(modTaperScale.value || 0.25);
-    next.mod_guidance.advanced.mod_final_w = Number(modFinalW.value || 0);
-    applyVisibleGeneratorSettings(node, next);
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
 
 function normalizeImageSaverHashBundles(value) {
   if (typeof value === "string") {
@@ -5252,6 +4855,57 @@ const openDetailerSettings = aioCreateDetailerSettingsDialog({
   dependencyAdapter: {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
+    load: loadGeneratorOptionalDependencies,
+  },
+});
+
+const openSamplerSettings = aioCreateSamplerSettingsDialog({
+  document,
+  controls: {
+    createDialog,
+    field,
+    numberInput,
+    selectInput,
+    checkbox,
+    textInput,
+    nodeInputControlForSpec,
+    valueFromNodeInputControl,
+  },
+  text: {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+    applyTooltipText,
+  },
+  settingsCore: {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    seedControls: GENERATOR_SEED_CONTROLS,
+    specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,
+    fallbackSamplerNames: GENERATOR_FALLBACK_SAMPLER_NAMES,
+    fallbackSchedulerNames: GENERATOR_FALLBACK_SCHEDULER_NAMES,
+    mergeDefaults,
+    normalizeSeedControl,
+    normalizeSeedValue,
+    clampNumber: clampGeneratorNumber,
+  },
+  nodeAdapter: {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    parseSettings,
+    mergeVisibleSettings: mergeVisibleGeneratorSettings,
+    widgetOptions,
+    applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  },
+  dependencyAdapter: {
+    backendDependencies: AIO_BACKEND_DEPENDENCIES,
+    isLoaded: () => generatorOptionalDependencyState.loaded,
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    nodeInputMap,
+    nodeInputTooltip,
+    nodeInputSupported,
     load: loadGeneratorOptionalDependencies,
   },
 });


### PR DESCRIPTION
## 변경 요약

- AiO Sampler 설정 dialog와 전용 dynamic optional-node input editor를 `web/js/aio/sampler_settings_dialog.js`의 단일 lifecycle factory로 분리했습니다.
- dialog 전용 Spectrum/SPD known-input Set과 input-support 표시 helper도 같은 경계로 이동했습니다.
- optional dependency cache 객체 대신 live `isLoaded()` query adapter를 주입해 entry의 내부 상태 표현과 결합하지 않도록 했습니다.
- 사용자 동작은 변경하지 않는 기계적 추출입니다.

## 주요 파일

- `web/js/aio/sampler_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_sampler_settings_dialog_smoke.mjs`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- focused Sampler Fake DOM smoke: 통과
- 관련 Python source/ownership tests: 67개 통과
- JavaScript syntax 검사: 통과
- TypeScript 6.0.3: 통과
- official full runner: Python 366 tests, frontend 91 JavaScript files 통과
- `git diff --check`: 통과
- 행동 보존 / 아키텍처·DI / 테스트 적정성 3중 감사: Blocker, P2, P3 없음

## ComfyUI 표면

- ComfyUI Codex test surface: official full project validation
- Legacy canvas / Node 2.0 browser smoke: 미실행 (동작 변경 없는 lifecycle extraction)
- ComfyUI v0.27.0 user instance: 전체 유지보수 완료 후 최종 수동 확인 예정

## 보류 finding

- optional dependency가 아직 로드되지 않았거나 unavailable인 상태에서 빠르게 Apply하면 기존 `spectrum_extra` / `spd_extra`가 rendered-controls-only `{}`로 직렬화될 수 있습니다.
- 이 PR에서는 기존 동작을 보존하며, 실제 보존 수정은 별도 behavior PR과 dual-canvas 검증으로 처리합니다.

- 이 PR은 Issue #54의 Sampler lifecycle 경계 조각이며 Issue #54 전체를 닫지 않습니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`