### PR TITLE
refactor: extract autocomplete popup geometry

### DIFF
--- a/tests/frontend_autocomplete_popup_geometry_smoke.mjs
+++ b/tests/frontend_autocomplete_popup_geometry_smoke.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const geometry = await import(dataModule("../web/js/autocomplete/popup_geometry.js"));
+
+assert.deepEqual(Object.keys(geometry).sort(), [
+  "calculateAutocompletePopupGeometry",
+  "calculateCaretMirrorGeometry",
+  "normalizeCaretClientRect",
+].sort());
+
+const {
+  calculateAutocompletePopupGeometry,
+  calculateCaretMirrorGeometry,
+  normalizeCaretClientRect,
+} = geometry;
+
+function rect(left, top, width, height) {
+  return {
+    left,
+    right: left + width,
+    top,
+    bottom: top + height,
+    width,
+    height,
+  };
+}
+
+assert.deepEqual(
+  calculateCaretMirrorGeometry(rect(10, 20, 400, 180), 200, 120),
+  {
+    layoutWidth: 200,
+    layoutHeight: 120,
+    scaleX: 2,
+    scaleY: 1.5,
+  },
+);
+assert.deepEqual(
+  calculateCaretMirrorGeometry(rect(10, 20, 0, 0), 0, 0),
+  {
+    layoutWidth: 1,
+    layoutHeight: 1,
+    scaleX: 1,
+    scaleY: 1,
+  },
+);
+
+const inputRect = rect(100, 50, 420, 160);
+const markerRect = rect(240, 120, 1, 0);
+assert.deepEqual(
+  normalizeCaretClientRect(markerRect, inputRect, 24),
+  { ...markerRect, height: 24 },
+);
+const invalidMarker = { ...markerRect, left: Number.NaN };
+assert.equal(normalizeCaretClientRect(invalidMarker, inputRect, 24), inputRect);
+
+assert.deepEqual(
+  calculateAutocompletePopupGeometry(
+    inputRect,
+    rect(240, 120, 1, 24),
+    { width: 1024, height: 768 },
+    18,
+  ),
+  {
+    left: 240,
+    top: 180,
+    width: 380,
+    maxHeight: 280,
+  },
+);
+
+assert.deepEqual(
+  calculateAutocompletePopupGeometry(
+    rect(900, 700, 200, 60),
+    rect(1200, 800, 1, 0),
+    { width: 1024, height: 768 },
+    20,
+  ),
+  {
+    left: 760,
+    top: 792,
+    width: 260,
+    maxHeight: 56,
+  },
+);
+
+console.log("frontend autocomplete popup geometry smoke passed");

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -90,11 +90,41 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
         popup_body = entry_source[popup_start:scroll_start]
         self.assertIn("calculateCaretMirrorGeometry(", caret_body)
         self.assertIn("normalizeCaretClientRect(", caret_body)
+        self.assertRegex(
+            caret_body,
+            re.compile(
+                r"const fallbackLineHeight = \(\s*"
+                r"Number\.isFinite\(markerRect\.left\)\s*"
+                r"&& Number\.isFinite\(markerRect\.top\)\s*"
+                r"&& !markerRect\.height\s*\)\s*"
+                r"\? Number\.parseFloat\("
+                r"getComputedStyle\(input\)\.lineHeight\)\s*"
+                r": 0;",
+                re.DOTALL,
+            ),
+        )
         self.assertIn("calculateAutocompletePopupGeometry(", popup_body)
