### PR TITLE
fix: AiO 네이티브 프리뷰 lifecycle 정리

### DIFF
--- a/tests/frontend_aio_native_preview_runtime_smoke.mjs
+++ b/tests/frontend_aio_native_preview_runtime_smoke.mjs
@@ -18,15 +18,27 @@ function createScheduler() {
   const frames = [];
   const timers = new Map();
   const cleared = [];
+  const canceledFrames = [];
+  const staleFrames = [];
+  const staleTimers = [];
 
   return {
     frames,
     timers,
     cleared,
+    canceledFrames,
     requestAnimationFrame(callback) {
       const id = nextId++;
       frames.push({ id, callback });
       return id;
+    },
+    cancelAnimationFrame(id) {
+      canceledFrames.push(id);
+      const index = frames.findIndex((frame) => frame.id === id);
+      if (index >= 0) {
+        staleFrames.push(frames[index]);
+        frames.splice(index, 1);
+      }
     },
     setTimeout(callback, delay) {
       const id = nextId++;
@@ -35,12 +47,21 @@ function createScheduler() {
     },
     clearTimeout(id) {
       cleared.push(id);
+      const timer = timers.get(id);
+      if (timer) {
+        staleTimers.push(timer);
+      }
       timers.delete(id);
     },
     runNextFrame() {
       const frame = frames.shift();
       assert.ok(frame, "missing scheduled animation frame");
       frame.callback();
+    },
+    runAllFrames() {
+      while (frames.length) {
+        this.runNextFrame();
+      }
     },
     runDelay(delay) {
       const entries = [...timers.values()]
@@ -55,7 +76,40 @@ function createScheduler() {
     delays() {
       return [...timers.values()].map(({ delay }) => delay).sort((left, right) => left - right);
     },
+    runCanceledCallbacks() {
+      const callbacks = [
+        ...staleFrames.splice(0).map(({ callback }) => callback),
+        ...staleTimers.splice(0).map(({ callback }) => callback),
+      ];
+      for (const callback of callbacks) {
+        callback();
+      }
+    },
   };
+}
+
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function plannedResult(plan, fallback, context) {
+  if (!plan?.length) {
+    return fallback();
+  }
+  const value = plan.shift();
+  if (value instanceof Error) {
+    throw value;
+  }
+  if (typeof value === "function") {
+    return value(context);
+  }
+  return value;
 }
 
 function graphFromNodes(nodes) {
@@ -104,6 +158,9 @@ function createFixture({
   graph = graphFromNodes([]),
   generatorNodes = [],
   suppressResult = true,
+  directStorePlan = null,
+  frontendHtmlPlan = null,
+  assetImportPlan = null,
 } = {}) {
   const document = createFakeDocument();
   const scheduler = createScheduler();
@@ -173,6 +230,7 @@ function createFixture({
       window: { location: { href: "https://comfy.test/" } },
       MutationObserver: FakeMutationObserver,
       requestAnimationFrame: scheduler.requestAnimationFrame,
+      cancelAnimationFrame: scheduler.cancelAnimationFrame,
       setTimeout: scheduler.setTimeout,
       clearTimeout: scheduler.clearTimeout,
     },
@@ -187,29 +245,45 @@ function createFixture({
       },
       async loadDirectStoreModules() {
         calls.directStoreLoads += 1;
-        if (storeMode !== "direct") {
-          throw new Error("direct stores unavailable");
-        }
-        return [
-          { useNodeOutputStore: () => outputStore },
-          { useWorkflowStore: () => workflowStore },
-        ];
+        return plannedResult(
+          directStorePlan,
+          () => {
+            if (storeMode !== "direct") {
+              throw new Error("direct stores unavailable");
+            }
+            return [
+              { useNodeOutputStore: () => outputStore },
+              { useWorkflowStore: () => workflowStore },
+            ];
+          },
+          { outputStore, workflowStore },
+        );
       },
       async fetchFrontendHtml() {
         calls.frontendFetches += 1;
-        return storeMode === "html-fallback"
-          ? '<script src="./assets/dialogService-html.js"></script>'
-          : "";
+        return plannedResult(
+          frontendHtmlPlan,
+          () => storeMode === "html-fallback"
+            ? '<script src="./assets/dialogService-html.js"></script>'
+            : "",
+          { outputStore, workflowStore },
+        );
       },
       async importAssetModule(url) {
         calls.assetImports.push(url);
-        if (storeMode === "hashed" || storeMode === "html-fallback") {
-          return {
-            cn: () => outputStore,
-            M: () => workflowStore,
-          };
-        }
-        throw new Error("hashed store unavailable");
+        return plannedResult(
+          assetImportPlan,
+          () => {
+            if (storeMode === "hashed" || storeMode === "html-fallback") {
+              return {
+                cn: () => outputStore,
+                M: () => workflowStore,
+              };
+            }
+            throw new Error("hashed store unavailable");
+          },
+          { outputStore, workflowStore, url },
+        );
       },
     },
     previewCore: {
@@ -303,6 +377,17 @@ function assertHidden(element, message) {
   assert.equal(element.style.getPropertyPriority("display"), "important", message);
 }
 
+async function drainScheduledPreviewWork(fixture) {
+  fixture.scheduler.runAllFrames();
+  await flushPromises();
+  for (const delay of [80, 120, 240, 360]) {
+    if (fixture.scheduler.delays().includes(delay)) {
+      fixture.scheduler.runDelay(delay);
+      await flushPromises();
+    }
+  }
+}
+
 {
   const fixture = createFixture({ suppressResult: "suppressed" });
   assert.equal(fixture.document.createdElements.length, 0, "Factory must not create DOM elements");
@@ -321,8 +406,10 @@ function assertHidden(element, message) {
   assert.equal(fixture.revokeCalls.length, 0);
   assert.equal(fixture.workflowLocatorCalls.length, 0);
   assert.deepEqual(
-    Object.keys(fixture.runtime),
+    Object.keys(fixture.runtime).sort(),
     [
+      "activateGeneratorNativePreviewLifecycle",
+      "disposeGeneratorNativePreviewLifecycle",
       "markGeneratorNativeLivePreviewHidden",
       "suppressGeneratorDefaultPreview",
       "scheduleGeneratorDefaultPreviewSuppression",
@@ -332,7 +419,7 @@ function assertHidden(element, message) {
       "handleGeneratorDenoisePreviewEvent",
       "handleGeneratorExecutingEvent",
       "clearGeneratorDenoisePreviews",
-    ],
+    ].sort(),
     "Runtime facade changed",
   );
 
@@ -526,6 +613,103 @@ function assertHidden(element, message) {
 
 {
   const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({ graph: graphFromNodes([node]), storeMode: "direct" });
+  appendNodeRoot(fixture.document, "42");
+  const detailOnlyIds = ["91", "92", "93"];
+  for (const [index, realNodeId] of detailOnlyIds.entries()) {
+    fixture.runtime.handleGeneratorPreviewEvent({
+      detail: {
+        data: {
+          node: "42",
+          realNodeId,
+          images: [{ filename: `burst-${index}.webp` }],
+          run_id: `burst-${index}`,
+        },
+      },
+    });
+  }
+  await flushPromises();
+
+  assert.equal(fixture.calls.legacyGets, detailOnlyIds.length, "Every burst request needs its immediate purge");
+  assert.equal(fixture.scheduler.frames.length, 3, "Burst requests must share purge, hide, and suppression RAF tails");
+  assert.deepEqual(
+    fixture.scheduler.delays(),
+    [80, 80, 120, 240, 240, 360, 5000],
+    "Burst requests must keep one bounded timer set",
+  );
+  for (const id of detailOnlyIds) {
+    assert.equal(fixture.revokeCalls.filter((value) => value === `locator:${id}`).length, 1);
+  }
+
+  await drainScheduledPreviewWork(fixture);
+  assert.equal(
+    fixture.calls.legacyGets,
+    detailOnlyIds.length + 3,
+    "A burst of N requests must add only one shared RAF/80/240 purge tail",
+  );
+  assert.equal(fixture.scheduler.frames.length, 0);
+  assert.deepEqual(fixture.scheduler.delays(), [5000]);
+  for (const id of detailOnlyIds) {
+    assert.equal(
+      fixture.revokeCalls.filter((value) => value === `locator:${id}`).length,
+      4,
+      `The shared tail lost a burst locator: ${id}`,
+    );
+  }
+
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: {
+      data: {
+        node: "42",
+        realNodeId: "94",
+        images: [{ filename: "next-batch.webp" }],
+        run_id: "next-batch",
+      },
+    },
+  });
+  await flushPromises();
+  assert.equal(fixture.calls.legacyGets, detailOnlyIds.length + 4, "A terminal batch must release the next immediate purge");
+  assert.equal(fixture.scheduler.frames.length, 3, "A new post-terminal request must own a fresh tail");
+  await drainScheduledPreviewWork(fixture);
+  assert.equal(fixture.calls.legacyGets, detailOnlyIds.length + 7);
+  assert.equal(fixture.revokeCalls.filter((value) => value === "locator:94").length, 4);
+  assert.equal(fixture.calls.directStoreLoads, 1, "Purge coalescing must preserve the positive store cache");
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({ storeMode: "direct" });
+  appendNodeRoot(fixture.document, "42");
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node);
+  await flushPromises();
+  assert.equal(fixture.calls.legacyGets, 1);
+  assert.equal(fixture.scheduler.frames.length, 3);
+  assert.deepEqual(fixture.scheduler.delays(), [80, 80, 120, 240, 240, 360, 5000]);
+
+  await drainScheduledPreviewWork(fixture);
+  assert.equal(
+    fixture.calls.legacyGets,
+    7,
+    "Default suppression may run three direct delayed purges but must not recursively schedule purge waves",
+  );
+  assert.equal(fixture.revokeCalls.filter((value) => value === "locator:42").length, 7);
+  assert.equal(fixture.scheduler.frames.length, 0);
+  assert.deepEqual(fixture.scheduler.delays(), [5000]);
+
+  const noPurgeFixture = createFixture({ storeMode: "direct" });
+  appendNodeRoot(noPurgeFixture.document, "42");
+  noPurgeFixture.runtime.scheduleGeneratorDefaultPreviewSuppression(
+    { id: 42 },
+    { purgeStore: false },
+  );
+  await drainScheduledPreviewWork(noPurgeFixture);
+  assert.equal(noPurgeFixture.calls.legacyGets, 0);
+  assert.equal(noPurgeFixture.calls.directStoreLoads, 0);
+  assert.equal(noPurgeFixture.revokeCalls.length, 0, "purgeStore false must survive every delayed callback");
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
   const fixture = createFixture({ graph: graphFromNodes([node]), storeMode: "hashed" });
   const script = fixture.document.createElement("script");
   script.setAttribute("src", "/assets/dialogService-hash.js?build=1");
@@ -551,6 +735,125 @@ function assertHidden(element, message) {
   await flushPromises();
   assert.equal(fixture.calls.directStoreLoads, 1, "Store resolution must stay promise-cached");
   assert.equal(fixture.calls.assetImports.length, 1, "Hashed module import must stay promise-cached");
+}
+
+for (const { label, assetModule, expectWorkflowPurge } of [
+  {
+    label: "later-callable-aliases",
+    assetModule: ({ outputStore, workflowStore }) => ({
+      useNodeOutputStore: "not-a-function",
+      cn: () => outputStore,
+      useWorkflowStore: { invalid: true },
+      M: () => workflowStore,
+    }),
+    expectWorkflowPurge: true,
+  },
+  {
+    label: "workflow-alias-unavailable",
+    assetModule: ({ outputStore }) => ({
+      useNodeOutputStore: "not-a-function",
+      cn: () => outputStore,
+      useWorkflowStore: { invalid: true },
+      M: "not-a-function",
+    }),
+    expectWorkflowPurge: false,
+  },
+]) {
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({
+    graph: graphFromNodes([node]),
+    storeMode: "none",
+    assetImportPlan: [assetModule],
+  });
+  const script = fixture.document.createElement("script");
+  script.setAttribute("src", `/assets/dialogService-${label}.js`);
+  fixture.document.body.append(script);
+  fixture.outputPreviewImages.set("42", true);
+  fixture.outputPreviewImages.set("locator:42", true);
+
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: { data: { node: "42", images: [{ filename: `${label}.webp` }] } },
+  });
+  await flushPromises();
+
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.calls.frontendFetches, 0);
+  assert.deepEqual(
+    fixture.calls.assetImports,
+    [`https://comfy.test/assets/dialogService-${label}.js`],
+  );
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(
+    fixture.outputPreviewImages.has("locator:42"),
+    !expectWorkflowPurge,
+    `Unexpected workflow-locator purge for ${label}`,
+  );
+  assert.equal(
+    fixture.workflowLocatorCalls.length > 0,
+    expectWorkflowPurge,
+    `Unexpected workflow provider normalization for ${label}`,
+  );
+}
+
+for (const label of ["workflow-provider-throws", "workflow-mapper-throws"]) {
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const workflowBoundaryCalls = [];
+  const useWorkflowStore = label === "workflow-provider-throws"
+    ? () => {
+      workflowBoundaryCalls.push("provider");
+      throw new Error("optional workflow provider unavailable");
+    }
+    : () => ({
+      nodeIdToNodeLocatorId(id) {
+        workflowBoundaryCalls.push(String(id));
+        throw new Error("optional workflow mapper unavailable");
+      },
+    });
+  const fixture = createFixture({
+    graph: graphFromNodes([node]),
+    storeMode: "none",
+    directStorePlan: [({ outputStore }) => [
+      { useNodeOutputStore: () => outputStore },
+      { useWorkflowStore },
+    ]],
+  });
+  appendNodeRoot(fixture.document, "7:42");
+  const rawLocators = ["42", "7:42", "8:42", "99"];
+  for (const locator of [...rawLocators, "locator:42", "locator:99"]) {
+    fixture.outputPreviewImages.set(locator, true);
+  }
+
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: {
+      data: {
+        node: "42",
+        displayNodeId: "8:42",
+        realNodeId: "99",
+        images: [{ filename: `${label}.webp` }],
+      },
+    },
+  });
+  await flushPromises();
+
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.calls.frontendFetches, 0);
+  assert.equal(fixture.calls.assetImports.length, 0);
+  for (const locator of rawLocators) {
+    assert.equal(fixture.outputPreviewImages.has(locator), false, `${label} retained ${locator}`);
+    assert.equal(
+      fixture.revokeCalls.includes(locator),
+      true,
+      `${label} prevented raw/leaf revoke for ${locator}`,
+    );
+  }
+  assert.equal(fixture.outputPreviewImages.has("locator:42"), true);
+  assert.equal(fixture.outputPreviewImages.has("locator:99"), true);
+  if (label === "workflow-provider-throws") {
+    assert.deepEqual(workflowBoundaryCalls, ["provider"]);
+  } else {
+    assert.equal(workflowBoundaryCalls.includes("42"), true);
+    assert.equal(workflowBoundaryCalls.includes("99"), true);
+  }
 }
 
 {
@@ -580,22 +883,364 @@ function assertHidden(element, message) {
   assert.equal(fixture.calls.assetImports.length, 1, "HTML-discovered module import must stay cached");
 }
 
+for (const [label, workflowStoreModule] of [
+  ["absent", {}],
+  ["non-function", { useWorkflowStore: "not-a-function" }],
+]) {
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({
+    graph: graphFromNodes([node]),
+    storeMode: "none",
+    directStorePlan: [({ outputStore }) => [
+      { useNodeOutputStore: () => outputStore },
+      workflowStoreModule,
+    ]],
+  });
+  fixture.outputPreviewImages.set("42", true);
+  fixture.outputPreviewImages.set("locator:42", true);
+
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: { data: { node: "42", images: [{ filename: `output-only-${label}.webp` }] } },
+  });
+  await flushPromises();
+
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(
+    fixture.calls.frontendFetches,
+    0,
+    `An output-only direct tuple must not fall back when workflow is ${label}`,
+  );
+  assert.equal(fixture.calls.assetImports.length, 0);
+  assert.equal(fixture.workflowLocatorCalls.length, 0);
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(
+    fixture.outputPreviewImages.has("locator:42"),
+    true,
+    "Without a workflow provider only raw output locators can be purged",
+  );
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({
+    graph: graphFromNodes([node]),
+    storeMode: "none",
+    directStorePlan: [({ workflowStore }) => [
+      { useNodeOutputStore: "not-a-function" },
+      { useWorkflowStore: () => workflowStore },
+    ]],
+    frontendHtmlPlan: ['<script src="./assets/dialogService-invalid-output.js"></script>'],
+    assetImportPlan: [({ outputStore, workflowStore }) => ({
+      cn: () => outputStore,
+      M: () => workflowStore,
+    })],
+  });
+  fixture.outputPreviewImages.set("42", true);
+  fixture.outputPreviewImages.set("locator:42", true);
+
+  fixture.runtime.handleGeneratorPreviewEvent({
+    detail: { data: { node: "42", images: [{ filename: "invalid-output.webp" }] } },
+  });
+  await flushPromises();
+
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(
+    fixture.calls.frontendFetches,
+    1,
+    "An invalid output provider must fall through to frontend discovery",
+  );
+  assert.deepEqual(
+    fixture.calls.assetImports,
+    ["https://comfy.test/assets/dialogService-invalid-output.js"],
+  );
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(fixture.outputPreviewImages.has("locator:42"), false);
+}
+
+{
+  const pendingDirectStore = createDeferred();
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const directStorePlan = [
+    pendingDirectStore.promise,
+    ({ outputStore, workflowStore }) => [
+      { useNodeOutputStore: () => outputStore },
+      { useWorkflowStore: () => workflowStore },
+    ],
+  ];
+  const fixture = createFixture({
+    graph: graphFromNodes([node]),
+    storeMode: "none",
+    directStorePlan,
+    frontendHtmlPlan: [""],
+  });
+  const previewEvent = (realNodeId) => ({
+    detail: {
+      data: {
+        node: "42",
+        realNodeId,
+        images: [{ filename: `${realNodeId}.webp` }],
+        run_id: `retry-${realNodeId}`,
+      },
+    },
+  });
+
+  fixture.runtime.handleGeneratorPreviewEvent(previewEvent("91"));
+  fixture.runtime.handleGeneratorPreviewEvent(previewEvent("92"));
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1, "Concurrent purges must share one provider attempt");
+  pendingDirectStore.reject(new Error("transient direct-store failure"));
+  await flushPromises();
+  assert.equal(fixture.calls.frontendFetches, 1);
+  await drainScheduledPreviewWork(fixture);
+  assert.equal(fixture.calls.directStoreLoads, 1, "A failed provider lookup must not retry inside its active batch");
+  assert.equal(fixture.calls.frontendFetches, 1);
+
+  fixture.outputPreviewImages.set("93", true);
+  fixture.outputPreviewImages.set("locator:93", true);
+  fixture.runtime.handleGeneratorPreviewEvent(previewEvent("93"));
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 2, "A later batch must retry a transient direct-store failure");
+  assert.equal(fixture.outputPreviewImages.has("93"), false);
+  assert.equal(fixture.outputPreviewImages.has("locator:93"), false);
+
+  await drainScheduledPreviewWork(fixture);
+  fixture.runtime.handleGeneratorPreviewEvent(previewEvent("94"));
+  await flushPromises();
+  assert.equal(
+    fixture.calls.directStoreLoads,
+    2,
+    "A successful retry must remain positive-cached in a later batch",
+  );
+  assert.equal(fixture.calls.frontendFetches, 1);
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({
+    graph: graphFromNodes([node]),
+    storeMode: "none",
+    directStorePlan: [
+      new Error("direct unavailable first batch"),
+      new Error("direct unavailable second batch"),
+    ],
+    frontendHtmlPlan: [
+      "",
+      '<script src="./assets/dialogService-retry-html.js"></script>',
+    ],
+    assetImportPlan: [({ outputStore, workflowStore }) => ({
+      cn: () => outputStore,
+      M: () => workflowStore,
+    })],
+  });
+  const event = {
+    detail: { data: { node: "42", images: [{ filename: "html-retry.webp" }] } },
+  };
+
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.calls.frontendFetches, 1);
+  assert.equal(fixture.calls.assetImports.length, 0);
+  await drainScheduledPreviewWork(fixture);
+  assert.equal(fixture.calls.frontendFetches, 1, "Empty HTML discovery must stay bounded to one active batch");
+
+  fixture.outputPreviewImages.set("42", true);
+  fixture.outputPreviewImages.set("locator:42", true);
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 2);
+  assert.equal(fixture.calls.frontendFetches, 2, "A later batch must retry empty HTML discovery");
+  assert.deepEqual(
+    fixture.calls.assetImports,
+    ["https://comfy.test/assets/dialogService-retry-html.js"],
+  );
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(fixture.outputPreviewImages.has("locator:42"), false);
+
+  await drainScheduledPreviewWork(fixture);
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 2);
+  assert.equal(fixture.calls.frontendFetches, 2);
+  assert.equal(
+    fixture.calls.assetImports.length,
+    1,
+    "Recovered HTML providers must remain positive-cached in a later batch",
+  );
+}
+
+{
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({
+    graph: graphFromNodes([node]),
+    storeMode: "none",
+    directStorePlan: [
+      new Error("direct unavailable first batch"),
+      new Error("direct unavailable second batch"),
+    ],
+    frontendHtmlPlan: ['<script src="./assets/dialogService-retry-import.js"></script>'],
+    assetImportPlan: [
+      new Error("transient asset import failure"),
+      ({ outputStore, workflowStore }) => ({
+        cn: () => outputStore,
+        M: () => workflowStore,
+      }),
+    ],
+  });
+  const event = {
+    detail: { data: { node: "42", images: [{ filename: "import-retry.webp" }] } },
+  };
+
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.calls.frontendFetches, 1);
+  assert.equal(fixture.calls.assetImports.length, 1);
+  await drainScheduledPreviewWork(fixture);
+  assert.equal(fixture.calls.assetImports.length, 1, "A failed import must not retry inside its active batch");
+
+  fixture.outputPreviewImages.set("42", true);
+  fixture.outputPreviewImages.set("locator:42", true);
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 2);
+  assert.equal(fixture.calls.frontendFetches, 1, "A successful asset URL may remain cached across import retry");
+  assert.equal(fixture.calls.assetImports.length, 2, "A later batch must retry a transient asset import failure");
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(fixture.outputPreviewImages.has("locator:42"), false);
+
+  await drainScheduledPreviewWork(fixture);
+  fixture.runtime.handleGeneratorPreviewEvent(event);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 2);
+  assert.equal(fixture.calls.frontendFetches, 1);
+  assert.equal(
+    fixture.calls.assetImports.length,
+    2,
+    "Recovered asset providers must remain positive-cached in a later batch",
+  );
+}
+
+{
+  const pendingStores = createDeferred();
+  const nodeA = { id: 41, type: GENERATOR_NODE_TYPE };
+  const nodeB = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({
+    graph: graphFromNodes([nodeA, nodeB]),
+    storeMode: "none",
+    directStorePlan: [pendingStores.promise],
+  });
+  const rootA = appendNodeRoot(fixture.document, "41");
+  const rootB = appendNodeRoot(fixture.document, "42");
+  for (const locator of ["41", "locator:41", "42", "locator:42"]) {
+    fixture.outputPreviewImages.set(locator, true);
+  }
+  const previewEvent = (nodeId) => ({
+    detail: {
+      data: {
+        node: String(nodeId),
+        images: [{ filename: `multi-${nodeId}.webp` }],
+        run_id: `multi-${nodeId}`,
+      },
+    },
+  });
+
+  fixture.runtime.handleGeneratorPreviewEvent(previewEvent(41));
+  await flushPromises();
+  const nodeAFrameIds = fixture.scheduler.frames.map(({ id }) => id);
+  const nodeATimerIds = [...fixture.scheduler.timers.keys()];
+  const nodeAObserver = fixture.mutationObservers[0];
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(nodeAFrameIds.length, 3);
+  assert.equal(nodeATimerIds.length, 7);
+
+  fixture.runtime.handleGeneratorPreviewEvent(previewEvent(42));
+  await flushPromises();
+  const nodeBFrameIds = fixture.scheduler.frames
+    .map(({ id }) => id)
+    .filter((id) => !nodeAFrameIds.includes(id));
+  const nodeBTimerIds = [...fixture.scheduler.timers.keys()]
+    .filter((id) => !nodeATimerIds.includes(id));
+  const nodeBObserver = fixture.mutationObservers[1];
+  assert.equal(
+    fixture.calls.directStoreLoads,
+    1,
+    "Concurrent nodes must share one unresolved provider attempt",
+  );
+  assert.equal(nodeBFrameIds.length, 3);
+  assert.equal(nodeBTimerIds.length, 7);
+  assert.equal(fixture.mutationObservers.length, 2);
+
+  fixture.runtime.disposeGeneratorNativePreviewLifecycle(nodeA);
+  assert.deepEqual(
+    fixture.scheduler.frames.map(({ id }) => id).sort((left, right) => left - right),
+    [...nodeBFrameIds].sort((left, right) => left - right),
+    "Disposing node A must retain every node B frame",
+  );
+  assert.deepEqual(
+    [...fixture.scheduler.timers.keys()].sort((left, right) => left - right),
+    [...nodeBTimerIds].sort((left, right) => left - right),
+    "Disposing node A must retain every node B timer",
+  );
+  assert.deepEqual(
+    [...fixture.scheduler.canceledFrames].sort((left, right) => left - right),
+    [...nodeAFrameIds].sort((left, right) => left - right),
+  );
+  for (const timerId of nodeATimerIds) {
+    assert.equal(fixture.scheduler.cleared.includes(timerId), true);
+  }
+  assert.equal(nodeAObserver.disconnectCalls, 1);
+  assert.equal(nodeBObserver.disconnectCalls, 0);
+
+  const lateNodeAImage = fixture.document.createElement("img");
+  lateNodeAImage.className = "pointer-events-none object-contain";
+  rootA.append(lateNodeAImage);
+  const afterDisposeSnapshot = adapterChannelSnapshot(fixture.calls);
+  fixture.scheduler.runCanceledCallbacks();
+  nodeAObserver.trigger();
+  assert.deepEqual(
+    adapterChannelSnapshot(fixture.calls),
+    afterDisposeSnapshot,
+    "Node A stale callbacks must not affect node B adapters",
+  );
+  assert.equal(lateNodeAImage.classList.contains(NATIVE_HIDDEN_CLASS), false);
+  assert.deepEqual(fixture.scheduler.frames.map(({ id }) => id), nodeBFrameIds);
+  assert.deepEqual([...fixture.scheduler.timers.keys()], nodeBTimerIds);
+  assert.equal(nodeBObserver.disconnectCalls, 0);
+
+  pendingStores.resolve([
+    { useNodeOutputStore: () => fixture.outputStore },
+    { useWorkflowStore: () => fixture.workflowStore },
+  ]);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.outputPreviewImages.has("41"), true);
+  assert.equal(fixture.outputPreviewImages.has("locator:41"), true);
+  assert.equal(fixture.revokeCalls.filter((value) => value === "locator:41").length, 0);
+  assert.equal(fixture.outputPreviewImages.has("42"), false);
+  assert.equal(fixture.outputPreviewImages.has("locator:42"), false);
+  assert.equal(fixture.revokeCalls.filter((value) => value === "locator:42").length, 1);
+
+  await drainScheduledPreviewWork(fixture);
+  assert.equal(fixture.scheduler.frames.length, 0);
+  assert.deepEqual(fixture.scheduler.delays(), [5000]);
+  assert.equal(fixture.revokeCalls.filter((value) => value === "locator:41").length, 0);
+  assert.equal(fixture.revokeCalls.filter((value) => value === "locator:42").length, 4);
+  const lateNodeBImage = fixture.document.createElement("img");
+  lateNodeBImage.className = "pointer-events-none object-contain";
+  rootB.append(lateNodeBImage);
+  nodeBObserver.trigger();
+  assertHidden(lateNodeBImage, "Node B observer must remain live after node A disposal");
+  assert.equal(nodeBObserver.disconnectCalls, 0);
+}
+
 {
   const fixture = createFixture({ storeMode: "none" });
   const root = appendNodeRoot(fixture.document, "42");
   const node = { id: 42 };
-  const staleRoot = { isConnected: false };
-  const staleObserver = {
-    disconnectCalls: 0,
-    disconnect() {
-      this.disconnectCalls += 1;
-    },
-  };
-  node.__easyuseAnimaNativeLivePreviewObservers = new Map([[staleRoot, staleObserver]]);
 
   fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
   assert.equal(fixture.calls.suppress.length, 1);
-  assert.equal(staleObserver.disconnectCalls, 1, "Disconnected roots must be pruned");
   assert.equal(fixture.mutationObservers.length, 1);
   assert.deepEqual(
     fixture.mutationObservers[0].observeCalls,
@@ -618,49 +1263,230 @@ function assertHidden(element, message) {
   assertHidden(qualifiedImage, "A newly matched qualified root must be hidden immediately");
   assert.equal(fixture.calls.suppress.length, 2, "A deduped call must still suppress immediately");
   assert.equal(fixture.mutationObservers.length, 2, "Only the new qualified root needs an observer");
-  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.get(root), existingObserver);
   assert.equal(existingObserver.disconnectCalls, 0, "The existing connected observer must be retained");
   assert.deepEqual(
     fixture.mutationObservers[1].observeCalls,
     [{ root: qualifiedRoot, options: { childList: true, subtree: true } }],
   );
-  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.has(unrelatedRoot), false);
-  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.size, 2);
+  const observedRoots = fixture.mutationObservers.flatMap(
+    (observer) => observer.observeCalls.map(({ root: observedRoot }) => observedRoot),
+  );
+  assert.equal(observedRoots.includes(unrelatedRoot), false);
+  assert.deepEqual(observedRoots, [root, qualifiedRoot]);
   assert.equal(fixture.scheduler.frames.length, 2, "A deduped call must not add delayed RAF batches");
   assert.deepEqual(fixture.scheduler.delays(), [80, 120, 240, 360, 5000]);
