### PR TITLE
refactor: extract LoRA preset preview lifecycle

### DIFF
--- a/tests/frontend_lora_preset_preview_lifecycle_smoke.mjs
+++ b/tests/frontend_lora_preset_preview_lifecycle_smoke.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createFakeDocument } from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const previewModule = await import(
+  dataModule("../web/js/lora_preset/preview_lifecycle.js")
+);
+
+assert.deepEqual(Object.keys(previewModule).sort(), [
+  "createLoraPresetPreviewLifecycle",
+  "loraPreviewPosition",
+]);
+
+assert.deepEqual(
+  previewModule.loraPreviewPosition(
+    { clientX: 20, clientY: 30 },
+    { width: 800, height: 600 },
+    360,
+  ),
+  [38, 48],
+);
+assert.deepEqual(
+  previewModule.loraPreviewPosition(
+    { clientX: 780, clientY: 590 },
+    { width: 800, height: 600 },
+    360,
+  ),
+  [402, 228],
+);
+
+const document = createFakeDocument();
+document.body.boundingClientRect = { left: 0, top: 0, width: 800, height: 600 };
+document.querySelector = (selector) => document.body.querySelector(selector);
+document.body.appendChild = (child) => {
+  document.body.append(child);
+  return child;
+};
+const createElement = document.createElement.bind(document);
+document.createElement = (tagName) => {
+  const element = createElement(tagName);
+  element.removeAttribute = (name) => element.attributes.delete(String(name));
+  return element;
+};
+
+const encodedNames = [];
+const lifecycle = previewModule.createLoraPresetPreviewLifecycle({
+  document,
+  encodeURIComponent(value) {
+    encodedNames.push(value);
+    return `encoded:${value}`;
+  },
+  previewSize: 360,
+});
+
+assert.deepEqual(Object.keys(lifecycle).sort(), [
+  "forgetMissingPreview",
+  "hidePreview",
+  "showPreview",
+]);
+assert.equal(document.body.children.length, 0, "factory creation must not create DOM state");
+
+lifecycle.showPreview("", { clientX: 20, clientY: 30 });
+lifecycle.showPreview("None", { clientX: 20, clientY: 30 });
+assert.equal(document.body.children.length, 0);
+assert.deepEqual(encodedNames, []);
+
+const firstName = "style/foo.safetensors";
+lifecycle.showPreview(firstName, { clientX: 20, clientY: 30 });
+assert.equal(document.body.children.length, 1);
+const preview = document.body.children[0];
+assert.equal(preview.className, "easyuse-anima-lora-preview");
+assert.equal(preview.listenerCount("error"), 1);
+assert.equal(preview.listenerCount("load"), 1);
+assert.equal(preview.getAttribute("data-name"), firstName);
+assert.equal(preview.getAttribute("data-visible"), "1");
+assert.equal(preview.getAttribute("data-loaded"), null);
+assert.equal(preview.style.display, "none");
+assert.equal(preview.style.left, "38px");
+assert.equal(preview.style.top, "48px");
+assert.equal(
+  preview.src,
+  "/easyuse_anima/lora_preview?name=encoded:style/foo.safetensors",
+);
+assert.deepEqual(encodedNames, [firstName]);
+
+preview.naturalWidth = 512;
+preview.emit("load");
+assert.equal(preview.getAttribute("data-loaded"), "1");
+assert.equal(preview.style.display, "block");
+
+lifecycle.hidePreview();
+assert.equal(preview.getAttribute("data-visible"), null);
+assert.equal(preview.style.display, "none");
+
+lifecycle.showPreview(firstName, { clientX: 780, clientY: 590 });
+assert.equal(document.body.children[0], preview, "the lifecycle must reuse its singleton image");
+assert.equal(preview.getAttribute("data-visible"), "1");
+assert.equal(preview.style.display, "block");
+assert.equal(preview.style.left, "402px");
+assert.equal(preview.style.top, "228px");
+
+preview.emit("error");
+assert.equal(preview.getAttribute("data-name"), null);
+assert.equal(preview.getAttribute("data-loaded"), null);
+assert.equal(preview.getAttribute("data-visible"), null);
+assert.equal(preview.style.display, "none");
+
+lifecycle.showPreview(firstName, { clientX: 40, clientY: 50 });
+assert.equal(document.body.children.length, 1);
+assert.equal(preview.getAttribute("data-name"), null);
+assert.deepEqual(
+  encodedNames,
+  [firstName, firstName],
+  "a cached failed name must not request another preview URL",
+);
+
+lifecycle.forgetMissingPreview(firstName);
+lifecycle.showPreview(firstName, { clientX: 40, clientY: 50 });
+assert.equal(preview.getAttribute("data-name"), firstName);
+assert.equal(preview.getAttribute("data-visible"), "1");
+assert.equal(preview.style.display, "none");
+assert.deepEqual(encodedNames, [firstName, firstName, firstName]);
+preview.emit("error");
+
+const secondName = "style/bar.safetensors";
+lifecycle.showPreview(secondName, { clientX: 40, clientY: 50 });
+assert.equal(document.body.children[0], preview);
+assert.equal(preview.getAttribute("data-name"), secondName);
+assert.equal(preview.getAttribute("data-visible"), "1");
+assert.equal(preview.style.display, "none");
+assert.equal(preview.style.left, "58px");
+assert.equal(preview.style.top, "68px");
+assert.equal(
+  preview.src,
+  "/easyuse_anima/lora_preview?name=encoded:style/bar.safetensors",
+);
+assert.deepEqual(encodedNames, [firstName, firstName, firstName, secondName]);
+
+console.log("LoRA preset preview lifecycle smoke passed.");

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -15,6 +15,12 @@ LORA_PRESET_API_CLIENT = ROOT / "web" / "js" / "lora_preset" / "api_client.js"
 LORA_PRESET_API_CLIENT_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_api_client_smoke.mjs"
 )
