### PR TITLE
refactor: AiO native preview runtime lifecycle 분리

### DIFF
--- a/tests/frontend_aio_native_preview_runtime_smoke.mjs
+++ b/tests/frontend_aio_native_preview_runtime_smoke.mjs
@@ -1,0 +1,779 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createFakeDocument } from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+async function flushPromises() {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function createScheduler() {
+  let nextId = 1;
+  const frames = [];
+  const timers = new Map();
+  const cleared = [];
+
+  return {
+    frames,
+    timers,
+    cleared,
+    requestAnimationFrame(callback) {
+      const id = nextId++;
+      frames.push({ id, callback });
+      return id;
+    },
+    setTimeout(callback, delay) {
+      const id = nextId++;
+      timers.set(id, { id, callback, delay });
+      return id;
+    },
+    clearTimeout(id) {
+      cleared.push(id);
+      timers.delete(id);
+    },
+    runNextFrame() {
+      const frame = frames.shift();
+      assert.ok(frame, "missing scheduled animation frame");
+      frame.callback();
+    },
+    runDelay(delay) {
+      const entries = [...timers.values()]
+        .filter((entry) => entry.delay === delay)
+        .sort((left, right) => left.id - right.id);
+      assert.ok(entries.length, `missing timer delay: ${delay}`);
+      for (const entry of entries) {
+        timers.delete(entry.id);
+        entry.callback();
+      }
+    },
+    delays() {
+      return [...timers.values()].map(({ delay }) => delay).sort((left, right) => left - right);
+    },
+  };
+}
+
+function graphFromNodes(nodes) {
+  const byId = new Map(nodes.map((node) => [String(node.id), node]));
+  return {
+    _nodes_by_id: Object.fromEntries(byId),
+    getNodeById(id) {
+      return byId.get(String(id)) || null;
+    },
+  };
+}
+
+function adapterChannelSnapshot(calls) {
+  return Object.fromEntries(
+    Object.entries(calls).map(([name, value]) => [name, Array.isArray(value) ? value.length : value]),
+  );
+}
+
+function blockDirectNodeIdSelectors(document) {
+  const querySelectorAll = document.querySelectorAll.bind(document);
+  const blocked = [];
+  document.querySelectorAll = (selector) => {
+    if (/^\[data-node-id(?:=|\$=)/.test(String(selector))) {
+      blocked.push(String(selector));
+      return [];
+    }
+    return querySelectorAll(selector);
+  };
+  return blocked;
+}
+
+const nativePreviewModule = await import(dataModule("../web/js/aio/native_preview_runtime.js"));
+const previewCoreModule = await import(dataModule("../web/js/aio/preview.js"));
+assert.deepEqual(
+  Object.keys(nativePreviewModule),
+  ["aioCreateNativePreviewRuntime"],
+  "Native preview runtime must expose only its lifecycle factory",
+);
+
+const GENERATOR_NODE_TYPE = "EasyUseAnimaAIOGenerator";
+const GENERATOR_VUE_NODE_CLASS = "easyuse-anima-aio-hide-native-live-preview";
+const NATIVE_HIDDEN_CLASS = "easyuse-anima-aio-native-live-preview-hidden";
+
+function createFixture({
+  storeMode = "direct",
+  graph = graphFromNodes([]),
+  generatorNodes = [],
+  suppressResult = true,
+} = {}) {
+  const document = createFakeDocument();
+  const scheduler = createScheduler();
+  const mutationObservers = [];
+  const legacyPreviewImages = new Map();
+  const outputPreviewImages = new Map();
+  const revokeCalls = [];
+  const workflowLocatorCalls = [];
+  const outputStore = {
+    nodePreviewImages: outputPreviewImages,
+    revokePreviewsByLocatorId(locator) {
+      revokeCalls.push(String(locator));
+    },
+  };
+  const workflowStore = {
+    nodeIdToNodeLocatorId(id) {
+      const text = String(id);
+      workflowLocatorCalls.push(text);
+      return `locator:${text}`;
+    },
+  };
+  const calls = {
+    legacyGets: 0,
+    directStoreLoads: 0,
+    frontendFetches: 0,
+    assetImports: [],
+    deleteStore: [],
+    eventDetails: [],
+    images: [],
+    nodeIds: [],
+    suppress: [],
+    addImages: [],
+    clearDenoise: [],
+    setDenoise: [],
+    markDirty: [],
+    progress: [],
+    progressState: [],
+    progressClear: 0,
+    graphGets: 0,
+    generatorLists: 0,
+  };
+
+  class FakeMutationObserver {
+    constructor(callback) {
+      this.callback = callback;
+      this.observeCalls = [];
+      this.disconnectCalls = 0;
+      mutationObservers.push(this);
+    }
+
+    observe(root, options) {
+      this.observeCalls.push({ root, options });
+    }
+
+    disconnect() {
+      this.disconnectCalls += 1;
+    }
+
+    trigger() {
+      this.callback();
+    }
+  }
+
+  const runtime = nativePreviewModule.aioCreateNativePreviewRuntime({
+    environment: {
+      document,
+      window: { location: { href: "https://comfy.test/" } },
+      MutationObserver: FakeMutationObserver,
+      requestAnimationFrame: scheduler.requestAnimationFrame,
+      setTimeout: scheduler.setTimeout,
+      clearTimeout: scheduler.clearTimeout,
+    },
+    constants: {
+      generatorNodeType: GENERATOR_NODE_TYPE,
+      generatorVueNodeClass: GENERATOR_VUE_NODE_CLASS,
+    },
+    storeAdapter: {
+      getLegacyPreviewImages() {
+        calls.legacyGets += 1;
+        return legacyPreviewImages;
+      },
+      async loadDirectStoreModules() {
+        calls.directStoreLoads += 1;
+        if (storeMode !== "direct") {
+          throw new Error("direct stores unavailable");
+        }
+        return [
+          { useNodeOutputStore: () => outputStore },
+          { useWorkflowStore: () => workflowStore },
+        ];
+      },
+      async fetchFrontendHtml() {
+        calls.frontendFetches += 1;
+        return storeMode === "html-fallback"
+          ? '<script src="./assets/dialogService-html.js"></script>'
+          : "";
+      },
+      async importAssetModule(url) {
+        calls.assetImports.push(url);
+        if (storeMode === "hashed" || storeMode === "html-fallback") {
+          return {
+            cn: () => outputStore,
+            M: () => workflowStore,
+          };
+        }
+        throw new Error("hashed store unavailable");
+      },
+    },
+    previewCore: {
+      deleteStoreEntry(container, locator) {
+        calls.deleteStore.push({ container, locator: String(locator) });
+        previewCoreModule.aioDeletePreviewStoreEntry(container, locator);
+      },
+      eventDetail(event) {
+        const detail = previewCoreModule.aioPreviewEventDetail(event);
+        calls.eventDetails.push(detail);
+        return detail;
+      },
+      images(message) {
+        const images = previewCoreModule.aioPreviewImages(message);
+        calls.images.push(images);
+        return images;
+      },
+      nodeIdsFromDetail(detail) {
+        const ids = previewCoreModule.aioPreviewNodeIdsFromDetail(detail);
+        calls.nodeIds.push(ids);
+        return ids;
+      },
+      suppressDefaultPreview(node, options) {
+        calls.suppress.push({ node, options });
+        return suppressResult;
+      },
+    },
+    nodeAdapter: {
+      getGraph() {
+        calls.graphGets += 1;
+        return graph;
+      },
+      listGeneratorNodes() {
+        calls.generatorLists += 1;
+        return generatorNodes;
+      },
+      addPreviewImages(node, images, runId, options) {
+        calls.addImages.push({ node, images, runId, options });
+      },
+      clearDenoisePreview(node, update) {
+        calls.clearDenoise.push({ node, update });
+      },
+      setDenoisePreview(node, blob, detail) {
+        calls.setDenoise.push({ node, blob, detail });
+      },
+      markDirty(node) {
+        calls.markDirty.push(node);
+      },
+    },
+    progressAdapter: {
+      remember(detail) {
+        calls.progress.push(detail);
+      },
+      rememberState(detail) {
+        calls.progressState.push(detail);
+      },
+      clear() {
+        calls.progressClear += 1;
+      },
+    },
+  });
+
+  return {
+    runtime,
+    document,
+    scheduler,
+    mutationObservers,
+    legacyPreviewImages,
+    outputPreviewImages,
+    outputStore,
+    workflowStore,
+    revokeCalls,
+    workflowLocatorCalls,
+    calls,
+  };
+}
+
+function appendNodeRoot(document, id, className = "lg-node") {
+  const root = document.createElement("div");
+  root.className = className;
+  root.setAttribute("data-node-id", String(id));
+  root.isConnected = true;
+  document.body.append(root);
+  return root;
+}
+
+function assertHidden(element, message) {
+  assert.equal(element.classList.contains(NATIVE_HIDDEN_CLASS), true, message);
+  assert.equal(element.getAttribute("aria-hidden"), "true", message);
+  assert.equal(element.style.getPropertyValue("display"), "none", message);
+  assert.equal(element.style.getPropertyPriority("display"), "important", message);
+}
+
+{
+  const fixture = createFixture({ suppressResult: "suppressed" });
+  assert.equal(fixture.document.createdElements.length, 0, "Factory must not create DOM elements");
+  assert.equal(fixture.document.body.children.length, 0, "Factory must not attach DOM elements");
+  assert.equal(fixture.calls.legacyGets, 0);
+  assert.equal(fixture.calls.directStoreLoads, 0);
+  assert.equal(fixture.calls.suppress.length, 0);
+  assert.equal(fixture.scheduler.frames.length, 0);
+  assert.equal(fixture.scheduler.timers.size, 0);
+  assert.equal(fixture.mutationObservers.length, 0);
+  assert.deepEqual(
+    adapterChannelSnapshot(fixture.calls),
+    Object.fromEntries(Object.keys(fixture.calls).map((name) => [name, 0])),
+    "Factory construction must not invoke any tracked adapter channel",
+  );
+  assert.equal(fixture.revokeCalls.length, 0);
+  assert.equal(fixture.workflowLocatorCalls.length, 0);
+  assert.deepEqual(
+    Object.keys(fixture.runtime),
+    [
+      "markGeneratorNativeLivePreviewHidden",
+      "suppressGeneratorDefaultPreview",
+      "scheduleGeneratorDefaultPreviewSuppression",
+      "handleGeneratorPreviewEvent",
+      "handleGeneratorProgressEvent",
+      "handleGeneratorProgressStateEvent",
+      "handleGeneratorDenoisePreviewEvent",
+      "handleGeneratorExecutingEvent",
+      "clearGeneratorDenoisePreviews",
+    ],
+    "Runtime facade changed",
+  );
+
+  const root = appendNodeRoot(fixture.document, "42");
+  const nativeContent = fixture.document.createElement("div");
+  nativeContent.className = "lg-node-content";
+  const mainImage = fixture.document.createElement("img");
+  mainImage.setAttribute("data-testid", "main-image");
+  nativeContent.append(mainImage);
+  root.append(nativeContent);
+
+  const legacyWrapper = fixture.document.createElement("div");
+  const legacyImage = fixture.document.createElement("img");
+  legacyImage.className = "pointer-events-none object-contain";
+  const dimension = fixture.document.createElement("span");
+  dimension.textContent = "1024 x 1536";
+  legacyWrapper.append(legacyImage, dimension);
+  root.append(legacyWrapper);
+
+  const customContent = fixture.document.createElement("div");
+  customContent.className = "lg-node-content";
+  const panel = fixture.document.createElement("div");
+  panel.className = "easyuse-anima-aio-node-panel";
+  const panelImage = fixture.document.createElement("img");
+  panelImage.className = "pointer-events-none object-contain";
+  const panelLabel = fixture.document.createElement("span");
+  panelLabel.className = "text-node-component-header-text";
+  panel.append(panelImage, panelLabel);
+  customContent.append(panel);
+  root.append(customContent);
+
+  const qualifiedRoot = appendNodeRoot(fixture.document, "7:42");
+  const qualifiedLabel = fixture.document.createElement("span");
+  qualifiedLabel.className = "text-node-component-header-text";
+  qualifiedRoot.append(qualifiedLabel);
+  const unrelatedRoot = appendNodeRoot(fixture.document, "99");
+  const unrelatedImage = fixture.document.createElement("img");
+  unrelatedImage.className = "pointer-events-none object-contain";
+  unrelatedRoot.append(unrelatedImage);
+
+  const node = { id: 42, __easyuseAnimaGeneratorPanelEl: panel };
+  fixture.runtime.markGeneratorNativeLivePreviewHidden(node);
+  assert.equal(root.classList.contains(GENERATOR_VUE_NODE_CLASS), true);
+  assert.equal(qualifiedRoot.classList.contains(GENERATOR_VUE_NODE_CLASS), true);
+  assert.equal(unrelatedRoot.classList.contains(GENERATOR_VUE_NODE_CLASS), false);
+  assertHidden(nativeContent, "Node 2.0 native content must be hidden");
+  assertHidden(legacyImage, "Legacy native image must be hidden");
+  assertHidden(dimension, "Native dimension label must be hidden");
+  assertHidden(legacyWrapper, "Native image/dimension wrapper must be hidden");
+  assertHidden(qualifiedLabel, "Qualified Node 2.0 label must be hidden");
+  for (const element of [customContent, panel, panelImage, panelLabel, unrelatedImage]) {
+    assert.equal(
+      element.classList.contains(NATIVE_HIDDEN_CLASS),
+      false,
+      "AiO and unrelated preview elements must remain visible",
+    );
+  }
+
+  const result = fixture.runtime.suppressGeneratorDefaultPreview(node, { markDirty: false });
+  assert.equal(result, "suppressed", "Suppression wrapper must preserve the core return value");
+  assert.equal(fixture.calls.suppress.length, 1);
+  assert.equal(fixture.calls.suppress[0].node, node);
+  assert.equal(fixture.calls.suppress[0].options.markDirty, false);
+  assert.equal(typeof fixture.calls.suppress[0].options.markNodeDirty, "function");
+  fixture.calls.suppress[0].options.markNodeDirty(node);
+  assert.deepEqual(fixture.calls.markDirty, [node]);
+}
+
+{
+  const fixture = createFixture();
+  const blockedSelectors = blockDirectNodeIdSelectors(fixture.document);
+  const targetRoot = appendNodeRoot(fixture.document, "42");
+  const targetPanel = fixture.document.createElement("div");
+  targetPanel.className = "easyuse-anima-aio-node-panel";
+  const targetNativeImage = fixture.document.createElement("img");
+  targetNativeImage.className = "pointer-events-none object-contain";
+  targetRoot.append(targetPanel, targetNativeImage);
+
+  const unrelatedRoot = appendNodeRoot(fixture.document, "99");
+  const unrelatedPanel = fixture.document.createElement("div");
+  unrelatedPanel.className = "easyuse-anima-aio-node-panel";
+  const unrelatedNativeImage = fixture.document.createElement("img");
+  unrelatedNativeImage.className = "pointer-events-none object-contain";
+  unrelatedRoot.append(unrelatedPanel, unrelatedNativeImage);
+
+  fixture.runtime.markGeneratorNativeLivePreviewHidden({ id: 42 });
+  assert.deepEqual(
+    blockedSelectors,
+    ['[data-node-id="42"]', '[data-node-id$=":42"]'],
+    "Panel fallback must run after both direct data-id selectors are blocked",
+  );
+  assert.equal(targetRoot.classList.contains(GENERATOR_VUE_NODE_CLASS), true);
+  assertHidden(targetNativeImage, "Panel fallback must hide only the matching root preview");
+  assert.equal(targetPanel.classList.contains(NATIVE_HIDDEN_CLASS), false);
+  assert.equal(unrelatedRoot.classList.contains(GENERATOR_VUE_NODE_CLASS), false);
+  assert.equal(unrelatedNativeImage.classList.contains(NATIVE_HIDDEN_CLASS), false);
+}
+
+{
+  const fixture = createFixture();
+  const blockedSelectors = blockDirectNodeIdSelectors(fixture.document);
+  const targetRoot = appendNodeRoot(fixture.document, "7:42");
+  const targetHeader = fixture.document.createElement("span");
+  targetHeader.className = "text-node-component-header-text";
+  targetRoot.append(targetHeader);
+  const unrelatedRoot = appendNodeRoot(fixture.document, "7:99");
+  const unrelatedHeader = fixture.document.createElement("span");
+  unrelatedHeader.className = "text-node-component-header-text";
+  unrelatedRoot.append(unrelatedHeader);
+
+  fixture.runtime.markGeneratorNativeLivePreviewHidden({ id: 42 });
+  assert.deepEqual(
+    blockedSelectors,
+    ['[data-node-id="42"]', '[data-node-id$=":42"]'],
+    "Header fallback must run after both direct data-id selectors are blocked",
+  );
+  assert.equal(targetRoot.classList.contains(GENERATOR_VUE_NODE_CLASS), true);
+  assertHidden(targetHeader, "Header fallback must hide the qualified matching root");
+  assert.equal(unrelatedRoot.classList.contains(GENERATOR_VUE_NODE_CLASS), false);
+  assert.equal(unrelatedHeader.classList.contains(NATIVE_HIDDEN_CLASS), false);
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const graph = graphFromNodes([node]);
+  const fixture = createFixture({ graph, storeMode: "direct" });
+  appendNodeRoot(fixture.document, "7:42");
+  for (const locator of ["42", "7:42", "8:42", "99", "locator:42", "locator:99", "unrelated"]) {
+    fixture.legacyPreviewImages.set(locator, true);
+    fixture.outputPreviewImages.set(locator, true);
+  }
+
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: {
+      data: {
+        node: "42",
+        displayNodeId: "8:42",
+        realNodeId: "99",
+        images: [{ filename: "direct.webp" }],
+        run_id: "run-direct",
+      },
+    },
+  });
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1, "Direct store modules must load once");
+  assert.equal(fixture.calls.frontendFetches, 0);
+  assert.equal(fixture.calls.assetImports.length, 0);
+  for (const locator of ["42", "7:42", "8:42", "99"]) {
+    assert.equal(fixture.legacyPreviewImages.has(locator), false, `legacy store retained: ${locator}`);
+    assert.equal(fixture.outputPreviewImages.has(locator), false, `output store retained: ${locator}`);
+  }
+  for (const locator of ["locator:42", "locator:99"]) {
+    assert.equal(
+      fixture.legacyPreviewImages.has(locator),
+      true,
+      `legacy store must not receive workflow-only locator deletion: ${locator}`,
+    );
+    assert.equal(fixture.outputPreviewImages.has(locator), false, `output store retained: ${locator}`);
+  }
+  assert.equal(fixture.legacyPreviewImages.has("unrelated"), true);
+  assert.equal(fixture.outputPreviewImages.has("unrelated"), true);
+  assert.equal(fixture.revokeCalls.filter((value) => value === "locator:42").length, 1);
+  assert.equal(fixture.calls.addImages.length, 1);
+  assert.equal(fixture.calls.addImages[0].runId, "run-direct");
+  assert.equal(fixture.calls.addImages[0].images[0].filename, "direct.webp");
+  assert.equal(fixture.scheduler.frames.length, 3, "Purge, hide, and suppression frames must be scheduled");
+
+  fixture.scheduler.runNextFrame();
+  await flushPromises();
+  fixture.scheduler.runDelay(80);
+  await flushPromises();
+  fixture.scheduler.runDelay(240);
+  await flushPromises();
+  assert.equal(
+    fixture.revokeCalls.filter((value) => value === "locator:42").length,
+    4,
+    "Store purge must run immediately, on RAF, at 80ms, and at 240ms",
+  );
+  assert.equal(
+    fixture.revokeCalls.filter((value) => value === "locator:99").length,
+    4,
+    "A detail-only locator must reach every immediate and delayed purge",
+  );
+  assert.equal(
+    fixture.workflowLocatorCalls.filter((value) => value === "99").length,
+    4,
+    "A detail-only node id must be remapped during every purge",
+  );
+  assert.equal(fixture.calls.directStoreLoads, 1, "Scheduled purges must reuse the store promise");
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({ graph: graphFromNodes([node]), storeMode: "hashed" });
+  const script = fixture.document.createElement("script");
+  script.setAttribute("src", "/assets/dialogService-hash.js?build=1");
+  fixture.document.body.append(script);
+  fixture.outputPreviewImages.set("42", true);
+  fixture.outputPreviewImages.set("locator:42", true);
+
+  const event = {
+    detail: { data: { node: "42", images: [{ filename: "hashed.webp" }], run_id: "hash-a" } },
+  };
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.calls.frontendFetches, 0, "Visible hashed asset must avoid an HTML fetch");
+  assert.deepEqual(
+    fixture.calls.assetImports,
+    ["https://comfy.test/assets/dialogService-hash.js?build=1"],
+  );
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(fixture.outputPreviewImages.has("locator:42"), false);
+
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1, "Store resolution must stay promise-cached");
+  assert.equal(fixture.calls.assetImports.length, 1, "Hashed module import must stay promise-cached");
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({ graph: graphFromNodes([node]), storeMode: "html-fallback" });
+  fixture.outputPreviewImages.set("42", true);
+  fixture.outputPreviewImages.set("locator:42", true);
+  const event = {
+    detail: { data: { node: "42", images: [{ filename: "html.webp" }], run_id: "html-a" } },
+  };
+
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.calls.frontendFetches, 1, "Missing asset tags must use the HTML fallback");
+  assert.deepEqual(
+    fixture.calls.assetImports,
+    ["https://comfy.test/assets/dialogService-html.js"],
+  );
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(fixture.outputPreviewImages.has("locator:42"), false);
+
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1, "HTML fallback store resolution must stay cached");
+  assert.equal(fixture.calls.frontendFetches, 1, "HTML discovery must stay promise-cached");
+  assert.equal(fixture.calls.assetImports.length, 1, "HTML-discovered module import must stay cached");
+}
+
+{
+  const fixture = createFixture({ storeMode: "none" });
+  const root = appendNodeRoot(fixture.document, "42");
+  const node = { id: 42 };
+  const staleRoot = { isConnected: false };
+  const staleObserver = {
+    disconnectCalls: 0,
+    disconnect() {
+      this.disconnectCalls += 1;
+    },
+  };
+  node.__easyuseAnimaNativeLivePreviewObservers = new Map([[staleRoot, staleObserver]]);
+
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+  assert.equal(fixture.calls.suppress.length, 1);
+  assert.equal(staleObserver.disconnectCalls, 1, "Disconnected roots must be pruned");
+  assert.equal(fixture.mutationObservers.length, 1);
+  assert.deepEqual(
+    fixture.mutationObservers[0].observeCalls,
+    [{ root, options: { childList: true, subtree: true } }],
+  );
+  const existingObserver = fixture.mutationObservers[0];
+  assert.equal(fixture.scheduler.frames.length, 2, "Hide and suppression RAF batches must be scheduled");
+  assert.deepEqual(fixture.scheduler.delays(), [80, 120, 240, 360, 5000]);
+
+  const lateImage = fixture.document.createElement("img");
+  lateImage.className = "pointer-events-none object-contain";
+  root.append(lateImage);
+  const qualifiedRoot = appendNodeRoot(fixture.document, "7:42");
+  const qualifiedImage = fixture.document.createElement("img");
+  qualifiedImage.className = "pointer-events-none object-contain";
+  qualifiedRoot.append(qualifiedImage);
+  const unrelatedRoot = appendNodeRoot(fixture.document, "99");
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+  assertHidden(lateImage, "A deduped call must still perform its immediate hide");
+  assertHidden(qualifiedImage, "A newly matched qualified root must be hidden immediately");
+  assert.equal(fixture.calls.suppress.length, 2, "A deduped call must still suppress immediately");
+  assert.equal(fixture.mutationObservers.length, 2, "Only the new qualified root needs an observer");
+  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.get(root), existingObserver);
+  assert.equal(existingObserver.disconnectCalls, 0, "The existing connected observer must be retained");
+  assert.deepEqual(
+    fixture.mutationObservers[1].observeCalls,
+    [{ root: qualifiedRoot, options: { childList: true, subtree: true } }],
+  );
+  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.has(unrelatedRoot), false);
+  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.size, 2);
+  assert.equal(fixture.scheduler.frames.length, 2, "A deduped call must not add delayed RAF batches");
+  assert.deepEqual(fixture.scheduler.delays(), [80, 120, 240, 360, 5000]);
+  assert.equal(fixture.scheduler.cleared.length, 2, "Observer stop timer must be refreshed on each ensure");
+
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+  assert.equal(fixture.calls.suppress.length, 3);
+  assert.equal(fixture.mutationObservers.length, 2, "Existing root observers must not be duplicated");
+  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.get(root), existingObserver);
+  assert.equal(fixture.scheduler.frames.length, 2, "Partial dedupe must retain the original RAF batches");
+  assert.deepEqual(fixture.scheduler.delays(), [80, 120, 240, 360, 5000]);
+  assert.equal(fixture.scheduler.cleared.length, 3);
+
+  const observerImage = fixture.document.createElement("img");
+  observerImage.className = "pointer-events-none object-contain";
+  root.append(observerImage);
+  fixture.mutationObservers[0].trigger();
+  assertHidden(observerImage, "Observer callback must re-hide late native previews");
+
+  fixture.scheduler.runNextFrame();
+  fixture.scheduler.runNextFrame();
+  assert.equal(fixture.calls.suppress.length, 4);
+  fixture.scheduler.runDelay(80);
+  fixture.scheduler.runDelay(120);
+  assert.equal(fixture.calls.suppress.length, 5);
+  fixture.scheduler.runDelay(240);
+  fixture.scheduler.runDelay(360);
+  assert.equal(fixture.calls.suppress.length, 6);
+  assert.equal(node.__easyuseAnimaNativeLivePreviewHideScheduled, false);
+  assert.equal(node.__easyuseAnimaDefaultPreviewSuppressionScheduled, false);
+  assert.equal(fixture.calls.legacyGets, 0, "purgeStore false must survive every delayed callback");
+
+  fixture.scheduler.runDelay(5000);
+  assert.equal(existingObserver.disconnectCalls, 1);
+  assert.equal(fixture.mutationObservers[1].disconnectCalls, 1);
+  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.size, 0);
+}
+
+{
+  const topGenerator = { id: 2, type: GENERATOR_NODE_TYPE };
+  const nonGenerator = { id: 3, type: "OtherNode" };
+  const subGenerator = { id: 7, type: GENERATOR_NODE_TYPE };
+  const subgraph = graphFromNodes([subGenerator]);
+  const parent = { id: 5, type: "Subgraph", subgraph };
+  const graph = graphFromNodes([topGenerator, nonGenerator, parent]);
+  const fixture = createFixture({
+    graph,
+    generatorNodes: [topGenerator, nonGenerator, subGenerator],
+    storeMode: "none",
+  });
+
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: {
+      data: {
+        node: "5:7",
+        images: [{ filename: "event.webp" }],
+        run_id: "event-run",
+      },
+    },
+  });
+  assert.equal(fixture.calls.addImages.length, 1);
+  assert.equal(fixture.calls.addImages[0].node, subGenerator);
+  assert.equal(fixture.calls.addImages[0].runId, "event-run");
+  assert.equal(fixture.calls.legacyGets, 1, "Preview suppression must not duplicate explicit purge");
+  const previewCounts = {
+    add: fixture.calls.addImages.length,
+    purge: fixture.calls.legacyGets,
+    suppress: fixture.calls.suppress.length,
+  };
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: { data: { node: "3", images: [{ filename: "ignored.webp" }] } },
+  });
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: { data: { node: "404", images: [{ filename: "missing.webp" }] } },
+  });
+  assert.deepEqual(
+    {
+      add: fixture.calls.addImages.length,
+      purge: fixture.calls.legacyGets,
+      suppress: fixture.calls.suppress.length,
+    },
+    previewCounts,
+    "Wrong-type and missing preview targets must be no-ops",
+  );
+
+  let stopCalls = 0;
+  const blob = { type: "image/webp" };
+  fixture.runtime.handleGeneratorDenoisePreviewEvent({
+    detail: {
+      data: {
+        nodeId: "3",
+        realNodeId: "5:7",
+        blob,
+      },
+    },
+    stopImmediatePropagation() {
+      stopCalls += 1;
+    },
+  });
+  assert.equal(stopCalls, 1, "Valid denoise events must stop native capture propagation");
+  assert.equal(fixture.calls.setDenoise.length, 1);
+  assert.equal(fixture.calls.setDenoise[0].node, subGenerator);
+  assert.equal(fixture.calls.setDenoise[0].blob, blob);
+  assert.equal(fixture.calls.legacyGets, 2, "Denoise suppression must not duplicate explicit purge");
+  fixture.runtime.handleGeneratorDenoisePreviewEvent({
+    detail: { data: { nodeId: "5:7" } },
+    stopImmediatePropagation() {
+      stopCalls += 1;
+    },
+  });
+  fixture.runtime.handleGeneratorDenoisePreviewEvent({
+    detail: { data: { nodeId: "3", blob } },
+    stopImmediatePropagation() {
+      stopCalls += 1;
+    },
+  });
+  assert.equal(stopCalls, 1, "Missing-blob and wrong-type denoise events must not stop propagation");
+  assert.equal(fixture.calls.setDenoise.length, 1);
+
+  const progressDetail = { nodeId: "2", value: 3, max: 10 };
+  const progressStateDetail = { nodes: { 2: { node_id: "2", value: 4, max: 10 } } };
+  fixture.runtime.handleGeneratorProgressEvent({ detail: { data: progressDetail } });
+  fixture.runtime.handleGeneratorProgressStateEvent({ detail: { data: progressStateDetail } });
+  assert.deepEqual(fixture.calls.progress, [progressDetail]);
+  assert.deepEqual(fixture.calls.progressState, [progressStateDetail]);
+
+  fixture.runtime.handleGeneratorExecutingEvent({ detail: "5:7" });
+  assert.deepEqual(fixture.calls.clearDenoise.at(-1), { node: subGenerator, update: true });
+  const executingClearCount = fixture.calls.clearDenoise.length;
+  fixture.runtime.handleGeneratorExecutingEvent({ detail: "3" });
+  assert.equal(fixture.calls.clearDenoise.length, executingClearCount);
+
+  fixture.runtime.clearGeneratorDenoisePreviews();
+  assert.equal(fixture.calls.progressClear, 1);
+  assert.deepEqual(
+    fixture.calls.clearDenoise.slice(-2),
+    [
+      { node: topGenerator, update: true },
+      { node: subGenerator, update: true },
+    ],
+    "Terminal routing must clear only Generator nodes",
+  );
+  assert.equal(
+    fixture.calls.legacyGets,
+    5,
+    "Preview, denoise, executing, and two terminal Generator nodes must each own one purge batch",
+  );
+  assert.equal(fixture.calls.suppress.length, 5);
+  await flushPromises();
+}
+
+console.log("AiO native preview runtime smoke passed.");