-  assert.equal(fixture.scheduler.cleared.length, 2, "Observer stop timer must be refreshed on each ensure");
+  assert.equal(fixture.scheduler.cleared.length, 1, "Observer stop timer must be refreshed on each ensure");
 
   fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
   assert.equal(fixture.calls.suppress.length, 3);
   assert.equal(fixture.mutationObservers.length, 2, "Existing root observers must not be duplicated");
-  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.get(root), existingObserver);
+  assert.equal(existingObserver.disconnectCalls, 0);
   assert.equal(fixture.scheduler.frames.length, 2, "Partial dedupe must retain the original RAF batches");
   assert.deepEqual(fixture.scheduler.delays(), [80, 120, 240, 360, 5000]);
-  assert.equal(fixture.scheduler.cleared.length, 3);
-
-  const observerImage = fixture.document.createElement("img");
-  observerImage.className = "pointer-events-none object-contain";
-  root.append(observerImage);
-  fixture.mutationObservers[0].trigger();
-  assertHidden(observerImage, "Observer callback must re-hide late native previews");
+  assert.equal(fixture.scheduler.cleared.length, 2);
 
   fixture.scheduler.runNextFrame();
   fixture.scheduler.runNextFrame();
   assert.equal(fixture.calls.suppress.length, 4);