+LORA_PRESET_PREVIEW_LIFECYCLE = (
+    ROOT / "web" / "js" / "lora_preset" / "preview_lifecycle.js"
+)
+LORA_PRESET_PREVIEW_LIFECYCLE_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_preview_lifecycle_smoke.mjs"
+)
 LORA_PRESET_PROFILE_DATA = ROOT / "web" / "js" / "lora_preset" / "profile_data.js"
 LORA_PRESET_PROFILE_DATA_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_profile_data_smoke.mjs"
@@ -135,6 +141,97 @@ class LoraPresetFrontendTests(unittest.TestCase):
 
         completed = subprocess.run(
             [node_bin, str(LORA_PRESET_API_CLIENT_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
+    def test_preview_lifecycle_module_boundary(self):
+        module_source = LORA_PRESET_PREVIEW_LIFECYCLE.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            set(
+                re.findall(
+                    r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                    module_source,
+                    re.MULTILINE,
+                )
+            ),
+            {
+                "createLoraPresetPreviewLifecycle",
+                "loraPreviewPosition",
+            },
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            r"\b(?:app|api|LiteGraph|registerExtension|MutationObserver)\b",
+        )
+        self.assertIn(
+            'import { createLoraPresetPreviewLifecycle } from '
+            '"./lora_preset/preview_lifecycle.js";',
+            entry_source,
+        )
+
+        factory_match = re.search(
+            r"const\s+loraPreviewLifecycle\s*=\s*"
+            r"createLoraPresetPreviewLifecycle"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().rstrip(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "document",
+                "encodeURIComponent: encodeRFC3986URIComponent",
+                "previewSize: PREVIEW_SIZE",
+            },
+        )
+
+        for moved_name in (
+            "missingPreviewNames",
+            "positionPreview",
+            "showPreview",
+            "hidePreview",
+        ):
+            with self.subTest(moved_declaration=moved_name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\b(?:const|let|var|function|class)\s+{moved_name}\b",
+                )
+        self.assertEqual(entry_source.count("loraPreviewLifecycle.showPreview"), 4)
+        self.assertEqual(entry_source.count("loraPreviewLifecycle.hidePreview"), 6)
+        self.assertEqual(
+            entry_source.count("loraPreviewLifecycle.forgetMissingPreview"),
+            1,
+        )
+        self.assertTrue(LORA_PRESET_PREVIEW_LIFECYCLE_SMOKE.is_file())
+        self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+
+    def test_preview_lifecycle_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_PREVIEW_LIFECYCLE_SMOKE)],
             cwd=ROOT,
             text=True,
             capture_output=True,
