### PR TITLE
refactor: AiO Advanced 설정 dialog lifecycle 분리

### DIFF
--- a/tests/frontend_aio_advanced_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_advanced_settings_dialog_smoke.mjs
@@ -1,0 +1,837 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+  descendants,
+} from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function find(root, predicate) {
+  return [root, ...descendants(root)].find(predicate) || null;
+}
+
+function findByText(root, textContent) {
+  return find(root, (element) => element.textContent === textContent);
+}
+
+function rowByLabel(root, label) {
+  return find(root, (element) => element.getAttribute?.("data-test-label") === label);
+}
+
+function controlIn(root, label) {
+  const row = rowByLabel(root, label);
+  assert.ok(row, `missing field row: ${label}`);
+  assert.ok(row.children[0], `missing field control: ${label}`);
+  return row.children[0];
+}
+
+function sectionByHeading(root, heading) {
+  const title = findByText(root, `static:${heading}`);
+  assert.ok(title?.parentElement, `missing section: ${heading}`);
+  assert.equal(title.tagName, "H3", `expected section heading for: ${heading}`);
+  return title.parentElement;
+}
+
+function subsectionByHeading(root, heading) {
+  const title = findByText(root, `static:${heading}`);
+  assert.ok(title?.parentElement, `missing subsection: ${heading}`);
+  assert.equal(title.tagName, "H4", `expected subsection heading for: ${heading}`);
+  return title.parentElement;
+}
+
+function action(dialog, key) {
+  const button = findByText(dialog.actions, `text:${key}`);
+  assert.ok(button, `missing action: ${key}`);
+  return button;
+}
+
+function assertValues(entries) {
+  for (const [root, label, expected] of entries) {
+    assert.equal(controlIn(root, label).value, String(expected), `unexpected value for: ${label}`);
+  }
+}
+
+function assertChecked(entries) {
+  for (const [root, label, expected] of entries) {
+    assert.equal(controlIn(root, label).checked, expected, `unexpected checked state for: ${label}`);
+  }
+}
+
+function assertDisabled(entries, expected = true) {
+  for (const [root, label] of entries) {
+    assert.equal(controlIn(root, label).disabled, expected, `unexpected disabled state for: ${label}`);
+  }
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const advancedDialogModule = await import(dataModule("../web/js/aio/advanced_settings_dialog.js"));
+const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+assert.deepEqual(
+  Object.keys(advancedDialogModule),
+  ["aioCreateAdvancedSettingsDialog"],
+  "Advanced settings dialog must expose only its lifecycle factory",
+);
+
+function configuredSettings() {
+  return {
+    sampler: {
+      dave: { legacy: true },
+      future_sampler_key: "keep-sampler",
+    },
+    model_patches: {
+      future_model_patch_key: "keep-model-patches",
+      aura_flow: {
+        enabled: true,
+        shift: 6.5,
+        future_aura_key: "keep-aura",
+      },
+      dave: {
+        enabled: true,
+        mask: "configured-dave.npz",
+        strength: 0.42,
+        tau: 0.21,
+        future_dave_key: "keep-dave",
+      },
+      safe_pag: {
+        enabled: true,
+        scale: 5.5,
+        block_indices: "3, 7",
+        perturbation_strength: 0.35,
+        head_indices: "1, 2",
+        start_percent: 0.1,
+        end_percent: 0.9,
+        rescale: 0.4,
+        rescale_mode: "partial",
+        future_safe_pag_key: "keep-safe-pag",
+      },
+      kj: {
+        fp16_accumulation: true,
+        sage_attention: "auto",
+        sage_allow_compile: true,
+        future_kj_key: "keep-kj",
+        torch_compile: {
+          enabled: true,
+          backend: "configured-backend",
+          fullgraph: true,
+          mode: "reduce-overhead",
+          dynamic: "default",
+          compile_transformer_blocks_only: false,
+          dynamo_cache_size_limit: 128,
+          debug_compile_keys: true,
+          disable_dynamic_vram: false,
+          future_torch_key: "keep-torch",
+        },
+      },
+    },
+    artist_mix: {
+      mode: "exact",
+      start_percent: 0.2,
+      strength_scale: 1.4,
+      future_artist_key: "keep-artist",
+    },
+    future_root_key: "keep-root",
+  };
+}
+
+function createFixture({ settings = {}, available = {}, deferLoads = false } = {}) {
+  let dependencyCalls = 0;
+  let currentDialog = null;
+  const dialogs = [];
+  const loadCalls = [];
+  const loadResolvers = [];
+  const mergeCalls = [];
+  const clampCalls = [];
+  const writes = [];
+  const renders = [];
+  const document = createFakeDocument();
+  const availabilityState = { ...available };
+  const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
+  const node = {
+    settings: settingsModule.aioMergeDefaults(defaultSettings, settings),
+    widgets: [{ name: "generation_settings", value: "" }],
+  };
+  node.widgets[0].value = JSON.stringify(node.settings);
+
+  function createDialog(title, subtitle) {
+    dependencyCalls += 1;
+    const dialog = {
+      title,
+      subtitle,
+      backdrop: document.createElement("div"),
+      body: document.createElement("div"),
+      actions: document.createElement("div"),
+      trace: [],
+    };
+    dialog.backdrop.remove = () => {
+      dialog.backdrop.removed = true;
+      dialog.trace.push("remove");
+    };
+    dialogs.push(dialog);
+    currentDialog = dialog;
+    return dialog;
+  }
+
+  function field(section, label, element, tooltipKey = "") {
+    dependencyCalls += 1;
+    const row = document.createElement("label");
+    row.className = "easyuse-anima-aio-field";
+    row.setAttribute("data-test-label", label);
+    row.setAttribute("data-test-tooltip", tooltipKey);
+    row.append(element);
+    section.append(row);
+    return element;
+  }
+
+  function numberInput(value, step = "1") {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "number";
+    input.step = step;
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function checkbox(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = !!value;
+    return input;
+  }
+
+  function textInput(value) {
+    dependencyCalls += 1;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = String(value ?? "");
+    return input;
+  }
+
+  function selectInput(options, value) {
+    dependencyCalls += 1;
+    const select = document.createElement("select");
+    select.options = [];
+    for (const optionSpec of options) {
+      const option = document.createElement("option");
+      option.value = typeof optionSpec === "object"
+        ? String(optionSpec.value ?? "")
+        : String(optionSpec ?? "");
+      option.textContent = typeof optionSpec === "object"
+        ? String(optionSpec.label ?? option.value)
+        : option.value;
+      option.selected = option.value === String(value ?? "");
+      select.options.push(option);
+      select.append(option);
+    }
+    if (!select.options.some((option) => option.selected)) {
+      select.value = String(value ?? "");
+    }
+    return select;
+  }
+
+  function staticText(value) {
+    dependencyCalls += 1;
+    return `static:${value}`;
+  }
+
+  function text(key) {
+    dependencyCalls += 1;
+    return `text:${key}`;
+  }
+
+  function format(key, values = {}) {
+    dependencyCalls += 1;
+    return `format:${key}:${JSON.stringify(values)}`;
+  }
+
+  function mergeDefaults(defaults, current) {
+    dependencyCalls += 1;
+    mergeCalls.push({ defaults: clone(defaults), current: clone(current) });
+    if (currentDialog) {
+      currentDialog.trace.push("merge");
+    }
+    return settingsModule.aioMergeDefaults(defaults, current);
+  }
+
+  function clampNumber(value, fallback, min, max) {
+    dependencyCalls += 1;
+    clampCalls.push([value, fallback, min, max]);
+    const parsed = Number(value);
+    const next = Number.isFinite(parsed) ? parsed : fallback;
+    return Math.max(min, Math.min(max, next));
+  }
+
+  function findWidget(targetNode, name) {
+    dependencyCalls += 1;
+    return targetNode.widgets?.find((widget) => widget.name === name);
+  }
+
+  function getSettings(targetNode) {
+    dependencyCalls += 1;
+    return clone(targetNode.settings);
+  }
+
+  function writeSettings(targetNode, widget, nextSettings) {
+    dependencyCalls += 1;
+    const snapshot = clone(nextSettings);
+    targetNode.settings = snapshot;
+    widget.value = JSON.stringify(snapshot);
+    writes.push({ node: targetNode, widget, settings: snapshot });
+    currentDialog.trace.push("write");
+  }
+
+  function renderPanel(targetNode) {
+    dependencyCalls += 1;
+    renders.push(targetNode);
+    currentDialog.trace.push("render");
+  }
+
+  const openAdvancedSettings = advancedDialogModule.aioCreateAdvancedSettingsDialog({
+    document,
+    controls: {
+      createDialog,
+      field,
+      numberInput,
+      checkbox,
+      textInput,
+      selectInput,
+    },
+    text: {
+      staticText,
+      get: text,
+      format,
+    },
+    settingsCore: {
+      defaultGenerationSettings: defaultSettings,
+      mergeDefaults,
+      clampNumber,
+    },
+    nodeAdapter: {
+      generatorSettingsWidget: "generation_settings",
+      findWidget,
+      getSettings,
+      writeSettings,
+      renderPanel,
+    },
+    dependencyAdapter: {
+      available(key) {
+        dependencyCalls += 1;
+        return Object.hasOwn(availabilityState, key) ? !!availabilityState[key] : true;
+      },
+      pack(key) {
+        dependencyCalls += 1;
+        return `pack:${key}`;
+      },
+      load(options) {
+        dependencyCalls += 1;
+        loadCalls.push(options);
+        if (!deferLoads) {
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => loadResolvers.push(resolve));
+      },
+    },
+  });
+
+  return {
+    openAdvancedSettings,
+    document,
+    node,
+    defaultSettings,
+    dialogs,
+    loadCalls,
+    availabilityState,
+    mergeCalls,
+    clampCalls,
+    writes,
+    renders,
+    dependencyCallCount: () => dependencyCalls,
+    resolveLoads() {
+      for (const resolve of loadResolvers.splice(0)) {
+        resolve();
+      }
+    },
+  };
+}
+
+{
+  const fixture = createFixture({ settings: configuredSettings() });
+  const originalSettings = clone(fixture.node.settings);
+  const originalWidget = fixture.node.widgets[0].value;
+  const originalDefaults = clone(fixture.defaultSettings);
+  assert.equal(fixture.dependencyCallCount(), 0, "Factory composition must be side-effect free");
+  assert.equal(fixture.dialogs.length, 0);
+  assert.equal(fixture.loadCalls.length, 0);
+  assert.equal(fixture.mergeCalls.length, 0);
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+  assert.equal(fixture.document.createdElements.length, 0, "Factory composition must not create DOM elements");
+  assert.equal(fixture.document.body.children.length, 0, "Factory composition must not attach DOM elements");
+
+  fixture.openAdvancedSettings(fixture.node);
+  await flushPromises();
+  const cancelDialog = fixture.dialogs[0];
+  assert.equal(cancelDialog.title, "Advanced Options");
+  assert.equal(
+    cancelDialog.subtitle,
+    "Advanced generation options stay in a popup and are serialized as versioned settings.",
+  );
+  const modelPatches = sectionByHeading(cancelDialog.body, "Model Patch / Optimization");
+  const artistMix = sectionByHeading(cancelDialog.body, "Artist Mix");
+  const dave = subsectionByHeading(modelPatches, "Anima DAVE");
+  const safePag = subsectionByHeading(modelPatches, "Anima Safe PAG");
+  const kj = subsectionByHeading(modelPatches, "KJNodes Optimization");
+  const sage = subsectionByHeading(kj, "SageAttention (KJNodes)");
+  const torch = subsectionByHeading(kj, "Torch Compile (KJNodes)");
+  const torchDetails = subsectionByHeading(torch, "Torch Compile Parameters");
+  const warning = find(
+    modelPatches,
+    (element) => element.classList.contains("easyuse-anima-aio-warning"),
+  );
+  assert.ok(warning);
+  assert.equal(warning.hidden, true);
+  assert.equal(warning.textContent, "");
+  assert.equal(fixture.loadCalls.length, 1);
+
+  assertValues([
+    [modelPatches, "AuraFlow shift", 6.5],
+    [dave, "Mask", "configured-dave.npz"],
+    [dave, "DAVE strength", 0.42],
+    [dave, "DAVE tau", 0.21],
+    [safePag, "Safe PAG scale", 5.5],
+    [safePag, "Safe PAG blocks", "3, 7"],
+    [safePag, "PAG perturbation", 0.35],
+    [safePag, "PAG heads", "1, 2"],
+    [safePag, "PAG start percent", 0.1],
+    [safePag, "PAG end percent", 0.9],
+    [safePag, "PAG rescale", 0.4],
+    [safePag, "PAG rescale mode", "partial"],
+    [sage, "Mode", "auto"],
+    [torchDetails, "Backend", "configured-backend"],
+    [torchDetails, "Mode", "reduce-overhead"],
+    [torchDetails, "Dynamic", "default"],
+    [torchDetails, "Dynamo cache limit", 128],
+    [artistMix, "Mode", "exact"],
+    [artistMix, "Start", 0.2],
+    [artistMix, "Strength", 1.4],
+  ]);
+  assertChecked([
+    [dave, "Use DAVE", true],
+    [safePag, "Use Safe PAG", true],
+    [kj, "KJNodes FP16 accum", true],
+    [sage, "Allow compile", true],
+    [torch, "Use Torch compile", true],
+    [torchDetails, "Fullgraph", true],
+    [torchDetails, "Transformer blocks only", false],
+    [torchDetails, "Debug keys", true],
+    [torchDetails, "Disable dynamic VRAM", false],
+  ]);
+  assert.equal(controlIn(modelPatches, "AuraFlow shift").min, "1");
+  assert.equal(controlIn(modelPatches, "AuraFlow shift").max, "10");
+  assert.equal(controlIn(safePag, "Safe PAG scale").min, "0");
+  assert.equal(controlIn(safePag, "Safe PAG scale").max, "100");
+  assert.equal(rowByLabel(sage, "Allow compile").style.display, "");
+  assert.equal(torchDetails.style.display, "");
+
+  const sageMode = controlIn(sage, "Mode");
+  sageMode.value = "disabled";
+  sageMode.emit("change");
+  assert.equal(rowByLabel(sage, "Allow compile").style.display, "none");
+  sageMode.value = "auto";
+  sageMode.emit("change");
+  assert.equal(rowByLabel(sage, "Allow compile").style.display, "");
+  const torchEnabled = controlIn(torch, "Use Torch compile");
+  torchEnabled.checked = false;
+  torchEnabled.emit("change");
+  assert.equal(torchDetails.style.display, "none");
+  torchEnabled.checked = true;
+  torchEnabled.emit("change");
+  assert.equal(torchDetails.style.display, "");
+
+  controlIn(modelPatches, "AuraFlow shift").value = "9";
+  controlIn(dave, "Use DAVE").checked = false;
+  controlIn(safePag, "PAG rescale mode").value = "full";
+  controlIn(kj, "KJNodes FP16 accum").checked = false;
+  sageMode.value = "disabled";
+  sageMode.emit("change");
+  torchEnabled.checked = false;
+  torchEnabled.emit("change");
+  controlIn(artistMix, "Start").value = "0.9";
+  action(cancelDialog, "button.cancel").emit("click");
+  assert.deepEqual(cancelDialog.trace, ["remove"]);
+  assert.deepEqual(fixture.node.settings, originalSettings, "Cancel must not mutate node settings");
+  assert.equal(fixture.node.widgets[0].value, originalWidget, "Cancel must not rewrite the hidden widget");
+  assert.deepEqual(fixture.defaultSettings, originalDefaults, "Cancel must not mutate injected defaults");
+  assert.equal(fixture.mergeCalls.length, 0);
+  assert.equal(fixture.writes.length, 0);
+  assert.equal(fixture.renders.length, 0);
+
+  fixture.openAdvancedSettings(fixture.node);
+  await flushPromises();
+  const applyDialog = fixture.dialogs[1];
+  const applyModelPatches = sectionByHeading(applyDialog.body, "Model Patch / Optimization");
+  const applyArtistMix = sectionByHeading(applyDialog.body, "Artist Mix");
+  const applyDave = subsectionByHeading(applyModelPatches, "Anima DAVE");
+  const applySafePag = subsectionByHeading(applyModelPatches, "Anima Safe PAG");
+  const applyKj = subsectionByHeading(applyModelPatches, "KJNodes Optimization");
+  const applySage = subsectionByHeading(applyKj, "SageAttention (KJNodes)");
+  const applyTorch = subsectionByHeading(applyKj, "Torch Compile (KJNodes)");
+  const applyTorchDetails = subsectionByHeading(applyTorch, "Torch Compile Parameters");
+
+  controlIn(applyModelPatches, "AuraFlow shift").value = "99";
+  controlIn(applyDave, "Use DAVE").checked = true;
+  controlIn(applyDave, "Mask").value = "";
+  controlIn(applyDave, "DAVE strength").value = "0";
+  controlIn(applyDave, "DAVE tau").value = "";
+  controlIn(applySafePag, "Use Safe PAG").checked = true;
+  controlIn(applySafePag, "Safe PAG scale").value = "101";
+  controlIn(applySafePag, "Safe PAG blocks").value = "";
+  controlIn(applySafePag, "PAG perturbation").value = "-1";
+  controlIn(applySafePag, "PAG heads").value = "2, 4";
+  controlIn(applySafePag, "PAG start percent").value = "2";
+  controlIn(applySafePag, "PAG end percent").value = "-1";
+  controlIn(applySafePag, "PAG rescale").value = "2";
+  controlIn(applySafePag, "PAG rescale mode").value = "";
+  controlIn(applyKj, "KJNodes FP16 accum").checked = true;
+  const applySageMode = controlIn(applySage, "Mode");
+  applySageMode.value = "sageattn";
+  applySageMode.emit("change");
+  controlIn(applySage, "Allow compile").checked = true;
+  const applyTorchEnabled = controlIn(applyTorch, "Use Torch compile");
+  applyTorchEnabled.checked = true;
+  applyTorchEnabled.emit("change");
+  controlIn(applyTorchDetails, "Backend").value = "";
+  controlIn(applyTorchDetails, "Fullgraph").checked = false;
+  controlIn(applyTorchDetails, "Mode").value = "";
+  controlIn(applyTorchDetails, "Dynamic").value = "";
+  controlIn(applyTorchDetails, "Transformer blocks only").checked = true;
+  controlIn(applyTorchDetails, "Dynamo cache limit").value = "";
+  controlIn(applyTorchDetails, "Debug keys").checked = false;
+  controlIn(applyTorchDetails, "Disable dynamic VRAM").checked = true;
+  controlIn(applyArtistMix, "Mode").value = "";
+  controlIn(applyArtistMix, "Start").value = "0";
+  controlIn(applyArtistMix, "Strength").value = "";
+
+  action(applyDialog, "button.apply").emit("click");
+  assert.deepEqual(applyDialog.trace, ["merge", "write", "render", "remove"]);
+  assert.equal(fixture.mergeCalls.length, 1);
+  assert.equal(fixture.writes.length, 1);
+  assert.equal(fixture.renders.length, 1);
+  assert.equal(fixture.writes[0].node, fixture.node);
+  assert.equal(fixture.writes[0].widget, fixture.node.widgets[0]);
+  assert.equal(fixture.renders[0], fixture.node);
+  assert.deepEqual(
+    fixture.clampCalls,
+    [
+      ["99", 3, 1, 10],
+      ["101", 4, 0, 100],
+      ["-1", 0.75, 0, 1],
+      ["2", 0, 0, 1],
+      ["-1", 0.7, 0, 1],
+      ["2", 0.2, 0, 1],
+    ],
+    "Apply must preserve the exact clamp inputs, defaults, and bounds",
+  );
+
+  const written = fixture.node.settings;
+  assert.equal(written.model_patches.aura_flow.shift, 10);
+  assert.equal(Object.hasOwn(written.model_patches.aura_flow, "enabled"), false);
+  assert.deepEqual(
+    {
+      enabled: written.model_patches.dave.enabled,
+      mask: written.model_patches.dave.mask,
+      strength: written.model_patches.dave.strength,
+      tau: written.model_patches.dave.tau,
+    },
+    { enabled: true, mask: "dave_alpha.npz", strength: 0, tau: 0.1 },
+  );
+  assert.deepEqual(
+    {
+      enabled: written.model_patches.safe_pag.enabled,
+      scale: written.model_patches.safe_pag.scale,
+      block_indices: written.model_patches.safe_pag.block_indices,
+      perturbation_strength: written.model_patches.safe_pag.perturbation_strength,
+      head_indices: written.model_patches.safe_pag.head_indices,
+      start_percent: written.model_patches.safe_pag.start_percent,
+      end_percent: written.model_patches.safe_pag.end_percent,
+      rescale: written.model_patches.safe_pag.rescale,
+      rescale_mode: written.model_patches.safe_pag.rescale_mode,
+    },
+    {
+      enabled: true,
+      scale: 100,
+      block_indices: "18",
+      perturbation_strength: 0,
+      head_indices: "2, 4",
+      start_percent: 1,
+      end_percent: 0,
+      rescale: 1,
+      rescale_mode: "full",
+    },
+  );
+  assert.equal(written.model_patches.kj.fp16_accumulation, true);
+  assert.equal(written.model_patches.kj.sage_attention, "sageattn");
+  assert.equal(written.model_patches.kj.sage_allow_compile, true);
+  assert.deepEqual(
+    {
+      enabled: written.model_patches.kj.torch_compile.enabled,
+      backend: written.model_patches.kj.torch_compile.backend,
+      fullgraph: written.model_patches.kj.torch_compile.fullgraph,
+      mode: written.model_patches.kj.torch_compile.mode,
+      dynamic: written.model_patches.kj.torch_compile.dynamic,
+      compile_transformer_blocks_only: (
+        written.model_patches.kj.torch_compile.compile_transformer_blocks_only
+      ),
+      dynamo_cache_size_limit: written.model_patches.kj.torch_compile.dynamo_cache_size_limit,
+      debug_compile_keys: written.model_patches.kj.torch_compile.debug_compile_keys,
+      disable_dynamic_vram: written.model_patches.kj.torch_compile.disable_dynamic_vram,
+    },
+    {
+      enabled: true,
+      backend: "inductor",
+      fullgraph: false,
+      mode: "max-autotune-no-cudagraphs",
+      dynamic: "false",
+      compile_transformer_blocks_only: true,
+      dynamo_cache_size_limit: 64,
+      debug_compile_keys: false,
+      disable_dynamic_vram: true,
+    },
+  );
+  assert.equal(written.artist_mix.mode, "prompt_data");
+  assert.equal(written.artist_mix.start_percent, 0, "String zero must remain a valid Artist Mix start");
+  assert.equal(written.artist_mix.strength_scale, 1);
+  assert.equal(Object.hasOwn(written.sampler, "dave"), false, "Apply must remove legacy sampler.dave");
+  assert.equal(written.future_root_key, "keep-root");
+  assert.equal(written.sampler.future_sampler_key, "keep-sampler");
+  assert.equal(written.model_patches.future_model_patch_key, "keep-model-patches");
+  assert.equal(written.model_patches.aura_flow.future_aura_key, "keep-aura");
+  assert.equal(written.model_patches.dave.future_dave_key, "keep-dave");
+  assert.equal(written.model_patches.safe_pag.future_safe_pag_key, "keep-safe-pag");
+  assert.equal(written.model_patches.kj.future_kj_key, "keep-kj");
+  assert.equal(written.model_patches.kj.torch_compile.future_torch_key, "keep-torch");
+  assert.equal(written.artist_mix.future_artist_key, "keep-artist");
+  assert.deepEqual(fixture.writes[0].settings, written);
+  assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), written);
+  assert.deepEqual(fixture.defaultSettings, originalDefaults, "Apply must not mutate injected defaults");
+}
+
+for (const dependencyCase of [
+  { key: "dave", backend: "Anima DAVE" },
+  { key: "safePag", backend: "Anima Safe PAG" },
+  { key: "kjFp16", backend: "KJNodes FP16 accum" },
+  { key: "kjSage", backend: "SageAttention" },
+  { key: "kjTorchCompile", backend: "Torch Compile" },
+]) {
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    available: {
+      dave: true,
+      safePag: true,
+      kjFp16: true,
+      kjSage: true,
+      kjTorchCompile: true,
+    },
+    deferLoads: true,
+  });
+  fixture.openAdvancedSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const modelPatches = sectionByHeading(dialog.body, "Model Patch / Optimization");
+  const dave = subsectionByHeading(modelPatches, "Anima DAVE");
+  const safePag = subsectionByHeading(modelPatches, "Anima Safe PAG");
+  const kj = subsectionByHeading(modelPatches, "KJNodes Optimization");
+  const sage = subsectionByHeading(kj, "SageAttention (KJNodes)");
+  const torch = subsectionByHeading(kj, "Torch Compile (KJNodes)");
+  const torchDetails = subsectionByHeading(torch, "Torch Compile Parameters");
+  const warning = find(
+    modelPatches,
+    (element) => element.classList.contains("easyuse-anima-aio-warning"),
+  );
+  assert.ok(warning);
+  const controlGroups = {
+    dave: [
+      [dave, "Use DAVE"],
+      [dave, "Mask"],
+      [dave, "DAVE strength"],
+      [dave, "DAVE tau"],
+    ],
+    safePag: [
+      [safePag, "Use Safe PAG"],
+      [safePag, "Safe PAG scale"],
+      [safePag, "Safe PAG blocks"],
+      [safePag, "PAG perturbation"],
+      [safePag, "PAG heads"],
+      [safePag, "PAG start percent"],
+      [safePag, "PAG end percent"],
+      [safePag, "PAG rescale"],
+      [safePag, "PAG rescale mode"],
+    ],
+    kjFp16: [
+      [kj, "KJNodes FP16 accum"],
+    ],
+    kjSage: [
+      [sage, "Mode"],
+      [sage, "Allow compile"],
+    ],
+    kjTorchCompile: [
+      [torch, "Use Torch compile"],
+      [torchDetails, "Backend"],
+      [torchDetails, "Fullgraph"],
+      [torchDetails, "Mode"],
+      [torchDetails, "Dynamic"],
+      [torchDetails, "Transformer blocks only"],
+      [torchDetails, "Dynamo cache limit"],
+      [torchDetails, "Debug keys"],
+      [torchDetails, "Disable dynamic VRAM"],
+    ],
+  };
+  assert.equal(fixture.loadCalls.length, 1);
+  assert.equal(warning.hidden, true);
+
+  fixture.availabilityState[dependencyCase.key] = false;
+  fixture.resolveLoads();
+  await flushPromises();
+
+  for (const [groupKey, controls] of Object.entries(controlGroups)) {
+    assertDisabled(
+      controls,
+      groupKey === dependencyCase.key,
+    );
+  }
+  assert.equal(warning.hidden, false);
+  assert.equal(
+    warning.textContent,
+    `format:warning.optionalDependencyMissing:${JSON.stringify({
+      backend: dependencyCase.backend,
+      pack: `pack:${dependencyCase.key}`,
+    })}`,
+    `Only ${dependencyCase.key} must contribute its warning`,
+  );
+}
+
+{
+  const fixture = createFixture({
+    settings: configuredSettings(),
+    available: {
+      dave: true,
+      safePag: true,
+      kjFp16: true,
+      kjSage: true,
+      kjTorchCompile: true,
+    },
+    deferLoads: true,
+  });
+  assert.equal(fixture.dependencyCallCount(), 0, "Deferred fixture factory must be side-effect free");
+  fixture.openAdvancedSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const modelPatches = sectionByHeading(dialog.body, "Model Patch / Optimization");
+  const dave = subsectionByHeading(modelPatches, "Anima DAVE");
+  const safePag = subsectionByHeading(modelPatches, "Anima Safe PAG");
+  const kj = subsectionByHeading(modelPatches, "KJNodes Optimization");
+  const sage = subsectionByHeading(kj, "SageAttention (KJNodes)");
+  const torch = subsectionByHeading(kj, "Torch Compile (KJNodes)");
+  const torchDetails = subsectionByHeading(torch, "Torch Compile Parameters");
+  const warning = find(
+    modelPatches,
+    (element) => element.classList.contains("easyuse-anima-aio-warning"),
+  );
+  assert.ok(warning);
+  assert.equal(fixture.loadCalls.length, 1);
+  assert.equal(warning.hidden, true);
+  assertDisabled([
+    [dave, "Use DAVE"],
+    [safePag, "Use Safe PAG"],
+    [kj, "KJNodes FP16 accum"],
+    [sage, "Mode"],
+    [torch, "Use Torch compile"],
+  ], false);
+
+  for (const key of ["dave", "safePag", "kjFp16", "kjSage", "kjTorchCompile"]) {
+    fixture.availabilityState[key] = false;
+  }
+  fixture.resolveLoads();
+  await flushPromises();
+
+  assertDisabled([
+    [dave, "Use DAVE"],
+    [dave, "Mask"],
+    [dave, "DAVE strength"],
+    [dave, "DAVE tau"],
+    [safePag, "Use Safe PAG"],
+    [safePag, "Safe PAG scale"],
+    [safePag, "Safe PAG blocks"],
+    [safePag, "PAG perturbation"],
+    [safePag, "PAG heads"],
+    [safePag, "PAG start percent"],
+    [safePag, "PAG end percent"],
+    [safePag, "PAG rescale"],
+    [safePag, "PAG rescale mode"],
+    [kj, "KJNodes FP16 accum"],
+    [sage, "Mode"],
+    [sage, "Allow compile"],
+    [torch, "Use Torch compile"],
+    [torchDetails, "Backend"],
+    [torchDetails, "Fullgraph"],
+    [torchDetails, "Mode"],
+    [torchDetails, "Dynamic"],
+    [torchDetails, "Transformer blocks only"],
+    [torchDetails, "Dynamo cache limit"],
+    [torchDetails, "Debug keys"],
+    [torchDetails, "Disable dynamic VRAM"],
+  ]);
+  assertChecked([
+    [dave, "Use DAVE", false],
+    [safePag, "Use Safe PAG", false],
+    [kj, "KJNodes FP16 accum", false],
+    [sage, "Allow compile", false],
+    [torch, "Use Torch compile", false],
+  ]);
+  assert.equal(controlIn(sage, "Mode").value, "disabled");
+  assert.equal(rowByLabel(sage, "Allow compile").style.display, "none");
+  assert.equal(torchDetails.style.display, "none");
+  assert.equal(warning.hidden, false);
+  assert.equal(
+    warning.textContent,
+    [
+      'format:warning.optionalDependencyMissing:{"backend":"Anima DAVE","pack":"pack:dave"}',
+      'format:warning.optionalDependencyMissing:{"backend":"Anima Safe PAG","pack":"pack:safePag"}',
+      'format:warning.optionalDependencyMissing:{"backend":"KJNodes FP16 accum","pack":"pack:kjFp16"}',
+      'format:warning.optionalDependencyMissing:{"backend":"SageAttention","pack":"pack:kjSage"}',
+      'format:warning.optionalDependencyMissing:{"backend":"Torch Compile","pack":"pack:kjTorchCompile"}',
+    ].join(" "),
+    "Missing dependency warning order and pack mapping must remain stable",
+  );
+
+  controlIn(dave, "Use DAVE").checked = true;
+  controlIn(safePag, "Use Safe PAG").checked = true;
+  controlIn(kj, "KJNodes FP16 accum").checked = true;
+  controlIn(sage, "Mode").value = "auto";
+  controlIn(sage, "Allow compile").checked = true;
+  controlIn(torch, "Use Torch compile").checked = true;
+  action(dialog, "button.apply").emit("click");
+
+  assert.deepEqual(dialog.trace, ["merge", "write", "render", "remove"]);
+  assert.equal(fixture.writes.length, 1);
+  assert.equal(fixture.renders.length, 1);
+  assert.equal(fixture.node.settings.model_patches.dave.enabled, false);
+  assert.equal(fixture.node.settings.model_patches.safe_pag.enabled, false);
+  assert.equal(fixture.node.settings.model_patches.kj.fp16_accumulation, false);
+  assert.equal(fixture.node.settings.model_patches.kj.sage_attention, "disabled");
+  assert.equal(fixture.node.settings.model_patches.kj.sage_allow_compile, false);
+  assert.equal(fixture.node.settings.model_patches.kj.torch_compile.enabled, false);
+  assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), fixture.node.settings);
+}
+
+console.log("AiO Advanced settings dialog smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -27,6 +27,9 @@ AIO_DETAILER_SETTINGS_DIALOG_JS = (
 AIO_SAVE_SETTINGS_DIALOG_JS = (
     ROOT / "web" / "js" / "aio" / "save_settings_dialog.js"
 )
+AIO_ADVANCED_SETTINGS_DIALOG_JS = (
+    ROOT / "web" / "js" / "aio" / "advanced_settings_dialog.js"
+)
 AIO_PREVIEW_JS = ROOT / "web" / "js" / "aio" / "preview.js"
 AIO_SETTINGS_JS = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
@@ -360,9 +363,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("backendBadge", body)
 
     def test_safe_pag_advanced_labels_do_not_reuse_generic_labels(self):
-        source = AIO_JS.read_text(encoding="utf-8")
+        source = AIO_ADVANCED_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
         start = source.index("function openAdvancedSettings")
-        end = source.index("\nfunction openGeneratorSettings", start)
+        end = source.index("  return openAdvancedSettings;", start)
         body = source[start:end]
 
         self.assertIn('"Safe PAG scale"', body)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -63,6 +63,10 @@ AIO_SAVE_SETTINGS_DIALOG_JS = AIO_MODULES / "save_settings_dialog.js"
 AIO_SAVE_SETTINGS_DIALOG_SMOKE = (
     ROOT / "tests" / "frontend_aio_save_settings_dialog_smoke.mjs"
 )
+AIO_ADVANCED_SETTINGS_DIALOG_JS = AIO_MODULES / "advanced_settings_dialog.js"
+AIO_ADVANCED_SETTINGS_DIALOG_SMOKE = (
+    ROOT / "tests" / "frontend_aio_advanced_settings_dialog_smoke.mjs"
+)
 AIO_PREVIEW_JS = AIO_MODULES / "preview.js"
 AIO_PREVIEW_CORE_SMOKE = ROOT / "tests" / "frontend_aio_preview_core_smoke.mjs"
 AIO_PRESETS_JS = AIO_MODULES / "presets.js"
@@ -772,7 +776,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         composition_start = entry_source.index(
             "const openSaveSettings = aioCreateSaveSettingsDialog({"
         )
-        composition_end = entry_source.index("\n\nconst generatorPanelRuntime", composition_start)
+        composition_end = entry_source.index(
+            "const openAdvancedSettings = aioCreateAdvancedSettingsDialog({",
+            composition_start,
+        )
         composition = entry_source[composition_start:composition_end]
         for expected in (
             "createDialog,",
@@ -803,13 +810,80 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(composition_dependency=expected):
                 self.assertIn(expected, composition)
         sampler_composition = entry_source.index("const openSamplerSettings")
-        generator_panel_composition = entry_source.index("const generatorPanelRuntime")
+        advanced_composition = entry_source.index("const openAdvancedSettings")
         self.assertLess(sampler_composition, composition_start)
-        self.assertLess(composition_start, generator_panel_composition)
+        self.assertLess(composition_start, advanced_composition)
         self.assertIn("return openSaveSettings;", source)
         self.assertTrue(AIO_SAVE_SETTINGS_DIALOG_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_save_settings_dialog_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_advanced_settings_dialog_has_closed_lifecycle_boundary(self):
+        source = AIO_ADVANCED_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(source.startswith("// @ts-check\n"))
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotRegex(source, r"(?m)^\s*import\s")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertEqual(
+            re.findall(r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE),
+            ["aioCreateAdvancedSettingsDialog"],
+        )
+        self.assertEqual(len(re.findall(r"(?m)^export\s+", source)), 1)
+        self.assertIn(
+            'import { aioCreateAdvancedSettingsDialog } from '
+            '"./aio/advanced_settings_dialog.js";',
+            entry_source,
+        )
+        self.assertRegex(source, r"\bfunction\s+openAdvancedSettings\(")
+        self.assertNotRegex(entry_source, r"\bfunction\s+openAdvancedSettings\(")
+        self.assertNotRegex(source, r"\bfunction\s+openGeneratorSettings\(")
+
+        composition_start = entry_source.index(
+            "const openAdvancedSettings = aioCreateAdvancedSettingsDialog({"
+        )
+        composition_end = entry_source.index(
+            "const generatorPanelRuntime = aioCreateGeneratorPanelRuntime({",
+            composition_start,
+        )
+        composition = entry_source[composition_start:composition_end]
+        for expected in (
+            "createDialog,",
+            "field,",
+            "checkbox,",
+            "textInput,",
+            "numberInput,",
+            "selectInput,",
+            "staticText: aioStaticText,",
+            "get: aioText,",
+            "format: aioFormat,",
+            "defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,",
+            "mergeDefaults,",
+            "clampNumber: clampGeneratorNumber,",
+            "generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,",
+            "findWidget,",
+            "getSettings: generatorSettings,",
+            "writeSettings,",
+            "renderPanel: renderGeneratorPanel,",
+            "available: optionalDependencyAvailable,",
+            "pack: optionalDependencyPack,",
+            "load: loadGeneratorOptionalDependencies,",
+        ):
+            with self.subTest(composition_dependency=expected):
+                self.assertIn(expected, composition)
+        save_composition = entry_source.index("const openSaveSettings")
+        generator_panel_composition = entry_source.index("const generatorPanelRuntime")
+        self.assertLess(save_composition, composition_start)
+        self.assertLess(composition_start, generator_panel_composition)
+        self.assertIn("return openAdvancedSettings;", source)
+        self.assertTrue(AIO_ADVANCED_SETTINGS_DIALOG_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_advanced_settings_dialog_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -79,6 +79,11 @@ try {
         throw "Frontend AiO Save settings dialog smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_advanced_settings_dialog_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO Advanced settings dialog smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_dependency_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO dependency core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/advanced_settings_dialog.js
+++ b/web/js/aio/advanced_settings_dialog.js
@@ -1,0 +1,455 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioAdvancedDialogControls
+ * @property {(title: any, subtitle: any) => {backdrop: any, body: any, actions: any}} createDialog
+ * @property {(section: any, label: any, control: any, tooltipKey?: string) => any} field
+ * @property {(value: any, step?: string) => any} numberInput
+ * @property {(value: any) => any} checkbox
+ * @property {(value: any) => any} textInput
+ * @property {(options: any[], value: any) => any} selectInput
+ */
+
+/**
+ * @typedef {object} AioAdvancedDialogText
+ * @property {(value: any) => string} staticText
+ * @property {(key: string) => string} get
+ * @property {(key: string, values?: Record<string, any>) => string} format
+ */
+
+/**
+ * @typedef {object} AioAdvancedDialogSettingsCore
+ * @property {any} defaultGenerationSettings
+ * @property {(defaults: any, current: any) => any} mergeDefaults
+ * @property {(value: any, fallback: number, min: number, max: number) => number} clampNumber
+ */
+
+/**
+ * @typedef {object} AioAdvancedDialogNodeAdapter
+ * @property {string} generatorSettingsWidget
+ * @property {(node: any, name: string) => any} findWidget
+ * @property {(node: any) => any} getSettings
+ * @property {(node: any, widget: any, settings: any) => void} writeSettings
+ * @property {(node: any) => void} renderPanel
+ */
+
+/**
+ * @typedef {object} AioAdvancedDialogDependencyAdapter
+ * @property {(key: string) => boolean} available
+ * @property {(key: string) => string} pack
+ * @property {(options?: Record<string, any>) => Promise<any>} load
+ */
+
+/**
+ * @typedef {object} AioAdvancedSettingsDialogDependencies
+ * @property {any} document
+ * @property {AioAdvancedDialogControls} controls
+ * @property {AioAdvancedDialogText} text
+ * @property {AioAdvancedDialogSettingsCore} settingsCore
+ * @property {AioAdvancedDialogNodeAdapter} nodeAdapter
+ * @property {AioAdvancedDialogDependencyAdapter} dependencyAdapter
+ */
+
+/**
+ * Own the Advanced settings dialog, model-patch dependency locks, visibility,
+ * and Apply/Cancel lifecycle. Extension registration, dependency discovery,
+ * generator-panel rendering, and durable storage remain adapters.
+ *
+ * @param {AioAdvancedSettingsDialogDependencies} dependencies
+ * @returns {(node: any) => void}
+ */
+export function aioCreateAdvancedSettingsDialog(dependencies) {
+  const {
+    document,
+    controls,
+    text,
+    settingsCore,
+    nodeAdapter,
+    dependencyAdapter,
+  } = dependencies;
+  const {
+    createDialog,
+    field,
+    numberInput,
+    checkbox,
+    textInput,
+    selectInput,
+  } = controls;
+  const {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+  } = text;
+  const {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    mergeDefaults,
+    clampNumber: clampGeneratorNumber,
+  } = settingsCore;
+  const {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  } = nodeAdapter;
+  const {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    load: loadGeneratorOptionalDependencies,
+  } = dependencyAdapter;
+
+  function openAdvancedSettings(node) {
+    const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
+    const settings = generatorSettings(node);
+    const { backdrop, body, actions } = createDialog(
+      "Advanced Options",
+      "Advanced generation options stay in a popup and are serialized as versioned settings."
+    );
+
+    const makeSubsection = (title) => {
+      const section = document.createElement("div");
+      section.className = "easyuse-anima-aio-subsection";
+      section.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
+      return section;
+    };
+
+    const modelPatches = document.createElement("section");
+    modelPatches.className = "easyuse-anima-aio-section full";
+    modelPatches.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Model Patch / Optimization") }));
+
+    const auraShift = field(
+      modelPatches,
+      "AuraFlow shift",
+      numberInput(settings.model_patches.aura_flow.shift, "0.5"),
+      "tip.shift",
+    );
+    auraShift.min = "1";
+    auraShift.max = "10";
+
+    const dave = makeSubsection("Anima DAVE");
+    const daveEnabled = field(dave, "Use DAVE", checkbox(settings.model_patches.dave.enabled), "tip.daveEnabled");
+    const daveMask = field(dave, "Mask", textInput(settings.model_patches.dave.mask || "dave_alpha.npz"), "tip.daveMask");
+    const daveStrength = field(dave, "DAVE strength", numberInput(settings.model_patches.dave.strength ?? 0.30, "0.01"), "tip.daveStrength");
+    const daveTau = field(dave, "DAVE tau", numberInput(settings.model_patches.dave.tau ?? 0.10, "0.01"), "tip.daveTau");
+    daveStrength.min = "0";
+    daveTau.min = "0";
+    daveTau.max = "1";
+
+    const safePag = makeSubsection("Anima Safe PAG");
+    const safePagSettings = settings.model_patches.safe_pag || DEFAULT_GENERATION_SETTINGS.model_patches.safe_pag;
+    const safePagEnabled = field(safePag, "Use Safe PAG", checkbox(safePagSettings.enabled), "tip.safePagEnabled");
+    const safePagScale = field(safePag, "Safe PAG scale", numberInput(safePagSettings.scale ?? 4.0, "0.1"), "tip.safePagScale");
+    const safePagBlocks = field(safePag, "Safe PAG blocks", textInput(safePagSettings.block_indices || "18"), "tip.safePagBlocks");
+    const safePagPerturbation = field(
+      safePag,
+      "PAG perturbation",
+      numberInput(safePagSettings.perturbation_strength ?? 0.75, "0.01"),
+      "tip.safePagPerturbation",
+    );
+    const safePagHeads = field(safePag, "PAG heads", textInput(safePagSettings.head_indices || ""), "tip.safePagHeads");
+    const safePagStart = field(
+      safePag,
+      "PAG start percent",
+      numberInput(safePagSettings.start_percent ?? 0.0, "0.001"),
+      "tip.safePagStart",
+    );
+    const safePagEnd = field(
+      safePag,
+      "PAG end percent",
+      numberInput(safePagSettings.end_percent ?? 0.7, "0.001"),
+      "tip.safePagEnd",
+    );
+    const safePagRescale = field(safePag, "PAG rescale", numberInput(safePagSettings.rescale ?? 0.2, "0.01"), "tip.safePagRescale");
+    const safePagRescaleMode = field(
+      safePag,
+      "PAG rescale mode",
+      selectInput(["full", "partial"], safePagSettings.rescale_mode || "full"),
+      "tip.safePagRescaleMode",
+    );
+    safePagScale.min = "0";
+    safePagScale.max = "100";
+    safePagPerturbation.min = "0";
+    safePagPerturbation.max = "1";
+    safePagStart.min = "0";
+    safePagStart.max = "1";
+    safePagEnd.min = "0";
+    safePagEnd.max = "1";
+    safePagRescale.min = "0";
+    safePagRescale.max = "1";
+
+    const kj = makeSubsection("KJNodes Optimization");
+    const fp16Accum = field(kj, "KJNodes FP16 accum", checkbox(settings.model_patches.kj.fp16_accumulation), "tip.kjFp16Accum");
+
+    const sage = makeSubsection("SageAttention (KJNodes)");
+    const sageAttention = field(
+      sage,
+      "Mode",
+      selectInput([
+        "disabled",
+        "auto",
+        "sageattn",
+        "sageattn_qk_int8_pv_fp16_cuda",
+        "sageattn_qk_int8_pv_fp8_cuda",
+      ], settings.model_patches.kj.sage_attention),
+      "tip.kjSageMode",
+    );
+    const sageAllowCompile = field(sage, "Allow compile", checkbox(settings.model_patches.kj.sage_allow_compile), "tip.kjSageCompile");
+    kj.append(sage);
+
+    const torch = makeSubsection("Torch Compile (KJNodes)");
+    const torchCompileEnabled = field(
+      torch,
+      "Use Torch compile",
+      checkbox(settings.model_patches.kj.torch_compile.enabled),
+      "tip.torchCompileEnabled",
+    );
+    const torchDetails = document.createElement("div");
+    torchDetails.className = "easyuse-anima-aio-subsection";
+    torchDetails.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("Torch Compile Parameters") }));
+    const torchCompileBackend = field(torchDetails, "Backend", textInput(settings.model_patches.kj.torch_compile.backend), "tip.torchCompileBackend");
+    const torchCompileFullgraph = field(torchDetails, "Fullgraph", checkbox(settings.model_patches.kj.torch_compile.fullgraph), "tip.torchCompileFullgraph");
+    const torchCompileMode = field(
+      torchDetails,
+      "Mode",
+      selectInput([
+        "default",
+        "reduce-overhead",
+        "max-autotune",
+        "max-autotune-no-cudagraphs",
+      ], settings.model_patches.kj.torch_compile.mode),
+      "tip.torchCompileMode",
+    );
+    const torchCompileDynamic = field(
+      torchDetails,
+      "Dynamic",
+      selectInput(["false", "true", "default"], settings.model_patches.kj.torch_compile.dynamic),
+      "tip.torchCompileDynamic",
+    );
+    const torchCompileBlocksOnly = field(
+      torchDetails,
+      "Transformer blocks only",
+      checkbox(settings.model_patches.kj.torch_compile.compile_transformer_blocks_only),
+      "tip.torchCompileBlocks",
+    );
+    const torchCompileCache = field(
+      torchDetails,
+      "Dynamo cache limit",
+      numberInput(settings.model_patches.kj.torch_compile.dynamo_cache_size_limit, "1"),
+      "tip.torchCompileCache",
+    );
+    const torchCompileDebug = field(
+      torchDetails,
+      "Debug keys",
+      checkbox(settings.model_patches.kj.torch_compile.debug_compile_keys),
+      "tip.torchCompileDebug",
+    );
+    const torchCompileDisableVram = field(
+      torchDetails,
+      "Disable dynamic VRAM",
+      checkbox(settings.model_patches.kj.torch_compile.disable_dynamic_vram),
+      "tip.torchCompileVram",
+    );
+    torch.append(torchDetails);
+    kj.append(torch);
+
+    const modelWarning = document.createElement("div");
+    modelWarning.className = "easyuse-anima-aio-warning";
+    modelWarning.hidden = true;
+    modelPatches.append(dave, safePag, kj, modelWarning);
+    body.append(modelPatches);
+
+    const artistMix = document.createElement("section");
+    artistMix.className = "easyuse-anima-aio-section full";
+    artistMix.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Artist Mix") }));
+    const artistMode = field(
+      artistMix,
+      "Mode",
+      selectInput([
+        "prompt_data",
+        "off",
+        "prompt",
+        "average",
+        "delta_rms",
+        "hybrid",
+        "clustered",
+        "exact",
+        "composite_exact",
+        "late_exact",
+        "average_late_exact",
+        "scheduled_average",
+      ], settings.artist_mix.mode),
+      "tip.artistMixMode",
+    );
+    const artistStart = field(artistMix, "Start", numberInput(settings.artist_mix.start_percent, "0.01"));
+    const artistStrength = field(artistMix, "Strength", numberInput(settings.artist_mix.strength_scale, "0.01"));
+    body.append(artistMix);
+
+    const refreshSageDetails = () => {
+      sageAllowCompile.parentElement.style.display = sageAttention.value === "disabled" ? "none" : "";
+    };
+    const refreshTorchDetails = () => {
+      torchDetails.style.display = torchCompileEnabled.checked ? "" : "none";
+    };
+    const setControlsDisabled = (controls, disabled) => {
+      for (const control of controls) {
+        if (control) {
+          control.disabled = disabled;
+        }
+      }
+    };
+    const refreshAdvancedDependencyLocks = () => {
+      const messages = [];
+
+      const daveMissing = !optionalDependencyAvailable("dave");
+      setControlsDisabled([daveEnabled, daveMask, daveStrength, daveTau], daveMissing);
+      if (daveMissing && daveEnabled.checked) {
+        daveEnabled.checked = false;
+      }
+      if (daveMissing) {
+        messages.push(aioFormat("warning.optionalDependencyMissing", {
+          backend: "Anima DAVE",
+          pack: optionalDependencyPack("dave"),
+        }));
+      }
+
+      const safePagMissing = !optionalDependencyAvailable("safePag");
+      setControlsDisabled([
+        safePagEnabled,
+        safePagScale,
+        safePagBlocks,
+        safePagPerturbation,
+        safePagHeads,
+        safePagStart,
+        safePagEnd,
+        safePagRescale,
+        safePagRescaleMode,
+      ], safePagMissing);
+      if (safePagMissing && safePagEnabled.checked) {
+        safePagEnabled.checked = false;
+      }
+      if (safePagMissing) {
+        messages.push(aioFormat("warning.optionalDependencyMissing", {
+          backend: "Anima Safe PAG",
+          pack: optionalDependencyPack("safePag"),
+        }));
+      }
+
+      const kjFp16Missing = !optionalDependencyAvailable("kjFp16");
+      fp16Accum.disabled = kjFp16Missing;
+      if (kjFp16Missing && fp16Accum.checked) {
+        fp16Accum.checked = false;
+      }
+      if (kjFp16Missing) {
+        messages.push(aioFormat("warning.optionalDependencyMissing", {
+          backend: "KJNodes FP16 accum",
+          pack: optionalDependencyPack("kjFp16"),
+        }));
+      }
+
+      const kjSageMissing = !optionalDependencyAvailable("kjSage");
+      setControlsDisabled([sageAttention, sageAllowCompile], kjSageMissing);
+      if (kjSageMissing && sageAttention.value !== "disabled") {
+        sageAttention.value = "disabled";
+        sageAllowCompile.checked = false;
+      }
+      if (kjSageMissing) {
+        messages.push(aioFormat("warning.optionalDependencyMissing", {
+          backend: "SageAttention",
+          pack: optionalDependencyPack("kjSage"),
+        }));
+      }
+
+      const kjCompileMissing = !optionalDependencyAvailable("kjTorchCompile");
+      setControlsDisabled([
+        torchCompileEnabled,
+        torchCompileBackend,
+        torchCompileFullgraph,
+        torchCompileMode,
+        torchCompileDynamic,
+        torchCompileBlocksOnly,
+        torchCompileCache,
+        torchCompileDebug,
+        torchCompileDisableVram,
+      ], kjCompileMissing);
+      if (kjCompileMissing && torchCompileEnabled.checked) {
+        torchCompileEnabled.checked = false;
+      }
+      if (kjCompileMissing) {
+        messages.push(aioFormat("warning.optionalDependencyMissing", {
+          backend: "Torch Compile",
+          pack: optionalDependencyPack("kjTorchCompile"),
+        }));
+      }
+
+      modelWarning.hidden = messages.length === 0;
+      modelWarning.textContent = messages.join(" ");
+      refreshSageDetails();
+      refreshTorchDetails();
+    };
+    sageAttention.addEventListener("change", refreshSageDetails);
+    torchCompileEnabled.addEventListener("change", refreshTorchDetails);
+    refreshSageDetails();
+    refreshTorchDetails();
+    refreshAdvancedDependencyLocks();
+    loadGeneratorOptionalDependencies().then(refreshAdvancedDependencyLocks);
+
+    const cancel = document.createElement("button");
+    cancel.textContent = aioText("button.cancel");
+    const apply = document.createElement("button");
+    apply.className = "primary";
+    apply.textContent = aioText("button.apply");
+    actions.append(cancel, apply);
+    cancel.addEventListener("click", () => backdrop.remove());
+    apply.addEventListener("click", () => {
+      const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
+      delete next.sampler.dave;
+      delete next.model_patches.aura_flow.enabled;
+      next.model_patches.aura_flow.shift = clampGeneratorNumber(
+        auraShift.value,
+        DEFAULT_GENERATION_SETTINGS.model_patches.aura_flow.shift,
+        1,
+        10,
+      );
+      next.model_patches.dave.enabled = daveEnabled.checked && !daveEnabled.disabled;
+      next.model_patches.dave.mask = daveMask.value || "dave_alpha.npz";
+      next.model_patches.dave.strength = Number(daveStrength.value || 0.30);
+      next.model_patches.dave.tau = Number(daveTau.value || 0.10);
+      next.model_patches.safe_pag ||= {};
+      next.model_patches.safe_pag.enabled = safePagEnabled.checked && !safePagEnabled.disabled;
+      next.model_patches.safe_pag.scale = clampGeneratorNumber(safePagScale.value, 4.0, 0, 100);
+      next.model_patches.safe_pag.block_indices = safePagBlocks.value || "18";
+      next.model_patches.safe_pag.perturbation_strength = clampGeneratorNumber(
+        safePagPerturbation.value,
+        0.75,
+        0,
+        1,
+      );
+      next.model_patches.safe_pag.head_indices = safePagHeads.value || "";
+      next.model_patches.safe_pag.start_percent = clampGeneratorNumber(safePagStart.value, 0.0, 0, 1);
+      next.model_patches.safe_pag.end_percent = clampGeneratorNumber(safePagEnd.value, 0.7, 0, 1);
+      next.model_patches.safe_pag.rescale = clampGeneratorNumber(safePagRescale.value, 0.2, 0, 1);
+      next.model_patches.safe_pag.rescale_mode = safePagRescaleMode.value || "full";
+      next.model_patches.kj.fp16_accumulation = fp16Accum.checked && !fp16Accum.disabled;
+      next.model_patches.kj.sage_attention = sageAttention.disabled ? "disabled" : (sageAttention.value || "disabled");
+      next.model_patches.kj.sage_allow_compile = sageAllowCompile.checked && !sageAttention.disabled;
+      next.model_patches.kj.torch_compile.enabled = torchCompileEnabled.checked && !torchCompileEnabled.disabled;
+      next.model_patches.kj.torch_compile.backend = torchCompileBackend.value || "inductor";
+      next.model_patches.kj.torch_compile.fullgraph = torchCompileFullgraph.checked;
+      next.model_patches.kj.torch_compile.mode = torchCompileMode.value || "max-autotune-no-cudagraphs";
+      next.model_patches.kj.torch_compile.dynamic = torchCompileDynamic.value || "false";
+      next.model_patches.kj.torch_compile.compile_transformer_blocks_only = torchCompileBlocksOnly.checked;
+      next.model_patches.kj.torch_compile.dynamo_cache_size_limit = Number(torchCompileCache.value || 64);
+      next.model_patches.kj.torch_compile.debug_compile_keys = torchCompileDebug.checked;
+      next.model_patches.kj.torch_compile.disable_dynamic_vram = torchCompileDisableVram.checked;
+      next.artist_mix.mode = artistMode.value || "prompt_data";
+      next.artist_mix.start_percent = Number(artistStart.value || 0.5);
+      next.artist_mix.strength_scale = Number(artistStrength.value || 1.0);
+      writeSettings(node, widget, next);
+      renderGeneratorPanel(node);
+      backdrop.remove();
+    });
+  }
+
+  return openAdvancedSettings;
+}
+

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -23,6 +23,7 @@ import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
 import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
 import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";
+import { aioCreateAdvancedSettingsDialog } from "./aio/advanced_settings_dialog.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -3917,358 +3918,6 @@ function randomSeed() {
 
 
 
-function openAdvancedSettings(node) {
-  const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-  const settings = generatorSettings(node);
-  const { backdrop, body, actions } = createDialog(
-    "Advanced Options",
-    "Advanced generation options stay in a popup and are serialized as versioned settings."
-  );
-
-  const makeSubsection = (title) => {
-    const section = document.createElement("div");
-    section.className = "easyuse-anima-aio-subsection";
-    section.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
-    return section;
-  };
-
-  const modelPatches = document.createElement("section");
-  modelPatches.className = "easyuse-anima-aio-section full";
-  modelPatches.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Model Patch / Optimization") }));
-
-  const auraShift = field(
-    modelPatches,
-    "AuraFlow shift",
-    numberInput(settings.model_patches.aura_flow.shift, "0.5"),
-    "tip.shift",
-  );
-  auraShift.min = "1";
-  auraShift.max = "10";
-
-  const dave = makeSubsection("Anima DAVE");
-  const daveEnabled = field(dave, "Use DAVE", checkbox(settings.model_patches.dave.enabled), "tip.daveEnabled");
-  const daveMask = field(dave, "Mask", textInput(settings.model_patches.dave.mask || "dave_alpha.npz"), "tip.daveMask");
-  const daveStrength = field(dave, "DAVE strength", numberInput(settings.model_patches.dave.strength ?? 0.30, "0.01"), "tip.daveStrength");
-  const daveTau = field(dave, "DAVE tau", numberInput(settings.model_patches.dave.tau ?? 0.10, "0.01"), "tip.daveTau");
-  daveStrength.min = "0";
-  daveTau.min = "0";
-  daveTau.max = "1";
-
-  const safePag = makeSubsection("Anima Safe PAG");
-  const safePagSettings = settings.model_patches.safe_pag || DEFAULT_GENERATION_SETTINGS.model_patches.safe_pag;
-  const safePagEnabled = field(safePag, "Use Safe PAG", checkbox(safePagSettings.enabled), "tip.safePagEnabled");
-  const safePagScale = field(safePag, "Safe PAG scale", numberInput(safePagSettings.scale ?? 4.0, "0.1"), "tip.safePagScale");
-  const safePagBlocks = field(safePag, "Safe PAG blocks", textInput(safePagSettings.block_indices || "18"), "tip.safePagBlocks");
-  const safePagPerturbation = field(
-    safePag,
-    "PAG perturbation",
-    numberInput(safePagSettings.perturbation_strength ?? 0.75, "0.01"),
-    "tip.safePagPerturbation",
-  );
-  const safePagHeads = field(safePag, "PAG heads", textInput(safePagSettings.head_indices || ""), "tip.safePagHeads");
-  const safePagStart = field(
-    safePag,
-    "PAG start percent",
-    numberInput(safePagSettings.start_percent ?? 0.0, "0.001"),
-    "tip.safePagStart",
-  );
-  const safePagEnd = field(
-    safePag,
-    "PAG end percent",
-    numberInput(safePagSettings.end_percent ?? 0.7, "0.001"),
-    "tip.safePagEnd",
-  );
-  const safePagRescale = field(safePag, "PAG rescale", numberInput(safePagSettings.rescale ?? 0.2, "0.01"), "tip.safePagRescale");
-  const safePagRescaleMode = field(
-    safePag,
-    "PAG rescale mode",
-    selectInput(["full", "partial"], safePagSettings.rescale_mode || "full"),
-    "tip.safePagRescaleMode",
-  );
-  safePagScale.min = "0";
-  safePagScale.max = "100";
-  safePagPerturbation.min = "0";
-  safePagPerturbation.max = "1";
-  safePagStart.min = "0";
-  safePagStart.max = "1";
-  safePagEnd.min = "0";
-  safePagEnd.max = "1";
-  safePagRescale.min = "0";
-  safePagRescale.max = "1";
-
-  const kj = makeSubsection("KJNodes Optimization");
-  const fp16Accum = field(kj, "KJNodes FP16 accum", checkbox(settings.model_patches.kj.fp16_accumulation), "tip.kjFp16Accum");
-
-  const sage = makeSubsection("SageAttention (KJNodes)");
-  const sageAttention = field(
-    sage,
-    "Mode",
-    selectInput([
-      "disabled",
-      "auto",
-      "sageattn",
-      "sageattn_qk_int8_pv_fp16_cuda",
-      "sageattn_qk_int8_pv_fp8_cuda",
-    ], settings.model_patches.kj.sage_attention),
-    "tip.kjSageMode",
-  );
-  const sageAllowCompile = field(sage, "Allow compile", checkbox(settings.model_patches.kj.sage_allow_compile), "tip.kjSageCompile");
-  kj.append(sage);
-
-  const torch = makeSubsection("Torch Compile (KJNodes)");
-  const torchCompileEnabled = field(
-    torch,
-    "Use Torch compile",
-    checkbox(settings.model_patches.kj.torch_compile.enabled),
-    "tip.torchCompileEnabled",
-  );
-  const torchDetails = document.createElement("div");
-  torchDetails.className = "easyuse-anima-aio-subsection";
-  torchDetails.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText("Torch Compile Parameters") }));
-  const torchCompileBackend = field(torchDetails, "Backend", textInput(settings.model_patches.kj.torch_compile.backend), "tip.torchCompileBackend");
-  const torchCompileFullgraph = field(torchDetails, "Fullgraph", checkbox(settings.model_patches.kj.torch_compile.fullgraph), "tip.torchCompileFullgraph");
-  const torchCompileMode = field(
-    torchDetails,
-    "Mode",
-    selectInput([
-      "default",
-      "reduce-overhead",
-      "max-autotune",
-      "max-autotune-no-cudagraphs",
-    ], settings.model_patches.kj.torch_compile.mode),
-    "tip.torchCompileMode",
-  );
-  const torchCompileDynamic = field(
-    torchDetails,
-    "Dynamic",
-    selectInput(["false", "true", "default"], settings.model_patches.kj.torch_compile.dynamic),
-    "tip.torchCompileDynamic",
-  );
-  const torchCompileBlocksOnly = field(
-    torchDetails,
-    "Transformer blocks only",
-    checkbox(settings.model_patches.kj.torch_compile.compile_transformer_blocks_only),
-    "tip.torchCompileBlocks",
-  );
-  const torchCompileCache = field(
-    torchDetails,
-    "Dynamo cache limit",
-    numberInput(settings.model_patches.kj.torch_compile.dynamo_cache_size_limit, "1"),
-    "tip.torchCompileCache",
-  );
-  const torchCompileDebug = field(
-    torchDetails,
-    "Debug keys",
-    checkbox(settings.model_patches.kj.torch_compile.debug_compile_keys),
-    "tip.torchCompileDebug",
-  );
-  const torchCompileDisableVram = field(
-    torchDetails,
-    "Disable dynamic VRAM",
-    checkbox(settings.model_patches.kj.torch_compile.disable_dynamic_vram),
-    "tip.torchCompileVram",
-  );
-  torch.append(torchDetails);
-  kj.append(torch);
-
-  const modelWarning = document.createElement("div");
-  modelWarning.className = "easyuse-anima-aio-warning";
-  modelWarning.hidden = true;
-  modelPatches.append(dave, safePag, kj, modelWarning);
-  body.append(modelPatches);
-
-  const artistMix = document.createElement("section");
-  artistMix.className = "easyuse-anima-aio-section full";
-  artistMix.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Artist Mix") }));
-  const artistMode = field(
-    artistMix,
-    "Mode",
-    selectInput([
-      "prompt_data",
-      "off",
-      "prompt",
-      "average",
-      "delta_rms",
-      "hybrid",
-      "clustered",
-      "exact",
-      "composite_exact",
-      "late_exact",
-      "average_late_exact",
-      "scheduled_average",
-    ], settings.artist_mix.mode),
-    "tip.artistMixMode",
-  );
-  const artistStart = field(artistMix, "Start", numberInput(settings.artist_mix.start_percent, "0.01"));
-  const artistStrength = field(artistMix, "Strength", numberInput(settings.artist_mix.strength_scale, "0.01"));
-  body.append(artistMix);
-
-  const refreshSageDetails = () => {
-    sageAllowCompile.parentElement.style.display = sageAttention.value === "disabled" ? "none" : "";
-  };
-  const refreshTorchDetails = () => {
-    torchDetails.style.display = torchCompileEnabled.checked ? "" : "none";
-  };
-  const setControlsDisabled = (controls, disabled) => {
-    for (const control of controls) {
-      if (control) {
-        control.disabled = disabled;
-      }
-    }
-  };
-  const refreshAdvancedDependencyLocks = () => {
-    const messages = [];
-
-    const daveMissing = !optionalDependencyAvailable("dave");
-    setControlsDisabled([daveEnabled, daveMask, daveStrength, daveTau], daveMissing);
-    if (daveMissing && daveEnabled.checked) {
-      daveEnabled.checked = false;
-    }
-    if (daveMissing) {
-      messages.push(aioFormat("warning.optionalDependencyMissing", {
-        backend: "Anima DAVE",
-        pack: optionalDependencyPack("dave"),
-      }));
-    }
-
-    const safePagMissing = !optionalDependencyAvailable("safePag");
-    setControlsDisabled([
-      safePagEnabled,
-      safePagScale,
-      safePagBlocks,
-      safePagPerturbation,
-      safePagHeads,
-      safePagStart,
-      safePagEnd,
-      safePagRescale,
-      safePagRescaleMode,
-    ], safePagMissing);
-    if (safePagMissing && safePagEnabled.checked) {
-      safePagEnabled.checked = false;
-    }
-    if (safePagMissing) {
-      messages.push(aioFormat("warning.optionalDependencyMissing", {
-        backend: "Anima Safe PAG",
-        pack: optionalDependencyPack("safePag"),
-      }));
-    }
-
-    const kjFp16Missing = !optionalDependencyAvailable("kjFp16");
-    fp16Accum.disabled = kjFp16Missing;
-    if (kjFp16Missing && fp16Accum.checked) {
-      fp16Accum.checked = false;
-    }
-    if (kjFp16Missing) {
-      messages.push(aioFormat("warning.optionalDependencyMissing", {
-        backend: "KJNodes FP16 accum",
-        pack: optionalDependencyPack("kjFp16"),
-      }));
-    }
-
-    const kjSageMissing = !optionalDependencyAvailable("kjSage");
-    setControlsDisabled([sageAttention, sageAllowCompile], kjSageMissing);
-    if (kjSageMissing && sageAttention.value !== "disabled") {
-      sageAttention.value = "disabled";
-      sageAllowCompile.checked = false;
-    }
-    if (kjSageMissing) {
-      messages.push(aioFormat("warning.optionalDependencyMissing", {
-        backend: "SageAttention",
-        pack: optionalDependencyPack("kjSage"),
-      }));
-    }
-
-    const kjCompileMissing = !optionalDependencyAvailable("kjTorchCompile");
-    setControlsDisabled([
-      torchCompileEnabled,
-      torchCompileBackend,
-      torchCompileFullgraph,
-      torchCompileMode,
-      torchCompileDynamic,
-      torchCompileBlocksOnly,
-      torchCompileCache,
-      torchCompileDebug,
-      torchCompileDisableVram,
-    ], kjCompileMissing);
-    if (kjCompileMissing && torchCompileEnabled.checked) {
-      torchCompileEnabled.checked = false;
-    }
-    if (kjCompileMissing) {
-      messages.push(aioFormat("warning.optionalDependencyMissing", {
-        backend: "Torch Compile",
-        pack: optionalDependencyPack("kjTorchCompile"),
-      }));
-    }
-
-    modelWarning.hidden = messages.length === 0;
-    modelWarning.textContent = messages.join(" ");
-    refreshSageDetails();
-    refreshTorchDetails();
-  };
-  sageAttention.addEventListener("change", refreshSageDetails);
-  torchCompileEnabled.addEventListener("change", refreshTorchDetails);
-  refreshSageDetails();
-  refreshTorchDetails();
-  refreshAdvancedDependencyLocks();
-  loadGeneratorOptionalDependencies().then(refreshAdvancedDependencyLocks);
-
-  const cancel = document.createElement("button");
-  cancel.textContent = aioText("button.cancel");
-  const apply = document.createElement("button");
-  apply.className = "primary";
-  apply.textContent = aioText("button.apply");
-  actions.append(cancel, apply);
-  cancel.addEventListener("click", () => backdrop.remove());
-  apply.addEventListener("click", () => {
-    const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-    delete next.sampler.dave;
-    delete next.model_patches.aura_flow.enabled;
-    next.model_patches.aura_flow.shift = clampGeneratorNumber(
-      auraShift.value,
-      DEFAULT_GENERATION_SETTINGS.model_patches.aura_flow.shift,
-      1,
-      10,
-    );
-    next.model_patches.dave.enabled = daveEnabled.checked && !daveEnabled.disabled;
-    next.model_patches.dave.mask = daveMask.value || "dave_alpha.npz";
-    next.model_patches.dave.strength = Number(daveStrength.value || 0.30);
-    next.model_patches.dave.tau = Number(daveTau.value || 0.10);
-    next.model_patches.safe_pag ||= {};
-    next.model_patches.safe_pag.enabled = safePagEnabled.checked && !safePagEnabled.disabled;
-    next.model_patches.safe_pag.scale = clampGeneratorNumber(safePagScale.value, 4.0, 0, 100);
-    next.model_patches.safe_pag.block_indices = safePagBlocks.value || "18";
-    next.model_patches.safe_pag.perturbation_strength = clampGeneratorNumber(
-      safePagPerturbation.value,
-      0.75,
-      0,
-      1,
-    );
-    next.model_patches.safe_pag.head_indices = safePagHeads.value || "";
-    next.model_patches.safe_pag.start_percent = clampGeneratorNumber(safePagStart.value, 0.0, 0, 1);
-    next.model_patches.safe_pag.end_percent = clampGeneratorNumber(safePagEnd.value, 0.7, 0, 1);
-    next.model_patches.safe_pag.rescale = clampGeneratorNumber(safePagRescale.value, 0.2, 0, 1);
-    next.model_patches.safe_pag.rescale_mode = safePagRescaleMode.value || "full";
-    next.model_patches.kj.fp16_accumulation = fp16Accum.checked && !fp16Accum.disabled;
-    next.model_patches.kj.sage_attention = sageAttention.disabled ? "disabled" : (sageAttention.value || "disabled");
-    next.model_patches.kj.sage_allow_compile = sageAllowCompile.checked && !sageAttention.disabled;
-    next.model_patches.kj.torch_compile.enabled = torchCompileEnabled.checked && !torchCompileEnabled.disabled;
-    next.model_patches.kj.torch_compile.backend = torchCompileBackend.value || "inductor";
-    next.model_patches.kj.torch_compile.fullgraph = torchCompileFullgraph.checked;
-    next.model_patches.kj.torch_compile.mode = torchCompileMode.value || "max-autotune-no-cudagraphs";
-    next.model_patches.kj.torch_compile.dynamic = torchCompileDynamic.value || "false";
-    next.model_patches.kj.torch_compile.compile_transformer_blocks_only = torchCompileBlocksOnly.checked;
-    next.model_patches.kj.torch_compile.dynamo_cache_size_limit = Number(torchCompileCache.value || 64);
-    next.model_patches.kj.torch_compile.debug_compile_keys = torchCompileDebug.checked;
-    next.model_patches.kj.torch_compile.disable_dynamic_vram = torchCompileDisableVram.checked;
-    next.artist_mix.mode = artistMode.value || "prompt_data";
-    next.artist_mix.start_percent = Number(artistStart.value || 0.5);
-    next.artist_mix.strength_scale = Number(artistStrength.value || 1.0);
-    writeSettings(node, widget, next);
-    renderGeneratorPanel(node);
-    backdrop.remove();
-  });
-}
-
 function openGeneratorSettings(node) {
   openAdvancedSettings(node);
 }
