### PR TITLE
fix: preserve AiO sampler optional settings

### DIFF
--- a/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
@@ -711,6 +711,7 @@ for (const testCase of [
         spectrum_extra: Object.fromEntries([
           ["constructor", 2.5],
           ["toString", "quality"],
+          ["__proto__", true],
         ]),
       },
     },
@@ -718,7 +719,7 @@ for (const testCase of [
       spectrumAdvanced: Object.fromEntries([
         ["constructor", ["FLOAT", { default: 1 }]],
         ["toString", [["speed", "quality"], { default: "speed" }]],
-        ["__proto__", ["BOOLEAN", { default: true }]],
+        ["__proto__", ["BOOLEAN", { default: false }]],
       ]),
     },
   });

--- a/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
@@ -634,6 +634,121 @@ for (const testCase of [
   const fixture = createFixture({
     loaded: false,
     deferLoads: true,
+    settings: {
+      sampler: {
+        spectrum_extra: {
+          future_gain: 1.5,
+          future_mode: "quality",
+        },
+        spd_extra: {
+          future_flag: true,
+        },
+      },
+    },
+    nodeInputs: {
+      spectrumAdvanced: {
+        future_gain: ["FLOAT", { default: 1 }],
+        future_mode: [["speed", "quality"], { default: "speed" }],
+      },
+      spectrumSpd: {
+        future_flag: ["BOOLEAN", { default: false }],
+      },
+    },
+  });
+  fixture.openSamplerSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  assert.equal(sectionByHeading(dialog, "Detected Spectrum Inputs").classList.contains("hidden"), true);
+  assert.equal(sectionByHeading(dialog, "Detected SPD Inputs").classList.contains("hidden"), true);
+
+  action(dialog, "button.apply").emit("click");
+
+  assert.deepEqual(
+    fixture.node.settings.sampler.spectrum_extra,
+    { future_gain: 1.5, future_mode: "quality" },
+    "Fast Apply before optional dependency discovery must preserve Spectrum extras",
+  );
+  assert.deepEqual(
+    fixture.node.settings.sampler.spd_extra,
+    { future_flag: true },
+    "Fast Apply before optional dependency discovery must preserve SPD extras",
+  );
+  assert.deepEqual(dialog.trace.slice(-5), ["merge", "apply-visible", "write", "render", "remove"]);
+}
+
+{
+  const fixture = createFixture({
+    loaded: false,
+    deferLoads: true,
+    settings: {
+      sampler: {
+        spectrum_extra: ["invalid"],
+        spd_extra: "invalid",
+      },
+    },
+  });
+  fixture.openSamplerSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+
+  action(dialog, "button.apply").emit("click");
+
+  assert.deepEqual(
+    fixture.node.settings.sampler.spectrum_extra,
+    {},
+    "Malformed Spectrum extras must not be serialized as numeric array keys",
+  );
+  assert.deepEqual(
+    fixture.node.settings.sampler.spd_extra,
+    {},
+    "Malformed SPD extras must not be serialized as numeric string keys",
+  );
+}
+
+{
+  const fixture = createFixture({
+    available: { spectrumAdvanced: true },
+    settings: {
+      sampler: {
+        spectrum_extra: Object.fromEntries([
+          ["constructor", 2.5],
+          ["toString", "quality"],
+        ]),
+      },
+    },
+    nodeInputs: {
+      spectrumAdvanced: Object.fromEntries([
+        ["constructor", ["FLOAT", { default: 1 }]],
+        ["toString", [["speed", "quality"], { default: "speed" }]],
+        ["__proto__", ["BOOLEAN", { default: true }]],
+      ]),
+    },
+  });
+  fixture.openSamplerSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const dynamicSpectrum = sectionByHeading(dialog, "Detected Spectrum Inputs");
+  assert.equal(controlIn(dynamicSpectrum, "constructor").value, "2.5");
+  assert.equal(controlIn(dynamicSpectrum, "toString").value, "quality");
+  assert.equal(controlIn(dynamicSpectrum, "__proto__").checked, true);
+
+  controlIn(dynamicSpectrum, "constructor").value = "3.5";
+  setSelectValue(controlIn(dynamicSpectrum, "toString"), "speed");
+  controlIn(dynamicSpectrum, "__proto__").checked = false;
+  action(dialog, "button.apply").emit("click");
+
+  assert.deepEqual(
+    fixture.node.settings.sampler.spectrum_extra,
+    Object.fromEntries([
+      ["constructor", 3.5],
+      ["toString", "speed"],
+      ["__proto__", false],
+    ]),
+    "Dynamic input values must retain own-key semantics for Object prototype names",
+  );
+}
+
+{
+  const fixture = createFixture({
+    loaded: false,
+    deferLoads: true,
     available: {
       spectrumAdvanced: true,
       spectrumSpd: true,
@@ -652,7 +767,8 @@ for (const testCase of [
         spd_extra: {
           future_variant: "single",
           future_strength: 1.25,
-          retired_spd_input: "remove-on-render",
+          retired_spd_input: "preserve-unrendered",
+          unsupported_image: "opaque-image-ref",
         },
         dave: { legacy: true },
         preserved_sampler_key: "keep-sampler",
@@ -780,12 +896,17 @@ for (const testCase of [
   assert.equal(written.preserved_root_key, "keep-root");
   assert.deepEqual(
     written.sampler.spectrum_extra,
-    {},
-    "Unavailable dynamic Spectrum controls retain the existing rendered-controls-only serialization behavior",
+    {
+      future_gain: 1.5,
+      retired_spectrum_input: "tracked-separately",
+    },
+    "Unavailable dynamic Spectrum controls must preserve existing extra values",
   );
   assert.deepEqual(written.sampler.spd_extra, {
     future_variant: "dual",
     future_strength: 2.5,
+    retired_spd_input: "preserve-unrendered",
+    unsupported_image: "opaque-image-ref",
   });
   assert.deepEqual(JSON.parse(fixture.node.widgets[0].value), written);
   assert.equal(fixture.applyVisibleCalls[0].sampler.seed, settingsModule.AIO_GENERATOR_MAX_SEED);

--- a/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
@@ -705,7 +705,7 @@ for (const testCase of [
 
 {
   const fixture = createFixture({
-    available: { spectrumAdvanced: true },
+    available: { spectrumAdvanced: true, spectrumSpd: true },
     settings: {
       sampler: {
         spectrum_extra: Object.fromEntries([
@@ -721,28 +721,58 @@ for (const testCase of [
         ["toString", [["speed", "quality"], { default: "speed" }]],
         ["__proto__", ["BOOLEAN", { default: false }]],
       ]),
+      spectrumSpd: Object.fromEntries([
+        ["constructor", ["FLOAT", { default: 1.25 }]],
+        ["toString", [["speed", "quality"], { default: "speed" }]],
+        ["__proto__", ["BOOLEAN", { default: false }]],
+      ]),
     },
   });
   fixture.openSamplerSettings(fixture.node);
   const dialog = fixture.dialogs[0];
   const dynamicSpectrum = sectionByHeading(dialog, "Detected Spectrum Inputs");
+  const dynamicSpd = sectionByHeading(dialog, "Detected SPD Inputs");
   assert.equal(controlIn(dynamicSpectrum, "constructor").value, "2.5");
   assert.equal(controlIn(dynamicSpectrum, "toString").value, "quality");
   assert.equal(controlIn(dynamicSpectrum, "__proto__").checked, true);
+  assert.equal(controlIn(dynamicSpd, "constructor").value, "1.25");
+  assert.equal(controlIn(dynamicSpd, "toString").value, "speed");
+  assert.equal(controlIn(dynamicSpd, "__proto__").checked, false);
 
   controlIn(dynamicSpectrum, "constructor").value = "3.5";
   setSelectValue(controlIn(dynamicSpectrum, "toString"), "speed");
   controlIn(dynamicSpectrum, "__proto__").checked = false;
   action(dialog, "button.apply").emit("click");
 
+  const expectedSpecialExtras = Object.fromEntries([
+    ["constructor", 3.5],
+    ["toString", "speed"],
+    ["__proto__", false],
+  ]);
   assert.deepEqual(
     fixture.node.settings.sampler.spectrum_extra,
-    Object.fromEntries([
-      ["constructor", 3.5],
-      ["toString", "speed"],
-      ["__proto__", false],
-    ]),
+    expectedSpecialExtras,
     "Dynamic input values must retain own-key semantics for Object prototype names",
+  );
+  assert.deepEqual(
+    JSON.parse(fixture.node.widgets[0].value).sampler.spectrum_extra,
+    expectedSpecialExtras,
+    "Special dynamic input names must survive hidden-widget JSON serialization",
+  );
+  const expectedNewSpecialExtras = Object.fromEntries([
+    ["constructor", 1.25],
+    ["toString", "speed"],
+    ["__proto__", false],
+  ]);
+  assert.deepEqual(
+    fixture.node.settings.sampler.spd_extra,
+    expectedNewSpecialExtras,
+    "New special dynamic input names must use defaults instead of inherited values",
+  );
+  assert.deepEqual(
+    JSON.parse(fixture.node.widgets[0].value).sampler.spd_extra,
+    expectedNewSpecialExtras,
+    "New special dynamic input names must retain own keys in hidden-widget JSON",
   );
 }
 

--- a/tests/frontend_aio_settings_core_smoke.mjs
+++ b/tests/frontend_aio_settings_core_smoke.mjs
@@ -119,6 +119,33 @@ assert(
     && JSON.stringify(mergeValue) === mergeValueSnapshot,
   "Default merging must not mutate either input while merging",
 );
+
+const prototypePollutionKey = "__easyuseAnimaMergePollution";
+delete Object.prototype[prototypePollutionKey];
+try {
+  const specialKeyMerge = aioMergeDefaults({}, JSON.parse(`{
+    "__proto__": {"${prototypePollutionKey}": true},
+    "constructor": {"mode": "saved"},
+    "toString": "saved"
+  }`));
+  assert(
+    Object.getPrototypeOf(specialKeyMerge) === Object.prototype
+      && !Object.prototype.hasOwnProperty.call(Object.prototype, prototypePollutionKey),
+    "Default merging must not mutate Object.prototype",
+  );
+  assertJsonEqual(
+    specialKeyMerge,
+    JSON.parse(`{
+      "__proto__": {"${prototypePollutionKey}": true},
+      "constructor": {"mode": "saved"},
+      "toString": "saved"
+    }`),
+    "Default merging must preserve special names as own data properties",
+  );
+} finally {
+  delete Object.prototype[prototypePollutionKey];
+}
+
 assertJsonEqual(
   aioMergeDefaults(mergeDefaults, null),
   mergeDefaults,

--- a/web/js/aio/sampler_settings_dialog.js
+++ b/web/js/aio/sampler_settings_dialog.js
@@ -219,10 +219,14 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
     section.className = "easyuse-anima-aio-subsection";
     section.append(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
     const controls = new Map();
+    const currentValues = new Map(
+      values && typeof values === "object" && !Array.isArray(values)
+        ? Object.entries(values)
+        : [],
+    );
     const render = () => {
-      const currentValues = { ...(values || {}) };
       for (const [name, control] of controls.entries()) {
-        currentValues[name] = valueFromNodeInputControl(control);
+        currentValues.set(name, valueFromNodeInputControl(control));
       }
       controls.clear();
       section.replaceChildren(Object.assign(document.createElement("h4"), { textContent: aioStaticText(title) }));
@@ -239,7 +243,7 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
       section.classList.remove("hidden");
       for (const name of dynamicNames) {
         const spec = inputMap[name];
-        const control = nodeInputControlForSpec(spec, currentValues[name]);
+        const control = nodeInputControlForSpec(spec, currentValues.get(name));
         if (!control) {
           continue;
         }
@@ -256,11 +260,11 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
     return {
       section,
       values() {
-        const output = {};
+        const output = new Map(currentValues);
         for (const [name, control] of controls.entries()) {
-          output[name] = valueFromNodeInputControl(control);
+          output.set(name, valueFromNodeInputControl(control));
         }
-        return output;
+        return Object.fromEntries(output);
       },
     };
   }

--- a/web/js/aio/settings.js
+++ b/web/js/aio/settings.js
@@ -448,17 +448,25 @@ export function aioMergeDefaults(defaults, value) {
   }
   const merge = (base, incoming) => {
     for (const [key, incomingValue] of Object.entries(incoming)) {
+      const baseValue = Object.prototype.hasOwnProperty.call(base, key)
+        ? base[key]
+        : undefined;
       if (
-        base[key]
-        && typeof base[key] === "object"
-        && !Array.isArray(base[key])
+        baseValue
+        && typeof baseValue === "object"
+        && !Array.isArray(baseValue)
         && incomingValue
         && typeof incomingValue === "object"
         && !Array.isArray(incomingValue)
       ) {
-        merge(base[key], incomingValue);
+        merge(baseValue, incomingValue);
       } else {
-        base[key] = incomingValue;
+        Object.defineProperty(base, key, {
+          value: incomingValue,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
       }
     }
     return base;


### PR DESCRIPTION
## 변경 요약

- AiO 샘플러 대화상자의 `spectrum_extra` / `spd_extra` 값을 선택 의존성 탐지 결과와 무관하게 보존합니다.
- 현재 UI에서 렌더링할 수 없는 retired/unknown 설정도 Apply 및 워크플로우 저장·재열기에서 유실되지 않도록 했습니다.
- `constructor`, `toString`, `__proto__` 같은 특수 키를 own key로 안전하게 병합하고 prototype pollution을 방지했습니다.
- 레거시 backend 시그니처에서는 지원하지 않는 선택 kwargs를 걸러 기존 호환성을 유지합니다.

## 주요 파일

- `web/js/aio/sampler_settings_dialog.js`
- `web/js/aio/settings.js`
- `tests/frontend_aio_sampler_settings_dialog_smoke.mjs`
- `tests/frontend_aio_settings_core_smoke.mjs`

## 검증

- Official full runner: `powershell -ExecutionPolicy Bypass -File tools/check_custom_node.ps1 -Project <PR worktree> -Profile full`
  - Python: 375 tests passed
  - Frontend: 94 JS files passed
  - TypeScript: 6.0.3 passed
  - `git diff --check`: passed
- ComfyUI 0.27.0 Codex test instance
  - API/module smoke: passed
  - Legacy canvas: Cancel, Apply, reopen, save/reload, unavailable optional controls, queue success
  - Node 2.0: Cancel, Apply, reopen, save/reload, unavailable optional controls, queue success
  - 두 표면 모두 EasyUseAnima 콘솔 오류 없음
- 사용자 v0.27.0 인스턴스 수동 확인: 전체 유지보수 종료 후 1회 수행 예정

## 남은 위험

- 실제 Spectrum/SPD 선택 노드팩이 설치된 브라우저 표면은 이번 smoke 환경에서 확인하지 못했습니다.
- available/unavailable/retired/unrenderable extra와 특수 키 roundtrip은 focused frontend smoke에서 검증했습니다.