@@ -350,6 +447,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const profileDataPath = process.argv[2];
             const loraStatePath = process.argv[3];
             const apiClientPath = process.argv[4];
+            const previewLifecyclePath = process.argv[5];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -365,10 +463,15 @@ class LoraPresetFrontendTests(unittest.TestCase):
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let previewLifecycleSource = fs.readFileSync(previewLifecyclePath, "utf8");
+            previewLifecycleSource = previewLifecycleSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${source}`;
-            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems, loraPresetApi, saveProfileSet };\n";
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${source}`;
+            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems, loraPresetApi, loraPreviewLifecycle, saveProfileSet };\n";
 
             class StubElement {
               constructor(tagName = "div") {
@@ -459,6 +562,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
               loraMenuElementValue,
               loraMenuItems,
               loraPresetApi,
+              loraPreviewLifecycle,
               saveProfileSet,
             } = context.__loraPresetTest;
 
@@ -500,6 +604,34 @@ class LoraPresetFrontendTests(unittest.TestCase):
 
             function loras(node) {
               return JSON.parse(node.widgets.find((item) => item.name === "loras").value);
+            }
+
+            {
+              const node = makeNode();
+              const row = makeRow();
+              const shown = [];
+              let hidden = 0;
+              const originalShowPreview = loraPreviewLifecycle.showPreview;
+              const originalHidePreview = loraPreviewLifecycle.hidePreview;
+              loraPreviewLifecycle.showPreview = (name, event) => {
+                shown.push({ name, event });
+              };
+              loraPreviewLifecycle.hidePreview = () => {
+                hidden += 1;
+              };
+
+              const hoverEvent = { type: "pointermove", clientX: 205, clientY: 10 };
+              assert.strictEqual(row.mouse(hoverEvent, [205, 10], node), false);
+              assert.strictEqual(shown.length, 1);
+              assert.strictEqual(shown[0].name, "style/foo.safetensors");
+              assert.strictEqual(shown[0].event, hoverEvent);
+              assert.strictEqual(row.mouse({ type: "pointermove" }, [10, 10], node), false);
+              assert.strictEqual(hidden, 1);
+              assert.strictEqual(row.mouse({ type: "pointerout" }, [10, 10], node), false);
+              assert.strictEqual(hidden, 2);
+
+              loraPreviewLifecycle.showPreview = originalShowPreview;
+              loraPreviewLifecycle.hidePreview = originalHidePreview;
             }
 
             {
@@ -644,6 +776,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_PROFILE_DATA),
                 str(LORA_PRESET_LORA_STATE),
                 str(LORA_PRESET_API_CLIENT),
+                str(LORA_PRESET_PREVIEW_LIFECYCLE),
             ],
             cwd=ROOT,
             text=True,

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -154,6 +154,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
         module_source = LORA_PRESET_PREVIEW_LIFECYCLE.read_text(encoding="utf-8")
         entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
         config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
         self.assertEqual(module_source.splitlines()[0], "// @ts-check")
         self.assertEqual(
@@ -224,6 +225,10 @@ class LoraPresetFrontendTests(unittest.TestCase):
         )
         self.assertTrue(LORA_PRESET_PREVIEW_LIFECYCLE_SMOKE.is_file())
         self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_lora_preset_preview_lifecycle_smoke.mjs"',