@@ -4635,6 +4284,40 @@ const openSaveSettings = aioCreateSaveSettingsDialog({
     findWidget,
     getSettings: generatorSettings,
     applyVisibleSettings: applyVisibleGeneratorSettings,
+    writeSettings,
+    renderPanel: renderGeneratorPanel,
+  },
+  dependencyAdapter: {
+    available: optionalDependencyAvailable,
+    pack: optionalDependencyPack,
+    load: loadGeneratorOptionalDependencies,
+  },
+});
+
+const openAdvancedSettings = aioCreateAdvancedSettingsDialog({
+  document,
+  controls: {
+    createDialog,
+    field,
+    numberInput,
+    checkbox,
+    textInput,
+    selectInput,
+  },
+  text: {
+    staticText: aioStaticText,
+    get: aioText,
+    format: aioFormat,
+  },
+  settingsCore: {
+    defaultGenerationSettings: DEFAULT_GENERATION_SETTINGS,
+    mergeDefaults,
+    clampNumber: clampGeneratorNumber,
+  },
+  nodeAdapter: {
+    generatorSettingsWidget: GENERATOR_SETTINGS_WIDGET,
+    findWidget,
+    getSettings: generatorSettings,
     writeSettings,
     renderPanel: renderGeneratorPanel,
   },


### PR DESCRIPTION
## 변경 요약

- AiO Advanced 설정 dialog의 model patch/Artist Mix UI, dependency lock, Apply/Cancel lifecycle을 `web/js/aio/advanced_settings_dialog.js`의 단일 factory로 분리했습니다.
- entry는 DOM/text/settings/dependency adapter 조립과 generator panel action 연결만 담당합니다.
- 공용 Fake DOM smoke로 hydrate, Sage/Torch visibility, Cancel/Apply 직렬화, 개별·전체 optional dependency lock을 검증합니다.
- 사용자 동작은 변경하지 않는 기계적 lifecycle 추출입니다.

## 주요 파일

- `web/js/aio/advanced_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_advanced_settings_dialog_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- moved body exact audit: 351 lines / 14,146 chars 일치
- focused Advanced Fake DOM smoke: 통과
- 관련 Python source/module tests: 69개 통과
- JavaScript syntax 검사: 통과
- official full runner: Python 368 tests, frontend 93 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과
- 행동·경계 및 테스트 적정성 2축 감사: 최종 Blocker/P2/P3 없음

## ComfyUI 표면

- ComfyUI Codex test surface: official full project validation
- Legacy canvas / Node 2.0 browser smoke: 미실행 (동작 변경 없는 lifecycle extraction)
- ComfyUI v0.27.0 user instance: 전체 유지보수 완료 후 최종 수동 확인 예정

## 호환성 및 후속

- dependency lock 순서, fail-closed Apply, legacy key 제거, unknown settings 보존, write → render → close 순서를 그대로 유지합니다.
- dead wrapper `openGeneratorSettings`와 preview/queue/hooks/extension runtime은 후속 entry 경계 조각으로 유지합니다.
- 이 PR은 Issue #54의 Advanced lifecycle 경계 조각이며 Issue #54 전체를 닫지 않습니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`