+  assert.equal(fixture.scheduler.frames.length, 0);
+
+  const observerImage = fixture.document.createElement("img");
+  observerImage.className = "pointer-events-none object-contain";
+  root.append(observerImage);
+  const unobservedQualifiedRoot = appendNodeRoot(fixture.document, "8:42");
+  const unobservedQualifiedImage = fixture.document.createElement("img");
+  unobservedQualifiedImage.className = "pointer-events-none object-contain";
+  unobservedQualifiedRoot.append(unobservedQualifiedImage);
+  fixture.mutationObservers[0].trigger();
+  assertHidden(observerImage, "Observer callback must re-hide late native previews");
+  assert.equal(
+    unobservedQualifiedImage.classList.contains(NATIVE_HIDDEN_CLASS),
+    false,
+    "A root-scoped observer callback must not rescan and hide another unobserved root",
+  );
+  assert.equal(unobservedQualifiedRoot.classList.contains(GENERATOR_VUE_NODE_CLASS), false);
+  assert.equal(fixture.scheduler.frames.length, 1, "The first mutation must schedule one root tail");
+
+  const burstObserverImage = fixture.document.createElement("img");
+  burstObserverImage.className = "pointer-events-none object-contain";
+  root.append(burstObserverImage);
+  fixture.mutationObservers[0].trigger();
+  fixture.mutationObservers[0].trigger();
+  assert.equal(
+    fixture.scheduler.frames.length,
+    1,
+    "Repeated callbacks in one mutation burst must share one root-scoped RAF tail",
+  );
+  assert.equal(
+    burstObserverImage.classList.contains(NATIVE_HIDDEN_CLASS),
+    false,
+    "A coalesced burst must not repeat its immediate root scan",
+  );
+  fixture.scheduler.runNextFrame();
+  assertHidden(burstObserverImage, "The shared observer RAF tail must re-scan its root");
+  assert.equal(unobservedQualifiedImage.classList.contains(NATIVE_HIDDEN_CLASS), false);
+  assert.equal(fixture.scheduler.frames.length, 0);
+
+  fixture.mutationObservers[0].trigger();
+  fixture.mutationObservers[1].trigger();
+  const rootScopedFrameIds = fixture.scheduler.frames.map(({ id }) => id);
+  assert.equal(
+    rootScopedFrameIds.length,
+    2,
+    "Two observed roots must reserve independent RAF tails in the same mutation burst",
+  );
+  const rootTailImage = fixture.document.createElement("img");
+  rootTailImage.className = "pointer-events-none object-contain";
+  root.append(rootTailImage);
+  const qualifiedTailImage = fixture.document.createElement("img");
+  qualifiedTailImage.className = "pointer-events-none object-contain";
+  qualifiedRoot.append(qualifiedTailImage);
+  fixture.mutationObservers[0].trigger();
+  fixture.mutationObservers[1].trigger();
+  assert.deepEqual(
+    fixture.scheduler.frames.map(({ id }) => id),
+    rootScopedFrameIds,
+    "Repeated callbacks must retain exactly one RAF tail per observed root",
+  );
+  assert.equal(rootTailImage.classList.contains(NATIVE_HIDDEN_CLASS), false);
+  assert.equal(qualifiedTailImage.classList.contains(NATIVE_HIDDEN_CLASS), false);
+
+  fixture.scheduler.runNextFrame();
+  assertHidden(rootTailImage, "The first root tail must re-scan only its own root");
+  assert.equal(qualifiedTailImage.classList.contains(NATIVE_HIDDEN_CLASS), false);
+  fixture.scheduler.runNextFrame();
+  assertHidden(qualifiedTailImage, "The qualified root must execute its independent tail");
+  assert.equal(fixture.scheduler.frames.length, 0);
   fixture.scheduler.runDelay(80);
   fixture.scheduler.runDelay(120);
   assert.equal(fixture.calls.suppress.length, 5);
   fixture.scheduler.runDelay(240);
   fixture.scheduler.runDelay(360);
   assert.equal(fixture.calls.suppress.length, 6);
