### PR TITLE
refactor: AiO Save 설정 dialog lifecycle 분리

### DIFF
--- a/tests/frontend_aio_save_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_save_settings_dialog_smoke.mjs
@@ -1,0 +1,632 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+  descendants,
+} from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function find(root, predicate) {
+  return [root, ...descendants(root)].find(predicate) || null;
+}
+
+function findAll(root, predicate) {
+  return [root, ...descendants(root)].filter(predicate);
+}
+
+function findByText(root, textContent) {
+  return find(root, (element) => element.textContent === textContent);
+}
+
+function rowByLabel(root, label) {
+  return find(root, (element) => element.getAttribute?.("data-test-label") === label);
+}
+
+function controlIn(root, label) {
+  const row = rowByLabel(root, label);
+  assert.ok(row, `missing field row: ${label}`);
+  assert.ok(row.children[0], `missing field control: ${label}`);
+  return row.children[0];
+}
+
+function action(dialog, key) {
+  const button = findByText(dialog.actions, `text:${key}`);
+  assert.ok(button, `missing action: ${key}`);
+  return button;
+}
+
+function sectionByHeading(root, heading) {
+  const title = findByText(root, `static:${heading}`);
+  assert.ok(title?.parentElement, `missing section: ${heading}`);
+  return title.parentElement;
+}
+
+function hashRows(editor) {
+  return findAll(
+    editor,
+    (element) => element.classList.contains("easyuse-anima-aio-hash-bundle-row"),
+  );
+}
+
+function hashValue(row) {
+  const textarea = row.querySelector("textarea");
+  assert.ok(textarea, "missing hash bundle textarea");
+  return textarea;
+}
+
+function civitaiRows(editor) {
+  return findAll(
+    editor,
+    (element) => element.classList.contains("easyuse-anima-aio-civitai-fetcher-row"),
+  );
+}
+
+function civitaiInputs(row) {
+  const inputs = row.querySelectorAll("input");
+  assert.equal(inputs.length, 4, "Civitai row must expose enabled, username, model, and version inputs");
+  return inputs;
+}
+
+function removeRow(row) {
+  const button = findByText(row, "text:button.remove");
+  assert.ok(button, "missing row remove action");
+  button.emit("click");
+}
+
+function addRow(editor, key) {
+  const button = findByText(editor, `text:${key}`);
+  assert.ok(button, `missing row add action: ${key}`);
+  button.emit("click");
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const saveDialogModule = await import(dataModule("../web/js/aio/save_settings_dialog.js"));
+const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+assert.deepEqual(
+  Object.keys(saveDialogModule),
+  ["aioCreateSaveSettingsDialog"],
+  "Save settings dialog must expose only its lifecycle factory",
+);
+
+function configuredSettings() {
+  return {
+    save: {
+      enabled: true,
+      backend: "image_saver",
+      future_save_key: "keep-save",
+      image_saver: {
+        filename: "configured-name",
+        path: "Configured/Path",
+        extension: "png",
+        quality_jpeg_or_webp: 88,
+        lossless_webp: true,
+        optimize_png: false,
+        counter: 7,
+        clip_skip: -2,
+        time_format: "%Y-custom",
+        embed_workflow: false,
+        save_workflow_as_json: true,
+        save_prompt_metadata: false,
+        additional_hashes: "Base:AAAA",
+        additional_hash_bundles: '["  constructor:HASH,  ","","ModelB:BBBB:0.8"]',
+        civitai_hash_fetchers: '[{"enabled":"false","username":" user-a ","model_name":" Model A ","version":" v1 ","constructor":"ignore","toString":"ignore","__proto__":"ignore"},{"enabled":true,"username":"user-b","model_name":"Model B","version":""}]',
+        download_civitai_data: false,
+        easy_remix: false,
+        custom: "configured metadata",
+        future_image_saver_key: "drop-on-apply",
+      },
+    },
+    future_root_key: "keep-root",
+  };
+}
+
+function createFixture({ settings = {}, available = {}, deferLoads = false } = {}) {
+  let dependencyCalls = 0;
+  let currentDialog = null;
+  const dialogs = [];
+  const loadCalls = [];
+  const loadResolvers = [];
+  const writes = [];
+  const renders = [];
+  const visibleApplies = [];
+  const document = createFakeDocument();
+  const availabilityState = { ...available };
+  const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
+  const node = {
+    settings: settingsModule.aioMergeDefaults(defaultSettings, settings),
+    widgets: [{ name: "generation_settings", value: "" }],
+    visibleSettings: null,
+  };
+  node.widgets[0].value = JSON.stringify(node.settings);
+
+  function createDialog(title, subtitle) {
+    dependencyCalls += 1;
+    const dialog = {
+      title,
+      subtitle,
+      backdrop: document.createElement("div"),
+      body: document.createElement("div"),
+      actions: document.createElement("div"),
+      trace: [],
+    };
+    dialog.backdrop.remove = () => {
+      dialog.backdrop.removed = true;
+      dialog.trace.push("remove");
+    };
+    dialogs.push(dialog);
+    currentDialog = dialog;
+    return dialog;
+  }
+
+  function field(section, label, element, tooltipKey = "") {
+    dependencyCalls += 1;
+    const row = document.createElement("label");
+    row.className = "easyuse-anima-aio-field";
+    row.setAttribute("data-test-label", label);
+    row.setAttribute("data-test-tooltip", tooltipKey);
+    row.append(element);
+    section.append(row);
+    return element;
+  }
+
+  function checkbox(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = !!value;
+    return input;
+  }
+
+  function textInput(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function numberInput(value, step = "1") {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "number";
+    input.step = step;
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function textareaInput(value) {
+    dependencyCalls += 1;
+    const textarea = document.createElement("textarea");
+    textarea.value = String(value ?? "");
+    return textarea;
+  }
+
+  function selectInput(options, value) {
+    dependencyCalls += 1;
+    const select = document.createElement("select");
+    select.options = [];
+    for (const optionSpec of options) {
+      const option = document.createElement("option");
+      option.value = typeof optionSpec === "object"
+        ? String(optionSpec.value ?? "")
+        : String(optionSpec ?? "");
+      option.textContent = typeof optionSpec === "object"
+        ? String(optionSpec.label ?? option.value)
+        : option.value;
+      option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
+      option.selected = option.value === String(value ?? "");
+      select.options.push(option);
+      select.append(option);
+    }
+    if (!select.options.some((option) => option.selected)) {
+      select.value = String(value ?? "");
+    }
+    return select;
+  }
+
+  function staticText(value) {
+    dependencyCalls += 1;
+    return `static:${value}`;
+  }
+
+  function text(key) {
+    dependencyCalls += 1;
+    return `text:${key}`;
+  }
+
+  function format(key, values = {}) {
+    dependencyCalls += 1;
+    return `format:${key}:${JSON.stringify(values)}`;
+  }
+
+  function applyTooltip(element, key) {
+    dependencyCalls += 1;
+    element.setAttribute("data-test-tooltip", key);
+    return element;
+  }
+
+  function applyTooltipText(element, value) {
+    dependencyCalls += 1;
+    element.title = String(value ?? "");
+    return element;
+  }
+
+  function mergeDefaults(defaults, current) {
+    dependencyCalls += 1;
+    if (currentDialog) {
+      currentDialog.trace.push("merge");
+    }
+    return settingsModule.aioMergeDefaults(defaults, current);
+  }
+
+  function findWidget(targetNode, name) {
+    dependencyCalls += 1;
+    return targetNode.widgets?.find((widget) => widget.name === name);
+  }
+
+  function getSettings(targetNode) {
+    dependencyCalls += 1;
+    return clone(targetNode.settings);
+  }
+
+  function applyVisibleSettings(targetNode, nextSettings) {
+    dependencyCalls += 1;
+    const snapshot = clone(nextSettings);
+    targetNode.visibleSettings = snapshot;
+    visibleApplies.push(snapshot);
+    currentDialog.trace.push("apply-visible");
+  }
+
+  function writeSettings(targetNode, widget, nextSettings) {
+    dependencyCalls += 1;
+    const snapshot = clone(nextSettings);
+    targetNode.settings = snapshot;
+    widget.value = JSON.stringify(snapshot);
+    writes.push(snapshot);
+    currentDialog.trace.push("write");
+  }
+
+  function renderPanel(targetNode) {
+    dependencyCalls += 1;
+    renders.push(targetNode);
+    currentDialog.trace.push("render");
+  }
+
+  const openSaveSettings = saveDialogModule.aioCreateSaveSettingsDialog({
+    document,
+    controls: {
+      createDialog,
+      field,
+      checkbox,
+      selectInput,
+      textInput,
+      numberInput,
+      textareaInput,
+    },
+    text: {
+      staticText,
+      get: text,
+      format,
+      applyTooltip,
+      applyTooltipText,
+    },
+    settingsCore: {
+      defaultGenerationSettings: defaultSettings,
+      asBool(value, fallback) {
+        dependencyCalls += 1;
+        return settingsModule.aioAsBool(value, fallback);
+      },
+      mergeDefaults,
+    },
+    nodeAdapter: {
+      generatorSettingsWidget: "generation_settings",
+      findWidget,
+      getSettings,
+      applyVisibleSettings,
+      writeSettings,
+      renderPanel,
+    },
+    dependencyAdapter: {
+      available(key) {
+        dependencyCalls += 1;
+        return Object.hasOwn(availabilityState, key) ? !!availabilityState[key] : true;
+      },
+      pack(key) {
+        dependencyCalls += 1;
+        return `pack:${key}`;
+      },
+      load(options) {
+        dependencyCalls += 1;
+        loadCalls.push(options);
+        if (!deferLoads) {
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => loadResolvers.push(resolve));
+      },
+    },
+  });
+
+  return {
+    openSaveSettings,
+    document,
+    node,
+    defaultSettings,
+    dialogs,
+    loadCalls,
+    availabilityState,
+    writes,
+    renders,
+    visibleApplies,
+    dependencyCallCount: () => dependencyCalls,
+    resolveLoads() {
+      for (const resolve of loadResolvers.splice(0)) {
+        resolve();
+      }
+    },
+  };
+}
+
+{
+  const fixture = createFixture({ settings: configuredSettings() });
+  const originalSettings = clone(fixture.node.settings);
+  const originalWidget = fixture.node.widgets[0].value;
+  assert.equal(fixture.dependencyCallCount(), 0, "Factory composition must be side-effect free");
+  assert.equal(fixture.dialogs.length, 0);
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.equal(fixture.document.createdElements.length, 0, "Factory composition must not create DOM elements");
+  assert.equal(fixture.document.body.children.length, 0, "Factory composition must not attach DOM elements");
+
+  fixture.openSaveSettings(fixture.node);
+  await flushPromises();
+  const dialog = fixture.dialogs[0];
+  assert.equal(dialog.title, "Save Options");
+  assert.equal(
+    dialog.subtitle,
+    "Image Saver requires ComfyUI-Image-Saver. Missing node packs are reported during queue execution.",
+  );
+  assert.ok(dialog.body.classList.contains("easyuse-anima-aio-save-body"));
+  const main = sectionByHeading(dialog.body, "Save Backend");
+  const files = sectionByHeading(dialog.body, "Image Saver Files");
+  const metadata = sectionByHeading(dialog.body, "Image Saver Metadata");
+  assert.equal(controlIn(main, "Save image").checked, true);
+  assert.equal(controlIn(main, "Backend").value, "image_saver");
+  assert.equal(controlIn(files, "Filename").value, "configured-name");
+  assert.equal(controlIn(files, "JPEG/WebP quality").value, "88");
+  assert.equal(controlIn(metadata, "Custom metadata").value, "configured metadata");
+
+  const hashEditor = controlIn(metadata, "Manual hash bundles");
+  assert.deepEqual(
+    hashRows(hashEditor).map((row) => hashValue(row).value),
+    ["constructor:HASH", "ModelB:BBBB:0.8"],
+    "JSON-string hash bundles must hydrate, trim edge punctuation, and drop blank rows",
+  );
+  const civitaiEditor = controlIn(metadata, "Civitai Hash Fetchers");
+  assert.equal(civitaiRows(civitaiEditor).length, 2);
+  const firstCivitaiInputs = civitaiInputs(civitaiRows(civitaiEditor)[0]);
+  assert.equal(firstCivitaiInputs[0].checked, false);
+  assert.deepEqual(
+    firstCivitaiInputs.slice(1).map((input) => input.value),
+    ["user-a", "Model A", "v1"],
+    "JSON-string Civitai rows must hydrate only the fixed visible fields",
+  );
+  assert.equal(
+    find(civitaiRows(civitaiEditor)[0], (element) => (
+      element.classList.contains("easyuse-anima-aio-civitai-fetcher-preview")
+    )).textContent,
+    'format:text.civitaiHashPreview:{"model":"Model A"}',
+  );
+
+  hashValue(hashRows(hashEditor)[0]).value = "cancelled:HASH";
+  addRow(hashEditor, "button.addHashBundle");
+  hashValue(hashRows(hashEditor).at(-1)).value = "cancelled-new:HASH";
+  removeRow(hashRows(hashEditor)[1]);
+  assert.deepEqual(
+    hashRows(hashEditor).map((row) => hashValue(row).value),
+    ["cancelled:HASH", "cancelled-new:HASH"],
+    "Hash remove must detach exactly the selected row",
+  );
+
+  firstCivitaiInputs[0].checked = true;
+  firstCivitaiInputs[2].value = "Cancelled Model";
+  firstCivitaiInputs[2].emit("input");
+  assert.equal(
+    find(civitaiRows(civitaiEditor)[0], (element) => (
+      element.classList.contains("easyuse-anima-aio-civitai-fetcher-preview")
+    )).textContent,
+    'format:text.civitaiHashPreview:{"model":"Cancelled Model"}',
+  );
+  addRow(civitaiEditor, "button.addCivitaiFetcher");
+  const cancelledNewInputs = civitaiInputs(civitaiRows(civitaiEditor).at(-1));
+  cancelledNewInputs[1].value = "cancelled-user";
+  cancelledNewInputs[2].value = "cancelled-model";
+  removeRow(civitaiRows(civitaiEditor)[1]);
+  assert.deepEqual(
+    civitaiRows(civitaiEditor).map((row) => civitaiInputs(row)[1].value),
+    ["user-a", "cancelled-user"],
+    "Civitai remove must detach exactly the selected row",
+  );
+  controlIn(files, "Filename").value = "cancelled-name";
+
+  action(dialog, "button.cancel").emit("click");
+  assert.deepEqual(fixture.node.settings, originalSettings, "Cancel must not mutate settings");
+  assert.equal(fixture.node.widgets[0].value, originalWidget, "Cancel must not rewrite the hidden widget");
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.equal(fixture.visibleApplies.length, 0);
+  assert.deepEqual(dialog.trace, ["remove"]);
+}
+
+{
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    available: { imageSaver: true },
+    deferLoads: true,
+  });
+  assert.equal(fixture.dependencyCallCount(), 0, "Deferred fixture factory must also be side-effect free");
+  fixture.openSaveSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const main = sectionByHeading(dialog.body, "Save Backend");
+  const files = sectionByHeading(dialog.body, "Image Saver Files");
+  const metadata = sectionByHeading(dialog.body, "Image Saver Metadata");
+  const backend = controlIn(main, "Backend");
+  const imageSaverOption = backend.options.find((option) => option.value === "image_saver");
+  const warning = find(
+    main,
+    (element) => element.classList.contains("easyuse-anima-aio-warning"),
+  );
+  assert.ok(imageSaverOption);
+  assert.ok(warning);
+  assert.equal(imageSaverOption.disabled, false);
+  assert.equal(imageSaverOption.textContent, "image_saver");
+  assert.equal(backend.value, "image_saver");
+  assert.equal(warning.hidden, true);
+  assert.equal(fixture.loadCalls.length, 1);
+
+  fixture.availabilityState.imageSaver = false;
+  fixture.resolveLoads();
+  await flushPromises();
+  assert.equal(imageSaverOption.disabled, true, "Deferred dependency refresh must disable Image Saver");
+  assert.equal(imageSaverOption.textContent, "image_saver (pack:imageSaver missing)");
+  assert.equal(backend.value, "comfy_save_image", "Missing Image Saver must select the built-in fallback");
+  assert.equal(warning.hidden, false);
+  assert.equal(
+    warning.textContent,
+    'format:warning.optionalDependencyMissing:{"backend":"image_saver","pack":"pack:imageSaver"}',
+  );
+
+  controlIn(main, "Save image").checked = false;
+  controlIn(files, "Filename").value = "";
+  controlIn(files, "Path").value = "";
+  controlIn(files, "Extension").value = "jpeg";
+  controlIn(files, "JPEG/WebP quality").value = "";
+  controlIn(files, "Lossless WebP").checked = false;
+  controlIn(files, "Optimize PNG").checked = true;
+  controlIn(files, "Counter").value = "";
+  controlIn(metadata, "Time format").value = "";
+  controlIn(metadata, "Clip skip").value = "";
+  controlIn(metadata, "Embed workflow").checked = true;
+  controlIn(metadata, "Workflow JSON").checked = false;
+  controlIn(metadata, "Save prompt metadata").checked = true;
+  controlIn(metadata, "Additional hashes").value = "Base:UPDATED";
+  controlIn(metadata, "Civitai data").checked = true;
+  controlIn(metadata, "Easy remix").checked = true;
+  controlIn(metadata, "Custom metadata").value = "updated metadata";
+
+  const hashEditor = controlIn(metadata, "Manual hash bundles");
+  hashValue(hashRows(hashEditor)[1]).value = "  Updated:BBBB,  ";
+  addRow(hashEditor, "button.addHashBundle");
+  hashValue(hashRows(hashEditor).at(-1)).value = "Third:CCCC";
+  addRow(hashEditor, "button.addHashBundle");
+
+  const civitaiEditor = controlIn(metadata, "Civitai Hash Fetchers");
+  const secondInputs = civitaiInputs(civitaiRows(civitaiEditor)[1]);
+  secondInputs[1].value = " user-b-updated ";
+  secondInputs[2].value = " Model B Updated ";
+  secondInputs[3].value = " v2 ";
+  addRow(civitaiEditor, "button.addCivitaiFetcher");
+  const thirdInputs = civitaiInputs(civitaiRows(civitaiEditor).at(-1));
+  thirdInputs[0].checked = false;
+  thirdInputs[1].value = "user-c";
+  thirdInputs[2].value = "Model C";
+  thirdInputs[3].value = "v3";
+  addRow(civitaiEditor, "button.addCivitaiFetcher");
+
+  action(dialog, "button.apply").emit("click");
+  assert.deepEqual(dialog.trace, ["merge", "apply-visible", "write", "render", "remove"]);
+  assert.equal(fixture.visibleApplies.length, 1);
+  assert.equal(fixture.writes.length, 1);
+  assert.equal(fixture.renders.length, 1);
+  assert.equal(fixture.node.settings.future_root_key, "keep-root");
+  assert.equal(fixture.node.settings.save.future_save_key, "keep-save");
+  assert.equal(fixture.node.settings.save.enabled, false);
+  assert.equal(fixture.node.settings.save.backend, "comfy_save_image");
+
+  const imageSaver = fixture.node.settings.save.image_saver;
+  assert.deepEqual(
+    Object.keys(imageSaver),
+    [
+      "filename",
+      "path",
+      "extension",
+      "lossless_webp",
+      "quality_jpeg_or_webp",
+      "optimize_png",
+      "counter",
+      "clip_skip",
+      "time_format",
+      "save_workflow_as_json",
+      "embed_workflow",
+      "save_prompt_metadata",
+      "additional_hashes",
+      "additional_hash_bundles",
+      "civitai_hash_fetchers",
+      "download_civitai_data",
+      "easy_remix",
+      "custom",
+    ],
+    "Apply must replace Image Saver settings with the fixed schema and stable key order",
+  );
+  assert.equal(imageSaver.filename, "%time_%basemodelname");
+  assert.equal(imageSaver.path, "EasyUseAnima/AiO");
+  assert.equal(imageSaver.extension, "jpeg");
+  assert.equal(imageSaver.quality_jpeg_or_webp, 97);
+  assert.equal(imageSaver.counter, 0);
+  assert.equal(imageSaver.clip_skip, 0);
+  assert.equal(imageSaver.time_format, "%Y-%m-%d-%H%M%S");
+  assert.equal(imageSaver.lossless_webp, false);
+  assert.equal(imageSaver.optimize_png, true);
+  assert.equal(imageSaver.embed_workflow, true);
+  assert.equal(imageSaver.save_workflow_as_json, false);
+  assert.equal(imageSaver.save_prompt_metadata, true);
+  assert.equal(imageSaver.additional_hashes, "Base:UPDATED");
+  assert.equal(imageSaver.download_civitai_data, true);
+  assert.equal(imageSaver.easy_remix, true);
+  assert.equal(imageSaver.custom, "updated metadata");
+  assert.deepEqual(
+    imageSaver.additional_hash_bundles,
+    ["constructor:HASH", "Updated:BBBB", "Third:CCCC"],
+    "Hash bundle serialization must preserve content order, including a literal constructor hash",
+  );
+  assert.deepEqual(
+    imageSaver.civitai_hash_fetchers,
+    [
+      { enabled: false, username: "user-a", model_name: "Model A", version: "v1" },
+      { enabled: true, username: "user-b-updated", model_name: "Model B Updated", version: "v2" },
+      { enabled: false, username: "user-c", model_name: "Model C", version: "v3" },
+    ],
+    "Civitai serialization must trim, filter blank rows, and preserve visible row order",
+  );
+  for (const fetcher of imageSaver.civitai_hash_fetchers) {
+    assert.deepEqual(
+      Object.keys(fetcher),
+      ["enabled", "username", "model_name", "version"],
+      "Civitai rows must serialize only the fixed allowlist",
+    );
+    assert.equal(Object.hasOwn(fetcher, "constructor"), false);
+    assert.equal(Object.hasOwn(fetcher, "toString"), false);
+    assert.equal(Object.hasOwn(fetcher, "__proto__"), false);
+  }
+  assert.equal(
+    Object.hasOwn(imageSaver, "future_image_saver_key"),
+    false,
+    "Unknown Image Saver siblings must be removed by fixed-schema serialization",
+  );
+  assert.deepEqual(fixture.visibleApplies[0], fixture.node.settings);
+  assert.deepEqual(fixture.writes[0], fixture.node.settings);
+  assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), fixture.node.settings);
+}
+
+console.log("AiO Save settings dialog smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -24,6 +24,9 @@ AIO_STAGE_SETTINGS_DIALOGS_JS = (
 AIO_DETAILER_SETTINGS_DIALOG_JS = (
     ROOT / "web" / "js" / "aio" / "detailer_settings_dialog.js"
 )
+AIO_SAVE_SETTINGS_DIALOG_JS = (
+    ROOT / "web" / "js" / "aio" / "save_settings_dialog.js"
+)
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
@@ -374,17 +377,18 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn('field(safePag, "Rescale"', body)
 
     def test_save_settings_expose_prompt_metadata_toggle(self):
-        source = AIO_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        source = AIO_SAVE_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
         settings_source = AIO_SETTINGS_JS.read_text(encoding="utf-8")
         start = source.index("function openSaveSettings")
-        end = source.index("\nfunction openAdvancedSettings", start)
+        end = source.index("\n\n  return openSaveSettings", start)
         body = source[start:end]
 
         self.assertIn("save_prompt_metadata: true", settings_source)
         self.assertIn('field(metadata, "Save prompt metadata"', body)
         self.assertIn("checkbox(imageSaver.save_prompt_metadata)", body)
         self.assertIn("save_prompt_metadata: savePromptMetadata.checked", body)
-        self.assertIn('"Save prompt metadata": "tip.savePromptMetadata"', source)
+        self.assertIn('"Save prompt metadata": "tip.savePromptMetadata"', entry_source)
 
     def test_detailer_settings_support_custom_blocks(self):
         source = AIO_DETAILER_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -59,6 +59,10 @@ AIO_SAMPLER_SETTINGS_DIALOG_JS = AIO_MODULES / "sampler_settings_dialog.js"
 AIO_SAMPLER_SETTINGS_DIALOG_SMOKE = (
     ROOT / "tests" / "frontend_aio_sampler_settings_dialog_smoke.mjs"
 )
+AIO_SAVE_SETTINGS_DIALOG_JS = AIO_MODULES / "save_settings_dialog.js"
+AIO_SAVE_SETTINGS_DIALOG_SMOKE = (
+    ROOT / "tests" / "frontend_aio_save_settings_dialog_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -702,7 +706,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         composition_start = entry_source.index(
             "const openSamplerSettings = aioCreateSamplerSettingsDialog({"
         )
-        composition_end = entry_source.index("\n\nconst generatorPanelRuntime", composition_start)
+        composition_end = entry_source.index("\n\nconst openSaveSettings", composition_start)
         composition = entry_source[composition_start:composition_end]
         for expected in (
             "createDialog,",
@@ -725,13 +729,87 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(composition_dependency=expected):
                 self.assertIn(expected, composition)
         detailer_composition = entry_source.index("const openDetailerSettings")
-        generator_panel_composition = entry_source.index("const generatorPanelRuntime")
+        save_composition = entry_source.index("const openSaveSettings")
         self.assertLess(detailer_composition, composition_start)
-        self.assertLess(composition_start, generator_panel_composition)
+        self.assertLess(composition_start, save_composition)
         self.assertIn("return openSamplerSettings;", source)
         self.assertTrue(AIO_SAMPLER_SETTINGS_DIALOG_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_sampler_settings_dialog_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_save_settings_dialog_has_closed_lifecycle_boundary(self):
+        source = AIO_SAVE_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(source.startswith("// @ts-check\n"))
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotRegex(source, r"(?m)^\s*import\s")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertEqual(
+            re.findall(r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE),
+            ["aioCreateSaveSettingsDialog"],
+        )
+        self.assertEqual(len(re.findall(r"(?m)^export\s+", source)), 1)
+        self.assertIn(
+            'import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";',
+            entry_source,
+        )
+        for moved_function in (
+            "normalizeImageSaverHashBundles",
+            "normalizeImageSaverCivitaiHashFetchers",
+            "createImageSaverHashBundleEditor",
+            "createImageSaverCivitaiHashFetcherEditor",
+            "openSaveSettings",
+        ):
+            with self.subTest(moved_function=moved_function):
+                self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
+                self.assertNotRegex(entry_source, rf"\bfunction\s+{moved_function}\(")
+
+        composition_start = entry_source.index(
+            "const openSaveSettings = aioCreateSaveSettingsDialog({"
+        )
+        composition_end = entry_source.index("\n\nconst generatorPanelRuntime", composition_start)
+        composition = entry_source[composition_start:composition_end]
+        for expected in (
+            "createDialog,",
+            "field,",
+            "checkbox,",
+            "selectInput,",
+            "textInput,",
+            "numberInput,",
+            "textareaInput,",
+            "staticText: aioStaticText,",
+            "get: aioText,",
+            "format: aioFormat,",
+            "applyTooltip,",
+            "applyTooltipText,",
+            "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,",
+            "asBool,",
+            "mergeDefaults,",
+            "generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,",
+            "findWidget,",
+            "getSettings: generatorSettings,",
+            "applyVisibleSettings: applyVisibleGeneratorSettings,",
+            "writeSettings,",
+            "renderPanel: renderGeneratorPanel,",
+            "available: optionalDependencyAvailable,",
+            "pack: optionalDependencyPack,",
+            "load: loadGeneratorOptionalDependencies,",
+        ):
+            with self.subTest(composition_dependency=expected):
+                self.assertIn(expected, composition)
+        sampler_composition = entry_source.index("const openSamplerSettings")
+        generator_panel_composition = entry_source.index("const generatorPanelRuntime")
+        self.assertLess(sampler_composition, composition_start)
+        self.assertLess(composition_start, generator_panel_composition)
+        self.assertIn("return openSaveSettings;", source)
+        self.assertTrue(AIO_SAVE_SETTINGS_DIALOG_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_save_settings_dialog_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -74,6 +74,11 @@ try {
         throw "Frontend AiO Sampler settings dialog smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_save_settings_dialog_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Save settings dialog smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_dependency_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/save_settings_dialog.js
+++ b/web/js/aio/save_settings_dialog.js
@@ -1,0 +1,416 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioSaveDialogControls
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(value: any) => any} checkbox
+ * @property {(options: any[], value: any) => any} selectInput
+ * @property {(value: any) => any} textInput
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(value: any) => any} textareaInput
+ */
+
+/**
+ * @typedef {object} AioSaveDialogText
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} get
+ * @property {(key: string, values?: Record<string, any>) => string} format
+ * @property {(element: any, key: string) => any} applyTooltip
+ * @property {(element: any, value: any) => any} applyTooltipText
+ */
+
+/**
+ * @typedef {object} AioSaveDialogSettingsCore
+ * @property {any} defaultGenerationSettings
+ * @property {(value: any, fallback?: boolean) => boolean} asBool
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ */
+
+/**
+ * @typedef {object} AioSaveDialogNodeAdapter
+ * @property {string} generatorSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(node: any) => any} getSettings
+ * @property {(node: any, settings: any) => void} applyVisibleSettings
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ * @property {(node: any) => void} renderPanel
+ */
+
+/**
+ * @typedef {object} AioSaveDialogDependencyAdapter
+ * @property {(key: string) => boolean} available
+ * @property {(key: string) => string} pack
+ * @property {(options?: Record<string, any>) => Promise<any>} load
+ */
+
+/**
+ * @typedef {object} AioSaveSettingsDialogDependencies
+ * @property {any} document
+ * @property {AioSaveDialogControls} controls
+ * @property {AioSaveDialogText} text
+ * @property {AioSaveDialogSettingsCore} settingsCore
+ * @property {AioSaveDialogNodeAdapter} nodeAdapter
+ * @property {AioSaveDialogDependencyAdapter} dependencyAdapter
+ */
+
+/**
+ * Own the Save settings dialog, Image Saver hash editors, normalization, and
+ * Apply/Cancel lifecycle. Extension registration, dependency discovery,
+ * generator-panel rendering, and durable storage remain adapters.
+ *
+ * @param {AioSaveSettingsDialogDependencies} dependencies
+ * @returns {(node: any) => void}
+ */
+export function aioCreateSaveSettingsDialog(dependencies) {
+  const {
+    document,
+    controls,
+    text,
+    settingsCore,
+    nodeAdapter,
+    dependencyAdapter,
+  } = dependencies;
+  const {
+    createDialog,
+    field,
+    checkbox,
+    selectInput,
+    textInput,
+    numberInput,
+    textareaInput,
+  } = controls;
+  const {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+    applyTooltip,
+    applyTooltipText,
+  } = text;
+  const {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    asBool,
+    mergeDefaults,
+  } = settingsCore;
+  const {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
+    applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  } = nodeAdapter;
+  const {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    load: loadGeneratorOptionalDependencies,
+  } = dependencyAdapter;
+
+  function normalizeImageSaverHashBundles(value) {
+    if (typeof value === "string") {
+      try {
+        return normalizeImageSaverHashBundles(JSON.parse(value || "[]"));
+      } catch {
+        return value.trim() ? [value.trim()] : [];
+      }
+    }
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value
+      .map((item) => String(item ?? "").trim().replace(/^[,\s]+|[,\s]+$/g, ""))
+      .filter(Boolean);
+  }
+
+  function normalizeImageSaverCivitaiHashFetchers(value) {
+    if (typeof value === "string") {
+      try {
+        return normalizeImageSaverCivitaiHashFetchers(JSON.parse(value || "[]"));
+      } catch {
+        return [];
+      }
+    }
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value
+      .filter((item) => item && typeof item === "object" && !Array.isArray(item))
+      .map((item) => ({
+        enabled: asBool(item.enabled, true),
+        username: String(item.username || "").trim(),
+        model_name: String(item.model_name || "").trim(),
+        version: String(item.version || "").trim(),
+      }))
+      .filter((item) => item.username || item.model_name || item.version);
+  }
+
+  function createImageSaverHashBundleEditor(initialBundles) {
+    const wrapper = document.createElement("div");
+    const list = document.createElement("div");
+    list.className = "easyuse-anima-aio-hash-bundle-list";
+    const addButton = document.createElement("button");
+    addButton.type = "button";
+    addButton.className = "easyuse-anima-aio-add-row";
+    addButton.textContent = aioText("button.addHashBundle");
+
+    const addRow = (value = "") => {
+      const row = document.createElement("div");
+      row.className = "easyuse-anima-aio-hash-bundle-row";
+      const textarea = textareaInput(value);
+      textarea.placeholder = "Name:HASH, HASH:Weight, Name:HASH:Weight";
+      applyTooltip(textarea, "tip.hashBundles");
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.textContent = aioText("button.remove");
+      applyTooltip(remove, "tip.hashBundles");
+      remove.addEventListener("click", () => {
+        row.remove();
+      });
+      row.append(textarea, remove);
+      list.append(row);
+    };
+
+    const bundles = normalizeImageSaverHashBundles(initialBundles);
+    if (bundles.length) {
+      for (const bundle of bundles) {
+        addRow(bundle);
+      }
+    } else {
+      addRow();
+    }
+    addButton.addEventListener("click", () => addRow());
+    wrapper.append(list, addButton);
+
+    return {
+      element: wrapper,
+      values() {
+        return [...list.querySelectorAll("textarea")]
+          .map((textarea) => String(textarea.value || "").trim().replace(/^[,\s]+|[,\s]+$/g, ""))
+          .filter(Boolean);
+      },
+    };
+  }
+
+  function createImageSaverCivitaiHashFetcherEditor(initialFetchers) {
+    const wrapper = document.createElement("div");
+    const list = document.createElement("div");
+    list.className = "easyuse-anima-aio-civitai-fetcher-list";
+    const addButton = document.createElement("button");
+    addButton.type = "button";
+    addButton.className = "easyuse-anima-aio-add-row";
+    addButton.textContent = aioText("button.addCivitaiFetcher");
+    applyTooltip(addButton, "tip.civitaiHashFetchers");
+
+    const miniField = (label, control, tooltipKey) => {
+      const item = document.createElement("div");
+      item.className = "easyuse-anima-aio-mini-field";
+      const labelEl = document.createElement("label");
+      labelEl.textContent = label;
+      const tooltip = aioText(tooltipKey);
+      applyTooltipText(item, tooltip);
+      applyTooltipText(labelEl, tooltip);
+      applyTooltipText(control, tooltip);
+      item.append(labelEl, control);
+      return item;
+    };
+
+    const addRow = (value = {}) => {
+      const row = document.createElement("div");
+      row.className = "easyuse-anima-aio-civitai-fetcher-row";
+      applyTooltip(row, "tip.civitaiHashFetchers");
+
+      const header = document.createElement("div");
+      header.className = "easyuse-anima-aio-civitai-fetcher-head";
+      const enabledLabel = document.createElement("label");
+      enabledLabel.className = "easyuse-anima-aio-civitai-fetcher-enabled";
+      const enabled = checkbox(value.enabled !== false);
+      enabledLabel.append(enabled, document.createTextNode(aioText("label.enabled")));
+      applyTooltip(enabledLabel, "tip.civitaiHashFetchers");
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.textContent = aioText("button.remove");
+      applyTooltip(remove, "tip.civitaiHashFetchers");
+      remove.addEventListener("click", () => row.remove());
+      header.append(enabledLabel, remove);
+
+      const grid = document.createElement("div");
+      grid.className = "easyuse-anima-aio-civitai-fetcher-grid";
+      const username = textInput(value.username || "");
+      const modelName = textInput(value.model_name || "");
+      const version = textInput(value.version || "");
+      username.placeholder = "N0VA39";
+      modelName.placeholder = "Anima All in One workflow";
+      version.placeholder = "";
+      grid.append(
+        miniField("Username", username, "tip.civitaiUsername"),
+        miniField("Model name", modelName, "tip.civitaiModelName"),
+        miniField("Version", version, "tip.civitaiVersion"),
+      );
+
+      const preview = document.createElement("div");
+      preview.className = "easyuse-anima-aio-civitai-fetcher-preview";
+      applyTooltip(preview, "tip.civitaiHashFetchers");
+      const updatePreview = () => {
+        const name = String(modelName.value || "").trim() || "model_name";
+        preview.textContent = aioFormat("text.civitaiHashPreview", { model: name });
+      };
+      modelName.addEventListener("input", updatePreview);
+      updatePreview();
+
+      row.append(header, grid, preview);
+      list.append(row);
+    };
+
+    const fetchers = normalizeImageSaverCivitaiHashFetchers(initialFetchers);
+    if (fetchers.length) {
+      for (const fetcher of fetchers) {
+        addRow(fetcher);
+      }
+    } else {
+      addRow();
+    }
+    addButton.addEventListener("click", () => addRow());
+    wrapper.append(list, addButton);
+
+    return {
+      element: wrapper,
+      values() {
+        return [...list.querySelectorAll(".easyuse-anima-aio-civitai-fetcher-row")]
+          .map((row) => {
+            const inputs = row.querySelectorAll("input");
+            const enabled = inputs[0]?.checked !== false;
+            const username = String(inputs[1]?.value || "").trim();
+            const modelName = String(inputs[2]?.value || "").trim();
+            const version = String(inputs[3]?.value || "").trim();
+            return {
+              enabled,
+              username,
+              model_name: modelName,
+              version,
+            };
+          })
+          .filter((item) => item.username || item.model_name || item.version);
+      },
+    };
+  }
+
+  function openSaveSettings(node) {
+    const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
+    const settings = generatorSettings(node);
+    const imageSaver = mergeDefaults(
+      DEFAULT_GENERATION_SETTINGS.save.image_saver,
+      settings.save.image_saver,
+    );
+    const { backdrop, body, actions } = createDialog(
+      "Save Options",
+      "Image Saver requires ComfyUI-Image-Saver. Missing node packs are reported during queue execution."
+    );
+    body.classList.add("easyuse-anima-aio-save-body");
+    const main = document.createElement("section");
+    main.className = "easyuse-anima-aio-section full";
+    main.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Save Backend") }));
+    const save = field(main, "Save image", checkbox(settings.save.enabled));
+    const backend = field(
+      main,
+      "Backend",
+      selectInput(["image_saver", "comfy_save_image"], settings.save.backend || "image_saver"),
+    );
+    const dependencyWarning = document.createElement("div");
+    dependencyWarning.className = "easyuse-anima-aio-warning";
+    dependencyWarning.hidden = true;
+    main.append(dependencyWarning);
+    const refreshSaveDependencyLocks = () => {
+      const imageSaverMissing = !optionalDependencyAvailable("imageSaver");
+      for (const option of Array.from(backend.options)) {
+        if (option.value === "image_saver") {
+          option.disabled = imageSaverMissing;
+          option.textContent = imageSaverMissing
+            ? `image_saver (${optionalDependencyPack("imageSaver")} missing)`
+            : "image_saver";
+        }
+      }
+      if (imageSaverMissing && backend.value === "image_saver") {
+        backend.value = "comfy_save_image";
+        dependencyWarning.hidden = false;
+        dependencyWarning.textContent = aioFormat("warning.optionalDependencyMissing", {
+          backend: "image_saver",
+          pack: optionalDependencyPack("imageSaver"),
+        });
+      } else {
+        dependencyWarning.hidden = true;
+        dependencyWarning.textContent = "";
+      }
+    };
+
+    const files = document.createElement("section");
+    files.className = "easyuse-anima-aio-section full";
+    files.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Saver Files") }));
+    const filename = field(files, "Filename", textInput(imageSaver.filename));
+    const path = field(files, "Path", textInput(imageSaver.path));
+    const extension = field(files, "Extension", selectInput(["webp", "png", "jpeg", "jpg"], imageSaver.extension));
+    const quality = field(files, "JPEG/WebP quality", numberInput(imageSaver.quality_jpeg_or_webp, "1"));
+    const losslessWebp = field(files, "Lossless WebP", checkbox(imageSaver.lossless_webp));
+    const optimizePng = field(files, "Optimize PNG", checkbox(imageSaver.optimize_png));
+    const counter = field(files, "Counter", numberInput(imageSaver.counter, "1"));
+
+    const metadata = document.createElement("section");
+    metadata.className = "easyuse-anima-aio-section full";
+    metadata.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Saver Metadata") }));
+    const timeFormat = field(metadata, "Time format", textInput(imageSaver.time_format));
+    const clipSkip = field(metadata, "Clip skip", numberInput(imageSaver.clip_skip, "1"));
+    const embedWorkflow = field(metadata, "Embed workflow", checkbox(imageSaver.embed_workflow));
+    const saveWorkflowJson = field(metadata, "Workflow JSON", checkbox(imageSaver.save_workflow_as_json));
+    const savePromptMetadata = field(metadata, "Save prompt metadata", checkbox(imageSaver.save_prompt_metadata));
+    const additionalHashes = field(metadata, "Additional hashes", textInput(imageSaver.additional_hashes), "tip.additionalHashes");
+    const hashBundles = createImageSaverHashBundleEditor(imageSaver.additional_hash_bundles);
+    field(metadata, "Manual hash bundles", hashBundles.element, "tip.hashBundles");
+    const civitaiHashFetchers = createImageSaverCivitaiHashFetcherEditor(imageSaver.civitai_hash_fetchers);
+    field(metadata, "Civitai Hash Fetchers", civitaiHashFetchers.element, "tip.civitaiHashFetchers");
+    const civitai = field(metadata, "Civitai data", checkbox(imageSaver.download_civitai_data));
+    const easyRemix = field(metadata, "Easy remix", checkbox(imageSaver.easy_remix));
+    const custom = field(metadata, "Custom metadata", textareaInput(imageSaver.custom));
+    body.append(main, files, metadata);
+    refreshSaveDependencyLocks();
+    loadGeneratorOptionalDependencies().then(refreshSaveDependencyLocks);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = aioText("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = aioText("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
+      next.save.enabled = save.checked;
+      next.save.backend = backend.value || "image_saver";
+      next.save.image_saver = {
+        filename: filename.value || "%time_%basemodelname",
+        path: path.value || "EasyUseAnima/AiO",
+        extension: extension.value || "webp",
+        lossless_webp: losslessWebp.checked,
+        quality_jpeg_or_webp: Number(quality.value || 97),
+        optimize_png: optimizePng.checked,
+        counter: Number(counter.value || 0),
+        clip_skip: Number(clipSkip.value || 0),
+        time_format: timeFormat.value || "%Y-%m-%d-%H%M%S",
+        save_workflow_as_json: saveWorkflowJson.checked,
+        embed_workflow: embedWorkflow.checked,
+        save_prompt_metadata: savePromptMetadata.checked,
+        additional_hashes: additionalHashes.value || "",
+        additional_hash_bundles: hashBundles.values(),
+        civitai_hash_fetchers: civitaiHashFetchers.values(),
+        download_civitai_data: civitai.checked,
+        easy_remix: easyRemix.checked,
+        custom: custom.value || "",
+      };
+      applyVisibleGeneratorSettings(node, next);
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  }
+
+
+  return openSaveSettings;
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -22,6 +22,7 @@ import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js
 import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
 import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
+import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -3915,310 +3916,6 @@ function randomSeed() {
 }
 
 
-function normalizeImageSaverHashBundles(value) {
-  if (typeof value === "string") {
-    try {
-      return normalizeImageSaverHashBundles(JSON.parse(value || "[]"));
-    } catch {
-      return value.trim() ? [value.trim()] : [];
-    }
-  }
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .map((item) => String(item ?? "").trim().replace(/^[,\s]+|[,\s]+$/g, ""))
-    .filter(Boolean);
-}
-
-function normalizeImageSaverCivitaiHashFetchers(value) {
-  if (typeof value === "string") {
-    try {
-      return normalizeImageSaverCivitaiHashFetchers(JSON.parse(value || "[]"));
-    } catch {
-      return [];
-    }
-  }
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .filter((item) => item && typeof item === "object" && !Array.isArray(item))
-    .map((item) => ({
-      enabled: asBool(item.enabled, true),
-      username: String(item.username || "").trim(),
-      model_name: String(item.model_name || "").trim(),
-      version: String(item.version || "").trim(),
-    }))
-    .filter((item) => item.username || item.model_name || item.version);
-}
-
-function createImageSaverHashBundleEditor(initialBundles) {
-  const wrapper = document.createElement("div");
-  const list = document.createElement("div");
-  list.className = "easyuse-anima-aio-hash-bundle-list";
-  const addButton = document.createElement("button");
-  addButton.type = "button";
-  addButton.className = "easyuse-anima-aio-add-row";
-  addButton.textContent = aioText("button.addHashBundle");
-
-  const addRow = (value = "") => {
-    const row = document.createElement("div");
-    row.className = "easyuse-anima-aio-hash-bundle-row";
-    const textarea = textareaInput(value);
-    textarea.placeholder = "Name:HASH, HASH:Weight, Name:HASH:Weight";
-    applyTooltip(textarea, "tip.hashBundles");
-    const remove = document.createElement("button");
-    remove.type = "button";
-    remove.textContent = aioText("button.remove");
-    applyTooltip(remove, "tip.hashBundles");
-    remove.addEventListener("click", () => {
-      row.remove();
-    });
-    row.append(textarea, remove);
-    list.append(row);
-  };
-
-  const bundles = normalizeImageSaverHashBundles(initialBundles);
-  if (bundles.length) {
-    for (const bundle of bundles) {
-      addRow(bundle);
-    }
-  } else {
-    addRow();
-  }
-  addButton.addEventListener("click", () => addRow());
-  wrapper.append(list, addButton);
-
-  return {
-    element: wrapper,
-    values() {
-      return [...list.querySelectorAll("textarea")]
-        .map((textarea) => String(textarea.value || "").trim().replace(/^[,\s]+|[,\s]+$/g, ""))
-        .filter(Boolean);
-    },
-  };
-}
-
-function createImageSaverCivitaiHashFetcherEditor(initialFetchers) {
-  const wrapper = document.createElement("div");
-  const list = document.createElement("div");
-  list.className = "easyuse-anima-aio-civitai-fetcher-list";
-  const addButton = document.createElement("button");
-  addButton.type = "button";
-  addButton.className = "easyuse-anima-aio-add-row";
-  addButton.textContent = aioText("button.addCivitaiFetcher");
-  applyTooltip(addButton, "tip.civitaiHashFetchers");
-
-  const miniField = (label, control, tooltipKey) => {
-    const item = document.createElement("div");
-    item.className = "easyuse-anima-aio-mini-field";
-    const labelEl = document.createElement("label");
-    labelEl.textContent = label;
-    const tooltip = aioText(tooltipKey);
-    applyTooltipText(item, tooltip);
-    applyTooltipText(labelEl, tooltip);
-    applyTooltipText(control, tooltip);
-    item.append(labelEl, control);
-    return item;
-  };
-
-  const addRow = (value = {}) => {
-    const row = document.createElement("div");
-    row.className = "easyuse-anima-aio-civitai-fetcher-row";
-    applyTooltip(row, "tip.civitaiHashFetchers");
-
-    const header = document.createElement("div");
-    header.className = "easyuse-anima-aio-civitai-fetcher-head";
-    const enabledLabel = document.createElement("label");
-    enabledLabel.className = "easyuse-anima-aio-civitai-fetcher-enabled";
-    const enabled = checkbox(value.enabled !== false);
-    enabledLabel.append(enabled, document.createTextNode(aioText("label.enabled")));
-    applyTooltip(enabledLabel, "tip.civitaiHashFetchers");
-    const remove = document.createElement("button");
-    remove.type = "button";
-    remove.textContent = aioText("button.remove");
-    applyTooltip(remove, "tip.civitaiHashFetchers");
-    remove.addEventListener("click", () => row.remove());
-    header.append(enabledLabel, remove);
-
-    const grid = document.createElement("div");
-    grid.className = "easyuse-anima-aio-civitai-fetcher-grid";
-    const username = textInput(value.username || "");
-    const modelName = textInput(value.model_name || "");
-    const version = textInput(value.version || "");
-    username.placeholder = "N0VA39";
-    modelName.placeholder = "Anima All in One workflow";
-    version.placeholder = "";
-    grid.append(
-      miniField("Username", username, "tip.civitaiUsername"),
-      miniField("Model name", modelName, "tip.civitaiModelName"),
-      miniField("Version", version, "tip.civitaiVersion"),
-    );
-
-    const preview = document.createElement("div");
-    preview.className = "easyuse-anima-aio-civitai-fetcher-preview";
-    applyTooltip(preview, "tip.civitaiHashFetchers");
-    const updatePreview = () => {
-      const name = String(modelName.value || "").trim() || "model_name";
-      preview.textContent = aioFormat("text.civitaiHashPreview", { model: name });
-    };
-    modelName.addEventListener("input", updatePreview);
-    updatePreview();
-
-    row.append(header, grid, preview);
-    list.append(row);
-  };
-
-  const fetchers = normalizeImageSaverCivitaiHashFetchers(initialFetchers);
-  if (fetchers.length) {
-    for (const fetcher of fetchers) {
-      addRow(fetcher);
-    }
-  } else {
-    addRow();
-  }
-  addButton.addEventListener("click", () => addRow());
-  wrapper.append(list, addButton);
-
-  return {
-    element: wrapper,
-    values() {
-      return [...list.querySelectorAll(".easyuse-anima-aio-civitai-fetcher-row")]
-        .map((row) => {
-          const inputs = row.querySelectorAll("input");
-          const enabled = inputs[0]?.checked !== false;
-          const username = String(inputs[1]?.value || "").trim();
-          const modelName = String(inputs[2]?.value || "").trim();
-          const version = String(inputs[3]?.value || "").trim();
-          return {
-            enabled,
-            username,
-            model_name: modelName,
-            version,
-          };
-        })
-        .filter((item) => item.username || item.model_name || item.version);
-    },
-  };
-}
-
-function openSaveSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = generatorSettings(node);
-  const imageSaver = mergeDefaults(
-    DEFAULT_GENERATION_SETTINGS.save.image_saver,
-    settings.save.image_saver,
-  );
-  const { backdrop, body, actions } = createDialog(
-    "Save Options",
-    "Image Saver requires ComfyUI-Image-Saver. Missing node packs are reported during queue execution."
-  );
-  body.classList.add("easyuse-anima-aio-save-body");
-  const main = document.createElement("section");
-  main.className = "easyuse-anima-aio-section full";
-  main.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Save Backend") }));
-  const save = field(main, "Save image", checkbox(settings.save.enabled));
-  const backend = field(
-    main,
-    "Backend",
-    selectInput(["image_saver", "comfy_save_image"], settings.save.backend || "image_saver"),
-  );
-  const dependencyWarning = document.createElement("div");
-  dependencyWarning.className = "easyuse-anima-aio-warning";
-  dependencyWarning.hidden = true;
-  main.append(dependencyWarning);
-  const refreshSaveDependencyLocks = () => {
-    const imageSaverMissing = !optionalDependencyAvailable("imageSaver");
-    for (const option of Array.from(backend.options)) {
-      if (option.value === "image_saver") {
-        option.disabled = imageSaverMissing;
-        option.textContent = imageSaverMissing
-          ? `image_saver (${optionalDependencyPack("imageSaver")} missing)`
-          : "image_saver";
-      }
-    }
-    if (imageSaverMissing && backend.value === "image_saver") {
-      backend.value = "comfy_save_image";
-      dependencyWarning.hidden = false;
-      dependencyWarning.textContent = aioFormat("warning.optionalDependencyMissing", {
-        backend: "image_saver",
-        pack: optionalDependencyPack("imageSaver"),
-      });
-    } else {
-      dependencyWarning.hidden = true;
-      dependencyWarning.textContent = "";
-    }
-  };
-
-  const files = document.createElement("section");
-  files.className = "easyuse-anima-aio-section full";
-  files.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Saver Files") }));
-  const filename = field(files, "Filename", textInput(imageSaver.filename));
-  const path = field(files, "Path", textInput(imageSaver.path));
-  const extension = field(files, "Extension", selectInput(["webp", "png", "jpeg", "jpg"], imageSaver.extension));
-  const quality = field(files, "JPEG/WebP quality", numberInput(imageSaver.quality_jpeg_or_webp, "1"));
-  const losslessWebp = field(files, "Lossless WebP", checkbox(imageSaver.lossless_webp));
-  const optimizePng = field(files, "Optimize PNG", checkbox(imageSaver.optimize_png));
-  const counter = field(files, "Counter", numberInput(imageSaver.counter, "1"));
-
-  const metadata = document.createElement("section");
-  metadata.className = "easyuse-anima-aio-section full";
-  metadata.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Image Saver Metadata") }));
-  const timeFormat = field(metadata, "Time format", textInput(imageSaver.time_format));
-  const clipSkip = field(metadata, "Clip skip", numberInput(imageSaver.clip_skip, "1"));
-  const embedWorkflow = field(metadata, "Embed workflow", checkbox(imageSaver.embed_workflow));
-  const saveWorkflowJson = field(metadata, "Workflow JSON", checkbox(imageSaver.save_workflow_as_json));
-  const savePromptMetadata = field(metadata, "Save prompt metadata", checkbox(imageSaver.save_prompt_metadata));
-  const additionalHashes = field(metadata, "Additional hashes", textInput(imageSaver.additional_hashes), "tip.additionalHashes");
-  const hashBundles = createImageSaverHashBundleEditor(imageSaver.additional_hash_bundles);
-  field(metadata, "Manual hash bundles", hashBundles.element, "tip.hashBundles");
-  const civitaiHashFetchers = createImageSaverCivitaiHashFetcherEditor(imageSaver.civitai_hash_fetchers);
-  field(metadata, "Civitai Hash Fetchers", civitaiHashFetchers.element, "tip.civitaiHashFetchers");
-  const civitai = field(metadata, "Civitai data", checkbox(imageSaver.download_civitai_data));
-  const easyRemix = field(metadata, "Easy remix", checkbox(imageSaver.easy_remix));
-  const custom = field(metadata, "Custom metadata", textareaInput(imageSaver.custom));
-  body.append(main, files, metadata);
-  refreshSaveDependencyLocks();
-  loadGeneratorOptionalDependencies().then(refreshSaveDependencyLocks);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    next.save.enabled = save.checked;
-    next.save.backend = backend.value || "image_saver";
-    next.save.image_saver = {
-      filename: filename.value || "%time_%basemodelname",
-      path: path.value || "EasyUseAnima/AiO",
-      extension: extension.value || "webp",
-      lossless_webp: losslessWebp.checked,
-      quality_jpeg_or_webp: Number(quality.value || 97),
-      optimize_png: optimizePng.checked,
-      counter: Number(counter.value || 0),
-      clip_skip: Number(clipSkip.value || 0),
-      time_format: timeFormat.value || "%Y-%m-%d-%H%M%S",
-      save_workflow_as_json: saveWorkflowJson.checked,
-      embed_workflow: embedWorkflow.checked,
-      save_prompt_metadata: savePromptMetadata.checked,
-      additional_hashes: additionalHashes.value || "",
-      additional_hash_bundles: hashBundles.values(),
-      civitai_hash_fetchers: civitaiHashFetchers.values(),
-      download_civitai_data: civitai.checked,
-      easy_remix: easyRemix.checked,
-      custom: custom.value || "",
-    };
-    applyVisibleGeneratorSettings(node, next);
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
 
 function openAdvancedSettings(node) {
   const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
@@ -4906,6 +4603,44 @@ const openSamplerSettings = aioCreateSamplerSettingsDialog({
     nodeInputMap,
     nodeInputTooltip,
     nodeInputSupported,
+    load: loadGeneratorOptionalDependencies,
+  },
+});
+
+const openSaveSettings = aioCreateSaveSettingsDialog({
+  document,
+  controls: {
+    createDialog,
+    field,
+    checkbox,
+    selectInput,
+    textInput,
+    numberInput,
+    textareaInput,
+  },
+  text: {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+    applyTooltip,
+    applyTooltipText,
+  },
+  settingsCore: {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    asBool,
+    mergeDefaults,
+  },
+  nodeAdapter: {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
+    applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  },
+  dependencyAdapter: {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
     load: loadGeneratorOptionalDependencies,
   },
 });


### PR DESCRIPTION
## 변경 요약

- AiO Save 설정 dialog와 Image Saver 전용 normalize/editor helper 4개를 `web/js/aio/save_settings_dialog.js`의 단일 lifecycle factory로 분리했습니다.
- entry는 DOM/text/settings/dependency adapter 조립과 generator panel action 연결만 담당합니다.
- 공용 Fake DOM smoke로 hash bundle/Civitai 행 lifecycle, dependency fallback, Cancel/Apply 직렬화를 검증합니다.
- 사용자 동작은 변경하지 않는 기계적 추출입니다.

## 주요 파일

- `web/js/aio/save_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_save_settings_dialog_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- focused Save Fake DOM smoke: 통과
- 관련 Python source/ownership tests: 68개 통과
- JavaScript syntax 검사: 통과
- TypeScript 6.0.3: 통과
- official full runner: Python 367 tests, frontend 92 JavaScript files 통과
- `git diff --check`: 통과
- 행동 보존 / 테스트 적정성 감사: Blocker, P2, P3 없음

## ComfyUI 표면

- ComfyUI Codex test surface: official full project validation
- Legacy canvas / Node 2.0 browser smoke: 미실행 (동작 변경 없는 lifecycle extraction)
- ComfyUI v0.27.0 user instance: 전체 유지보수 완료 후 최종 수동 확인 예정

## 호환성 및 후속

- root/save sibling의 알 수 없는 키는 기존처럼 보존하고, `save.image_saver`는 기존 고정 스키마 교체 동작을 유지합니다.
- color serializer의 `constructor`/`toString` own-key allowlist hardening은 PR #82에서 이미 병합·smoke 검증됐으며 이 PR에서는 관련 파일을 변경하지 않습니다.
- 이 PR은 Issue #54의 Save lifecycle 경계 조각이며 Issue #54 전체를 닫지 않습니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`