--- a/tests/frontend_support/fake_dom.mjs
+++ b/tests/frontend_support/fake_dom.mjs
@@ -51,22 +51,30 @@ class FakeStyle {
     this.background = "";
     this.borderColor = "";
     this.values = new Map();
+    this.priorities = new Map();
   }
 
-  setProperty(name, value) {
+  setProperty(name, value, priority = "") {
+    const key = String(name);
     const text = String(value);
-    this.values.set(String(name), text);
-    this[name] = text;
+    this.values.set(key, text);
+    this.priorities.set(key, String(priority || ""));
+    this[key] = text;
   }
 
   getPropertyValue(name) {
     return this.values.get(String(name)) ?? this[name] ?? "";
   }
 
+  getPropertyPriority(name) {
+    return this.priorities.get(String(name)) ?? "";
+  }
+
   removeProperty(name) {
     const key = String(name);
     const previous = this.getPropertyValue(key);
     this.values.delete(key);
+    this.priorities.delete(key);
     delete this[key];
     return previous;
   }
@@ -78,15 +86,44 @@ function matchesSelector(element, selector) {
     if (!expected) {
       return false;
     }
-    if (expected.startsWith(".")) {
-      return element.classList.contains(expected.slice(1));
+    const attributes = [];
+    const withoutAttributes = expected.replace(
+      /\[([A-Za-z0-9_:-]+)(?:(\$?=)"([^"]*)")?\]/g,
+      (_match, name, operator, value) => {
+        attributes.push({ name, operator: operator || "", value: value ?? "" });
+        return "";
+      },
+    );
+    if (withoutAttributes.includes("[") || withoutAttributes.includes("]")) {
+      return false;
     }
-    const attribute = expected.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/);
-    if (attribute) {
-      const actual = element.getAttribute(attribute[1]);
-      return actual != null && (attribute[2] == null || actual === attribute[2]);
+    const tagMatch = withoutAttributes.match(/^[A-Za-z][A-Za-z0-9-]*/);
+    const tagName = tagMatch?.[0] || "";
+    if (tagName && element.tagName !== tagName.toUpperCase()) {
+      return false;
     }
-    return element.tagName === expected.toUpperCase();
+    const classNames = [...withoutAttributes.matchAll(/\.([A-Za-z0-9_-]+)/g)]
+      .map((match) => match[1]);
+    if (classNames.some((name) => !element.classList.contains(name))) {
+      return false;
+    }
+    const remainder = withoutAttributes
+      .slice(tagName.length)
+      .replace(/\.[A-Za-z0-9_-]+/g, "")
+      .trim();
+    if (remainder) {
+      return false;
+    }
+    return attributes.every(({ name, operator, value }) => {
+      const actual = element.getAttribute(name);
+      if (actual == null) {
+        return false;
+      }
+      if (!operator) {
+        return true;
+      }
+      return operator === "$=" ? actual.endsWith(value) : actual === value;
+    });
   });
 }
 