-  assert.equal(node.__easyuseAnimaNativeLivePreviewHideScheduled, false);
-  assert.equal(node.__easyuseAnimaDefaultPreviewSuppressionScheduled, false);
+  assert.equal(fixture.scheduler.frames.length, 0);
+  assert.deepEqual(fixture.scheduler.delays(), [5000]);
   assert.equal(fixture.calls.legacyGets, 0, "purgeStore false must survive every delayed callback");
 
   fixture.scheduler.runDelay(5000);
   assert.equal(existingObserver.disconnectCalls, 1);
   assert.equal(fixture.mutationObservers[1].disconnectCalls, 1);
-  assert.equal(node.__easyuseAnimaNativeLivePreviewObservers.size, 0);
+}
+
+{
+  const fixture = createFixture({ storeMode: "none" });
+  const node = { id: 42 };
+  const staleRoot = appendNodeRoot(fixture.document, "42");
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+  const staleObserver = fixture.mutationObservers[0];
+
+  staleRoot.remove();
+  staleRoot.isConnected = false;
+  const replacementRoot = appendNodeRoot(fixture.document, "42");
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+
+  assert.equal(staleObserver.disconnectCalls, 1, "Disconnected roots must be pruned");
+  assert.equal(fixture.mutationObservers.length, 2);
+  assert.deepEqual(
+    fixture.mutationObservers[1].observeCalls,
+    [{ root: replacementRoot, options: { childList: true, subtree: true } }],
+  );
+}
+
+{
+  const pendingDirectStore = createDeferred();
+  const node = { id: 42, type: GENERATOR_NODE_TYPE };
+  const fixture = createFixture({
+    storeMode: "none",
+    directStorePlan: [pendingDirectStore.promise],
+  });
+  const root = appendNodeRoot(fixture.document, "42");
+
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node);
+  await flushPromises();
+  assert.equal(fixture.calls.directStoreLoads, 1);
+  assert.equal(fixture.mutationObservers.length, 1);
+  const disposedObserver = fixture.mutationObservers[0];
+  const pendingFrameIds = fixture.scheduler.frames.map(({ id }) => id).sort((left, right) => left - right);
+  const pendingTimerIds = [...fixture.scheduler.timers.keys()].sort((left, right) => left - right);
+
+  fixture.runtime.disposeGeneratorNativePreviewLifecycle(node);
+  assert.equal(fixture.scheduler.frames.length, 0, "Dispose must cancel every node-owned RAF");
+  assert.equal(fixture.scheduler.timers.size, 0, "Dispose must clear every node-owned timer");
+  assert.deepEqual(
+    [...fixture.scheduler.canceledFrames].sort((left, right) => left - right),
+    pendingFrameIds,
+  );
+  for (const timerId of pendingTimerIds) {
+    assert.equal(fixture.scheduler.cleared.includes(timerId), true, `Dispose retained timer ${timerId}`);
+  }
+  assert.equal(disposedObserver.disconnectCalls, 1, "Dispose must disconnect each observer once");
+
+  const canceledFramesAfterDispose = [...fixture.scheduler.canceledFrames];
+  const clearedAfterDispose = [...fixture.scheduler.cleared];
+  fixture.runtime.disposeGeneratorNativePreviewLifecycle(node);
+  assert.deepEqual(fixture.scheduler.canceledFrames, canceledFramesAfterDispose, "Dispose must be idempotent");
+  assert.deepEqual(fixture.scheduler.cleared, clearedAfterDispose, "Idempotent dispose must not clear twice");
+  assert.equal(disposedObserver.disconnectCalls, 1);
+
+  const disposedSnapshot = adapterChannelSnapshot(fixture.calls);
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node);
+  assert.deepEqual(
+    adapterChannelSnapshot(fixture.calls),
+    disposedSnapshot,
+    "A disposed lifecycle must reject new scheduling",
+  );
+  assert.equal(fixture.scheduler.frames.length, 0);
+  assert.equal(fixture.scheduler.timers.size, 0);
+  assert.equal(fixture.mutationObservers.length, 1);
+
+  fixture.runtime.activateGeneratorNativePreviewLifecycle(node);
+  fixture.runtime.scheduleGeneratorDefaultPreviewSuppression(node, { purgeStore: false });
+  assert.equal(fixture.calls.suppress.length, disposedSnapshot.suppress + 1);
+  assert.equal(fixture.mutationObservers.length, 2, "Activate must permit a fresh observer");
+  const activeObserver = fixture.mutationObservers[1];
+  const activeFrameIds = fixture.scheduler.frames.map(({ id }) => id);
+  const activeTimerIds = [...fixture.scheduler.timers.keys()];
+  const reactivatedTarget = fixture.document.createElement("img");
+  reactivatedTarget.className = "pointer-events-none object-contain";
+  root.append(reactivatedTarget);
+  const unobservedRoot = appendNodeRoot(fixture.document, "7:42");
+  const unobservedTarget = fixture.document.createElement("img");
+  unobservedTarget.className = "pointer-events-none object-contain";
+  unobservedRoot.append(unobservedTarget);
+  const activeSnapshot = adapterChannelSnapshot(fixture.calls);
+
+  fixture.scheduler.runCanceledCallbacks();
+  assert.deepEqual(
+    adapterChannelSnapshot(fixture.calls),
+    activeSnapshot,
+    "Canceled callbacks from a disposed generation must remain no-ops after activate",
+  );
+  assert.deepEqual(fixture.scheduler.frames.map(({ id }) => id), activeFrameIds);
+  assert.deepEqual([...fixture.scheduler.timers.keys()], activeTimerIds);
+  assert.equal(activeObserver.disconnectCalls, 0, "A stale stop timer must not disconnect the active observer");
+  disposedObserver.trigger();
+  assert.equal(
+    reactivatedTarget.classList.contains(NATIVE_HIDDEN_CLASS),
+    false,
+    "An observer from the disposed generation must not touch the reactivated root",
+  );
+  assert.equal(
+    unobservedTarget.classList.contains(NATIVE_HIDDEN_CLASS),
+    false,
+    "An observer from the disposed generation must not rescan an unobserved root",
+  );
+
+  pendingDirectStore.resolve([
+    { useNodeOutputStore: () => fixture.outputStore },
+    { useWorkflowStore: () => fixture.workflowStore },
+  ]);
+  await flushPromises();
+  assert.equal(fixture.revokeCalls.length, 0, "A late store resolution from a disposed generation must be ignored");
+  assert.equal(fixture.workflowLocatorCalls.length, 0);
+
+  activeObserver.trigger();
+  assertHidden(reactivatedTarget, "Activate must restore the current observer lifecycle");
+  assert.equal(unobservedTarget.classList.contains(NATIVE_HIDDEN_CLASS), false);
 }
 
 {

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -212,9 +212,19 @@ class AIOFrontendSourceTests(unittest.TestCase):
         body = generator_block[start:end]
 
         self.assertIn("nodeType.prototype.hideOutputImages = true", source)
-        self.assertIn(
-            "module?.useNodeOutputStore || module?.cn || module?.L",
-            native_preview_source,
+        for store_alias in (
+            "module?.useNodeOutputStore,",
+            "module?.cn,",
+            "module?.L,",
+            "module?.useWorkflowStore,",
+            "module?.M,",
+        ):
+            self.assertIn(store_alias, native_preview_source)
+        self.assertGreaterEqual(
+            native_preview_source.count(
+                '.find((candidate) => typeof candidate === "function")'
+            ),
+            2,
         )
         self.assertIn(
             "outputStore.revokePreviewsByLocatorId?.(locator);",
@@ -236,7 +246,84 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground", source)
         self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)
         self.assertIn("updateGeneratorExecutedStatus(this, message);", body)
+        self.assertIn(
+            "scheduleGeneratorDefaultPreviewSuppression(this, { purgeStore: false });",
+            body,
+        )
+        self.assertEqual(
+            body.count("scheduleGeneratorDefaultPreviewSuppression(this"),
+            2,
+        )
+        self.assertLess(
+            body.index("scheduleGeneratorDefaultPreviewSuppression(this);"),
+            body.index("updateGeneratorExecutedStatus(this, message);"),
+        )
+        self.assertLess(
+            body.index("updateGeneratorExecutedStatus(this, message);"),
+            body.index(
+                "scheduleGeneratorDefaultPreviewSuppression(this, "
+                "{ purgeStore: false });"
+            ),
+        )
         self.assertNotIn("onExecuted?.apply", body)
+
+        suppression_start = native_preview_source.index(
+            "function scheduleGeneratorDefaultPreviewSuppression"
+        )
+        suppression_end = native_preview_source.index(
+            "\n  function findGeneratorNodeByQualifiedId", suppression_start
+        )
+        suppression_body = native_preview_source[suppression_start:suppression_end]
+        delayed_start = suppression_body.index("const suppress =")
+        delayed_end = suppression_body.index(
+            "\n    scheduleGeneratorNativePreviewFrame", delayed_start
+        )
+        delayed_body = suppression_body[delayed_start:delayed_end]
+        self.assertIn(
+            "scheduleGeneratorNativeLivePreviewPurge(node, purgeDetail);",
+            suppression_body[:delayed_start],
+        )
+        self.assertNotIn(
+            "scheduleGeneratorNativeLivePreviewPurge(",
+            delayed_body,
+        )
+
+    def test_generator_native_preview_lifecycle_disposes_on_generator_removal(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        registration_start = source.index("async beforeRegisterNodeDef")
+        configure_start = source.index(
+            "const onConfigure = nodeType.prototype.onConfigure;",
+            registration_start,
+        )
+        generator_hooks_start = source.index(
+            "    if (nodeData.name === GENERATOR_NODE_TYPE) {",
+            configure_start,
+        )
+        generator_hooks_end = source.index(
+            "\n    }\n  },\n});",
+            generator_hooks_start,
+        )
+        generator_hooks = source[generator_hooks_start:generator_hooks_end]
+
+        self.assertNotIn(
+            "const onRemoved = nodeType.prototype.onRemoved;",
+            source[registration_start:generator_hooks_start],
+        )
+        self.assertEqual(
+            source.count("const onRemoved = nodeType.prototype.onRemoved;"),
+            1,
+        )
+        self.assertIn(
+            """      const onRemoved = nodeType.prototype.onRemoved;
+      nodeType.prototype.onRemoved = function () {
+        try {
+          return onRemoved?.apply(this, arguments);
+        } finally {
+          disposeGeneratorNativePreviewLifecycle(this);
+        }
+      };""",
+            generator_hooks,
+        )
 
     def test_generator_preview_meta_keeps_dedicated_resolution_label(self):
         source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -563,7 +563,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         )
 
         moved_functions = {
+            "activateGeneratorNativePreviewLifecycle",
             "cssEscape",
+            "disposeGeneratorNativePreviewLifecycle",
             "generatorVueNodeRoots",
             "generatorNativePreviewRootMatchesNode",
             "addGeneratorPreviewLocatorCandidate",
@@ -608,6 +610,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 self.assertNotRegex(entry_source, rf"\blet\s+{moved_state}\s*=")
 
         expected_facades = {
+            "activateGeneratorNativePreviewLifecycle",
+            "disposeGeneratorNativePreviewLifecycle",
             "markGeneratorNativeLivePreviewHidden",
             "suppressGeneratorDefaultPreview",
             "scheduleGeneratorDefaultPreviewSuppression",
@@ -652,6 +656,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 "window",
                 "MutationObserver",
                 "requestAnimationFrame",
+                "cancelAnimationFrame",
                 "setTimeout",
                 "clearTimeout",
             },
@@ -713,9 +718,11 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "entry-relative direct store imports": (
                 r"loadDirectStoreModules\s*:\s*\(\s*\)\s*=>\s*"
                 r"Promise\.all\(\s*\[\s*"
-                r'import\(\s*"\.\./\.\./\.\./stores/nodeOutputStore\.js"\s*\)\s*,\s*'
+                r'import\(\s*"\.\./\.\./\.\./stores/nodeOutputStore\.js"\s*\)\s*'
+                r"\.catch\(\s*\(\s*\)\s*=>\s*null\s*\)\s*,\s*"
                 r'import\(\s*"\.\./\.\./\.\./platform/workflow/management/'
-                r'stores/workflowStore\.js"\s*\)\s*,?\s*'
+                r'stores/workflowStore\.js"\s*\)\s*'
+                r"\.catch\(\s*\(\s*\)\s*=>\s*null\s*\)\s*,?\s*"
                 r"\]\s*\)"
             ),
             "frontend HTML fetch": (
@@ -728,6 +735,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
             ),
             "live graph getter": (
                 r"getGraph\s*:\s*\(\s*\)\s*=>\s*app\.graph"
+            ),
+            "animation frame canceler": (
+                r"cancelAnimationFrame\s*:\s*\(\s*frame\s*\)\s*=>\s*"
+                r"cancelAnimationFrame\(\s*frame\s*\)"
             ),
         }
         for adapter_name, pattern in expected_adapter_values.items():
@@ -795,6 +806,17 @@ class FrontendModuleStructureTests(unittest.TestCase):
                     rf"\bfunction\s+{entry_owned_function}\(",
                 )
 
+        hook_start = entry_source.index("function hookGeneratorNode")
+        hook_end = entry_source.index(
+            "\nfunction addGeneratorPreviewImagesToNode", hook_start
+        )
+        hook_body = entry_source[hook_start:hook_end]
+        self.assertIn("activateGeneratorNativePreviewLifecycle(node);", hook_body)
+        self.assertLess(
+            hook_body.index("activateGeneratorNativePreviewLifecycle(node);"),
+            hook_body.index("suppressGeneratorDefaultPreview(node"),
+        )
+
         for progress_facade in (
             "rememberGeneratorProgress",
             "rememberGeneratorProgressState",
@@ -828,6 +850,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "onSerialize",
             "onExecuted",
             "onResize",
+            "onRemoved",
         ):
             with self.subTest(entry_owned_prototype_hook=prototype_hook):
                 self.assertIn(f"nodeType.prototype.{prototype_hook}", entry_source)

--- a/web/js/aio/native_preview_runtime.js
+++ b/web/js/aio/native_preview_runtime.js
@@ -11,6 +11,7 @@
  *     window: any,
  *     MutationObserver: any,
  *     requestAnimationFrame: (callback: any) => any,
+ *     cancelAnimationFrame: (frame: any) => void,
  *     setTimeout: (callback: any, delay: number) => any,
  *     clearTimeout: (timer: any) => void,
  *   },