+        self.assertRegex(
+            popup_body,
+            re.compile(
+                r"const fallbackLineHeight = caretRect\.height\s*"
+                r"\? 0\s*"
+                r": Number\.parseFloat\("
+                r"getComputedStyle\(input\)\.lineHeight\);",
+                re.DOTALL,
+            ),
+        )
         self.assertNotIn("Math.max(260", popup_body)
         self.assertNotIn("const caretLeft =", popup_body)
 
     def test_popup_geometry_module_semantics(self):
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+        self.assertTrue(AUTOCOMPLETE_POPUP_GEOMETRY_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_autocomplete_popup_geometry_smoke.mjs"',
+            frontend_check_source,
+        )
+
         node_bin = shutil.which("node")
         if not node_bin:
             self.skipTest("node executable is not available")

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -20,11 +22,94 @@ AUTOCOMPLETE_TEXT_MODEL = (
 AUTOCOMPLETE_TEXT_MODEL_SMOKE = (
     ROOT / "tests" / "frontend_autocomplete_text_model_smoke.mjs"
 )
+AUTOCOMPLETE_POPUP_GEOMETRY = (
+    ROOT / "web" / "js" / "autocomplete" / "popup_geometry.js"
+)
+AUTOCOMPLETE_POPUP_GEOMETRY_SMOKE = (
+    ROOT / "tests" / "frontend_autocomplete_popup_geometry_smoke.mjs"
+)
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class AutocompleteFrontendBoundaryTests(unittest.TestCase):
+    def test_popup_geometry_has_exact_dom_free_boundary(self):
+        module_source = AUTOCOMPLETE_POPUP_GEOMETRY.read_text(encoding="utf-8")
+        entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
+        expected_exports = {
+            "calculateAutocompletePopupGeometry",
+            "calculateCaretMirrorGeometry",
+            "normalizeCaretClientRect",
+        }
+
+        exported_names = set(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            )
+        )
+        self.assertEqual(exported_names, expected_exports)
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|registerExtension|"
+                r"addEventListener|removeEventListener|MutationObserver|"
+                r"HTMLElement|HTMLInputElement|HTMLTextAreaElement)\b"
+            ),
+        )
+
+        import_match = re.search(
+            (
+                r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*'
+                r'"\./autocomplete/popup_geometry\.js";'
+            ),
+            entry_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip().rstrip(",")
+            for name in import_match.group("names").splitlines()
+            if name.strip()
+        }
+        self.assertEqual(imported_names, expected_exports)
+
+        caret_start = entry_source.index("function caretClientRect")
+        popup_start = entry_source.index("\nfunction positionPopup", caret_start)
+        scroll_start = entry_source.index(
+            "\nfunction scrollActiveAutocompleteItemIntoView",
+            popup_start,
+        )
+        caret_body = entry_source[caret_start:popup_start]
+        popup_body = entry_source[popup_start:scroll_start]
+        self.assertIn("calculateCaretMirrorGeometry(", caret_body)
+        self.assertIn("normalizeCaretClientRect(", caret_body)
+        self.assertIn("calculateAutocompletePopupGeometry(", popup_body)
+        self.assertNotIn("Math.max(260", popup_body)
+        self.assertNotIn("const caretLeft =", popup_body)
+
+    def test_popup_geometry_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(AUTOCOMPLETE_POPUP_GEOMETRY_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_data_adapter_has_exact_io_boundary(self):
         module_source = AUTOCOMPLETE_DATA_ADAPTER.read_text(encoding="utf-8")
         entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -159,6 +159,11 @@ try {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_autocomplete_popup_geometry_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend autocomplete popup geometry smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_text_model_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete text model smoke failed with exit code $LASTEXITCODE."

--- a/web/js/autocomplete/popup_geometry.js
+++ b/web/js/autocomplete/popup_geometry.js
@@ -1,0 +1,102 @@
+// @ts-check
+
+/**
+ * @typedef {object} AutocompleteRect
+ * @property {number} left
+ * @property {number} right
+ * @property {number} top
+ * @property {number} bottom
+ * @property {number} width
+ * @property {number} height
+ */
+
+/**
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ */
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Calculate the unscaled mirror size and the transform needed to match the
+ * rendered input rectangle.
+ *
+ * @param {AutocompleteRect} inputRect
+ * @param {number} offsetWidth
+ * @param {number} offsetHeight
+ */
+export function calculateCaretMirrorGeometry(inputRect, offsetWidth, offsetHeight) {
+  const layoutWidth = offsetWidth || inputRect.width || 1;
+  const layoutHeight = offsetHeight || inputRect.height || 1;
+  const scaleX = inputRect.width > 0 ? inputRect.width / layoutWidth : 1;
+  const scaleY = inputRect.height > 0 ? inputRect.height / layoutHeight : scaleX;
+  return {
+    layoutWidth,
+    layoutHeight,
+    scaleX,
+    scaleY,
+  };
+}
+
+/**
+ * Normalize the temporary mirror marker into the caret rectangle consumed by
+ * popup placement. A failed marker measurement falls back to the input.
+ *
+ * @param {AutocompleteRect} markerRect
+ * @param {AutocompleteRect} inputRect
+ * @param {number} fallbackLineHeight
+ * @returns {AutocompleteRect}
+ */
+export function normalizeCaretClientRect(markerRect, inputRect, fallbackLineHeight) {
+  if (!Number.isFinite(markerRect.left) || !Number.isFinite(markerRect.top)) {
+    return inputRect;
+  }
+  return {
+    left: markerRect.left,
+    right: markerRect.right,
+    top: markerRect.top,
+    bottom: markerRect.bottom,
+    width: markerRect.width,
+    height: markerRect.height || fallbackLineHeight || 18,
+  };
+}
+
+/**
+ * Calculate fixed-position popup geometry from measured input/caret rectangles.
+ *
+ * @param {AutocompleteRect} inputRect
+ * @param {AutocompleteRect} caretRect
+ * @param {{ width: number, height: number }} viewport
+ * @param {number} fallbackLineHeight
+ */
+export function calculateAutocompletePopupGeometry(
+  inputRect,
+  caretRect,
+  viewport,
+  fallbackLineHeight,
+) {
+  const width = Math.max(260, Math.min(380, inputRect.width, viewport.width - 8));
+  const lineHeight = Math.max(14, caretRect.height || fallbackLineHeight || 18);
+  const caretLeft = clamp(caretRect.left, inputRect.left, inputRect.right);
+  const caretTop = clamp(
+    caretRect.top,
+    inputRect.top,
+    Math.max(inputRect.top, inputRect.bottom - lineHeight),
+  );
+  const caretBottom = clamp(
+    caretTop + lineHeight,
+    inputRect.top + lineHeight,
+    inputRect.bottom,
+  );
+  const left = clamp(caretLeft, 4, Math.max(4, viewport.width - width - 4));
+  const top = caretBottom + lineHeight + 12;
+  const maxHeight = Math.max(56, viewport.height - top - 8);
+  return {
+    left,
+    top,
+    width,
+    maxHeight: Math.min(280, maxHeight),
+  };
+}

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -744,10 +744,17 @@ function caretClientRect(input) {
   mirror.scrollLeft = input.scrollLeft;
   const markerRect = marker.getBoundingClientRect();
   mirror.remove();
+  const fallbackLineHeight = (
+    Number.isFinite(markerRect.left)
+    && Number.isFinite(markerRect.top)
+    && !markerRect.height
+  )
+    ? Number.parseFloat(getComputedStyle(input).lineHeight)
+    : 0;
   return normalizeCaretClientRect(
     markerRect,
     rect,
-    Number.parseFloat(getComputedStyle(input).lineHeight),
+    fallbackLineHeight,
   );
 }
 
@@ -755,11 +762,14 @@ function positionPopup(input) {
   const menu = ensurePopup();
   const inputRect = input.getBoundingClientRect();
   const caretRect = caretClientRect(input);
+  const fallbackLineHeight = caretRect.height
+    ? 0
+    : Number.parseFloat(getComputedStyle(input).lineHeight);
   const geometry = calculateAutocompletePopupGeometry(
     inputRect,
     caretRect,
     { width: window.innerWidth, height: window.innerHeight },
-    Number.parseFloat(getComputedStyle(input).lineHeight),
+    fallbackLineHeight,
   );
   menu.style.left = `${geometry.left}px`;
   menu.style.top = `${geometry.top}px`;

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -7,6 +7,11 @@ import { easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_
 import { easyuseAnimaText } from "./easyuse_anima_i18n.js";
 import { createAutocompleteDataAdapter } from "./autocomplete/data_adapter.js";
 import {
+  calculateAutocompletePopupGeometry,
+  calculateCaretMirrorGeometry,
+  normalizeCaretClientRect,
+} from "./autocomplete/popup_geometry.js";
+import {
   autocompleteQuery,
   currentToken as currentAutocompleteToken,
   currentWildcardToken as currentAutocompleteWildcardToken,
@@ -697,10 +702,12 @@ function caretClientRect(input) {
   const mirror = document.createElement("div");
   const marker = document.createElement("span");
   const value = String(input.value || "");
-  const layoutWidth = input.offsetWidth || rect.width || 1;
-  const layoutHeight = input.offsetHeight || rect.height || 1;
-  const scaleX = rect.width > 0 ? rect.width / layoutWidth : 1;
-  const scaleY = rect.height > 0 ? rect.height / layoutHeight : scaleX;
+  const {
+    layoutWidth,
+    layoutHeight,
+    scaleX,
+    scaleY,
+  } = calculateCaretMirrorGeometry(rect, input.offsetWidth, input.offsetHeight);
 
   mirror.style.cssText = [
     "position: fixed",
@@ -737,44 +744,27 @@ function caretClientRect(input) {
   mirror.scrollLeft = input.scrollLeft;
   const markerRect = marker.getBoundingClientRect();
   mirror.remove();
-
-  if (!Number.isFinite(markerRect.left) || !Number.isFinite(markerRect.top)) {
-    return rect;
-  }
-  return {
-    left: markerRect.left,
-    right: markerRect.right,
-    top: markerRect.top,
-    bottom: markerRect.bottom,
-    width: markerRect.width,
-    height: markerRect.height || Number.parseFloat(getComputedStyle(input).lineHeight) || 18,
-  };
+  return normalizeCaretClientRect(
+    markerRect,
+    rect,
+    Number.parseFloat(getComputedStyle(input).lineHeight),
+  );
 }
 
 function positionPopup(input) {
   const menu = ensurePopup();
   const inputRect = input.getBoundingClientRect();
   const caretRect = caretClientRect(input);
-  const width = Math.max(260, Math.min(380, inputRect.width, window.innerWidth - 8));
-  const lineHeight = Math.max(14, caretRect.height || Number.parseFloat(getComputedStyle(input).lineHeight) || 18);
-  const caretLeft = clamp(caretRect.left, inputRect.left, inputRect.right);
-  const caretTop = clamp(
-    caretRect.top,
-    inputRect.top,
-    Math.max(inputRect.top, inputRect.bottom - lineHeight),
+  const geometry = calculateAutocompletePopupGeometry(
+    inputRect,
+    caretRect,
+    { width: window.innerWidth, height: window.innerHeight },
+    Number.parseFloat(getComputedStyle(input).lineHeight),
   );
-  const caretBottom = clamp(
-    caretTop + lineHeight,
-    inputRect.top + lineHeight,
-    inputRect.bottom,
-  );
-  const left = clamp(caretLeft, 4, Math.max(4, window.innerWidth - width - 4));
-  const top = caretBottom + lineHeight + 12;
-  const maxHeight = Math.max(56, window.innerHeight - top - 8);
-  menu.style.left = `${left}px`;
-  menu.style.top = `${top}px`;
-  menu.style.width = `${width}px`;
-  menu.style.maxHeight = `${Math.min(280, maxHeight)}px`;
+  menu.style.left = `${geometry.left}px`;
+  menu.style.top = `${geometry.top}px`;
+  menu.style.width = `${geometry.width}px`;
+  menu.style.maxHeight = `${geometry.maxHeight}px`;
 }
 
 function scrollActiveAutocompleteItemIntoView(menu, index) {


### PR DESCRIPTION
## 변경 요약

- autocomplete popup의 marker/caret, width, line-height, viewport clamp 계산을 DOM 없는 순수 geometry 모듈로 분리했습니다.
- 기존 short-circuit 및 `getComputedStyle()` 호출 시점을 유지해 동작과 계산 결과를 바꾸지 않습니다.
- entry는 새 pure helper에만 위임하고, geometry 경계 smoke를 official frontend runner에 연결했습니다.

## 주요 파일

- `web/js/autocomplete/popup_geometry.js`
- `web/js/easyuse_anima_autocomplete.js`
- `tests/frontend_autocomplete_popup_geometry_smoke.mjs`
- `tests/test_autocomplete_frontend.py`
- `tools/check_frontend.ps1`

## 검증

- Official full runner: `powershell -ExecutionPolicy Bypass -File tools/check_custom_node.ps1 -Project <PR worktree> -Profile full`
  - Python: 377 tests passed
  - Frontend: 95 JS files passed
  - TypeScript: 6.0.3 passed
  - `git diff --check`: passed
- Focused audit
  - production JS syntax: passed
  - popup geometry smoke: passed
  - autocomplete frontend boundary tests: 7 passed
- Browser smoke: 동작을 바꾸지 않는 pure extraction이므로 실행하지 않음
- 사용자 v0.27.0 인스턴스: 전체 유지보수 종료 후 1회 확인 예정

## 남은 위험

- 실제 viewport에서의 시각 비교는 이번 조각에서 반복하지 않았습니다.
- scale, zero-size, line-height fallback, invalid marker, viewport clamp 경계는 pure smoke로 고정했습니다.