@@ -190,6 +227,14 @@ class FakeElement {
     return descendants(this).filter((element) => matchesSelector(element, selector));
   }
 
+  matches(selector) {
+    return matchesSelector(this, selector);
+  }
+
+  contains(element) {
+    return element === this || descendants(this).includes(element);
+  }
+
   closest(selector) {
     let current = this;
     while (current) {
@@ -256,6 +301,10 @@ class FakeDocument {
     element.textContent = String(value);
     this.createdElements.push(element);
     return element;
+  }
+
+  querySelectorAll(selector) {
+    return this.body.querySelectorAll(selector);
   }
 
   addEventListener(type, handler, capture = false) {

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -18,6 +18,9 @@ AIO_PROFILE_SETTINGS_RUNTIME_JS = (
 AIO_GENERATOR_PANEL_RUNTIME_JS = (
     ROOT / "web" / "js" / "aio" / "generator_panel_runtime.js"
 )
+AIO_NATIVE_PREVIEW_RUNTIME_JS = (
+    ROOT / "web" / "js" / "aio" / "native_preview_runtime.js"
+)
 AIO_STAGE_SETTINGS_DIALOGS_JS = (
     ROOT / "web" / "js" / "aio" / "stage_settings_dialogs.js"
 )
@@ -198,6 +201,9 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_generator_keeps_native_output_preview_suppressed_after_execution(self):
         source = AIO_JS.read_text(encoding="utf-8")
+        native_preview_source = AIO_NATIVE_PREVIEW_RUNTIME_JS.read_text(
+            encoding="utf-8"
+        )
         preview_source = AIO_PREVIEW_JS.read_text(encoding="utf-8")
         registration_start = source.index("async beforeRegisterNodeDef")
         generator_block = source[source.index("if (nodeData.name === GENERATOR_NODE_TYPE)", registration_start):]
@@ -206,13 +212,26 @@ class AIOFrontendSourceTests(unittest.TestCase):
         body = generator_block[start:end]
 
         self.assertIn("nodeType.prototype.hideOutputImages = true", source)
-        self.assertIn("module?.useNodeOutputStore || module?.cn || module?.L", source)
-        self.assertIn("outputStore.revokePreviewsByLocatorId?.(locator);", source)
-        self.assertIn("aioDeletePreviewStoreEntry(app.nodePreviewImages, id);", source)
-        self.assertIn("aioDeletePreviewStoreEntry(outputStore.nodePreviewImages, locator);", source)
+        self.assertIn(
+            "module?.useNodeOutputStore || module?.cn || module?.L",
+            native_preview_source,
+        )
+        self.assertIn(
+            "outputStore.revokePreviewsByLocatorId?.(locator);",
+            native_preview_source,
+        )
+        self.assertIn("getLegacyPreviewImages: () => app.nodePreviewImages", source)
+        self.assertIn(
+            "aioDeletePreviewStoreEntry(legacyPreviewImages, id);",
+            native_preview_source,
+        )
+        self.assertIn(
+            "aioDeletePreviewStoreEntry(outputStore.nodePreviewImages, locator);",
+            native_preview_source,
+        )
         self.assertIn('Object.defineProperty(node, "imgs"', preview_source)
         self.assertIn("lockLegacyCanvasPreview(node);", preview_source)
-        self.assertIn("aioSuppressDefaultPreview", source)
+        self.assertIn("aioSuppressDefaultPreview", native_preview_source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .text-node-component-header-text", source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground", source)
         self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -47,6 +47,10 @@ AIO_GENERATOR_PANEL_RUNTIME_JS = AIO_MODULES / "generator_panel_runtime.js"
 AIO_GENERATOR_PANEL_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_generator_panel_runtime_smoke.mjs"
 )
+AIO_NATIVE_PREVIEW_RUNTIME_JS = AIO_MODULES / "native_preview_runtime.js"
+AIO_NATIVE_PREVIEW_RUNTIME_SMOKE = (
+    ROOT / "tests" / "frontend_aio_native_preview_runtime_smoke.mjs"
+)
 AIO_STAGE_SETTINGS_DIALOGS_JS = AIO_MODULES / "stage_settings_dialogs.js"
 AIO_STAGE_SETTINGS_DIALOGS_SMOKE = (
     ROOT / "tests" / "frontend_aio_stage_settings_dialogs_smoke.mjs"
@@ -507,7 +511,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "syncGeneratorSerializedWidgets",
             "installGeneratorWheelForwarder",
             "installGeneratorQueuePromptHook",
-            "suppressGeneratorDefaultPreview",
             "hookGeneratorNode",
         ):
             with self.subTest(entry_owned_function=entry_owned_function):
@@ -531,6 +534,308 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_GENERATOR_PANEL_RUNTIME_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_generator_panel_runtime_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_native_preview_runtime_owns_dom_store_scheduler_and_event_lifecycle(self):
+        source = AIO_NATIVE_PREVIEW_RUNTIME_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
+        preview_source = AIO_PREVIEW_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertTrue(source.startswith("// @ts-check\n"))
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+        self.assertNotIn("api.addEventListener", source)
+        self.assertNotIn("nodeType.prototype", source)
+        self.assertEqual(
+            re.findall(r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE),
+            ["aioCreateNativePreviewRuntime"],
+        )
+        self.assertEqual(len(re.findall(r"(?m)^export\s+", source)), 1)
+        self.assertIn(
+            'import { aioCreateNativePreviewRuntime } from '
+            '"./aio/native_preview_runtime.js";',
+            entry_source,
+        )
+
+        moved_functions = {
+            "cssEscape",
+            "generatorVueNodeRoots",
+            "generatorNativePreviewRootMatchesNode",
+            "addGeneratorPreviewLocatorCandidate",
+            "generatorPreviewLocatorCandidates",
+            "hideGeneratorNativeLivePreviewElement",
+            "isGeneratorNativeDimensionLabel",
+            "hideGeneratorComfyOutputPreviewElements",
+            "hideGeneratorNativeLivePreviewElements",
+            "markGeneratorNativeLivePreviewHidden",
+            "generatorDialogServiceAssetUrl",
+            "generatorNativePreviewStores",
+            "purgeGeneratorNativeLivePreviewStore",
+            "scheduleGeneratorNativeLivePreviewPurge",
+            "stopGeneratorNativeLivePreviewObserver",
+            "ensureGeneratorNativeLivePreviewObserver",
+            "scheduleGeneratorNativeLivePreviewHidden",
+            "suppressGeneratorDefaultPreview",
+            "scheduleGeneratorDefaultPreviewSuppression",
+            "findGeneratorNodeByQualifiedId",
+            "handleGeneratorPreviewEvent",
+            "findGeneratorNodeForDenoisePreview",
+            "handleGeneratorProgressEvent",
+            "handleGeneratorProgressStateEvent",
+            "handleGeneratorDenoisePreviewEvent",
+            "handleGeneratorExecutingEvent",
+            "clearGeneratorDenoisePreviews",
+        }
+        for moved_function in sorted(moved_functions):
+            with self.subTest(moved_function=moved_function):
+                self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\bfunction\s+{moved_function}\(",
+                )
+
+        for moved_state in (
+            "generatorNativePreviewStoresPromise",
+            "generatorDialogServiceAssetUrlPromise",
+        ):
+            with self.subTest(moved_state=moved_state):
+                self.assertRegex(source, rf"\blet\s+{moved_state}\s*=")
+                self.assertNotRegex(entry_source, rf"\blet\s+{moved_state}\s*=")
+
+        expected_facades = {
+            "markGeneratorNativeLivePreviewHidden",
+            "suppressGeneratorDefaultPreview",
+            "scheduleGeneratorDefaultPreviewSuppression",
+            "handleGeneratorPreviewEvent",
+            "handleGeneratorProgressEvent",
+            "handleGeneratorProgressStateEvent",
+            "handleGeneratorDenoisePreviewEvent",
+            "handleGeneratorExecutingEvent",
+            "clearGeneratorDenoisePreviews",
+        }
+        return_match = re.search(
+            r"(?ms)^  return \{(?P<facades>[A-Za-z0-9_,\s]+)\};\s*\}\s*$",
+            source,
+        )
+        self.assertIsNotNone(return_match)
+        self.assertEqual(
+            set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", return_match.group("facades"))),
+            expected_facades,
+        )
+
+        composition_match = re.search(
+            r"const\s+\{(?P<facades>[A-Za-z0-9_,\s]+?)\}\s*=\s*"
+            r"aioCreateNativePreviewRuntime\(\{(?P<dependencies>.*?)\n\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(composition_match)
+        self.assertEqual(
+            set(
+                re.findall(
+                    r"\b[A-Za-z_][A-Za-z0-9_]*\b",
+                    composition_match.group("facades"),
+                )
+            ),
+            expected_facades,
+        )
+
+        dependencies = composition_match.group("dependencies")
+        expected_dependency_groups = {
+            "environment": {
+                "document",
+                "window",
+                "MutationObserver",
+                "requestAnimationFrame",
+                "setTimeout",
+                "clearTimeout",
+            },
+            "constants": {
+                "generatorNodeType",
+                "generatorVueNodeClass",
+            },
+            "storeAdapter": {
+                "getLegacyPreviewImages",
+                "loadDirectStoreModules",
+                "fetchFrontendHtml",
+                "importAssetModule",
+            },
+            "previewCore": {
+                "deleteStoreEntry",
+                "eventDetail",
+                "images",
+                "nodeIdsFromDetail",
+                "suppressDefaultPreview",
+            },
+            "nodeAdapter": {
+                "getGraph",
+                "listGeneratorNodes",
+                "addPreviewImages",
+                "clearDenoisePreview",
+                "setDenoisePreview",
+                "markDirty",
+            },
+            "progressAdapter": {
+                "remember",
+                "rememberState",
+                "clear",
+            },
+        }
+        actual_dependency_groups = set(
+            re.findall(r"(?m)^  ([A-Za-z_][A-Za-z0-9_]*): \{$", dependencies)
+        )
+        self.assertEqual(actual_dependency_groups, set(expected_dependency_groups))
+        for group_name, expected_keys in expected_dependency_groups.items():
+            with self.subTest(dependency_group=group_name):
+                group_match = re.search(
+                    rf"(?ms)^  {group_name}: \{{\n(?P<body>.*?)^  \}},?$",
+                    dependencies,
+                )
+                self.assertIsNotNone(group_match)
+                actual_keys = set(
+                    re.findall(
+                        r"(?m)^    ([A-Za-z_][A-Za-z0-9_]*)(?:\s*:|,)",
+                        group_match.group("body"),
+                    )
+                )
+                self.assertEqual(actual_keys, expected_keys)
+
+        expected_adapter_values = {
+            "legacy preview store getter": (
+                r"getLegacyPreviewImages\s*:\s*\(\s*\)\s*=>\s*"
+                r"app\.nodePreviewImages"
+            ),
+            "entry-relative direct store imports": (
+                r"loadDirectStoreModules\s*:\s*\(\s*\)\s*=>\s*"
+                r"Promise\.all\(\s*\[\s*"
+                r'import\(\s*"\.\./\.\./\.\./stores/nodeOutputStore\.js"\s*\)\s*,\s*'
+                r'import\(\s*"\.\./\.\./\.\./platform/workflow/management/'
+                r'stores/workflowStore\.js"\s*\)\s*,?\s*'
+                r"\]\s*\)"
+            ),
+            "frontend HTML fetch": (
+                r"fetchFrontendHtml\s*:\s*\(\s*\)\s*=>\s*"
+                r'easyuseAnimaFetchText\(\s*"/"\s*\)'
+            ),
+            "lazy asset importer": (
+                r"importAssetModule\s*:\s*\(\s*url\s*\)\s*=>\s*"
+                r"import\(\s*url\s*\)"
+            ),
+            "live graph getter": (
+                r"getGraph\s*:\s*\(\s*\)\s*=>\s*app\.graph"
+            ),
+        }
+        for adapter_name, pattern in expected_adapter_values.items():
+            with self.subTest(composition_adapter_value=adapter_name):
+                self.assertRegex(dependencies, re.compile(pattern, re.DOTALL))
+
+        self.assertLess(
+            entry_source.index("const openAdvancedSettings"),
+            composition_match.start(),
+        )
+        self.assertLess(
+            composition_match.end(),
+            entry_source.index("const generatorPanelRuntime"),
+        )
+        self.assertLess(
+            entry_source.index("const generatorPanelRuntime"),
+            entry_source.index("function hookInputNode"),
+        )
+        self.assertIn(
+            "suppressDefaultPreview: suppressGeneratorDefaultPreview,",
+            entry_source,
+        )
+        self.assertIn(
+            "markNativePreviewHidden: markGeneratorNativeLivePreviewHidden,",
+            entry_source,
+        )
+        self.assertNotRegex(
+            panel_source,
+            r"\bfunction\s+(?:suppressGeneratorDefaultPreview|"
+            r"markGeneratorNativeLivePreviewHidden)\(",
+        )
+
+        suppress_match = re.search(
+            r"(?ms)^  function suppressGeneratorDefaultPreview\(node, options = \{\}\) \{"
+            r"(?P<body>.*?)^  \}",
+            source,
+        )
+        self.assertIsNotNone(suppress_match)
+        suppress_body = suppress_match.group("body")
+        self.assertIn("aioSuppressDefaultPreview(node, {", suppress_body)
+        self.assertIn("markDirty: options.markDirty", suppress_body)
+        self.assertIn("markNodeDirty,", suppress_body)
+        self.assertNotIn('Object.defineProperty(node, "imgs"', suppress_body)
+        self.assertIn(
+            'Object.defineProperty(node, "imgs"',
+            preview_source,
+        )
+        self.assertNotRegex(preview_source, r"\b(?:document|window|app)\b")
+
+        for entry_owned_function in (
+            "generatorGraphNodes",
+            "clearGeneratorDenoisePreview",
+            "setGeneratorDenoisePreview",
+            "addGeneratorPreviewImagesToNode",
+            "updateGeneratorExecutedStatus",
+            "hookGeneratorNode",
+        ):
+            with self.subTest(entry_owned_function=entry_owned_function):
+                self.assertRegex(
+                    entry_source,
+                    rf"\bfunction\s+{entry_owned_function}\(",
+                )
+                self.assertNotRegex(
+                    source,
+                    rf"\bfunction\s+{entry_owned_function}\(",
+                )
+
+        for progress_facade in (
+            "rememberGeneratorProgress",
+            "rememberGeneratorProgressState",
+            "generatorProgressForPreviewDetail",
+            "clearGeneratorPreviewProgress",
+        ):
+            with self.subTest(entry_owned_progress_facade=progress_facade):
+                self.assertIn(progress_facade, entry_source)
+                self.assertNotRegex(
+                    source,
+                    rf"\b(?:const|let|function)\s+{progress_facade}\b",
+                )
+
+        self.assertIn("app.registerExtension({", entry_source)
+        for listener_registration in (
+            "api.addEventListener(GENERATOR_PREVIEW_EVENT, handleGeneratorPreviewEvent);",
+            'api.addEventListener("progress", handleGeneratorProgressEvent);',
+            'api.addEventListener("progress_state", handleGeneratorProgressStateEvent);',
+            'api.addEventListener("b_preview_with_metadata", '
+            "handleGeneratorDenoisePreviewEvent, true);",
+            'api.addEventListener("executing", handleGeneratorExecutingEvent);',
+            'api.addEventListener("execution_error", clearGeneratorDenoisePreviews);',
+            'api.addEventListener("execution_interrupted", clearGeneratorDenoisePreviews);',
+            'api.addEventListener("execution_success", clearGeneratorDenoisePreviews);',
+        ):
+            with self.subTest(entry_owned_listener_registration=listener_registration):
+                self.assertIn(listener_registration, entry_source)
+        for prototype_hook in (
+            "onNodeCreated",
+            "onConfigure",
+            "onSerialize",
+            "onExecuted",
+            "onResize",
+        ):
+            with self.subTest(entry_owned_prototype_hook=prototype_hook):
+                self.assertIn(f"nodeType.prototype.{prototype_hook}", entry_source)
+                self.assertNotIn(f"nodeType.prototype.{prototype_hook}", source)
+
+        self.assertTrue(AIO_NATIVE_PREVIEW_RUNTIME_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_native_preview_runtime_smoke.mjs"',
             frontend_check_source,
         )
 
@@ -1050,18 +1355,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
         ):
             with self.subTest(local_function=local_function):
                 self.assertNotIn(f"function {local_function}(", entry_source)
-
-        suppress_start = entry_source.index(
-            "function suppressGeneratorDefaultPreview(node, options = {})"
-        )
-        suppress_end = entry_source.index(
-            "\nfunction scheduleGeneratorDefaultPreviewSuppression", suppress_start
-        )
-        suppress_body = entry_source[suppress_start:suppress_end]
-        self.assertIn("return aioSuppressDefaultPreview(node, {", suppress_body)
-        self.assertIn("markDirty: options.markDirty", suppress_body)
-        self.assertIn("markNodeDirty,", suppress_body)
-        self.assertNotIn('Object.defineProperty(node, "imgs"', suppress_body)
 
         self.assertTrue(AIO_PREVIEW_CORE_SMOKE.is_file())
         self.assertIn(
@@ -2615,6 +2908,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
         self.assertIn(
             r'& node "tests\frontend_aio_preview_core_smoke.mjs"', source
+        )
+        self.assertIn(
+            r'& node "tests\frontend_aio_native_preview_runtime_smoke.mjs"',
+            source,
         )
         self.assertIn(
             r'& node "tests\frontend_aio_settings_core_smoke.mjs"', source

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -94,6 +94,11 @@ try {
         throw "Frontend AiO preview core smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_native_preview_runtime_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO native preview runtime smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_settings_core_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO settings core smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/native_preview_runtime.js
+++ b/web/js/aio/native_preview_runtime.js
@@ -1,0 +1,583 @@
+// @ts-check
+
+/**
+ * Own the native-preview store purge, DOM suppression, observer scheduling,
+ * and preview API event lifecycle. Extension registration and custom preview
+ * rendering remain adapters owned by the entry module.
+ *
+ * @param {{
+ *   environment: {
+ *     document: any,
+ *     window: any,
+ *     MutationObserver: any,
+ *     requestAnimationFrame: (callback: any) => any,
+ *     setTimeout: (callback: any, delay: number) => any,
+ *     clearTimeout: (timer: any) => void,
+ *   },
+ *   constants: {
+ *     generatorNodeType: string,
+ *     generatorVueNodeClass: string,
+ *   },
+ *   storeAdapter: {
+ *     getLegacyPreviewImages: () => any,
+ *     loadDirectStoreModules: () => Promise<any[]>,
+ *     fetchFrontendHtml: () => Promise<string>,
+ *     importAssetModule: (url: string) => Promise<any>,
+ *   },
+ *   previewCore: {
+ *     deleteStoreEntry: (container: any, locator: any) => void,
+ *     eventDetail: (event: any) => any,
+ *     images: (message: any) => any[],
+ *     nodeIdsFromDetail: (detail: any) => string[],
+ *     suppressDefaultPreview: (node: any, options?: Record<string, any>) => boolean,
+ *   },
+ *   nodeAdapter: {
+ *     getGraph: () => any,
+ *     listGeneratorNodes: () => any[],
+ *     addPreviewImages: (node: any, images: any[], runId?: string, options?: Record<string, any>) => void,
+ *     clearDenoisePreview: (node: any, update?: boolean) => void,
+ *     setDenoisePreview: (node: any, blob: any, detail?: Record<string, any>) => void,
+ *     markDirty: (node: any) => void,
+ *   },
+ *   progressAdapter: {
+ *     remember: (detail: any) => void,
+ *     rememberState: (detail: any) => void,
+ *     clear: () => void,
+ *   },
+ * }} dependencies
+ */
+export function aioCreateNativePreviewRuntime(dependencies) {
+  const {
+    document,
+    window,
+    MutationObserver,
+    requestAnimationFrame,
+    setTimeout,
+    clearTimeout,
+  } = dependencies.environment;
+  const {
+    generatorNodeType: GENERATOR_NODE_TYPE,
+    generatorVueNodeClass: GENERATOR_VUE_NODE_CLASS,
+  } = dependencies.constants;
+  const {
+    getLegacyPreviewImages,
+    loadDirectStoreModules,
+    fetchFrontendHtml,
+    importAssetModule,
+  } = dependencies.storeAdapter;
+  const {
+    deleteStoreEntry: aioDeletePreviewStoreEntry,
+    eventDetail: aioPreviewEventDetail,
+    images: aioPreviewImages,
+    nodeIdsFromDetail: aioPreviewNodeIdsFromDetail,
+    suppressDefaultPreview: aioSuppressDefaultPreview,
+  } = dependencies.previewCore;
+  const {
+    getGraph,
+    listGeneratorNodes,
+    addPreviewImages: addGeneratorPreviewImagesToNode,
+    clearDenoisePreview: clearGeneratorDenoisePreview,
+    setDenoisePreview: setGeneratorDenoisePreview,
+    markDirty: markNodeDirty,
+  } = dependencies.nodeAdapter;
+  const {
+    remember: rememberGeneratorProgress,
+    rememberState: rememberGeneratorProgressState,
+    clear: clearGeneratorPreviewProgress,
+  } = dependencies.progressAdapter;
+
+  function cssEscape(value) {
+    if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+      return CSS.escape(value);
+    }
+    return String(value).replace(/["\\]/g, "\\$&");
+  }
+
+  function generatorVueNodeRoots(node) {
+    const roots = new Set();
+    if (!node || typeof document === "undefined") {
+      return roots;
+    }
+    const panel = node?.__easyuseAnimaGeneratorPanelEl;
+    if (panel) {
+      const panelNodeRoot = panel.closest?.(".lg-node");
+      const panelDataRoot = panel.closest?.("[data-node-id]");
+      if (panelNodeRoot) {
+        roots.add(panelNodeRoot);
+      }
+      if (panelDataRoot) {
+        roots.add(panelDataRoot);
+      }
+    }
+    const id = node?.id;
+    if (id == null) {
+      return roots;
+    }
+    const textId = String(id);
+    const escapedId = cssEscape(textId);
+    const selectors = [
+      `[data-node-id="${escapedId}"]`,
+      `[data-node-id$=":${escapedId}"]`,
+    ];
+    for (const selector of selectors) {
+      for (const element of document.querySelectorAll(selector)) {
+        roots.add(element);
+      }
+    }
+    if (!roots.size) {
+      for (const element of document.querySelectorAll(".easyuse-anima-aio-node-panel")) {
+        const root = element.closest?.(".lg-node") || element.closest?.("[data-node-id]");
+        if (generatorNativePreviewRootMatchesNode(root, node)) {
+          roots.add(root);
+        }
+      }
+    }
+    if (!roots.size) {
+      for (const element of document.querySelectorAll(".text-node-component-header-text")) {
+        const root = element.closest?.("[data-node-id]");
+        if (generatorNativePreviewRootMatchesNode(root, node)) {
+          roots.add(root);
+        }
+      }
+    }
+    return roots;
+  }
+
+  function generatorNativePreviewRootMatchesNode(root, node) {
+    if (!root || !node) {
+      return false;
+    }
+    const panel = node.__easyuseAnimaGeneratorPanelEl;
+    if (panel && root.contains?.(panel)) {
+      return true;
+    }
+    const id = node.id == null ? "" : String(node.id);
+    const rootId = String(root.getAttribute?.("data-node-id") || "");
+    if (!id || !rootId) {
+      return false;
+    }
+    if (rootId === id) {
+      return true;
+    }
+    const parts = rootId.split(":");
+    return parts[parts.length - 1] === id;
+  }
+
+  function addGeneratorPreviewLocatorCandidate(ids, value) {
+    const text = String(value ?? "").trim();
+    if (!text) {
+      return;
+    }
+    ids.add(text);
+    const leaf = text.split(":").pop();
+    if (leaf) {
+      ids.add(leaf);
+    }
+  }
+
+  function generatorPreviewLocatorCandidates(node, detail = null) {
+    const ids = new Set();
+    if (node?.id != null) {
+      addGeneratorPreviewLocatorCandidate(ids, node.id);
+    }
+    for (const id of aioPreviewNodeIdsFromDetail(detail)) {
+      addGeneratorPreviewLocatorCandidate(ids, id);
+    }
+    for (const root of generatorVueNodeRoots(node)) {
+      addGeneratorPreviewLocatorCandidate(ids, root.getAttribute?.("data-node-id"));
+    }
+    return [...ids].filter(Boolean);
+  }
+
+  function hideGeneratorNativeLivePreviewElement(element) {
+    if (!element) {
+      return;
+    }
+    element.classList?.add("easyuse-anima-aio-native-live-preview-hidden");
+    element.setAttribute?.("aria-hidden", "true");
+    element.style?.setProperty?.("display", "none", "important");
+  }
+
+  function isGeneratorNativeDimensionLabel(element) {
+    const text = String(element?.textContent || "").trim();
+    return /^\d+\s*[x×]\s*\d+$/i.test(text) || /calculating dimensions/i.test(text);
+  }
+
+  function hideGeneratorComfyOutputPreviewElements(root) {
+    const contentRoots = root.matches?.(".lg-node-content")
+      ? [root, ...root.querySelectorAll(".lg-node-content")]
+      : root.querySelectorAll(".lg-node-content");
+    for (const content of contentRoots) {
+      if (content.querySelector?.(".easyuse-anima-aio-node-panel")) {
+        continue;
+      }
+      if (
+        content.querySelector?.('[data-testid="main-image"]')
+        || content.querySelector?.(".text-node-component-header-text")
+        || content.textContent?.match?.(/\b\d+\s*[x×]\s*\d+\b/i)
+      ) {
+        hideGeneratorNativeLivePreviewElement(content);
+      }
+    }
+    for (const image of root.querySelectorAll('[data-testid="main-image"]')) {
+      const content = image.closest?.(".lg-node-content");
+      if (content && !content.querySelector?.(".easyuse-anima-aio-node-panel")) {
+        hideGeneratorNativeLivePreviewElement(content);
+        continue;
+      }
+      hideGeneratorNativeLivePreviewElement(image);
+      const previewRoot = image.closest?.(".flex-auto, .relative, .overflow-hidden");
+      if (previewRoot && !previewRoot.querySelector?.(".easyuse-anima-aio-node-panel")) {
+        hideGeneratorNativeLivePreviewElement(previewRoot);
+      }
+    }
+  }
+
+  function hideGeneratorNativeLivePreviewElements(root) {
+    if (!root?.querySelectorAll) {
+      return;
+    }
+    hideGeneratorComfyOutputPreviewElements(root);
+    for (const image of root.querySelectorAll("img.pointer-events-none.object-contain")) {
+      if (image.closest?.(".easyuse-anima-aio-node-panel")) {
+        continue;
+      }
+      hideGeneratorNativeLivePreviewElement(image);
+    }
+    for (const element of root.querySelectorAll(".text-node-component-header-text, div, span")) {
+      if (element.closest?.(".easyuse-anima-aio-node-panel")) {
+        continue;
+      }
+      const shouldHide = element.classList?.contains("text-node-component-header-text")
+        || (!element.children?.length && isGeneratorNativeDimensionLabel(element));
+      if (!shouldHide) {
+        continue;
+      }
+      hideGeneratorNativeLivePreviewElement(element);
+      const parent = element.parentElement;
+      if (
+        parent
+        && !parent.querySelector?.(".easyuse-anima-aio-node-panel")
+        && parent.querySelector?.("img.pointer-events-none.object-contain")
+      ) {
+        hideGeneratorNativeLivePreviewElement(parent);
+      }
+    }
+  }
+
+  function markGeneratorNativeLivePreviewHidden(node) {
+    if (!node || typeof document === "undefined") {
+      return;
+    }
+    for (const root of generatorVueNodeRoots(node)) {
+      root.classList.add(GENERATOR_VUE_NODE_CLASS);
+      hideGeneratorNativeLivePreviewElements(root);
+    }
+  }
+
+  let generatorNativePreviewStoresPromise = null;
+  let generatorDialogServiceAssetUrlPromise = null;
+
+  async function generatorDialogServiceAssetUrl() {
+    if (!generatorDialogServiceAssetUrlPromise) {
+      generatorDialogServiceAssetUrlPromise = (async () => {
+        if (typeof document !== "undefined") {
+          const elements = document.querySelectorAll("link[href], script[src]");
+          for (const element of elements) {
+            const value = element.getAttribute("href") || element.getAttribute("src") || "";
+            if (/\/?assets\/dialogService-[^/]+\.js(?:$|\?)/.test(value)) {
+              return new URL(value, window.location.href).href;
+            }
+          }
+        }
+        const html = await fetchFrontendHtml();
+        const match = html.match(/(?:\.\/)?assets\/dialogService-[^"'<>]+\.js/);
+        return match ? new URL(match[0], window.location.href).href : "";
+      })().catch(() => "");
+    }
+    return generatorDialogServiceAssetUrlPromise;
+  }
+
+  async function generatorNativePreviewStores() {
+    if (!generatorNativePreviewStoresPromise) {
+      generatorNativePreviewStoresPromise = (async () => {
+        try {
+          const [nodeOutputStoreModule, workflowStoreModule] = await loadDirectStoreModules();
+          if (nodeOutputStoreModule?.useNodeOutputStore && workflowStoreModule?.useWorkflowStore) {
+            return {
+              useNodeOutputStore: nodeOutputStoreModule.useNodeOutputStore,
+              useWorkflowStore: workflowStoreModule.useWorkflowStore,
+            };
+          }
+        } catch {
+          // Packaged ComfyUI frontend builds bundle these stores into hashed assets.
+        }
+
+        const url = await generatorDialogServiceAssetUrl();
+        if (!url) {
+          return null;
+        }
+        try {
+          const module = await importAssetModule(url);
+          return {
+            useNodeOutputStore: module?.useNodeOutputStore || module?.cn || module?.L,
+            useWorkflowStore: module?.useWorkflowStore || module?.M,
+          };
+        } catch {
+          return null;
+        }
+      })();
+    }
+    return generatorNativePreviewStoresPromise;
+  }
+
+  async function purgeGeneratorNativeLivePreviewStore(node, detail = null) {
+    try {
+      if (!node) {
+        return;
+      }
+      const ids = generatorPreviewLocatorCandidates(node, detail);
+      if (!ids.length) {
+        return;
+      }
+      const legacyPreviewImages = getLegacyPreviewImages();
+      if (legacyPreviewImages && typeof legacyPreviewImages === "object") {
+        for (const id of ids) {
+          aioDeletePreviewStoreEntry(legacyPreviewImages, id);
+        }
+      }
+
+      const stores = await generatorNativePreviewStores();
+      const outputStore = stores?.useNodeOutputStore?.();
+      if (!outputStore) {
+        return;
+      }
+      const workflowStore = stores?.useWorkflowStore?.();
+      const locators = new Set(ids);
+      for (const id of ids) {
+        const leaf = String(id).split(":").pop();
+        if (!leaf) {
+          continue;
+        }
+        locators.add(leaf);
+        const locator = workflowStore?.nodeIdToNodeLocatorId?.(leaf);
+        if (locator) {
+          locators.add(locator);
+        }
+      }
+      for (const locator of locators) {
+        outputStore.revokePreviewsByLocatorId?.(locator);
+        aioDeletePreviewStoreEntry(outputStore.nodePreviewImages, locator);
+      }
+    } catch {
+      // Native preview store access is version-dependent; CSS/DOM fallback remains scoped to this node.
+    }
+  }
+
+  function scheduleGeneratorNativeLivePreviewPurge(node, detail = null) {
+    void purgeGeneratorNativeLivePreviewStore(node, detail);
+    requestAnimationFrame(() => {
+      void purgeGeneratorNativeLivePreviewStore(node, detail);
+    });
+    setTimeout(() => {
+      void purgeGeneratorNativeLivePreviewStore(node, detail);
+    }, 80);
+    setTimeout(() => {
+      void purgeGeneratorNativeLivePreviewStore(node, detail);
+    }, 240);
+  }
+
+  function stopGeneratorNativeLivePreviewObserver(node) {
+    const observers = node?.__easyuseAnimaNativeLivePreviewObservers;
+    if (!observers) {
+      return;
+    }
+    for (const observer of observers.values()) {
+      observer.disconnect();
+    }
+    observers.clear();
+  }
+
+  function ensureGeneratorNativeLivePreviewObserver(node) {
+    if (!node || !MutationObserver) {
+      return;
+    }
+    const observers = node.__easyuseAnimaNativeLivePreviewObservers || new Map();
+    node.__easyuseAnimaNativeLivePreviewObservers = observers;
+    for (const [root, observer] of observers) {
+      if (!root?.isConnected) {
+        observer.disconnect();
+        observers.delete(root);
+      }
+    }
+    for (const root of generatorVueNodeRoots(node)) {
+      if (!root || observers.has(root)) {
+        continue;
+      }
+      const observer = new MutationObserver(() => markGeneratorNativeLivePreviewHidden(node));
+      observer.observe(root, { childList: true, subtree: true });
+      observers.set(root, observer);
+    }
+    clearTimeout(node.__easyuseAnimaNativeLivePreviewObserverStopTimer);
+    node.__easyuseAnimaNativeLivePreviewObserverStopTimer = setTimeout(() => {
+      stopGeneratorNativeLivePreviewObserver(node);
+    }, 5000);
+  }
+
+  function scheduleGeneratorNativeLivePreviewHidden(node) {
+    markGeneratorNativeLivePreviewHidden(node);
+    ensureGeneratorNativeLivePreviewObserver(node);
+    if (node.__easyuseAnimaNativeLivePreviewHideScheduled) {
+      return;
+    }
+    node.__easyuseAnimaNativeLivePreviewHideScheduled = true;
+    const hide = () => markGeneratorNativeLivePreviewHidden(node);
+    requestAnimationFrame(hide);
+    setTimeout(hide, 80);
+    setTimeout(() => {
+      node.__easyuseAnimaNativeLivePreviewHideScheduled = false;
+      hide();
+    }, 240);
+  }
+
+  function suppressGeneratorDefaultPreview(node, options = {}) {
+    return aioSuppressDefaultPreview(node, {
+      markDirty: options.markDirty,
+      markNodeDirty,
+    });
+  }
+
+  function scheduleGeneratorDefaultPreviewSuppression(node, options = {}) {
+    const shouldPurgeStore = options.purgeStore !== false;
+    const purgeDetail = options.purgeDetail || null;
+    suppressGeneratorDefaultPreview(node);
+    if (shouldPurgeStore) {
+      scheduleGeneratorNativeLivePreviewPurge(node, purgeDetail);
+    }
+    scheduleGeneratorNativeLivePreviewHidden(node);
+    if (node.__easyuseAnimaDefaultPreviewSuppressionScheduled) {
+      return;
+    }
+    node.__easyuseAnimaDefaultPreviewSuppressionScheduled = true;
+    const suppress = () => {
+      suppressGeneratorDefaultPreview(node);
+      if (shouldPurgeStore) {
+        scheduleGeneratorNativeLivePreviewPurge(node, purgeDetail);
+      }
+      markGeneratorNativeLivePreviewHidden(node);
+    };
+    requestAnimationFrame(suppress);
+    setTimeout(suppress, 120);
+    setTimeout(() => {
+      node.__easyuseAnimaDefaultPreviewSuppressionScheduled = false;
+      suppress();
+    }, 360);
+  }
+
+  function findGeneratorNodeByQualifiedId(rootGraph, nodeId) {
+    if (!rootGraph || nodeId == null) {
+      return null;
+    }
+    const textId = String(nodeId);
+    if (!textId.includes(":")) {
+      const numericId = Number(textId);
+      return rootGraph.getNodeById?.(Number.isFinite(numericId) ? numericId : textId)
+        || rootGraph.getNodeById?.(textId)
+        || rootGraph._nodes_by_id?.[textId]
+        || rootGraph._nodes_by_id?.[numericId]
+        || null;
+    }
+    const parts = textId.split(":");
+    let graph = rootGraph;
+    for (let index = 0; index < parts.length - 1; index += 1) {
+      const parentId = Number(parts[index]);
+      if (!Number.isFinite(parentId)) {
+        return null;
+      }
+      const parentNode = graph?.getNodeById?.(parentId) || graph?._nodes_by_id?.[parentId];
+      if (!parentNode?.subgraph) {
+        return null;
+      }
+      graph = parentNode.subgraph;
+    }
+    const leafId = Number(parts[parts.length - 1]);
+    if (!Number.isFinite(leafId)) {
+      return null;
+    }
+    return graph?.getNodeById?.(leafId) || graph?._nodes_by_id?.[leafId] || null;
+  }
+
+  function handleGeneratorPreviewEvent(event) {
+    const detail = aioPreviewEventDetail(event);
+    const node = findGeneratorNodeByQualifiedId(getGraph(), detail.node);
+    if (!node || node.type !== GENERATOR_NODE_TYPE) {
+      return;
+    }
+    scheduleGeneratorNativeLivePreviewPurge(node, detail);
+    const images = aioPreviewImages({ easyuse_anima_preview: detail.images });
+    scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+    addGeneratorPreviewImagesToNode(node, images, String(detail.run_id || ""));
+  }
+
+  function findGeneratorNodeForDenoisePreview(detail) {
+    for (const id of aioPreviewNodeIdsFromDetail(detail)) {
+      const node = findGeneratorNodeByQualifiedId(getGraph(), id);
+      if (node?.type === GENERATOR_NODE_TYPE) {
+        return node;
+      }
+    }
+    return null;
+  }
+
+  function handleGeneratorProgressEvent(event) {
+    rememberGeneratorProgress(aioPreviewEventDetail(event));
+  }
+
+  function handleGeneratorProgressStateEvent(event) {
+    rememberGeneratorProgressState(aioPreviewEventDetail(event));
+  }
+
+  function handleGeneratorDenoisePreviewEvent(event) {
+    const detail = aioPreviewEventDetail(event);
+    const node = findGeneratorNodeForDenoisePreview(detail);
+    const blob = detail?.blob;
+    if (!node || !blob) {
+      return;
+    }
+    event.stopImmediatePropagation?.();
+    scheduleGeneratorNativeLivePreviewPurge(node, detail);
+    scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+    setGeneratorDenoisePreview(node, blob, detail);
+  }
+
+  function handleGeneratorExecutingEvent(event) {
+    const nodeId = aioPreviewEventDetail(event);
+    const node = findGeneratorNodeByQualifiedId(getGraph(), nodeId);
+    if (node?.type === GENERATOR_NODE_TYPE) {
+      clearGeneratorDenoisePreview(node, true);
+      scheduleGeneratorDefaultPreviewSuppression(node);
+    }
+  }
+
+  function clearGeneratorDenoisePreviews() {
+    clearGeneratorPreviewProgress();
+    for (const node of listGeneratorNodes()) {
+      if (node?.type === GENERATOR_NODE_TYPE) {
+        clearGeneratorDenoisePreview(node, true);
+        scheduleGeneratorDefaultPreviewSuppression(node);
+      }
+    }
+  }
+
+  return {
+    markGeneratorNativeLivePreviewHidden,
+    suppressGeneratorDefaultPreview,
+    scheduleGeneratorDefaultPreviewSuppression,
+    handleGeneratorPreviewEvent,
+    handleGeneratorProgressEvent,
+    handleGeneratorProgressStateEvent,
+    handleGeneratorDenoisePreviewEvent,
+    handleGeneratorExecutingEvent,
+    clearGeneratorDenoisePreviews,
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -24,6 +24,7 @@ import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
 import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";
 import { aioCreateAdvancedSettingsDialog } from "./aio/advanced_settings_dialog.js";
+import { aioCreateNativePreviewRuntime } from "./aio/native_preview_runtime.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -3508,396 +3509,6 @@ function refreshGeneratorSeedButtons(node) {
   return generatorPanelRuntime.refreshSeedButtons(node);
 }
 
-function cssEscape(value) {
-  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
-    return CSS.escape(value);
-  }
-  return String(value).replace(/["\\]/g, "\\$&");
-}
-
-function generatorVueNodeRoots(node) {
-  const roots = new Set();
-  if (!node || typeof document === "undefined") {
-    return roots;
-  }
-  const panel = node?.__easyuseAnimaGeneratorPanelEl;
-  if (panel) {
-    const panelNodeRoot = panel.closest?.(".lg-node");
-    const panelDataRoot = panel.closest?.("[data-node-id]");
-    if (panelNodeRoot) {
-      roots.add(panelNodeRoot);
-    }
-    if (panelDataRoot) {
-      roots.add(panelDataRoot);
-    }
-  }
-  const id = node?.id;
-  if (id == null) {
-    return roots;
-  }
-  const textId = String(id);
-  const escapedId = cssEscape(textId);
-  const selectors = [
-    `[data-node-id="${escapedId}"]`,
-    `[data-node-id$=":${escapedId}"]`,
-  ];
-  for (const selector of selectors) {
-    for (const element of document.querySelectorAll(selector)) {
-      roots.add(element);
-    }
-  }
-  if (!roots.size) {
-    for (const element of document.querySelectorAll(".easyuse-anima-aio-node-panel")) {
-      const root = element.closest?.(".lg-node") || element.closest?.("[data-node-id]");
-      if (generatorNativePreviewRootMatchesNode(root, node)) {
-        roots.add(root);
-      }
-    }
-  }
-  if (!roots.size) {
-    for (const element of document.querySelectorAll(".text-node-component-header-text")) {
-      const root = element.closest?.("[data-node-id]");
-      if (generatorNativePreviewRootMatchesNode(root, node)) {
-        roots.add(root);
-      }
-    }
-  }
-  return roots;
-}
-
-function generatorNativePreviewRootMatchesNode(root, node) {
-  if (!root || !node) {
-    return false;
-  }
-  const panel = node.__easyuseAnimaGeneratorPanelEl;
-  if (panel && root.contains?.(panel)) {
-    return true;
-  }
-  const id = node.id == null ? "" : String(node.id);
-  const rootId = String(root.getAttribute?.("data-node-id") || "");
-  if (!id || !rootId) {
-    return false;
-  }
-  if (rootId === id) {
-    return true;
-  }
-  const parts = rootId.split(":");
-  return parts[parts.length - 1] === id;
-}
-
-function addGeneratorPreviewLocatorCandidate(ids, value) {
-  const text = String(value ?? "").trim();
-  if (!text) {
-    return;
-  }
-  ids.add(text);
-  const leaf = text.split(":").pop();
-  if (leaf) {
-    ids.add(leaf);
-  }
-}
-
-function generatorPreviewLocatorCandidates(node, detail = null) {
-  const ids = new Set();
-  if (node?.id != null) {
-    addGeneratorPreviewLocatorCandidate(ids, node.id);
-  }
-  for (const id of aioPreviewNodeIdsFromDetail(detail)) {
-    addGeneratorPreviewLocatorCandidate(ids, id);
-  }
-  for (const root of generatorVueNodeRoots(node)) {
-    addGeneratorPreviewLocatorCandidate(ids, root.getAttribute?.("data-node-id"));
-  }
-  return [...ids].filter(Boolean);
-}
-
-function hideGeneratorNativeLivePreviewElement(element) {
-  if (!element) {
-    return;
-  }
-  element.classList?.add("easyuse-anima-aio-native-live-preview-hidden");
-  element.setAttribute?.("aria-hidden", "true");
-  element.style?.setProperty?.("display", "none", "important");
-}
-
-function isGeneratorNativeDimensionLabel(element) {
-  const text = String(element?.textContent || "").trim();
-  return /^\d+\s*[x×]\s*\d+$/i.test(text) || /calculating dimensions/i.test(text);
-}
-
-function hideGeneratorComfyOutputPreviewElements(root) {
-  const contentRoots = root.matches?.(".lg-node-content")
-    ? [root, ...root.querySelectorAll(".lg-node-content")]
-    : root.querySelectorAll(".lg-node-content");
-  for (const content of contentRoots) {
-    if (content.querySelector?.(".easyuse-anima-aio-node-panel")) {
-      continue;
-    }
-    if (
-      content.querySelector?.('[data-testid="main-image"]')
-      || content.querySelector?.(".text-node-component-header-text")
-      || content.textContent?.match?.(/\b\d+\s*[x×]\s*\d+\b/i)
-    ) {
-      hideGeneratorNativeLivePreviewElement(content);
-    }
-  }
-  for (const image of root.querySelectorAll('[data-testid="main-image"]')) {
-    const content = image.closest?.(".lg-node-content");
-    if (content && !content.querySelector?.(".easyuse-anima-aio-node-panel")) {
-      hideGeneratorNativeLivePreviewElement(content);
-      continue;
-    }
-    hideGeneratorNativeLivePreviewElement(image);
-    const previewRoot = image.closest?.(".flex-auto, .relative, .overflow-hidden");
-    if (previewRoot && !previewRoot.querySelector?.(".easyuse-anima-aio-node-panel")) {
-      hideGeneratorNativeLivePreviewElement(previewRoot);
-    }
-  }
-}
-
-function hideGeneratorNativeLivePreviewElements(root) {
-  if (!root?.querySelectorAll) {
-    return;
-  }
-  hideGeneratorComfyOutputPreviewElements(root);
-  for (const image of root.querySelectorAll("img.pointer-events-none.object-contain")) {
-    if (image.closest?.(".easyuse-anima-aio-node-panel")) {
-      continue;
-    }
-    hideGeneratorNativeLivePreviewElement(image);
-  }
-  for (const element of root.querySelectorAll(".text-node-component-header-text, div, span")) {
-    if (element.closest?.(".easyuse-anima-aio-node-panel")) {
-      continue;
-    }
-    const shouldHide = element.classList?.contains("text-node-component-header-text")
-      || (!element.children?.length && isGeneratorNativeDimensionLabel(element));
-    if (!shouldHide) {
-      continue;
-    }
-    hideGeneratorNativeLivePreviewElement(element);
-    const parent = element.parentElement;
-    if (
-      parent
-      && !parent.querySelector?.(".easyuse-anima-aio-node-panel")
-      && parent.querySelector?.("img.pointer-events-none.object-contain")
-    ) {
-      hideGeneratorNativeLivePreviewElement(parent);
-    }
-  }
-}
-
-function markGeneratorNativeLivePreviewHidden(node) {
-  if (!node || typeof document === "undefined") {
-    return;
-  }
-  for (const root of generatorVueNodeRoots(node)) {
-    root.classList.add(GENERATOR_VUE_NODE_CLASS);
-    hideGeneratorNativeLivePreviewElements(root);
-  }
-}
-
-let generatorNativePreviewStoresPromise = null;
-let generatorDialogServiceAssetUrlPromise = null;
-
-async function generatorDialogServiceAssetUrl() {
-  if (!generatorDialogServiceAssetUrlPromise) {
-    generatorDialogServiceAssetUrlPromise = (async () => {
-      if (typeof document !== "undefined") {
-        const elements = document.querySelectorAll("link[href], script[src]");
-        for (const element of elements) {
-          const value = element.getAttribute("href") || element.getAttribute("src") || "";
-          if (/\/?assets\/dialogService-[^/]+\.js(?:$|\?)/.test(value)) {
-            return new URL(value, window.location.href).href;
-          }
-        }
-      }
-      const html = await easyuseAnimaFetchText("/");
-      const match = html.match(/(?:\.\/)?assets\/dialogService-[^"'<>]+\.js/);
-      return match ? new URL(match[0], window.location.href).href : "";
-    })().catch(() => "");
-  }
-  return generatorDialogServiceAssetUrlPromise;
-}
-
-async function generatorNativePreviewStores() {
-  if (!generatorNativePreviewStoresPromise) {
-    generatorNativePreviewStoresPromise = (async () => {
-      try {
-        const [nodeOutputStoreModule, workflowStoreModule] = await Promise.all([
-          import("../../../stores/nodeOutputStore.js"),
-          import("../../../platform/workflow/management/stores/workflowStore.js"),
-        ]);
-        if (nodeOutputStoreModule?.useNodeOutputStore && workflowStoreModule?.useWorkflowStore) {
-          return {
-            useNodeOutputStore: nodeOutputStoreModule.useNodeOutputStore,
-            useWorkflowStore: workflowStoreModule.useWorkflowStore,
-          };
-        }
-      } catch {
-        // Packaged ComfyUI frontend builds bundle these stores into hashed assets.
-      }
-
-      const url = await generatorDialogServiceAssetUrl();
-      if (!url) {
-        return null;
-      }
-      try {
-        const module = await import(url);
-        return {
-          useNodeOutputStore: module?.useNodeOutputStore || module?.cn || module?.L,
-          useWorkflowStore: module?.useWorkflowStore || module?.M,
-        };
-      } catch {
-        return null;
-      }
-    })();
-  }
-  return generatorNativePreviewStoresPromise;
-}
-
-async function purgeGeneratorNativeLivePreviewStore(node, detail = null) {
-  try {
-    if (!node) {
-      return;
-    }
-    const ids = generatorPreviewLocatorCandidates(node, detail);
-    if (!ids.length) {
-      return;
-    }
-    if (app.nodePreviewImages && typeof app.nodePreviewImages === "object") {
-      for (const id of ids) {
-        aioDeletePreviewStoreEntry(app.nodePreviewImages, id);
-      }
-    }
-
-    const stores = await generatorNativePreviewStores();
-    const outputStore = stores?.useNodeOutputStore?.();
-    if (!outputStore) {
-      return;
-    }
-    const workflowStore = stores?.useWorkflowStore?.();
-    const locators = new Set(ids);
-    for (const id of ids) {
-      const leaf = String(id).split(":").pop();
-      if (!leaf) {
-        continue;
-      }
-      locators.add(leaf);
-      const locator = workflowStore?.nodeIdToNodeLocatorId?.(leaf);
-      if (locator) {
-        locators.add(locator);
-      }
-    }
-    for (const locator of locators) {
-      outputStore.revokePreviewsByLocatorId?.(locator);
-      aioDeletePreviewStoreEntry(outputStore.nodePreviewImages, locator);
-    }
-  } catch {
-    // Native preview store access is version-dependent; CSS/DOM fallback remains scoped to this node.
-  }
-}
-
-function scheduleGeneratorNativeLivePreviewPurge(node, detail = null) {
-  void purgeGeneratorNativeLivePreviewStore(node, detail);
-  requestAnimationFrame(() => {
-    void purgeGeneratorNativeLivePreviewStore(node, detail);
-  });
-  setTimeout(() => {
-    void purgeGeneratorNativeLivePreviewStore(node, detail);
-  }, 80);
-  setTimeout(() => {
-    void purgeGeneratorNativeLivePreviewStore(node, detail);
-  }, 240);
-}
-
-function stopGeneratorNativeLivePreviewObserver(node) {
-  const observers = node?.__easyuseAnimaNativeLivePreviewObservers;
-  if (!observers) {
-    return;
-  }
-  for (const observer of observers.values()) {
-    observer.disconnect();
-  }
-  observers.clear();
-}
-
-function ensureGeneratorNativeLivePreviewObserver(node) {
-  if (!node || typeof MutationObserver === "undefined") {
-    return;
-  }
-  const observers = node.__easyuseAnimaNativeLivePreviewObservers || new Map();
-  node.__easyuseAnimaNativeLivePreviewObservers = observers;
-  for (const [root, observer] of observers) {
-    if (!root?.isConnected) {
-      observer.disconnect();
-      observers.delete(root);
-    }
-  }
-  for (const root of generatorVueNodeRoots(node)) {
-    if (!root || observers.has(root)) {
-      continue;
-    }
-    const observer = new MutationObserver(() => markGeneratorNativeLivePreviewHidden(node));
-    observer.observe(root, { childList: true, subtree: true });
-    observers.set(root, observer);
-  }
-  clearTimeout(node.__easyuseAnimaNativeLivePreviewObserverStopTimer);
-  node.__easyuseAnimaNativeLivePreviewObserverStopTimer = setTimeout(() => {
-    stopGeneratorNativeLivePreviewObserver(node);
-  }, 5000);
-}
-
-function scheduleGeneratorNativeLivePreviewHidden(node) {
-  markGeneratorNativeLivePreviewHidden(node);
-  ensureGeneratorNativeLivePreviewObserver(node);
-  if (node.__easyuseAnimaNativeLivePreviewHideScheduled) {
-    return;
-  }
-  node.__easyuseAnimaNativeLivePreviewHideScheduled = true;
-  const hide = () => markGeneratorNativeLivePreviewHidden(node);
-  requestAnimationFrame(hide);
-  setTimeout(hide, 80);
-  setTimeout(() => {
-    node.__easyuseAnimaNativeLivePreviewHideScheduled = false;
-    hide();
-  }, 240);
-}
-
-function suppressGeneratorDefaultPreview(node, options = {}) {
-  return aioSuppressDefaultPreview(node, {
-    markDirty: options.markDirty,
-    markNodeDirty,
-  });
-}
-
-function scheduleGeneratorDefaultPreviewSuppression(node, options = {}) {
-  const shouldPurgeStore = options.purgeStore !== false;
-  const purgeDetail = options.purgeDetail || null;
-  suppressGeneratorDefaultPreview(node);
-  if (shouldPurgeStore) {
-    scheduleGeneratorNativeLivePreviewPurge(node, purgeDetail);
-  }
-  scheduleGeneratorNativeLivePreviewHidden(node);
-  if (node.__easyuseAnimaDefaultPreviewSuppressionScheduled) {
-    return;
-  }
-  node.__easyuseAnimaDefaultPreviewSuppressionScheduled = true;
-  const suppress = () => {
-    suppressGeneratorDefaultPreview(node);
-    if (shouldPurgeStore) {
-      scheduleGeneratorNativeLivePreviewPurge(node, purgeDetail);
-    }
-    markGeneratorNativeLivePreviewHidden(node);
-  };
-  requestAnimationFrame(suppress);
-  setTimeout(suppress, 120);
-  setTimeout(() => {
-    node.__easyuseAnimaDefaultPreviewSuppressionScheduled = false;
-    suppress();
-  }, 360);
-}
-
 function syncGeneratorStateFromDom(node) {
   const settings = generatorSettings(node);
   writeGeneratorSettingsFromState(node, settings, false);
@@ -4328,6 +3939,60 @@ const openAdvancedSettings = aioCreateAdvancedSettingsDialog({
   },
 });
 
+const {
+  markGeneratorNativeLivePreviewHidden,
+  suppressGeneratorDefaultPreview,
+  scheduleGeneratorDefaultPreviewSuppression,
+  handleGeneratorPreviewEvent,
+  handleGeneratorProgressEvent,
+  handleGeneratorProgressStateEvent,
+  handleGeneratorDenoisePreviewEvent,
+  handleGeneratorExecutingEvent,
+  clearGeneratorDenoisePreviews,
+} = aioCreateNativePreviewRuntime({
+  environment: {
+    document,
+    window,
+    MutationObserver: globalThis.MutationObserver,
+    requestAnimationFrame: (callback) => requestAnimationFrame(callback),
+    setTimeout: (callback, delay) => setTimeout(callback, delay),
+    clearTimeout: (timer) => clearTimeout(timer),
+  },
+  constants: {
+    generatorNodeType: GENERATOR_NODE_TYPE,
+    generatorVueNodeClass: GENERATOR_VUE_NODE_CLASS,
+  },
+  storeAdapter: {
+    getLegacyPreviewImages: () => app.nodePreviewImages,
+    loadDirectStoreModules: () => Promise.all([
+      import("../../../stores/nodeOutputStore.js"),
+      import("../../../platform/workflow/management/stores/workflowStore.js"),
+    ]),
+    fetchFrontendHtml: () => easyuseAnimaFetchText("/"),
+    importAssetModule: (url) => import(url),
+  },
+  previewCore: {
+    deleteStoreEntry: aioDeletePreviewStoreEntry,
+    eventDetail: aioPreviewEventDetail,
+    images: aioPreviewImages,
+    nodeIdsFromDetail: aioPreviewNodeIdsFromDetail,
+    suppressDefaultPreview: aioSuppressDefaultPreview,
+  },
+  nodeAdapter: {
+    getGraph: () => app.graph,
+    listGeneratorNodes: generatorGraphNodes,
+    addPreviewImages: addGeneratorPreviewImagesToNode,
+    clearDenoisePreview: clearGeneratorDenoisePreview,
+    setDenoisePreview: setGeneratorDenoisePreview,
+    markDirty: markNodeDirty,
+  },
+  progressAdapter: {
+    remember: rememberGeneratorProgress,
+    rememberState: rememberGeneratorProgressState,
+    clear: clearGeneratorPreviewProgress,
+  },
+});
+
 const generatorPanelRuntime = aioCreateGeneratorPanelRuntime({
   document,
   window,
@@ -4420,39 +4085,6 @@ function hookGeneratorNode(node) {
   });
 }
 
-function findGeneratorNodeByQualifiedId(rootGraph, nodeId) {
-  if (!rootGraph || nodeId == null) {
-    return null;
-  }
-  const textId = String(nodeId);
-  if (!textId.includes(":")) {
-    const numericId = Number(textId);
-    return rootGraph.getNodeById?.(Number.isFinite(numericId) ? numericId : textId)
-      || rootGraph.getNodeById?.(textId)
-      || rootGraph._nodes_by_id?.[textId]
-      || rootGraph._nodes_by_id?.[numericId]
-      || null;
-  }
-  const parts = textId.split(":");
-  let graph = rootGraph;
-  for (let index = 0; index < parts.length - 1; index += 1) {
-    const parentId = Number(parts[index]);
-    if (!Number.isFinite(parentId)) {
-      return null;
-    }
-    const parentNode = graph?.getNodeById?.(parentId) || graph?._nodes_by_id?.[parentId];
-    if (!parentNode?.subgraph) {
-      return null;
-    }
-    graph = parentNode.subgraph;
-  }
-  const leafId = Number(parts[parts.length - 1]);
-  if (!Number.isFinite(leafId)) {
-    return null;
-  }
-  return graph?.getNodeById?.(leafId) || graph?._nodes_by_id?.[leafId] || null;
-}
-
 function addGeneratorPreviewImagesToNode(node, nextImages, runId = "", options = {}) {
   if (!node || !Array.isArray(nextImages) || !nextImages.length) {
     return;
@@ -4506,68 +4138,6 @@ function updateGeneratorExecutedStatus(node, message) {
     sampler_backend: String(firstValue(message?.sampler_backend, "")),
   };
   updateGeneratorDomSummary(node);
-}
-
-function handleGeneratorPreviewEvent(event) {
-  const detail = aioPreviewEventDetail(event);
-  const node = findGeneratorNodeByQualifiedId(app.graph, detail.node);
-  if (!node || node.type !== GENERATOR_NODE_TYPE) {
-    return;
-  }
-  scheduleGeneratorNativeLivePreviewPurge(node, detail);
-  const images = aioPreviewImages({ easyuse_anima_preview: detail.images });
-  scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
-  addGeneratorPreviewImagesToNode(node, images, String(detail.run_id || ""));
-}
-
-function findGeneratorNodeForDenoisePreview(detail) {
-  for (const id of aioPreviewNodeIdsFromDetail(detail)) {
-    const node = findGeneratorNodeByQualifiedId(app.graph, id);
-    if (node?.type === GENERATOR_NODE_TYPE) {
-      return node;
-    }
-  }
-  return null;
-}
-
-function handleGeneratorProgressEvent(event) {
-  rememberGeneratorProgress(aioPreviewEventDetail(event));
-}
-
-function handleGeneratorProgressStateEvent(event) {
-  rememberGeneratorProgressState(aioPreviewEventDetail(event));
-}
-
-function handleGeneratorDenoisePreviewEvent(event) {
-  const detail = aioPreviewEventDetail(event);
-  const node = findGeneratorNodeForDenoisePreview(detail);
-  const blob = detail?.blob;
-  if (!node || !blob) {
-    return;
-  }
-  event.stopImmediatePropagation?.();
-  scheduleGeneratorNativeLivePreviewPurge(node, detail);
-  scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
-  setGeneratorDenoisePreview(node, blob, detail);
-}
-
-function handleGeneratorExecutingEvent(event) {
-  const nodeId = aioPreviewEventDetail(event);
-  const node = findGeneratorNodeByQualifiedId(app.graph, nodeId);
-  if (node?.type === GENERATOR_NODE_TYPE) {
-    clearGeneratorDenoisePreview(node, true);
-    scheduleGeneratorDefaultPreviewSuppression(node);
-  }
-}
-
-function clearGeneratorDenoisePreviews() {
-  clearGeneratorPreviewProgress();
-  for (const node of generatorGraphNodes()) {
-    if (node?.type === GENERATOR_NODE_TYPE) {
-      clearGeneratorDenoisePreview(node, true);
-      scheduleGeneratorDefaultPreviewSuppression(node);
-    }
-  }
 }
 
 function hookNode(node, nodeData) {


### PR DESCRIPTION
## 변경 요약

- AiO의 native preview DOM suppression, ComfyUI preview store purge, observer/timer scheduling, preview·denoise·progress event routing을 `web/js/aio/native_preview_runtime.js`의 단일 lifecycle factory로 분리했습니다.
- entry는 ComfyUI 환경/store/graph/custom-preview adapter 조립과 extension listener/prototype 등록만 담당합니다.
- direct store dynamic import는 entry-relative lazy loader로 유지해 파일 이동 뒤에도 기존 ComfyUI 경로 해석을 보존합니다.
- 공용 Fake DOM과 전용 smoke로 legacy/Node 2.0 DOM, direct/hashed store, observer, scheduling, qualified graph event routing을 검증합니다.
- 사용자 동작은 변경하지 않는 lifecycle extraction입니다.

## 주요 파일

- `web/js/aio/native_preview_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_native_preview_runtime_smoke.mjs`
- `tests/frontend_support/fake_dom.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`

## 검증

- moved body audit: 27 functions + 2 lazy caches, DI canonicalization 후 27/27 일치
- focused native preview runtime smoke: 통과
- 관련 Python source/module tests: 70개 통과
- JavaScript syntax 검사: 통과
- official full runner: Python 369 tests, frontend 94 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과
- 행동·DI / 테스트 적정성 / 아키텍처·호환성 3축 감사: 최종 Blocker/P2/P3 없음

## ComfyUI 표면

- ComfyUI Codex test surface: official full project validation
- Legacy canvas / Node 2.0 browser smoke: 미실행 (동작 변경 없는 lifecycle extraction)
- ComfyUI v0.27.0 user instance: 전체 유지보수 완료 후 최종 수동 확인 예정

## 호환성 및 후속

- direct store 경로, hashed dialogService alias fallback, locator method binding, capture listener, prototype hook 순서를 유지합니다.
- 명시적 node/extension dispose 부재, 예약 callback 증폭, transient store 탐색 실패 cache, observer 반복 탐색은 별도 behavior/performance PR에서 처리하며 그때 legacy/Node 2.0 smoke를 각각 1회 수행합니다.
- 이 PR은 Issue #54의 native-preview store/observer/event runtime 경계 조각이며 Issue #54 전체를 닫지 않습니다.

라벨 후보: `type: chore`, `area: frontend`, `status: ready`