@@ -52,6 +53,7 @@ export function aioCreateNativePreviewRuntime(dependencies) {
     window,
     MutationObserver,
     requestAnimationFrame,
+    cancelAnimationFrame,
     setTimeout,
     clearTimeout,
   } = dependencies.environment;
@@ -85,6 +87,140 @@ export function aioCreateNativePreviewRuntime(dependencies) {
     rememberState: rememberGeneratorProgressState,
     clear: clearGeneratorPreviewProgress,
   } = dependencies.progressAdapter;
+
+  const generatorNativePreviewLifecycleStates = new WeakMap();
+  const disposedGeneratorNativePreviewNodes = new WeakSet();
+
+  function createGeneratorNativePreviewLifecycleState() {
+    return {
+      frames: new Map(),
+      timers: new Map(),
+      observers: new Map(),
+      purgeBatchActive: false,
+      purgeIds: new Set(),
+      purgeStorePromise: null,
+      hideBatchActive: false,
+      suppressionBatchActive: false,
+      suppressionShouldPurge: false,
+      suppressionPurgeIds: new Set(),
+      suppressionStorePromise: null,
+    };
+  }
+
+  function activateGeneratorNativePreviewLifecycle(node) {
+    if (!node) {
+      return false;
+    }
+    disposedGeneratorNativePreviewNodes.delete(node);
+    if (!generatorNativePreviewLifecycleStates.has(node)) {
+      generatorNativePreviewLifecycleStates.set(
+        node,
+        createGeneratorNativePreviewLifecycleState(),
+      );
+    }
+    return true;
+  }
+
+  function isGeneratorNativePreviewDisposed(node) {
+    return !node || disposedGeneratorNativePreviewNodes.has(node);
+  }
+
+  function generatorNativePreviewLifecycleState(node) {
+    if (isGeneratorNativePreviewDisposed(node)) {
+      return null;
+    }
+    activateGeneratorNativePreviewLifecycle(node);
+    return generatorNativePreviewLifecycleStates.get(node) || null;
+  }
+
+  function isGeneratorNativePreviewLifecycleCurrent(node, state) {
+    return (
+      !!state
+      && !isGeneratorNativePreviewDisposed(node)
+      && generatorNativePreviewLifecycleStates.get(node) === state
+    );
+  }
+
+  function scheduleGeneratorNativePreviewFrame(node, key, callback) {
+    const state = generatorNativePreviewLifecycleState(node);
+    if (!state) {
+      return null;
+    }
+    const existing = state.frames.get(key);
+    if (existing != null) {
+      return existing;
+    }
+    let frame = null;
+    frame = requestAnimationFrame(() => {
+      if (state.frames.get(key) !== frame) {
+        return;
+      }
+      state.frames.delete(key);
+      if (isGeneratorNativePreviewLifecycleCurrent(node, state)) {
+        callback(state);
+      }
+    });
+    state.frames.set(key, frame);
+    return frame;
+  }
+
+  function scheduleGeneratorNativePreviewTimer(node, key, delay, callback, options = {}) {
+    const state = generatorNativePreviewLifecycleState(node);
+    if (!state) {
+      return null;
+    }
+    const existing = state.timers.get(key);
+    if (existing != null) {
+      if (options.replace !== true) {
+        return existing;
+      }
+      clearTimeout(existing);
+      state.timers.delete(key);
+    }
+    let timer = null;
+    timer = setTimeout(() => {
+      if (state.timers.get(key) !== timer) {
+        return;
+      }
+      state.timers.delete(key);
+      if (isGeneratorNativePreviewLifecycleCurrent(node, state)) {
+        callback(state);
+      }
+    }, delay);
+    state.timers.set(key, timer);
+    return timer;
+  }
+
+  function disconnectGeneratorNativePreviewObservers(state) {
+    for (const observer of state?.observers?.values?.() || []) {
+      observer.disconnect();
+    }
+    state?.observers?.clear?.();
+  }
+
+  function disposeGeneratorNativePreviewLifecycle(node) {
+    if (!node || disposedGeneratorNativePreviewNodes.has(node)) {
+      return false;
+    }
+    disposedGeneratorNativePreviewNodes.add(node);
+    const state = generatorNativePreviewLifecycleStates.get(node);
+    if (state) {
+      for (const frame of state.frames.values()) {
+        cancelAnimationFrame(frame);
+      }
+      state.frames.clear();
+      for (const timer of state.timers.values()) {
+        clearTimeout(timer);
+      }
+      state.timers.clear();
+      disconnectGeneratorNativePreviewObservers(state);
+      state.purgeIds.clear();
+      state.suppressionPurgeIds.clear();
+      generatorNativePreviewLifecycleStates.delete(node);
+    }
+    clearGeneratorDenoisePreview(node, false);
+    return true;
+  }
 
   function cssEscape(value) {
     if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
@@ -265,22 +401,26 @@ export function aioCreateNativePreviewRuntime(dependencies) {
     }
   }
 