+            frontend_check_source,
+        )
 
     def test_preview_lifecycle_module_semantics(self):
         node_bin = shutil.which("node")

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -471,7 +471,20 @@ class LoraPresetFrontendTests(unittest.TestCase):
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
             source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${source}`;
-            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems, loraPresetApi, loraPreviewLifecycle, saveProfileSet };\n";
+            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, addLoraMenuEntryHandlers, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems, loraPresetApi, loraPreviewLifecycle, saveProfileSet };\n";
+
+            const mutationObservers = [];
+            class StubMutationObserver {
+              constructor(callback) {
+                this.callback = callback;
+                mutationObservers.push(this);
+              }
+              observe(target, options) {
+                this.target = target;
+                this.options = options;
+              }
+              disconnect() {}
+            }
 
             class StubElement {
               constructor(tagName = "div") {
@@ -504,7 +517,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
               MouseEvent: class { constructor(type, options = {}) { this.type = type; Object.assign(this, options); } },
               HTMLInputElement: class {},
               HTMLTextAreaElement: class {},
-              MutationObserver: class { constructor() {} observe() {} disconnect() {} },
+              MutationObserver: StubMutationObserver,
               LiteGraph: {
                 WIDGET_TEXT_COLOR: "#ddd",
                 WIDGET_BGCOLOR: "#222",
@@ -558,6 +571,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const {
               LoraRowWidget,
               LORA_PRESET_SETTINGS,
+              addLoraMenuEntryHandlers,
               applyLoraPresetSettings,
               loraMenuElementValue,
               loraMenuItems,
@@ -631,6 +645,71 @@ class LoraPresetFrontendTests(unittest.TestCase):
               assert.strictEqual(hidden, 2);
 
               loraPreviewLifecycle.showPreview = originalShowPreview;
+              loraPreviewLifecycle.hidePreview = originalHidePreview;
+            }
+
+            {
+              const listeners = new Map();
+              const item = {
+                addEventListener(type, listener, options) {
+                  listeners.set(type, { listener, options });
+                },
+              };
+              const shown = [];
+              let hidden = 0;
+              const originalShowPreview = loraPreviewLifecycle.showPreview;
+              const originalHidePreview = loraPreviewLifecycle.hidePreview;
+              loraPreviewLifecycle.showPreview = (name, event) => {
+                shown.push({ name, event });
+              };
+              loraPreviewLifecycle.hidePreview = () => {
+                hidden += 1;
+              };
+
+              addLoraMenuEntryHandlers(item, "style/menu.safetensors");
+              assert.deepStrictEqual(Array.from(listeners.keys()).sort(), ["mousemove", "mouseout", "mouseover"]);
+              for (const { options } of listeners.values()) {
+                assert.strictEqual(options.passive, true);
+              }
+              const mouseoverEvent = { type: "mouseover", clientX: 120, clientY: 80 };
+              const mousemoveEvent = { type: "mousemove", clientX: 124, clientY: 84 };
+              listeners.get("mouseover").listener(mouseoverEvent);
+              listeners.get("mousemove").listener(mousemoveEvent);
+              listeners.get("mouseout").listener({ type: "mouseout" });
+              assert.deepStrictEqual(shown, [
+                { name: "style/menu.safetensors", event: mouseoverEvent },
+                { name: "style/menu.safetensors", event: mousemoveEvent },
+              ]);
+              assert.strictEqual(hidden, 1);
+
+              loraPreviewLifecycle.showPreview = originalShowPreview;
+              loraPreviewLifecycle.hidePreview = originalHidePreview;
+            }
+
+            {
+              const node = makeNode();
+              context.app.canvas.current_node = node;
+              let hidden = 0;
+              const originalHidePreview = loraPreviewLifecycle.hidePreview;
+              loraPreviewLifecycle.hidePreview = () => {
+                hidden += 1;
+              };
+
+              context.app.__extension.init();
+              assert.strictEqual(mutationObservers.length, 1);
+              const removedMenu = {
+                classList: {
+                  contains(className) {
+                    return className === "litecontextmenu";
+                  },
+                },
+              };
+              mutationObservers[0].callback([{
+                removedNodes: [removedMenu],
+                addedNodes: [],
+              }]);
+              assert.strictEqual(hidden, 1);
+
               loraPreviewLifecycle.hidePreview = originalHidePreview;
             }
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -154,6 +154,11 @@ try {
         throw "Frontend LoRA preset state smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_preview_lifecycle_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset preview lifecycle smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_data_adapter_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -3,6 +3,7 @@ import { api } from "../../../scripts/api.js";
 import { easyuseAnimaEncodeRFC3986URIComponent as encodeRFC3986URIComponent, easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
 import { createLoraPresetApiClient } from "./lora_preset/api_client.js";
+import { createLoraPresetPreviewLifecycle } from "./lora_preset/preview_lifecycle.js";
 import {
   INTERNAL_WIDGET_DEFAULTS,
   MAX_PROFILES,
@@ -43,7 +44,6 @@ const DEFAULT_STRENGTH_BUTTON_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_PIXELS = 8;
 const PREVIEW_SIZE = 360;
-const missingPreviewNames = new Set();
 let activeLoraMenuNode = null;
 let activeProfileWheelTarget = null;
 let profileWheelListenerInstalled = false;
@@ -296,6 +296,11 @@ async function fetchJson(url, options = {}) {
 const loraPresetApi = createLoraPresetApiClient({
   fetchJson,
   encodeURIComponent: encodeRFC3986URIComponent,
+});
+const loraPreviewLifecycle = createLoraPresetPreviewLifecycle({
+  document,
+  encodeURIComponent: encodeRFC3986URIComponent,
+  previewSize: PREVIEW_SIZE,
 });
 
 function firstValue(value, fallback = null) {
@@ -896,7 +901,7 @@ async function fetchLoraNameValues(node) {
     const data = await loraPresetApi.listLoras();
     const values = normalizeLoraNameList(data?.loras);
     for (const name of values) {
-      missingPreviewNames.delete(name);
+      loraPreviewLifecycle.forgetMissingPreview(name);
     }
     setLoraLookup(node, values);
     return values;
@@ -1347,73 +1352,6 @@ function normalizeSearchText(value) {
     .toLowerCase();
 }
 
-function positionPreview(element, event) {
-  const body = document.body.getBoundingClientRect();
-  let left = Number(event?.clientX || body.width / 2) + 18;
-  let top = Number(event?.clientY || body.height / 2) + 18;
-  if (left + PREVIEW_SIZE > body.width) {
-    left = Math.max(0, Number(event?.clientX || body.width / 2) - PREVIEW_SIZE - 18);
-  }
-  if (top + PREVIEW_SIZE > body.height) {
-    top = Math.max(0, body.height - PREVIEW_SIZE - 12);
-  }
-  element.style.left = `${left}px`;
-  element.style.top = `${top}px`;
-}
-
-function showPreview(name, event) {
-  if (!name || name === "None") {
-    hidePreview();
-    return;
-  }
-  if (missingPreviewNames.has(name)) {
-    hidePreview();
-    return;
-  }
-  let preview = document.querySelector(".easyuse-anima-lora-preview");
-  if (!preview) {
-    preview = createEl("img", { className: "easyuse-anima-lora-preview" });
-    preview.addEventListener("error", () => {
-      const failedName = preview.getAttribute("data-name");
-      if (failedName) {
-        missingPreviewNames.add(failedName);
-      }
-      preview.style.display = "none";
-      preview.removeAttribute("data-name");
-      preview.removeAttribute("data-loaded");
-      preview.removeAttribute("data-visible");
-    });
-    preview.addEventListener("load", () => {
-      preview.setAttribute("data-loaded", "1");
-      if (preview.getAttribute("data-name") && preview.getAttribute("data-visible") === "1") {
-        preview.style.display = "block";
-      }
-    });
-    document.body.appendChild(preview);
-  }
-  preview.setAttribute("data-visible", "1");
-  positionPreview(preview, event);
-  const src = `/easyuse_anima/lora_preview?name=${encodeRFC3986URIComponent(name)}`;
-  if (preview.getAttribute("data-name") !== name) {
-    preview.setAttribute("data-name", name);
-    preview.removeAttribute("data-loaded");
-    preview.style.display = "none";
-    preview.src = src;
-    return;
-  }
-  if (preview.getAttribute("data-loaded") === "1" && preview.naturalWidth > 0) {
-    preview.style.display = "block";
-  }
-}
-
-function hidePreview() {
-  const preview = document.querySelector(".easyuse-anima-lora-preview");
-  if (preview) {
-    preview.removeAttribute("data-visible");
-    preview.style.display = "none";
-  }
-}
-
 function loraDisplayName(name) {
   const text = String(name || "");
   if (LORA_PRESET_SETTINGS.nameDisplay === "path") {
@@ -1556,9 +1494,9 @@ function addLoraMenuEntryHandlers(item, value) {
     return;
   }
   item.__easyuseAnimaPreviewValue = value;
-  item.addEventListener("mouseover", (event) => showPreview(value, event), { passive: true });
-  item.addEventListener("mousemove", (event) => showPreview(value, event), { passive: true });
-  item.addEventListener("mouseout", hidePreview, { passive: true });
+  item.addEventListener("mouseover", (event) => loraPreviewLifecycle.showPreview(value, event), { passive: true });
+  item.addEventListener("mousemove", (event) => loraPreviewLifecycle.showPreview(value, event), { passive: true });
+  item.addEventListener("mouseout", loraPreviewLifecycle.hidePreview, { passive: true });
 }
 
 function normalizeLoraMenuEntries(menu, node, options = {}) {
@@ -2138,19 +2076,19 @@ class LoraRowWidget {
       return false;
     }
     if (event.type === "pointerout" || event.type === "pointerleave") {
-      hidePreview();
+      loraPreviewLifecycle.hidePreview();
       return false;
     }
     if (event.type === "pointercancel") {
-      hidePreview();
+      loraPreviewLifecycle.hidePreview();
       clearLoraStrengthDrag(node);
       return false;
     }
     if (event.type === "pointermove") {
       if (pointInArea(pos, this.hitAreas.info)) {
-        showPreview(lora.name, event);
+        loraPreviewLifecycle.showPreview(lora.name, event);
       } else {
-        hidePreview();
+        loraPreviewLifecycle.hidePreview();
       }
     }
     if (event.type !== "pointerdown") {
@@ -2181,7 +2119,7 @@ class LoraRowWidget {
       return true;
     }
     if (pointInArea(pos, this.hitAreas.info)) {
-      showPreview(lora.name, event);
+      loraPreviewLifecycle.showPreview(lora.name, event);
       return true;
     }
     if (pointInArea(pos, this.hitAreas.dec)) {
@@ -2562,7 +2500,7 @@ app.registerExtension({
       applyLoraPresetSettings(event.detail || {});
       refreshLoraPresetNodes();
     });
-    document.addEventListener("pointerdown", hidePreview, true);
+    document.addEventListener("pointerdown", loraPreviewLifecycle.hidePreview, true);
     installProfileWheelListener();
 
     document.head.appendChild(createEl("style", {
@@ -2625,7 +2563,7 @@ app.registerExtension({
       for (const mutation of mutations) {
         for (const removed of mutation.removedNodes) {
           if (removed.classList?.contains("litecontextmenu")) {
-            hidePreview();
+            loraPreviewLifecycle.hidePreview();
           }
         }
         for (const added of mutation.addedNodes) {

--- a/web/js/lora_preset/preview_lifecycle.js
+++ b/web/js/lora_preset/preview_lifecycle.js
@@ -1,0 +1,137 @@
+// @ts-check
+
+/**
+ * @typedef {object} LoraPresetPreviewDependencies
+ * @property {Document} document
+ * @property {(value: string) => string} encodeURIComponent
+ * @property {number} previewSize
+ */
+
+/**
+ * Keep preview geometry independent from the DOM lifecycle so viewport-edge
+ * behavior can be verified without creating a preview element.
+ *
+ * @param {{clientX?: number, clientY?: number} | null | undefined} event
+ * @param {{width: number, height: number}} bodyBounds
+ * @param {number} previewSize
+ * @returns {[number, number]}
+ */
+export function loraPreviewPosition(event, bodyBounds, previewSize) {
+  let left = Number(event?.clientX || bodyBounds.width / 2) + 18;
+  let top = Number(event?.clientY || bodyBounds.height / 2) + 18;
+  if (left + previewSize > bodyBounds.width) {
+    left = Math.max(
+      0,
+      Number(event?.clientX || bodyBounds.width / 2) - previewSize - 18,
+    );
+  }
+  if (top + previewSize > bodyBounds.height) {
+    top = Math.max(0, bodyBounds.height - previewSize - 12);
+  }
+  return [left, top];
+}
+
+/**
+ * Own the singleton LoRA preview element, failed-name cache, and visibility
+ * state without taking ownership of menu observers or extension listeners.
+ *
+ * @param {LoraPresetPreviewDependencies} dependencies
+ */
+export function createLoraPresetPreviewLifecycle(dependencies) {
+  const {
+    document,
+    encodeURIComponent,
+    previewSize,
+  } = dependencies;
+  const missingPreviewNames = new Set();
+
+  function findPreview() {
+    return /** @type {HTMLImageElement | null} */ (
+      document.querySelector(".easyuse-anima-lora-preview")
+    );
+  }
+
+  /**
+   * @param {HTMLImageElement} element
+   * @param {{clientX?: number, clientY?: number} | null | undefined} event
+   */
+  function positionPreview(element, event) {
+    const bodyBounds = document.body.getBoundingClientRect();
+    const [left, top] = loraPreviewPosition(event, bodyBounds, previewSize);
+    element.style.left = `${left}px`;
+    element.style.top = `${top}px`;
+  }
+
+  function hidePreview() {
+    const preview = findPreview();
+    if (preview) {
+      preview.removeAttribute("data-visible");
+      preview.style.display = "none";
+    }
+  }
+
+  /** @param {string} name */
+  function forgetMissingPreview(name) {
+    missingPreviewNames.delete(name);
+  }
+
+  /**
+   * @param {string} name
+   * @param {{clientX?: number, clientY?: number} | null | undefined} event
+   */
+  function showPreview(name, event) {
+    if (!name || name === "None") {
+      hidePreview();
+      return;
+    }
+    if (missingPreviewNames.has(name)) {
+      hidePreview();
+      return;
+    }
+    let preview = findPreview();
+    if (!preview) {
+      const created = document.createElement("img");
+      created.className = "easyuse-anima-lora-preview";
+      created.addEventListener("error", () => {
+        const failedName = created.getAttribute("data-name");
+        if (failedName) {
+          missingPreviewNames.add(failedName);
+        }
+        created.style.display = "none";
+        created.removeAttribute("data-name");
+        created.removeAttribute("data-loaded");
+        created.removeAttribute("data-visible");
+      });
+      created.addEventListener("load", () => {
+        created.setAttribute("data-loaded", "1");
+        if (
+          created.getAttribute("data-name")
+          && created.getAttribute("data-visible") === "1"
+        ) {
+          created.style.display = "block";
+        }
+      });
+      document.body.appendChild(created);
+      preview = created;
+    }
+    preview.setAttribute("data-visible", "1");
+    positionPreview(preview, event);
+    const src = `/easyuse_anima/lora_preview?name=${encodeURIComponent(name)}`;
+    if (preview.getAttribute("data-name") !== name) {
+      preview.setAttribute("data-name", name);
+      preview.removeAttribute("data-loaded");
+      preview.style.display = "none";
+      preview.src = src;
+      return;
+    }
+    if (preview.getAttribute("data-loaded") === "1" && preview.naturalWidth > 0) {
+      preview.style.display = "block";
+    }
+  }
+
+  return {
+    showPreview,
+    hidePreview,
+    forgetMissingPreview,
+  };
+}


### PR DESCRIPTION
## 변경 요약

- LoRA Preset preview element, viewport 위치 계산, visibility, missing-preview cache 책임을 별도 lifecycle 모듈로 분리했습니다.
- row hover, menu hover, pointer cancel/out, context-menu 제거 시점은 기존 entry에서 동일한 lifecycle API로 위임합니다.
- DOM 없는 위치 계산과 preview load/error 전이를 focused smoke로 고정하고 official frontend runner에 연결했습니다.

## 주요 파일

- `web/js/lora_preset/preview_lifecycle.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_preview_lifecycle_smoke.mjs`
- `tests/test_frontend_lora_preset.py`
- `tools/check_frontend.ps1`

## 검증

- Official full runner: `powershell -ExecutionPolicy Bypass -File tools/check_custom_node.ps1 -Project <PR worktree> -Profile full`
  - Python: 379 tests passed
  - Frontend: 96 JS files passed
  - TypeScript: 6.0.3 passed
  - `git diff --check`: passed
- Focused audit
  - preview lifecycle smoke: passed
  - module boundary 및 메뉴 cleanup semantics: passed
  - row/menu hover와 context-menu 제거 cleanup wiring 확인
- Browser smoke: 동작을 바꾸지 않는 lifecycle extraction이므로 실행하지 않음
- 사용자 v0.27.0 인스턴스: 전체 유지보수 종료 후 1회 확인 예정

## 남은 위험

- 실제 이미지 네트워크 로드의 시각 비교는 이번 조각에서 반복하지 않았습니다.
- load/error, missing cache reset, singleton 재사용, viewport edge 계산은 pure smoke에서 검증했습니다.