+  function hideGeneratorNativeLivePreviewRoot(root) {
+    root.classList?.add?.(GENERATOR_VUE_NODE_CLASS);
+    hideGeneratorNativeLivePreviewElements(root);
+  }
+
   function markGeneratorNativeLivePreviewHidden(node) {
-    if (!node || typeof document === "undefined") {
+    if (isGeneratorNativePreviewDisposed(node) || typeof document === "undefined") {
       return;
     }
     for (const root of generatorVueNodeRoots(node)) {
-      root.classList.add(GENERATOR_VUE_NODE_CLASS);
-      hideGeneratorNativeLivePreviewElements(root);
+      hideGeneratorNativeLivePreviewRoot(root);
     }
   }
 
   let generatorNativePreviewStoresPromise = null;
   let generatorDialogServiceAssetUrlPromise = null;
 
-  async function generatorDialogServiceAssetUrl() {
+  function generatorDialogServiceAssetUrl() {
     if (!generatorDialogServiceAssetUrlPromise) {
-      generatorDialogServiceAssetUrlPromise = (async () => {
+      const attempt = (async () => {
         if (typeof document !== "undefined") {
           const elements = document.querySelectorAll("link[href], script[src]");
           for (const element of elements) {
@@ -294,19 +434,29 @@ export function aioCreateNativePreviewRuntime(dependencies) {
         const match = html.match(/(?:\.\/)?assets\/dialogService-[^"'<>]+\.js/);
         return match ? new URL(match[0], window.location.href).href : "";
       })().catch(() => "");
+      generatorDialogServiceAssetUrlPromise = attempt;
+      void attempt.then((url) => {
+        if (!url && generatorDialogServiceAssetUrlPromise === attempt) {
+          generatorDialogServiceAssetUrlPromise = null;
+        }
+      });
     }
     return generatorDialogServiceAssetUrlPromise;
   }
 
-  async function generatorNativePreviewStores() {
+  function generatorNativePreviewStores() {
     if (!generatorNativePreviewStoresPromise) {
-      generatorNativePreviewStoresPromise = (async () => {
+      const attempt = (async () => {
         try {
           const [nodeOutputStoreModule, workflowStoreModule] = await loadDirectStoreModules();
-          if (nodeOutputStoreModule?.useNodeOutputStore && workflowStoreModule?.useWorkflowStore) {
+          const useNodeOutputStore = nodeOutputStoreModule?.useNodeOutputStore;
+          const useWorkflowStore = workflowStoreModule?.useWorkflowStore;
+          if (typeof useNodeOutputStore === "function") {
             return {
-              useNodeOutputStore: nodeOutputStoreModule.useNodeOutputStore,
-              useWorkflowStore: workflowStoreModule.useWorkflowStore,
+              useNodeOutputStore,
+              useWorkflowStore: typeof useWorkflowStore === "function"
+                ? useWorkflowStore
+                : null,
             };
           }
         } catch {
@@ -319,50 +469,83 @@ export function aioCreateNativePreviewRuntime(dependencies) {
         }
         try {
           const module = await importAssetModule(url);
-          return {
-            useNodeOutputStore: module?.useNodeOutputStore || module?.cn || module?.L,
-            useWorkflowStore: module?.useWorkflowStore || module?.M,
+          const useNodeOutputStore = [
+            module?.useNodeOutputStore,
+            module?.cn,
+            module?.L,
+          ].find((candidate) => typeof candidate === "function") || null;
+          const useWorkflowStore = [
+            module?.useWorkflowStore,
+            module?.M,
+          ].find((candidate) => typeof candidate === "function") || null;
+          const stores = {
+            useNodeOutputStore,
+            useWorkflowStore: typeof useWorkflowStore === "function"
+              ? useWorkflowStore
+              : null,
           };
+          if (typeof stores.useNodeOutputStore === "function") {
+            return stores;
+          }
+          return null;
         } catch {
           return null;
         }
-      })();
+      })().catch(() => null);
+      generatorNativePreviewStoresPromise = attempt;
+      void attempt.then((stores) => {
+        if (!stores && generatorNativePreviewStoresPromise === attempt) {
+          generatorNativePreviewStoresPromise = null;
+        }
+      });
     }
     return generatorNativePreviewStoresPromise;
   }
 
-  async function purgeGeneratorNativeLivePreviewStore(node, detail = null) {
+  async function purgeGeneratorNativeLivePreviewStore(node, ids, storesPromise, lifecycleState) {
     try {
-      if (!node) {
+      if (!isGeneratorNativePreviewLifecycleCurrent(node, lifecycleState)) {
         return;
       }
-      const ids = generatorPreviewLocatorCandidates(node, detail);
-      if (!ids.length) {
+      const purgeIds = [...new Set(ids || [])].filter(Boolean);
+      if (!purgeIds.length) {
         return;
       }
       const legacyPreviewImages = getLegacyPreviewImages();
       if (legacyPreviewImages && typeof legacyPreviewImages === "object") {
-        for (const id of ids) {
+        for (const id of purgeIds) {
           aioDeletePreviewStoreEntry(legacyPreviewImages, id);
         }
       }
 
-      const stores = await generatorNativePreviewStores();
+      const stores = await storesPromise;
+      if (!isGeneratorNativePreviewLifecycleCurrent(node, lifecycleState)) {
+        return;
+      }
       const outputStore = stores?.useNodeOutputStore?.();
       if (!outputStore) {
         return;
       }
-      const workflowStore = stores?.useWorkflowStore?.();
-      const locators = new Set(ids);
-      for (const id of ids) {
+      let workflowStore = null;
+      try {
+        workflowStore = stores?.useWorkflowStore?.() ?? null;
+      } catch {
+        // Workflow locator support is optional; raw output locators must still be purged.
+      }
+      const locators = new Set(purgeIds);
+      for (const id of purgeIds) {
         const leaf = String(id).split(":").pop();
         if (!leaf) {
           continue;
         }
         locators.add(leaf);
-        const locator = workflowStore?.nodeIdToNodeLocatorId?.(leaf);
-        if (locator) {
-          locators.add(locator);
+        try {
+          const locator = workflowStore?.nodeIdToNodeLocatorId?.(leaf);
+          if (locator) {
+            locators.add(locator);
+          }
+        } catch {
+          // Keep best-effort workflow mapping isolated from raw output-store cleanup.
         }
       }
       for (const locator of locators) {
@@ -374,36 +557,78 @@ export function aioCreateNativePreviewRuntime(dependencies) {
     }
   }
 
+  function addGeneratorNativePreviewPurgeIds(target, node, detail = null) {
+    const ids = generatorPreviewLocatorCandidates(node, detail);
+    for (const id of ids) {
+      target.add(id);
+    }
+    return ids;
+  }
+
   function scheduleGeneratorNativeLivePreviewPurge(node, detail = null) {
-    void purgeGeneratorNativeLivePreviewStore(node, detail);
-    requestAnimationFrame(() => {
-      void purgeGeneratorNativeLivePreviewStore(node, detail);
-    });
-    setTimeout(() => {
-      void purgeGeneratorNativeLivePreviewStore(node, detail);
-    }, 80);
-    setTimeout(() => {
-      void purgeGeneratorNativeLivePreviewStore(node, detail);
-    }, 240);
+    const state = generatorNativePreviewLifecycleState(node);
+    if (!state) {
+      return;
+    }
+    const requestIds = addGeneratorNativePreviewPurgeIds(state.purgeIds, node, detail);
+    if (!requestIds.length) {
+      return;
+    }
+    if (!state.purgeStorePromise) {
+      state.purgeStorePromise = generatorNativePreviewStores();
+    }
+    void purgeGeneratorNativeLivePreviewStore(
+      node,
+      requestIds,
+      state.purgeStorePromise,
+      state,
+    );
+    if (!state.purgeBatchActive) {
+      state.purgeBatchActive = true;
+      scheduleGeneratorNativePreviewFrame(node, "purge", (current) => {
+        addGeneratorNativePreviewPurgeIds(current.purgeIds, node);
+        void purgeGeneratorNativeLivePreviewStore(
+          node,
+          [...current.purgeIds],
+          current.purgeStorePromise,
+          current,
+        );
+      });
+    }
+    scheduleGeneratorNativePreviewTimer(node, "purge-80", 80, (current) => {
+      addGeneratorNativePreviewPurgeIds(current.purgeIds, node);
+      void purgeGeneratorNativeLivePreviewStore(
+        node,
+        [...current.purgeIds],
+        current.purgeStorePromise,
+        current,
+      );
+    }, { replace: true });
+    scheduleGeneratorNativePreviewTimer(node, "purge-240", 240, (current) => {
+      addGeneratorNativePreviewPurgeIds(current.purgeIds, node);
+      const pendingIds = [...current.purgeIds];
+      const storePromise = current.purgeStorePromise;
+      current.purgeBatchActive = false;
+      current.purgeIds.clear();
+      current.purgeStorePromise = null;
+      void purgeGeneratorNativeLivePreviewStore(node, pendingIds, storePromise, current);
+    }, { replace: true });
   }
 
   function stopGeneratorNativeLivePreviewObserver(node) {
-    const observers = node?.__easyuseAnimaNativeLivePreviewObservers;
-    if (!observers) {
+    const state = generatorNativePreviewLifecycleStates.get(node);
+    if (!state) {
       return;
     }
-    for (const observer of observers.values()) {
-      observer.disconnect();
-    }
-    observers.clear();
+    disconnectGeneratorNativePreviewObservers(state);
   }
 
   function ensureGeneratorNativeLivePreviewObserver(node) {
-    if (!node || !MutationObserver) {
+    const state = generatorNativePreviewLifecycleState(node);
+    if (!state || !MutationObserver) {
       return;
     }
-    const observers = node.__easyuseAnimaNativeLivePreviewObservers || new Map();
-    node.__easyuseAnimaNativeLivePreviewObservers = observers;
+    const { observers } = state;
     for (const [root, observer] of observers) {
       if (!root?.isConnected) {
         observer.disconnect();
@@ -414,33 +639,55 @@ export function aioCreateNativePreviewRuntime(dependencies) {
       if (!root || observers.has(root)) {
         continue;
       }
-      const observer = new MutationObserver(() => markGeneratorNativeLivePreviewHidden(node));
+      const observer = new MutationObserver(() => {
+        if (!isGeneratorNativePreviewLifecycleCurrent(node, state)) {
+          return;
+        }
+        if (!root?.isConnected) {
+          return;
+        }
+        if (state.frames.has(root)) {
+          return;
+        }
+        hideGeneratorNativeLivePreviewRoot(root);
+        scheduleGeneratorNativePreviewFrame(node, root, () => {
+          if (root?.isConnected) {
+            hideGeneratorNativeLivePreviewRoot(root);
+          }
+        });
+      });
       observer.observe(root, { childList: true, subtree: true });
       observers.set(root, observer);
     }
-    clearTimeout(node.__easyuseAnimaNativeLivePreviewObserverStopTimer);
-    node.__easyuseAnimaNativeLivePreviewObserverStopTimer = setTimeout(() => {
+    scheduleGeneratorNativePreviewTimer(node, "observer-stop", 5000, () => {
       stopGeneratorNativeLivePreviewObserver(node);
-    }, 5000);
+    }, { replace: true });
   }
 
   function scheduleGeneratorNativeLivePreviewHidden(node) {
-    markGeneratorNativeLivePreviewHidden(node);
-    ensureGeneratorNativeLivePreviewObserver(node);
-    if (node.__easyuseAnimaNativeLivePreviewHideScheduled) {
+    const state = generatorNativePreviewLifecycleState(node);
+    if (!state) {
       return;
     }
-    node.__easyuseAnimaNativeLivePreviewHideScheduled = true;
+    markGeneratorNativeLivePreviewHidden(node);
+    ensureGeneratorNativeLivePreviewObserver(node);
+    if (state.hideBatchActive) {
+      return;
+    }
+    state.hideBatchActive = true;
     const hide = () => markGeneratorNativeLivePreviewHidden(node);
-    requestAnimationFrame(hide);
-    setTimeout(hide, 80);
-    setTimeout(() => {
-      node.__easyuseAnimaNativeLivePreviewHideScheduled = false;
+    scheduleGeneratorNativePreviewFrame(node, "hide", hide);
+    scheduleGeneratorNativePreviewTimer(node, "hide-80", 80, hide);
+    scheduleGeneratorNativePreviewTimer(node, "hide-240", 240, (current) => {
+      current.hideBatchActive = false;
       hide();
-    }, 240);
+    });
   }
 
   function suppressGeneratorDefaultPreview(node, options = {}) {
+    if (isGeneratorNativePreviewDisposed(node)) {
+      return false;
+    }
     return aioSuppressDefaultPreview(node, {
       markDirty: options.markDirty,
       markNodeDirty,
@@ -448,30 +695,50 @@ export function aioCreateNativePreviewRuntime(dependencies) {
   }
 
   function scheduleGeneratorDefaultPreviewSuppression(node, options = {}) {
+    const state = generatorNativePreviewLifecycleState(node);
+    if (!state) {
+      return;
+    }
     const shouldPurgeStore = options.purgeStore !== false;
     const purgeDetail = options.purgeDetail || null;
     suppressGeneratorDefaultPreview(node);
     if (shouldPurgeStore) {
+      addGeneratorNativePreviewPurgeIds(state.suppressionPurgeIds, node, purgeDetail);
+      state.suppressionShouldPurge = true;
       scheduleGeneratorNativeLivePreviewPurge(node, purgeDetail);
+      state.suppressionStorePromise ||= state.purgeStorePromise;
     }
     scheduleGeneratorNativeLivePreviewHidden(node);
-    if (node.__easyuseAnimaDefaultPreviewSuppressionScheduled) {
+    if (state.suppressionBatchActive) {
       return;
     }
-    node.__easyuseAnimaDefaultPreviewSuppressionScheduled = true;
-    const suppress = () => {
+    state.suppressionBatchActive = true;
+    const suppress = (current, final = false) => {
       suppressGeneratorDefaultPreview(node);
-      if (shouldPurgeStore) {
-        scheduleGeneratorNativeLivePreviewPurge(node, purgeDetail);
+      if (current.suppressionShouldPurge) {
+        addGeneratorNativePreviewPurgeIds(current.suppressionPurgeIds, node);
+        const pendingIds = [...current.suppressionPurgeIds];
+        const storePromise = current.suppressionStorePromise;
+        if (final) {
+          current.suppressionShouldPurge = false;
+          current.suppressionPurgeIds.clear();
+          current.suppressionStorePromise = null;
+        }
+        void purgeGeneratorNativeLivePreviewStore(
+          node,
+          pendingIds,
+          storePromise,
+          current,
+        );
       }
       markGeneratorNativeLivePreviewHidden(node);
     };
-    requestAnimationFrame(suppress);
-    setTimeout(suppress, 120);
-    setTimeout(() => {
-      node.__easyuseAnimaDefaultPreviewSuppressionScheduled = false;
-      suppress();
-    }, 360);
+    scheduleGeneratorNativePreviewFrame(node, "suppress", suppress);
+    scheduleGeneratorNativePreviewTimer(node, "suppress-120", 120, suppress);
+    scheduleGeneratorNativePreviewTimer(node, "suppress-360", 360, (current) => {
+      current.suppressionBatchActive = false;
+      suppress(current, true);
+    });
   }
 
   function findGeneratorNodeByQualifiedId(rootGraph, nodeId) {
@@ -510,7 +777,7 @@ export function aioCreateNativePreviewRuntime(dependencies) {
   function handleGeneratorPreviewEvent(event) {
     const detail = aioPreviewEventDetail(event);
     const node = findGeneratorNodeByQualifiedId(getGraph(), detail.node);
-    if (!node || node.type !== GENERATOR_NODE_TYPE) {
+    if (!node || node.type !== GENERATOR_NODE_TYPE || isGeneratorNativePreviewDisposed(node)) {
       return;
     }
     scheduleGeneratorNativeLivePreviewPurge(node, detail);
@@ -522,7 +789,7 @@ export function aioCreateNativePreviewRuntime(dependencies) {
   function findGeneratorNodeForDenoisePreview(detail) {
     for (const id of aioPreviewNodeIdsFromDetail(detail)) {
       const node = findGeneratorNodeByQualifiedId(getGraph(), id);
-      if (node?.type === GENERATOR_NODE_TYPE) {
+      if (node?.type === GENERATOR_NODE_TYPE && !isGeneratorNativePreviewDisposed(node)) {
         return node;
       }
     }
@@ -553,7 +820,7 @@ export function aioCreateNativePreviewRuntime(dependencies) {
   function handleGeneratorExecutingEvent(event) {
     const nodeId = aioPreviewEventDetail(event);
     const node = findGeneratorNodeByQualifiedId(getGraph(), nodeId);
-    if (node?.type === GENERATOR_NODE_TYPE) {
+    if (node?.type === GENERATOR_NODE_TYPE && !isGeneratorNativePreviewDisposed(node)) {
       clearGeneratorDenoisePreview(node, true);
       scheduleGeneratorDefaultPreviewSuppression(node);
     }
@@ -562,7 +829,7 @@ export function aioCreateNativePreviewRuntime(dependencies) {
   function clearGeneratorDenoisePreviews() {
     clearGeneratorPreviewProgress();
     for (const node of listGeneratorNodes()) {
-      if (node?.type === GENERATOR_NODE_TYPE) {
+      if (node?.type === GENERATOR_NODE_TYPE && !isGeneratorNativePreviewDisposed(node)) {
         clearGeneratorDenoisePreview(node, true);
         scheduleGeneratorDefaultPreviewSuppression(node);
       }
@@ -570,6 +837,8 @@ export function aioCreateNativePreviewRuntime(dependencies) {
   }
 
   return {
+    activateGeneratorNativePreviewLifecycle,
+    disposeGeneratorNativePreviewLifecycle,
     markGeneratorNativeLivePreviewHidden,
     suppressGeneratorDefaultPreview,
     scheduleGeneratorDefaultPreviewSuppression,

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -3940,6 +3940,8 @@ const openAdvancedSettings = aioCreateAdvancedSettingsDialog({
 });
 
 const {
+  activateGeneratorNativePreviewLifecycle,
+  disposeGeneratorNativePreviewLifecycle,
   markGeneratorNativeLivePreviewHidden,
   suppressGeneratorDefaultPreview,
   scheduleGeneratorDefaultPreviewSuppression,
@@ -3955,6 +3957,7 @@ const {
     window,
     MutationObserver: globalThis.MutationObserver,
     requestAnimationFrame: (callback) => requestAnimationFrame(callback),
+    cancelAnimationFrame: (frame) => cancelAnimationFrame(frame),
     setTimeout: (callback, delay) => setTimeout(callback, delay),
     clearTimeout: (timer) => clearTimeout(timer),
   },
@@ -3965,8 +3968,8 @@ const {
   storeAdapter: {
     getLegacyPreviewImages: () => app.nodePreviewImages,
     loadDirectStoreModules: () => Promise.all([
-      import("../../../stores/nodeOutputStore.js"),
-      import("../../../platform/workflow/management/stores/workflowStore.js"),
+      import("../../../stores/nodeOutputStore.js").catch(() => null),
+      import("../../../platform/workflow/management/stores/workflowStore.js").catch(() => null),
     ]),
     fetchFrontendHtml: () => easyuseAnimaFetchText("/"),
     importAssetModule: (url) => import(url),
@@ -4072,6 +4075,7 @@ function hookInputNode(node) {
 }
 
 function hookGeneratorNode(node) {
+  activateGeneratorNativePreviewLifecycle(node);
   node.serialize_widgets = true;
   suppressGeneratorDefaultPreview(node, { markDirty: false });
   hideWidget(findWidget(node, GENERATOR_SETTINGS_WIDGET));
@@ -4205,7 +4209,7 @@ app.registerExtension({
       nodeType.prototype.onExecuted = function (message) {
         scheduleGeneratorDefaultPreviewSuppression(this);
         updateGeneratorExecutedStatus(this, message);
-        scheduleGeneratorDefaultPreviewSuppression(this);
+        scheduleGeneratorDefaultPreviewSuppression(this, { purgeStore: false });
         return undefined;
       };
       const onResize = nodeType.prototype.onResize;
@@ -4213,6 +4217,14 @@ app.registerExtension({
         const result = onResize?.apply(this, arguments);
         scheduleGeneratorLayout(this);
         return result;
+      };
+      const onRemoved = nodeType.prototype.onRemoved;
+      nodeType.prototype.onRemoved = function () {
+        try {
+          return onRemoved?.apply(this, arguments);
+        } finally {
+          disposeGeneratorNativePreviewLifecycle(this);
+        }
       };
     }
   },


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 native preview 관련 RAF, timer, observer, purge batch를 node-owned lifecycle로 묶고 제거 시 모두 정리합니다.
- dispose 후 늦게 도착한 callback/store resolution이 재활성화된 node나 다른 node를 건드리지 않도록 lifecycle generation을 검증합니다.
- preview purge와 suppression을 bounded batch로 coalesce하고, observer mutation burst는 root별 immediate 1회 + RAF tail 1회로 제한합니다.
- direct/hashed store provider 로딩을 output-only 및 optional workflow store에 맞게 보강하고, transient 실패는 다음 batch에서 재시도하되 성공 결과는 공유 cache합니다.
- optional workflow provider/locator가 예외를 던져도 raw output id/leaf purge가 계속되도록 격리합니다.
- Generator `onRemoved`에서 기존 hook의 반환/예외 동작을 보존하며 lifecycle dispose를 항상 실행합니다.

## 주요 파일

- `web/js/aio/native_preview_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_native_preview_runtime_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`

## 검증

테스트 커밋: `5b82273772030013f730479a75abffc344641656`

Focused:

- `node tests\frontend_aio_native_preview_runtime_smoke.mjs` — 통과
- `python -m unittest tests.test_aio_frontend tests.test_frontend_modules` — 71 tests 통과
- `node --check` — 변경 production JS 2개 통과
- `git diff --check` — 통과

Official full runner:

- `tools\check_custom_node.ps1 -Project <PR worktree> -Profile full`
- Python unittest 370 tests 통과
- frontend 94 JavaScript files, TypeScript 6.0.3 통과
- project diff check 통과

ComfyUI Codex test instance:

- Legacy canvas: modern-node switch OFF 확인
  - Generator panel 1개, visible native preview 0
  - 실행 중 Generator 제거 후 6.5초 동안 ghost/late reappearance 0
  - undo 후 panel owner 1개, 재실행 history `success/completed`, running=0, pending=0
  - workflow 저장/reload 후 seed와 panel 상태 유지
  - 새 EasyUse Anima console 오류 없음
- Node 2.0: modern-node switch ON 및 Vue node 8개 확인
  - Generator root suppression class 유지, visible native image/header/content 0, custom panel 1개
  - 실행 중 제거 후 6.5초 동안 ghost/late reappearance 0
  - undo 후 owner 1개, 재실행 history `success/completed`, running=0, pending=0
  - workflow 저장/reload 후 seed, panel, suppression 상태 유지
  - 새 EasyUse Anima console 오류 없음
- 초기 modern-node OFF 상태로 복원
- ComfyUI v0.27.0 user instance manual check: 전체 유지보수 목표 완료 후 1회 수행 예정

## 감사 결과

최종 diff를 행동/호환성, 테스트 적합성, 아키텍처/성능 세 축으로 재감사했으며 Blocker/P2/P3가 남지 않았습니다.

## 남은 범위

이 PR은 native preview lifecycle 경계만 다룹니다. Generator panel render lifecycle, sampler optional-extra 보존, queue/seed 및 entry/global listener 정리는 Issue #54의 후속 reviewable slice로 유지합니다.

## 라벨 후보

저장소 라벨 체계가 확인되면 `type: fix`, `area: frontend`, `status: ready`를 적용합니다.