### PR TITLE
fix: AiO 큐 시드 갱신을 트랜잭션화

### DIFF
--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -409,6 +409,7 @@ assert.deepEqual(Object.keys(fixture.runtime).sort(), [
   "renderPanel",
   "scheduleLayout",
   "scheduleSummary",
+  "updateSeed",
   "updateSummary",
 ]);
 assert.equal(fixture.dependencyCalls(), 0, "factory creation must have no side effects");
@@ -813,6 +814,28 @@ assert.equal(previewFeed.hidden, true);
 assert.equal(previewFeed.children.length, 0);
 assert.equal(previewMeta.textContent, "-");
 assert.equal(previewMeta.title, "");
+
+fixture.trace.length = 0;
+assert.equal(
+  fixture.runtime.updateSeed(node, 776, {
+    lastQueuedSeed: 777,
+    markDirty: false,
+  }),
+  776,
+);
+assert.equal(node.__easyuseAnimaLastQueuedSeed, 777);
+assert.equal(node.widgetValues.seed, 776);
+assert.equal(node.settings.sampler.seed, 776);
+assert.equal(panel.querySelector("[data-aio-seed-input]").value, 776);
+assert.equal(
+  fixture.trace.includes("dirty"),
+  false,
+  "accepted queue seed updates must not mark the workflow dirty",
+);
+assert.equal(
+  panel.querySelector("[data-aio-seed-last]").textContent,
+  'format:button.useLast:{"seed":777}',
+);
 
 node.__easyuseAnimaLastQueuedSeed = 777;
 fixture.runtime.refreshSeedButtons(node);

--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -50,6 +50,58 @@ assert.deepEqual(
   "Generator panel runtime must expose only its factory contract",
 );
 
+{
+  const entrySource = readFileSync(
+    new URL("../web/js/easyuse_anima_aio.js", import.meta.url),
+    "utf8",
+  );
+  const functionStart = entrySource.indexOf("function commitGeneratorSeedValue");
+  const functionEnd = entrySource.indexOf(
+    "\nfunction syncGeneratorSerializedWidgets",
+    functionStart,
+  );
+  assert.ok(functionStart >= 0 && functionEnd > functionStart);
+  const commitGeneratorSeedValue = new Function(
+    "findWidget",
+    "GENERATOR_SETTINGS_WIDGET",
+    "generatorSettings",
+    `"use strict";\n${entrySource.slice(functionStart, functionEnd)}\nreturn commitGeneratorSeedValue;`,
+  )(
+    (node, name) => node.widgets.find((widget) => widget.name === name),
+    "generation_settings",
+    (node) => clone(node.settings),
+  );
+  const seedCallbackError = new Error("seed callback failed");
+  const settingsCallbackError = new Error("settings callback failed");
+  const callbackTrace = [];
+  const seedWidget = {
+    name: "seed",
+    value: 10,
+    callback() {
+      callbackTrace.push("seed");
+      throw seedCallbackError;
+    },
+  };
+  const settingsWidget = {
+    name: "generation_settings",
+    value: JSON.stringify({ sampler: { seed: 10 } }),
+    callback() {
+      callbackTrace.push("settings");
+      throw settingsCallbackError;
+    },
+  };
+  const atomicNode = {
+    widgets: [seedWidget, settingsWidget],
+    settings: { sampler: { seed: 10, seed_after_generate: "increment" } },
+    __easyuseAnimaGeneratorUiValues: { seed: 10 },
+  };
+  assert.doesNotThrow(() => commitGeneratorSeedValue(atomicNode, 11));
+  assert.deepEqual(callbackTrace, ["seed", "settings"]);
+  assert.equal(seedWidget.value, 11);
+  assert.equal(atomicNode.__easyuseAnimaGeneratorUiValues.seed, 11);
+  assert.equal(JSON.parse(settingsWidget.value).sampler.seed, 11);
+}
+
 function createFixture() {
   let dependencyCalls = 0;
   let nextAnimationFrameId = 1;
@@ -260,6 +312,15 @@ function createFixture() {
       dependencyCalls += 1;
       trace.push("set-widget:" + name + ":" + value);
       node.widgetValues[name] = value;
+    },
+    commitSeedValue(node, seed) {
+      dependencyCalls += 1;
+      trace.push("commit-seed:" + seed);
+      if (node.failSeedCommit) {
+        throw node.failSeedCommit;
+      }
+      node.widgetValues.seed = seed;
+      node.settings.sampler.seed = seed;
     },
     markDirty(node) {
       dependencyCalls += 1;
@@ -816,9 +877,9 @@ assert.equal(previewMeta.textContent, "-");
 assert.equal(previewMeta.title, "");
 
 fixture.trace.length = 0;
+node.__easyuseAnimaLastQueuedSeed = 777;
 assert.equal(
   fixture.runtime.updateSeed(node, 776, {
-    lastQueuedSeed: 777,
     markDirty: false,
   }),
   776,
@@ -836,6 +897,19 @@ assert.equal(
   panel.querySelector("[data-aio-seed-last]").textContent,
   'format:button.useLast:{"seed":777}',
 );
+const seedCommitFailure = new Error("seed callback failed");
+node.failSeedCommit = seedCommitFailure;
+assert.throws(
+  () => fixture.runtime.updateSeed(node, 888, {
+    markDirty: false,
+  }),
+  (error) => error === seedCommitFailure,
+);
+delete node.failSeedCommit;
+assert.equal(node.__easyuseAnimaLastQueuedSeed, 777);
+assert.equal(node.widgetValues.seed, 776);
+assert.equal(node.settings.sampler.seed, 776);
+assert.equal(panel.querySelector("[data-aio-seed-input]").value, 776);
 
 node.__easyuseAnimaLastQueuedSeed = 777;
 fixture.runtime.refreshSeedButtons(node);
@@ -847,14 +921,14 @@ findByText(panel, "text:button.newFixed").emit("click");
 assert.equal(node.widgetValues.seed, 123456);
 assert.equal(node.settings.sampler.seed, 123456);
 assert.equal(fixture.trace.includes("random-seed"), true);
-assert.ok(fixture.trace.indexOf("set-widget:seed:123456") < fixture.trace.indexOf("sync-visible"));
-assert.ok(fixture.trace.indexOf("sync-visible") < fixture.trace.indexOf("get-settings"));
+assert.ok(fixture.trace.indexOf("random-seed") < fixture.trace.indexOf("commit-seed:123456"));
+assert.ok(fixture.trace.indexOf("commit-seed:123456") < fixture.trace.indexOf("get-settings"));
 assert.ok(fixture.trace.indexOf("get-settings") < fixture.trace.lastIndexOf("dirty"));
 fixture.trace.length = 0;
 findByText(panel, "text:button.randomEach").emit("click");
 assert.equal(node.widgetValues.seed, -1);
 assert.equal(node.settings.sampler.seed, -1);
-assert.ok(fixture.trace.indexOf("set-widget:seed:-1") < fixture.trace.indexOf("sync-visible"));
+assert.ok(fixture.trace.indexOf("commit-seed:-1") < fixture.trace.indexOf("get-settings"));
 const seedInput = panel.querySelector("[data-aio-seed-input]");
 seedInput.value = "314";
 fixture.trace.length = 0;

--- a/tests/frontend_aio_generator_queue_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_queue_runtime_smoke.mjs
@@ -37,47 +37,21 @@ function normalizeSeedControl(value) {
   return SEED_CONTROLS.includes(normalized) ? normalized : "fixed";
 }
 
-function createPrompt(nodeId = 42) {
-  return {
-    output: {
-      [String(nodeId)]: {
-        class_type: "EasyUseAnimaAIOGenerator",
-        inputs: {
-          generation_settings: "live-settings",
-          untouched: "payload-value",
-        },
-      },
-      99: {
-        class_type: "OtherNode",
-        inputs: { value: 9 },
-      },
-    },
-    workflow: {
-      nodes: [
-        {
-          id: nodeId,
-          type: "EasyUseAnimaAIOGenerator",
-          widgets_values: ["visible-widget", "live-settings"],
-        },
-        { id: 99, type: "OtherNode", widgets_values: [9] },
-      ],
-      links: [],
-    },
-    extra_data: { keep: true },
-  };
+function generationSettingsLabel(nodeId) {
+  return Number(nodeId) === 42 ? "live-settings" : `live-settings-${nodeId}`;
 }
 
-function createFixture(options = {}) {
-  const trace = [];
-  const randomValues = [...(options.randomValues || [17, 23, 31])];
+function createGeneratorNode(options = {}) {
   const node = {
     id: options.nodeId ?? 42,
     mode: options.mode ?? 0,
+    failAt: options.failAt || "",
     widgets: [
       { name: "seed" },
       { name: "generation_settings" },
     ],
     settings: {
+      __fixtureNodeId: options.nodeId ?? 42,
       sampler: {
         seed: options.seed ?? SPECIAL_RANDOM,
         seed_after_generate: options.seedControl ?? "fixed",
@@ -89,6 +63,44 @@ function createFixture(options = {}) {
   if (Object.prototype.hasOwnProperty.call(options, "lastSeed")) {
     node.lastSeed = options.lastSeed;
   }
+  return node;
+}
+
+function createPrompt(nodeIds = [42]) {
+  const normalizedNodeIds = Array.isArray(nodeIds) ? nodeIds : [nodeIds];
+  return {
+    output: Object.fromEntries([
+      ...normalizedNodeIds.map((nodeId) => [String(nodeId), {
+        class_type: "EasyUseAnimaAIOGenerator",
+        inputs: {
+          generation_settings: generationSettingsLabel(nodeId),
+          untouched: "payload-value",
+        },
+      }]),
+      ["99", {
+        class_type: "OtherNode",
+        inputs: { value: 9 },
+      }],
+    ]),
+    workflow: {
+      nodes: [
+        ...normalizedNodeIds.map((nodeId) => ({
+          id: nodeId,
+          type: "EasyUseAnimaAIOGenerator",
+          widgets_values: ["visible-widget", generationSettingsLabel(nodeId)],
+        })),
+        { id: 99, type: "OtherNode", widgets_values: [9] },
+      ],
+      links: [],
+    },
+    extra_data: { keep: true },
+  };
+}
+
+function createFixture(options = {}) {
+  const trace = [];
+  const randomValues = [...(options.randomValues || [17, 23, 31])];
+  const node = createGeneratorNode(options);
   const nodes = options.nodes || [node];
   let cloneCalls = 0;
   const runtime = queueModule.aioCreateGeneratorQueueRuntime({
@@ -105,33 +117,95 @@ function createFixture(options = {}) {
       normalizeSeedControl,
       cloneJson(value) {
         cloneCalls += 1;
-        return clone(value);
+        const cloned = clone(value);
+        if (!cloned?.output || !Array.isArray(cloned?.workflow?.nodes)) {
+          return cloned;
+        }
+        for (const candidate of nodes) {
+          const nodeId = String(candidate.id);
+          if (candidate.failAt === "output") {
+            const queuedInputs = cloned.output[nodeId]?.inputs;
+            if (queuedInputs) {
+              cloned.output[nodeId].inputs = new Proxy(queuedInputs, {
+                set(target, property, nextValue) {
+                  if (property === "generation_settings") {
+                    throw new Error(`output write failed for ${candidate.id}`);
+                  }
+                  return Reflect.set(target, property, nextValue);
+                },
+              });
+            }
+          }
+          if (candidate.failAt === "workflow") {
+            const workflowNode = cloned.workflow.nodes.find(
+              (item) => String(item?.id) === nodeId,
+            );
+            if (workflowNode) {
+              let currentValues = workflowNode.widgets_values;
+              Object.defineProperty(workflowNode, "widgets_values", {
+                configurable: true,
+                enumerable: true,
+                get() {
+                  return currentValues;
+                },
+                set() {
+                  throw new Error(`workflow write failed for ${candidate.id}`);
+                },
+              });
+            }
+          }
+        }
+        return cloned;
       },
-      settingsToCompactJson: JSON.stringify,
+      settingsToCompactJson(settings) {
+        const candidate = nodes.find(
+          (item) => String(item.id) === String(settings.__fixtureNodeId),
+        );
+        if (candidate?.failAt === "serialize") {
+          throw new Error(`serialize failed for ${candidate.id}`);
+        }
+        return JSON.stringify(settings);
+      },
     },
     nodeAdapter: {
       listNodes: () => nodes,
       isBypassed: (candidate) => candidate.mode === 4,
-      getSettings: (candidate) => candidate.settings,
+      getSettings(candidate) {
+        if (candidate.failAt === "getSettings") {
+          throw new Error(`getSettings failed for ${candidate.id}`);
+        }
+        return candidate.settings;
+      },
       sanitizeSettings(settings) {
         trace.push("sanitize");
+        const candidate = nodes.find(
+          (item) => String(item.id) === String(settings.__fixtureNodeId),
+        );
+        if (candidate?.failAt === "sanitize") {
+          throw new Error(`sanitize failed for ${candidate.id}`);
+        }
         settings.optional_feature.enabled = false;
         settings.sampler.spectrum.enabled = false;
         return settings;
       },
       getLastQueuedSeed: (candidate) => candidate.lastSeed,
+      commitLastQueuedSeed(candidate, seed) {
+        candidate.lastSeed = seed;
+      },
       updateSeed(candidate, seed, updateOptions) {
-        trace.push(`commit:${seed}:${updateOptions.lastQueuedSeed}:${updateOptions.markDirty}`);
-        if (options.commitError) {
-          throw options.commitError;
+        trace.push(`commit:${seed}:${candidate.lastSeed}:${updateOptions.markDirty}`);
+        if (options.commitError || candidate.failAt === "updateSeed") {
+          throw options.commitError || new Error(`updateSeed failed for ${candidate.id}`);
         }
         candidate.settings.sampler.seed = seed;
-        candidate.lastSeed = updateOptions.lastQueuedSeed;
       },
     },
     queueAdapter: {
       async loadOptionalDependencies(loadOptions) {
         trace.push(`load:${loadOptions?.retryErrors}`);
+        if (options.loadError) {
+          throw options.loadError;
+        }
       },
     },
     randomSeed() {
@@ -142,6 +216,7 @@ function createFixture(options = {}) {
   return {
     runtime,
     node,
+    nodes,
     trace,
     cloneCalls: () => cloneCalls,
   };
@@ -184,53 +259,83 @@ function createFixture(options = {}) {
   assert.deepEqual(transaction.prompt.output["99"], prompt.output["99"]);
 }
 
-function preparedSeeds(options) {
+function preparedSeedCase(options) {
   const fixture = createFixture(options);
   const transaction = fixture.runtime.preparePrompt(createPrompt());
   assert.ok(transaction);
-  return transaction.commits[0];
+  return {
+    commit: transaction.commits[0],
+    randomCalls: fixture.trace.filter((item) => item === "random").length,
+  };
 }
 
 {
-  const commit = preparedSeeds({ seed: 10, seedControl: "fixed" });
+  const { commit } = preparedSeedCase({ seed: 10, seedControl: "fixed" });
   assert.equal(commit.queuedSeed, 10);
   assert.equal(commit.liveSeed, 10);
 }
 {
-  const commit = preparedSeeds({ seed: 10, seedControl: "randomize", randomValues: [29] });
+  const { commit } = preparedSeedCase({ seed: 10, seedControl: "randomize", randomValues: [29] });
   assert.equal(commit.queuedSeed, 10);
   assert.equal(commit.liveSeed, 29);
 }
 {
-  const commit = preparedSeeds({ seed: MAX_SEED, seedControl: "increment" });
+  const { commit } = preparedSeedCase({ seed: MAX_SEED, seedControl: "increment" });
   assert.equal(commit.queuedSeed, MAX_SEED);
   assert.equal(commit.liveSeed, MAX_SEED, "increment must clamp at max seed");
 }
 {
-  const commit = preparedSeeds({ seed: MIN_SEED, seedControl: "decrement" });
+  const { commit } = preparedSeedCase({ seed: MIN_SEED, seedControl: "decrement" });
   assert.equal(commit.queuedSeed, MIN_SEED);
   assert.equal(commit.liveSeed, MIN_SEED, "decrement must clamp at min seed");
 }
-{
-  const commit = preparedSeeds({
-    seed: SPECIAL_INCREMENT,
-    seedControl: "fixed",
-    lastSeed: 99,
-  });
-  assert.equal(commit.queuedSeed, MAX_SEED);
-  assert.equal(commit.liveSeed, SPECIAL_INCREMENT);
+
+for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
+  for (const seedControl of SEED_CONTROLS) {
+    for (const hasLastSeed of [false, true]) {
+      const options = {
+        seed,
+        seedControl,
+        randomValues: [17, 23, 31],
+      };
+      if (hasLastSeed) {
+        options.lastSeed = 40;
+      }
+      let expectedQueuedSeed;
+      let expectedRandomCalls;
+      if (seed === SPECIAL_RANDOM) {
+        expectedQueuedSeed = 17;
+        expectedRandomCalls = 1;
+      } else if (hasLastSeed) {
+        expectedQueuedSeed = seed === SPECIAL_INCREMENT ? 41 : 39;
+        expectedRandomCalls = 0;
+      } else {
+        expectedQueuedSeed = 17;
+        expectedRandomCalls = 1;
+      }
+      let expectedLiveSeed;
+      if (seedControl === "fixed") {
+        expectedLiveSeed = seed;
+      } else if (seedControl === "randomize") {
+        expectedLiveSeed = expectedRandomCalls === 0 ? 17 : 23;
+        expectedRandomCalls += 1;
+      } else if (seedControl === "increment") {
+        expectedLiveSeed = Math.min(MAX_SEED, expectedQueuedSeed + 1);
+      } else {
+        expectedLiveSeed = Math.max(MIN_SEED, expectedQueuedSeed - 1);
+      }
+
+      const { commit, randomCalls } = preparedSeedCase(options);
+      const caseLabel = `${seed}/${seedControl}/last:${hasLastSeed}`;
+      assert.equal(commit.queuedSeed, expectedQueuedSeed, `${caseLabel} queued seed`);
+      assert.equal(commit.liveSeed, expectedLiveSeed, `${caseLabel} live seed`);
+      assert.equal(randomCalls, expectedRandomCalls, `${caseLabel} random consumption`);
+    }
+  }
 }
+
 {
-  const commit = preparedSeeds({
-    seed: SPECIAL_DECREMENT,
-    seedControl: "fixed",
-    lastSeed: MIN_SEED,
-  });
-  assert.equal(commit.queuedSeed, MIN_SEED);
-  assert.equal(commit.liveSeed, SPECIAL_DECREMENT);
-}
-{
-  const commit = preparedSeeds({
+  const { commit } = preparedSeedCase({
     seed: SPECIAL_INCREMENT,
     seedControl: "fixed",
     lastSeed: null,
@@ -285,6 +390,156 @@ function preparedSeeds(options) {
 }
 
 {
+  const skippedNode = createGeneratorNode({
+    nodeId: 42,
+    seed: 10,
+    seedControl: "increment",
+  });
+  const targetedNode = createGeneratorNode({
+    nodeId: 43,
+    seed: 20,
+    seedControl: "increment",
+  });
+  const fixture = createFixture({ nodes: [skippedNode, targetedNode] });
+  const prompt = createPrompt([42, 43]);
+  const options = {
+    partialExecutionTargets: ["43"],
+    previewMethod: "latent2rgb",
+  };
+  let receivedPrompt = null;
+  let receivedOptions = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((number, queuedPrompt, queuedOptions) => {
+    assert.equal(number, 0);
+    receivedPrompt = queuedPrompt;
+    receivedOptions = queuedOptions;
+    return { prompt_id: "partial-target", node_errors: {} };
+  });
+  await wrapped(0, prompt, options);
+
+  assert.equal(receivedOptions, options, "partial execution options must preserve identity");
+  assert.equal(
+    receivedPrompt.output["42"].inputs.generation_settings,
+    generationSettingsLabel(42),
+    "untargeted AiO payload must stay untouched",
+  );
+  assert.equal(
+    receivedPrompt.workflow.nodes.find((item) => item.id === 42).widgets_values[1],
+    generationSettingsLabel(42),
+    "untargeted AiO workflow state must stay untouched",
+  );
+  assert.equal(
+    JSON.parse(receivedPrompt.output["43"].inputs.generation_settings).sampler.seed,
+    20,
+  );
+  assert.equal(skippedNode.settings.sampler.seed, 10);
+  assert.equal(skippedNode.lastSeed, undefined);
+  assert.equal(targetedNode.settings.sampler.seed, 21);
+  assert.equal(targetedNode.lastSeed, 20);
+}
+
+{
+  const invalidNode = createGeneratorNode({
+    nodeId: 42,
+    seed: 30,
+    seedControl: "increment",
+  });
+  const validNode = createGeneratorNode({
+    nodeId: 43,
+    seed: 50,
+    seedControl: "decrement",
+  });
+  const fixture = createFixture({ nodes: [invalidNode, validNode] });
+  const result = {
+    prompt_id: "partial-valid-queue",
+    node_errors: {
+      upstream_bad: {
+        errors: ["bad input"],
+        dependent_outputs: ["42"],
+      },
+    },
+  };
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  assert.equal(await wrapped(0, createPrompt([42, 43])), result);
+  assert.equal(invalidNode.settings.sampler.seed, 30);
+  assert.equal(invalidNode.lastSeed, undefined);
+  assert.equal(validNode.settings.sampler.seed, 49);
+  assert.equal(validNode.lastSeed, 50);
+}
+
+for (const failAt of ["getSettings", "sanitize", "serialize", "output", "workflow"]) {
+  const malformedNode = createGeneratorNode({
+    nodeId: 42,
+    seed: 11,
+    seedControl: "increment",
+    failAt,
+  });
+  const healthyNode = createGeneratorNode({
+    nodeId: 43,
+    seed: 21,
+    seedControl: "increment",
+  });
+  const fixture = createFixture({ nodes: [malformedNode, healthyNode] });
+  const prompt = createPrompt([42, 43]);
+  const originalMalformedSettings = clone(malformedNode.settings);
+  let queuedPrompt = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    queuedPrompt = nextPrompt;
+    return { prompt_id: `isolated-${failAt}`, node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.equal(
+    queuedPrompt.output["42"].inputs.generation_settings,
+    generationSettingsLabel(42),
+    `${failAt}: malformed output payload must stay untouched`,
+  );
+  assert.equal(
+    queuedPrompt.workflow.nodes.find((item) => item.id === 42).widgets_values[1],
+    generationSettingsLabel(42),
+    `${failAt}: malformed workflow hidden state must stay untouched`,
+  );
+  assert.deepEqual(
+    malformedNode.settings,
+    originalMalformedSettings,
+    `${failAt}: malformed live settings must stay untouched`,
+  );
+  assert.equal(malformedNode.lastSeed, undefined);
+  assert.equal(
+    JSON.parse(queuedPrompt.output["43"].inputs.generation_settings).sampler.seed,
+    21,
+    `${failAt}: healthy node must still queue`,
+  );
+  assert.equal(healthyNode.settings.sampler.seed, 22, `${failAt}: healthy live seed`);
+  assert.equal(healthyNode.lastSeed, 21, `${failAt}: healthy last seed`);
+}
+
+{
+  const failingCommitNode = createGeneratorNode({
+    nodeId: 42,
+    seed: 61,
+    seedControl: "increment",
+    failAt: "updateSeed",
+  });
+  const healthyCommitNode = createGeneratorNode({
+    nodeId: 43,
+    seed: 71,
+    seedControl: "decrement",
+  });
+  const fixture = createFixture({ nodes: [failingCommitNode, healthyCommitNode] });
+  const result = { prompt_id: "isolated-commit", node_errors: {} };
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  assert.equal(await wrapped(0, createPrompt([42, 43])), result);
+  assert.equal(failingCommitNode.settings.sampler.seed, 61);
+  assert.equal(
+    failingCommitNode.lastSeed,
+    61,
+    "accepted queue reservation must survive a live widget update failure",
+  );
+  assert.equal(healthyCommitNode.settings.sampler.seed, 70);
+  assert.equal(healthyCommitNode.lastSeed, 71);
+}
+
+{
   const commitError = new Error("panel update failed");
   const fixture = createFixture({
     seed: 18,
@@ -299,7 +554,7 @@ function preparedSeeds(options) {
     "a local seed commit failure must preserve the accepted queue result",
   );
   assert.equal(fixture.node.settings.sampler.seed, 18);
-  assert.equal(fixture.node.lastSeed, undefined);
+  assert.equal(fixture.node.lastSeed, 18);
   assert.equal(fixture.trace.includes("commit:19:18:false"), true);
 }
 
@@ -307,9 +562,11 @@ for (const nodeErrors of [
   { 42: { errors: ["bad input"] } },
   ["bad input"],
   "bad input",
+  true,
+  1,
 ]) {
   const fixture = createFixture({ seed: 12, seedControl: "increment" });
-  const result = { node_errors: nodeErrors };
+  const result = { prompt_id: "accepted-with-errors", node_errors: nodeErrors };
   const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
   assert.equal(await wrapped(0, createPrompt()), result);
   assert.equal(fixture.node.lastSeed, undefined);
@@ -319,6 +576,18 @@ for (const nodeErrors of [
     false,
     "non-empty node_errors must not commit queued or live seeds",
   );
+}
+
+for (const emptyNodeErrors of [undefined, null, [], "", false, 0]) {
+  const fixture = createFixture({ seed: 14, seedControl: "increment" });
+  const result = { prompt_id: "accepted-empty-node-errors" };
+  if (emptyNodeErrors !== undefined) {
+    result.node_errors = emptyNodeErrors;
+  }
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  assert.equal(await wrapped(0, createPrompt()), result);
+  assert.equal(fixture.node.settings.sampler.seed, 15);
+  assert.equal(fixture.node.lastSeed, 14);
 }
 
 {
@@ -354,6 +623,36 @@ for (const failureMode of ["throw", "reject"]) {
   assert.equal(fixture.node.lastSeed, undefined);
   assert.equal(fixture.node.settings.sampler.seed, 15);
   assert.equal(fixture.trace.some((item) => item.startsWith("commit:")), false);
+}
+
+{
+  const loadError = new Error("optional dependency load failed");
+  const fixture = createFixture({
+    seed: SPECIAL_RANDOM,
+    seedControl: "increment",
+    loadError,
+  });
+  const prompt = createPrompt();
+  const originalPrompt = clone(prompt);
+  const originalSettings = clone(fixture.node.settings);
+  let queueCalls = 0;
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => {
+    queueCalls += 1;
+    return { prompt_id: "must-not-run", node_errors: {} };
+  });
+  let caught = null;
+  try {
+    await wrapped(0, prompt);
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, loadError, "optional dependency rejection identity must be preserved");
+  assert.equal(queueCalls, 0);
+  assert.equal(fixture.cloneCalls(), 0);
+  assert.deepEqual(prompt, originalPrompt);
+  assert.deepEqual(fixture.node.settings, originalSettings);
+  assert.equal(fixture.node.lastSeed, undefined);
+  assert.deepEqual(fixture.trace, ["load:true"]);
 }
 
 {

--- a/tests/frontend_aio_generator_queue_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_queue_runtime_smoke.mjs
@@ -1,0 +1,400 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+const queueModule = await import(dataModule("../web/js/aio/generator_queue_runtime.js"));
+assert.deepEqual(
+  Object.keys(queueModule),
+  ["aioCreateGeneratorQueueRuntime"],
+  "Generator queue runtime must expose only its factory contract",
+);
+
+const SPECIAL_RANDOM = -1;
+const SPECIAL_INCREMENT = -2;
+const SPECIAL_DECREMENT = -3;
+const MIN_SEED = 0;
+const MAX_SEED = 100;
+const SEED_CONTROLS = ["fixed", "randomize", "increment", "decrement"];
+
+function normalizeSeedValue(value, fallback = SPECIAL_RANDOM) {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return fallback;
+  }
+  return Math.max(SPECIAL_DECREMENT, Math.min(MAX_SEED, Math.trunc(numberValue)));
+}
+
+function normalizeSeedControl(value) {
+  const normalized = String(value || "").trim();
+  return SEED_CONTROLS.includes(normalized) ? normalized : "fixed";
+}
+
+function createPrompt(nodeId = 42) {
+  return {
+    output: {
+      [String(nodeId)]: {
+        class_type: "EasyUseAnimaAIOGenerator",
+        inputs: {
+          generation_settings: "live-settings",
+          untouched: "payload-value",
+        },
+      },
+      99: {
+        class_type: "OtherNode",
+        inputs: { value: 9 },
+      },
+    },
+    workflow: {
+      nodes: [
+        {
+          id: nodeId,
+          type: "EasyUseAnimaAIOGenerator",
+          widgets_values: ["visible-widget", "live-settings"],
+        },
+        { id: 99, type: "OtherNode", widgets_values: [9] },
+      ],
+      links: [],
+    },
+    extra_data: { keep: true },
+  };
+}
+
+function createFixture(options = {}) {
+  const trace = [];
+  const randomValues = [...(options.randomValues || [17, 23, 31])];
+  const node = {
+    id: options.nodeId ?? 42,
+    mode: options.mode ?? 0,
+    widgets: [
+      { name: "seed" },
+      { name: "generation_settings" },
+    ],
+    settings: {
+      sampler: {
+        seed: options.seed ?? SPECIAL_RANDOM,
+        seed_after_generate: options.seedControl ?? "fixed",
+        spectrum: { enabled: true },
+      },
+      optional_feature: { enabled: true },
+    },
+  };
+  if (Object.prototype.hasOwnProperty.call(options, "lastSeed")) {
+    node.lastSeed = options.lastSeed;
+  }
+  const nodes = options.nodes || [node];
+  let cloneCalls = 0;
+  const runtime = queueModule.aioCreateGeneratorQueueRuntime({
+    constants: {
+      settingsWidgetName: "generation_settings",
+      minSeed: MIN_SEED,
+      maxSeed: MAX_SEED,
+      specialSeedRandom: SPECIAL_RANDOM,
+      specialSeedIncrement: SPECIAL_INCREMENT,
+      specialSeedDecrement: SPECIAL_DECREMENT,
+    },
+    settingsCore: {
+      normalizeSeedValue,
+      normalizeSeedControl,
+      cloneJson(value) {
+        cloneCalls += 1;
+        return clone(value);
+      },
+      settingsToCompactJson: JSON.stringify,
+    },
+    nodeAdapter: {
+      listNodes: () => nodes,
+      isBypassed: (candidate) => candidate.mode === 4,
+      getSettings: (candidate) => candidate.settings,
+      sanitizeSettings(settings) {
+        trace.push("sanitize");
+        settings.optional_feature.enabled = false;
+        settings.sampler.spectrum.enabled = false;
+        return settings;
+      },
+      getLastQueuedSeed: (candidate) => candidate.lastSeed,
+      updateSeed(candidate, seed, updateOptions) {
+        trace.push(`commit:${seed}:${updateOptions.lastQueuedSeed}:${updateOptions.markDirty}`);
+        if (options.commitError) {
+          throw options.commitError;
+        }
+        candidate.settings.sampler.seed = seed;
+        candidate.lastSeed = updateOptions.lastQueuedSeed;
+      },
+    },
+    queueAdapter: {
+      async loadOptionalDependencies(loadOptions) {
+        trace.push(`load:${loadOptions?.retryErrors}`);
+      },
+    },
+    randomSeed() {
+      trace.push("random");
+      return randomValues.length ? randomValues.shift() : 0;
+    },
+  });
+  return {
+    runtime,
+    node,
+    trace,
+    cloneCalls: () => cloneCalls,
+  };
+}
+
+{
+  const fixture = createFixture({ seed: SPECIAL_RANDOM, seedControl: "fixed" });
+  const prompt = createPrompt();
+  const originalPrompt = clone(prompt);
+  const originalSettings = clone(fixture.node.settings);
+  const transaction = fixture.runtime.preparePrompt(prompt);
+
+  assert.ok(transaction, "a live generator output must produce a queue transaction");
+  assert.notEqual(transaction.prompt, prompt, "queue preparation must clone the prompt");
+  assert.deepEqual(prompt, originalPrompt, "queue preparation must not mutate the caller prompt");
+  assert.deepEqual(
+    fixture.node.settings,
+    originalSettings,
+    "optional dependency sanitization must not mutate live settings",
+  );
+  assert.equal(transaction.commits.length, 1);
+  assert.equal(transaction.commits[0].queuedSeed, 17);
+  assert.equal(
+    transaction.commits[0].liveSeed,
+    SPECIAL_RANDOM,
+    "fixed mode must preserve the live random sentinel",
+  );
+  const queuedSettingsText = transaction.prompt.output["42"].inputs.generation_settings;
+  const queuedSettings = JSON.parse(queuedSettingsText);
+  assert.equal(queuedSettings.sampler.seed, 17);
+  assert.equal(queuedSettings.sampler.spectrum.enabled, false);
+  assert.equal(queuedSettings.optional_feature.enabled, false);
+  assert.equal(transaction.prompt.output["42"].inputs.untouched, "payload-value");
+  assert.equal(
+    transaction.prompt.workflow.nodes[0].widgets_values[1],
+    queuedSettingsText,
+    "the cloned workflow hidden widget must match the queued payload",
+  );
+  assert.equal(prompt.workflow.nodes[0].widgets_values[1], "live-settings");
+  assert.deepEqual(transaction.prompt.output["99"], prompt.output["99"]);
+}
+
+function preparedSeeds(options) {
+  const fixture = createFixture(options);
+  const transaction = fixture.runtime.preparePrompt(createPrompt());
+  assert.ok(transaction);
+  return transaction.commits[0];
+}
+
+{
+  const commit = preparedSeeds({ seed: 10, seedControl: "fixed" });
+  assert.equal(commit.queuedSeed, 10);
+  assert.equal(commit.liveSeed, 10);
+}
+{
+  const commit = preparedSeeds({ seed: 10, seedControl: "randomize", randomValues: [29] });
+  assert.equal(commit.queuedSeed, 10);
+  assert.equal(commit.liveSeed, 29);
+}
+{
+  const commit = preparedSeeds({ seed: MAX_SEED, seedControl: "increment" });
+  assert.equal(commit.queuedSeed, MAX_SEED);
+  assert.equal(commit.liveSeed, MAX_SEED, "increment must clamp at max seed");
+}
+{
+  const commit = preparedSeeds({ seed: MIN_SEED, seedControl: "decrement" });
+  assert.equal(commit.queuedSeed, MIN_SEED);
+  assert.equal(commit.liveSeed, MIN_SEED, "decrement must clamp at min seed");
+}
+{
+  const commit = preparedSeeds({
+    seed: SPECIAL_INCREMENT,
+    seedControl: "fixed",
+    lastSeed: 99,
+  });
+  assert.equal(commit.queuedSeed, MAX_SEED);
+  assert.equal(commit.liveSeed, SPECIAL_INCREMENT);
+}
+{
+  const commit = preparedSeeds({
+    seed: SPECIAL_DECREMENT,
+    seedControl: "fixed",
+    lastSeed: MIN_SEED,
+  });
+  assert.equal(commit.queuedSeed, MIN_SEED);
+  assert.equal(commit.liveSeed, SPECIAL_DECREMENT);
+}
+{
+  const commit = preparedSeeds({
+    seed: SPECIAL_INCREMENT,
+    seedControl: "fixed",
+    lastSeed: null,
+    randomValues: [37],
+  });
+  assert.equal(commit.queuedSeed, 37, "a null last seed must use a fresh random seed");
+}
+
+{
+  const fixture = createFixture({
+    seed: SPECIAL_RANDOM,
+    seedControl: "increment",
+    randomValues: [40],
+  });
+  const prompt = createPrompt();
+  const tailObject = { tail: true };
+  const owner = { name: "queue-owner" };
+  const result = { prompt_id: "accepted", node_errors: {} };
+  let receivedArgs = null;
+  let receivedThis = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt(function (...args) {
+    fixture.trace.push("queue");
+    receivedArgs = args;
+    receivedThis = this;
+    return result;
+  });
+
+  const returned = await wrapped.call(owner, 5, prompt, "tail", tailObject);
+  assert.equal(receivedThis, owner, "the original queue receiver must be preserved");
+  assert.equal(receivedArgs.length, 4);
+  assert.equal(receivedArgs[0], 5);
+  assert.notEqual(receivedArgs[1], prompt);
+  assert.equal(receivedArgs[2], "tail");
+  assert.equal(receivedArgs[3], tailObject);
+  assert.equal(returned, result, "the original resolved result must be preserved");
+  assert.deepEqual(fixture.trace, [
+    "load:true",
+    "sanitize",
+    "random",
+    "queue",
+    "commit:41:40:false",
+  ]);
+  assert.equal(fixture.node.lastSeed, 40);
+  assert.equal(fixture.node.settings.sampler.seed, 41);
+  assert.equal(
+    fixture.node.settings.sampler.spectrum.enabled,
+    true,
+    "accepted seed commit must not copy sanitized optional settings into live state",
+  );
+  assert.equal(JSON.parse(receivedArgs[1].output["42"].inputs.generation_settings).sampler.seed, 40);
+  assert.equal(prompt.output["42"].inputs.generation_settings, "live-settings");
+}
+
+{
+  const commitError = new Error("panel update failed");
+  const fixture = createFixture({
+    seed: 18,
+    seedControl: "increment",
+    commitError,
+  });
+  const result = { prompt_id: "accepted-despite-local-commit", node_errors: {} };
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  assert.equal(
+    await wrapped(0, createPrompt()),
+    result,
+    "a local seed commit failure must preserve the accepted queue result",
+  );
+  assert.equal(fixture.node.settings.sampler.seed, 18);
+  assert.equal(fixture.node.lastSeed, undefined);
+  assert.equal(fixture.trace.includes("commit:19:18:false"), true);
+}
+
+for (const nodeErrors of [
+  { 42: { errors: ["bad input"] } },
+  ["bad input"],
+  "bad input",
+]) {
+  const fixture = createFixture({ seed: 12, seedControl: "increment" });
+  const result = { node_errors: nodeErrors };
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  assert.equal(await wrapped(0, createPrompt()), result);
+  assert.equal(fixture.node.lastSeed, undefined);
+  assert.equal(fixture.node.settings.sampler.seed, 12);
+  assert.equal(
+    fixture.trace.some((item) => item.startsWith("commit:")),
+    false,
+    "non-empty node_errors must not commit queued or live seeds",
+  );
+}
+
+{
+  const fixture = createFixture({ seed: 13, seedControl: "increment" });
+  const result = { prompt_id: "accepted-with-malformed-validation-metadata" };
+  Object.defineProperty(result, "node_errors", {
+    get() {
+      throw new Error("malformed node_errors getter");
+    },
+  });
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  assert.equal(await wrapped(0, createPrompt()), result);
+  assert.equal(fixture.node.settings.sampler.seed, 13);
+  assert.equal(fixture.node.lastSeed, undefined);
+}
+
+for (const failureMode of ["throw", "reject"]) {
+  const fixture = createFixture({ seed: 15, seedControl: "decrement" });
+  const failure = new Error(`queue-${failureMode}`);
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => {
+    if (failureMode === "throw") {
+      throw failure;
+    }
+    return Promise.reject(failure);
+  });
+  let caught = null;
+  try {
+    await wrapped(0, createPrompt());
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, failure, "the original thrown/rejected error must be preserved");
+  assert.equal(fixture.node.lastSeed, undefined);
+  assert.equal(fixture.node.settings.sampler.seed, 15);
+  assert.equal(fixture.trace.some((item) => item.startsWith("commit:")), false);
+}
+
+{
+  const fixture = createFixture({ mode: 4 });
+  const prompt = createPrompt();
+  assert.equal(fixture.runtime.preparePrompt(prompt), null);
+  assert.equal(fixture.cloneCalls(), 0, "bypassed generators must not clone the prompt");
+}
+
+for (const malformedPrompt of [
+  null,
+  {},
+  { output: [] },
+  { output: { 42: { inputs: [] } } },
+]) {
+  const fixture = createFixture();
+  assert.equal(fixture.runtime.preparePrompt(malformedPrompt), null);
+  assert.equal(fixture.cloneCalls(), 0);
+}
+
+{
+  const fixture = createFixture();
+  const circularPrompt = createPrompt();
+  circularPrompt.circular = circularPrompt;
+  assert.equal(fixture.runtime.preparePrompt(circularPrompt), null);
+  assert.equal(fixture.node.settings.sampler.seed, SPECIAL_RANDOM);
+}
+
+{
+  const fixture = createFixture();
+  const prompt = { output: {}, workflow: { nodes: [] } };
+  const result = { prompt_id: "pass-through" };
+  let receivedPrompt = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt(function (number, nextPrompt) {
+    receivedPrompt = nextPrompt;
+    assert.equal(number, 3);
+    return result;
+  });
+  assert.equal(await wrapped(3, prompt), result);
+  assert.equal(receivedPrompt, prompt, "missing generator output must pass the original prompt through");
+  assert.deepEqual(fixture.trace, ["load:true"]);
+}
+
+console.log("Frontend AiO generator queue runtime smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -18,6 +18,9 @@ AIO_PROFILE_SETTINGS_RUNTIME_JS = (
 AIO_GENERATOR_PANEL_RUNTIME_JS = (
     ROOT / "web" / "js" / "aio" / "generator_panel_runtime.js"
 )
+AIO_GENERATOR_QUEUE_RUNTIME_JS = (
+    ROOT / "web" / "js" / "aio" / "generator_queue_runtime.js"
+)
 AIO_NATIVE_PREVIEW_RUNTIME_JS = (
     ROOT / "web" / "js" / "aio" / "native_preview_runtime.js"
 )
@@ -494,11 +497,10 @@ class AIOFrontendSourceTests(unittest.TestCase):
     def test_generator_panel_lifecycle_keeps_entry_behavior_boundaries(self):
         source = AIO_JS.read_text(encoding="utf-8")
         panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
+        queue_source = AIO_GENERATOR_QUEUE_RUNTIME_JS.read_text(encoding="utf-8")
 
         for entry_owned_function in (
             "loadGeneratorSamplerOptions",
-            "resolveGeneratorSeedForQueue",
-            "prepareGeneratorPromptForQueue",
             "installGeneratorQueuePromptHook",
             "installGeneratorWheelForwarder",
         ):
@@ -511,6 +513,18 @@ class AIOFrontendSourceTests(unittest.TestCase):
                     panel_source,
                     rf"\bfunction\s+{entry_owned_function}\(",
                 )
+
+        for queue_owned_function in (
+            "resolveQueuedSeed",
+            "preparePrompt",
+        ):
+            with self.subTest(queue_owned_function=queue_owned_function):
+                self.assertRegex(
+                    queue_source,
+                    rf"\bfunction\s+{queue_owned_function}\(",
+                )
+        self.assertNotIn("resolveGeneratorSeedForQueue", source)
+        self.assertNotIn("prepareGeneratorPromptForQueue", source)
 
         setup_start = source.index("  async setup() {")
         setup_end = source.index("\n  async beforeRegisterNodeDef", setup_start)
@@ -643,17 +657,27 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_optional_dependency_query_retries_errors_before_queueing(self):
         source = AIO_JS.read_text(encoding="utf-8")
+        queue_source = AIO_GENERATOR_QUEUE_RUNTIME_JS.read_text(encoding="utf-8")
         load_start = source.index("function loadGeneratorOptionalDependencies")
         load_end = source.index("\nfunction optionalDependencyStatus", load_start)
         load_body = source[load_start:load_end]
-        queue_start = source.index("function installGeneratorQueuePromptHook")
-        queue_end = source.index("\nfunction ensureButton", queue_start)
-        queue_body = source[queue_start:queue_end]
+        composition_start = source.index(
+            "const generatorQueueRuntime = aioCreateGeneratorQueueRuntime({"
+        )
+        composition_end = source.index("\n});", composition_start)
+        composition_body = source[composition_start:composition_end]
 
         self.assertIn("retryErrors = false", load_body)
         self.assertIn('includes("error")', load_body)
         self.assertIn("generatorOptionalDependencyState.loading = null", load_body)
-        self.assertIn("loadGeneratorOptionalDependencies({ retryErrors: true })", queue_body)
+        self.assertIn(
+            "loadOptionalDependencies: loadGeneratorOptionalDependencies,",
+            composition_body,
+        )
+        self.assertIn(
+            "loadOptionalDependencies({ retryErrors: true })",
+            queue_source,
+        )
 
     def test_generator_panel_renders_upscale_after_detailer(self):
         body = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -47,6 +47,10 @@ AIO_GENERATOR_PANEL_RUNTIME_JS = AIO_MODULES / "generator_panel_runtime.js"
 AIO_GENERATOR_PANEL_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_generator_panel_runtime_smoke.mjs"
 )
+AIO_GENERATOR_QUEUE_RUNTIME_JS = AIO_MODULES / "generator_queue_runtime.js"
+AIO_GENERATOR_QUEUE_RUNTIME_SMOKE = (
+    ROOT / "tests" / "frontend_aio_generator_queue_runtime_smoke.mjs"
+)
 AIO_NATIVE_PREVIEW_RUNTIME_JS = AIO_MODULES / "native_preview_runtime.js"
 AIO_NATIVE_PREVIEW_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_native_preview_runtime_smoke.mjs"
@@ -497,6 +501,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "createDomSettingsNumberControl",
             "createDomSettingsSelectControl",
             "createDomSelectControl",
+            "updateGeneratorSeed",
             "setGeneratorSeedFromUi",
         ):
             with self.subTest(moved_function=moved_function):
@@ -542,6 +547,109 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_GENERATOR_PANEL_RUNTIME_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_generator_panel_runtime_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_generator_queue_runtime_has_transaction_boundary(self):
+        source = AIO_GENERATOR_QUEUE_RUNTIME_JS.read_text(encoding="utf-8")
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreateGeneratorQueueRuntime"],
+        )
+        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertNotRegex(source, r"\b(?:document|window|app)\b")
+        self.assertNotIn("fetch(", source)
+        self.assertNotIn("app.registerExtension", source)
+
+        self.assertIn(
+            'import { aioCreateGeneratorQueueRuntime } from '
+            '"./aio/generator_queue_runtime.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+generatorQueueRuntime\s*=\s*"
+            r"aioCreateGeneratorQueueRuntime\(\{(?P<dependencies>.*?)\n\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        runtime_dependencies = factory_match.group("dependencies")
+        for expected in (
+            "settingsWidgetName: GENERATOR_SETTINGS_WIDGET,",
+            "minSeed: 0,",
+            "maxSeed: GENERATOR_MAX_SEED,",
+            "specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,",
+            "specialSeedIncrement: GENERATOR_SPECIAL_SEED_INCREMENT,",
+            "specialSeedDecrement: GENERATOR_SPECIAL_SEED_DECREMENT,",
+            "normalizeSeedValue,",
+            "normalizeSeedControl,",
+            "cloneJson: clone,",
+            "settingsToCompactJson,",
+            "listNodes: generatorGraphNodes,",
+            "syncGeneratorStateFromDom(node);",
+            "return generatorSettings(node);",
+            "sanitizeSettings: sanitizeGeneratorSettingsForOptionalDependencies,",
+            "getLastQueuedSeed: (node) => node.__easyuseAnimaLastQueuedSeed,",
+            "updateSeed: (node, seed, options) => generatorPanelRuntime.updateSeed(node, seed, options),",
+            "loadOptionalDependencies: loadGeneratorOptionalDependencies,",
+            "randomSeed,",
+        ):
+            with self.subTest(composition_dependency=expected):
+                self.assertIn(expected, runtime_dependencies)
+
+        for moved_function in (
+            "findWorkflowNode",
+            "resolveQueuedSeed",
+            "preparePrompt",
+            "setWorkflowSettingsValue",
+        ):
+            with self.subTest(moved_function=moved_function):
+                self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
+        for removed_entry_function in (
+            "findWorkflowNode",
+            "resolveGeneratorSeedForQueue",
+            "prepareGeneratorPromptForQueue",
+            "setWorkflowWidgetValue",
+        ):
+            with self.subTest(removed_entry_function=removed_entry_function):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\bfunction\s+{removed_entry_function}\(",
+                )
+
+        self.assertRegex(
+            entry_source,
+            r"\bfunction\s+installGeneratorQueuePromptHook\(",
+        )
+        self.assertNotRegex(
+            source,
+            r"\bfunction\s+installGeneratorQueuePromptHook\(",
+        )
+        install_start = entry_source.index("function installGeneratorQueuePromptHook")
+        install_end = entry_source.index("\nfunction ensureButton", install_start)
+        install_body = entry_source[install_start:install_end]
+        self.assertIn(
+            "api.queuePrompt = generatorQueueRuntime.wrapQueuePrompt(queuePrompt);",
+            install_body,
+        )
+        self.assertIn("api.queuePrompt.__easyuseAnimaAioWrapped = true;", install_body)
+        self.assertIn("updateSeed: updateGeneratorSeed,", panel_source)
+        self.assertLess(
+            entry_source.index("const generatorPanelRuntime"),
+            entry_source.index("const generatorQueueRuntime"),
+        )
+        self.assertLess(
+            entry_source.index("const generatorQueueRuntime"),
+            entry_source.index("function hookInputNode"),
+        )
+        self.assertTrue(AIO_GENERATOR_QUEUE_RUNTIME_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_generator_queue_runtime_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -418,6 +418,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 "widgetValue,",
                 "widgetOptions,",
                 "setWidgetValueIfChanged,",
+                "commitSeedValue: commitGeneratorSeedValue,",
                 "markDirty: markNodeDirty,",
                 "ensureStyle,",
                 "suppressDefaultPreview: suppressGeneratorDefaultPreview,",
@@ -521,6 +522,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 self.assertNotIn(removed_function, source)
 
         for entry_owned_function in (
+            "commitGeneratorSeedValue",
             "syncGeneratorSerializedWidgets",
             "installGeneratorWheelForwarder",
             "installGeneratorQueuePromptHook",
@@ -535,6 +537,24 @@ class FrontendModuleStructureTests(unittest.TestCase):
                     source,
                     rf"\bfunction\s+{entry_owned_function}\(",
                 )
+
+        seed_commit_start = entry_source.index("function commitGeneratorSeedValue")
+        seed_commit_end = entry_source.index(
+            "\nfunction syncGeneratorSerializedWidgets",
+            seed_commit_start,
+        )
+        seed_commit_body = entry_source[seed_commit_start:seed_commit_end]
+        self.assertLess(
+            seed_commit_body.index("seedWidget.value = seed;"),
+            seed_commit_body.index("seedWidget?.callback?.(seed);"),
+        )
+        self.assertLess(
+            seed_commit_body.index("settingsWidget.value = serializedSettings;"),
+            seed_commit_body.index("settingsWidget?.callback?.(serializedSettings);"),
+        )
+        self.assertEqual(seed_commit_body.count("} catch {"), 2)
+        self.assertNotIn("previousSeedWidgetValue", seed_commit_body)
+        self.assertNotIn("previousSettingsWidgetValue", seed_commit_body)
 
         self.assertLess(
             entry_source.index("const openPreviewSettings"),
@@ -591,22 +611,27 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "cloneJson: clone,",
             "settingsToCompactJson,",
             "listNodes: generatorGraphNodes,",
-            "syncGeneratorStateFromDom(node);",
-            "return generatorSettings(node);",
+            "getSettings: generatorSettings,",
             "sanitizeSettings: sanitizeGeneratorSettingsForOptionalDependencies,",
             "getLastQueuedSeed: (node) => node.__easyuseAnimaLastQueuedSeed,",
+            "commitLastQueuedSeed: (node, seed) => {",
+            "node.__easyuseAnimaLastQueuedSeed = seed;",
             "updateSeed: (node, seed, options) => generatorPanelRuntime.updateSeed(node, seed, options),",
             "loadOptionalDependencies: loadGeneratorOptionalDependencies,",
             "randomSeed,",
         ):
             with self.subTest(composition_dependency=expected):
                 self.assertIn(expected, runtime_dependencies)
+        self.assertNotIn("syncGeneratorStateFromDom", runtime_dependencies)
 
         for moved_function in (
             "findWorkflowNode",
+            "partialExecutionTargetIds",
             "resolveQueuedSeed",
             "preparePrompt",
-            "setWorkflowSettingsValue",
+            "stageWorkflowSettingsValue",
+            "applyQueuedSettingsTransaction",
+            "invalidCommitTargetIds",
         ):
             with self.subTest(moved_function=moved_function):
                 self.assertRegex(source, rf"\bfunction\s+{moved_function}\(")
@@ -633,6 +658,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         install_start = entry_source.index("function installGeneratorQueuePromptHook")
         install_end = entry_source.index("\nfunction ensureButton", install_start)
         install_body = entry_source[install_start:install_end]
+        self.assertIn(
+            "if (!api?.queuePrompt || api.queuePrompt.__easyuseAnimaAioWrapped)",
+            install_body,
+        )
         self.assertIn(
             "api.queuePrompt = generatorQueueRuntime.wrapQueuePrompt(queuePrompt);",
             install_body,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -59,6 +59,11 @@ try {
         throw "Frontend AiO generator panel runtime smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_generator_queue_runtime_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO generator queue runtime smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_stage_settings_dialogs_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO stage settings dialogs smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -46,6 +46,7 @@ const GENERATOR_PANEL_CONTROL_SELECTOR = "input, select, textarea, button";
  * @property {(node: any, name: string, fallback: any) => any} widgetValue
  * @property {(node: any, name: string, fallback: any[]) => any[]} widgetOptions
  * @property {(node: any, name: string, value: any) => void} setWidgetValueIfChanged
+ * @property {(node: any, seed: number) => void} commitSeedValue
  * @property {(node: any) => void} markDirty
  * @property {() => void} ensureStyle
  * @property {(node: any, options?: Record<string, any>) => void} suppressDefaultPreview
@@ -157,6 +158,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
     widgetValue,
     widgetOptions,
     setWidgetValueIfChanged,
+    commitSeedValue,
     markDirty: markNodeDirty,
     ensureStyle,
     suppressDefaultPreview: suppressGeneratorDefaultPreview,
@@ -1019,18 +1021,19 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
 
   function updateGeneratorSeed(node, value, options = {}) {
     const seed = normalizeSeedValue(value, GENERATOR_SPECIAL_SEED_RANDOM);
-    if (Object.prototype.hasOwnProperty.call(options, "lastQueuedSeed")) {
-      node.__easyuseAnimaLastQueuedSeed = options.lastQueuedSeed;
-    }
+    commitSeedValue(node, seed);
     const panel = node?.__easyuseAnimaGeneratorPanelEl;
     const seedInput = panel?.querySelector?.("[data-aio-seed-input]");
     if (seedInput) {
       seedInput.value = seed;
     }
-    setWidgetValueIfChanged(node, "seed", seed);
-    syncGeneratorSettingsFromVisible(node);
-    updateGeneratorDomSummary(node);
-    refreshGeneratorSeedButtons(node);
+    try {
+      updateGeneratorDomSummary(node);
+      refreshGeneratorSeedButtons(node);
+    } catch {
+      // The seed transaction is already committed. A stale/disposed panel must
+      // not make the queue wrapper treat that durable state change as failed.
+    }
     if (options.markDirty !== false) {
       markNodeDirty(node);
     }

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -1017,8 +1017,11 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
     return select;
   }
 
-  function setGeneratorSeedFromUi(node, value) {
+  function updateGeneratorSeed(node, value, options = {}) {
     const seed = normalizeSeedValue(value, GENERATOR_SPECIAL_SEED_RANDOM);
+    if (Object.prototype.hasOwnProperty.call(options, "lastQueuedSeed")) {
+      node.__easyuseAnimaLastQueuedSeed = options.lastQueuedSeed;
+    }
     const panel = node?.__easyuseAnimaGeneratorPanelEl;
     const seedInput = panel?.querySelector?.("[data-aio-seed-input]");
     if (seedInput) {
@@ -1028,7 +1031,14 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
     syncGeneratorSettingsFromVisible(node);
     updateGeneratorDomSummary(node);
     refreshGeneratorSeedButtons(node);
-    markNodeDirty(node);
+    if (options.markDirty !== false) {
+      markNodeDirty(node);
+    }
+    return seed;
+  }
+
+  function setGeneratorSeedFromUi(node, value) {
+    return updateGeneratorSeed(node, value);
   }
 
   function refreshGeneratorSeedButtons(node) {
@@ -1729,5 +1739,6 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
     updateSummary: updateGeneratorDomSummary,
     scheduleLayout: scheduleGeneratorLayout,
     refreshSeedButtons: refreshGeneratorSeedButtons,
+    updateSeed: updateGeneratorSeed,
   };
 }

--- a/web/js/aio/generator_queue_runtime.js
+++ b/web/js/aio/generator_queue_runtime.js
@@ -1,0 +1,316 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioGeneratorQueueSettingsCore
+ * @property {(value: any, fallback?: number) => number} normalizeSeedValue
+ * @property {(value: any) => string} normalizeSeedControl
+ * @property {(value: any) => any} cloneJson
+ * @property {(settings: any) => string} settingsToCompactJson
+ */
+
+/**
+ * @typedef {object} AioGeneratorQueueNodeAdapter
+ * @property {() => any[]} listNodes
+ * @property {(node: any) => boolean} isBypassed
+ * @property {(node: any) => any} getSettings
+ * @property {(settings: any) => any} sanitizeSettings
+ * @property {(node: any) => any} getLastQueuedSeed
+ * @property {(node: any, seed: number, options: {lastQueuedSeed: number, markDirty: boolean}) => void} updateSeed
+ */
+
+/**
+ * @typedef {object} AioGeneratorQueueDependencies
+ * @property {{settingsWidgetName: string, minSeed: number, maxSeed: number, specialSeedRandom: number, specialSeedIncrement: number, specialSeedDecrement: number}} constants
+ * @property {AioGeneratorQueueSettingsCore} settingsCore
+ * @property {AioGeneratorQueueNodeAdapter} nodeAdapter
+ * @property {{loadOptionalDependencies: (options?: {retryErrors?: boolean}) => any}} queueAdapter
+ * @property {() => number} randomSeed
+ */
+
+/**
+ * Own the transactional AiO queue payload and seed lifecycle. The runtime is
+ * DOM-free: extension registration, api.queuePrompt replacement, optional
+ * dependency discovery, settings sanitization, and panel rendering stay behind
+ * injected adapters.
+ *
+ * @param {AioGeneratorQueueDependencies} dependencies
+ */
+export function aioCreateGeneratorQueueRuntime(dependencies) {
+  const {
+    constants,
+    settingsCore,
+    nodeAdapter,
+    queueAdapter,
+    randomSeed,
+  } = dependencies;
+  const {
+    settingsWidgetName,
+    minSeed,
+    maxSeed,
+    specialSeedRandom,
+    specialSeedIncrement,
+    specialSeedDecrement,
+  } = constants;
+  const {
+    normalizeSeedValue,
+    normalizeSeedControl,
+    cloneJson,
+    settingsToCompactJson,
+  } = settingsCore;
+  const {
+    listNodes,
+    isBypassed,
+    getSettings,
+    sanitizeSettings,
+    getLastQueuedSeed,
+    updateSeed,
+  } = nodeAdapter;
+  const { loadOptionalDependencies } = queueAdapter;
+  const specialSeeds = new Set([
+    specialSeedRandom,
+    specialSeedIncrement,
+    specialSeedDecrement,
+  ]);
+
+  function isRecord(value) {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function clampConcreteSeed(value, fallback = minSeed) {
+    const numberValue = Number(value);
+    const concrete = Number.isFinite(numberValue) ? Math.trunc(numberValue) : fallback;
+    return Math.max(minSeed, Math.min(maxSeed, concrete));
+  }
+
+  function randomConcreteSeed() {
+    return clampConcreteSeed(randomSeed(), minSeed);
+  }
+
+  function lastConcreteSeed(node) {
+    const rawValue = getLastQueuedSeed(node);
+    if (rawValue == null) {
+      return null;
+    }
+    const value = Number(rawValue);
+    if (!Number.isFinite(value) || specialSeeds.has(value)) {
+      return null;
+    }
+    return clampConcreteSeed(value);
+  }
+
+  function resolveQueuedSeed(node, inputSeed) {
+    const seed = normalizeSeedValue(inputSeed, specialSeedRandom);
+    if (!specialSeeds.has(seed)) {
+      return clampConcreteSeed(seed);
+    }
+    const lastSeed = lastConcreteSeed(node);
+    if (lastSeed != null && seed === specialSeedIncrement) {
+      return clampConcreteSeed(lastSeed + 1);
+    }
+    if (lastSeed != null && seed === specialSeedDecrement) {
+      return clampConcreteSeed(lastSeed - 1);
+    }
+    return randomConcreteSeed();
+  }
+
+  function nextLiveSeed(seedControl, inputSeed, queuedSeed) {
+    switch (normalizeSeedControl(seedControl)) {
+      case "randomize":
+        return randomConcreteSeed();
+      case "increment":
+        return clampConcreteSeed(queuedSeed + 1);
+      case "decrement":
+        return clampConcreteSeed(queuedSeed - 1);
+      default:
+        return normalizeSeedValue(inputSeed, specialSeedRandom);
+    }
+  }
+
+  function findWorkflowNode(workflow, id) {
+    if (!Array.isArray(workflow?.nodes)) {
+      return null;
+    }
+    return workflow.nodes.find(
+      (workflowNode) => String(workflowNode?.id) === String(id),
+    ) || null;
+  }
+
+  function setWorkflowSettingsValue(node, workflowNode, value) {
+    if (
+      !workflowNode
+      || !Array.isArray(workflowNode.widgets_values)
+      || !Array.isArray(node?.widgets)
+    ) {
+      return;
+    }
+    const index = node.widgets.findIndex(
+      (widget) => widget?.name === settingsWidgetName,
+    );
+    if (index < 0) {
+      return;
+    }
+    while (workflowNode.widgets_values.length <= index) {
+      workflowNode.widgets_values.push(null);
+    }
+    workflowNode.widgets_values[index] = value;
+  }
+
+  function candidateNodes(prompt) {
+    let output;
+    try {
+      output = prompt?.output;
+    } catch {
+      return [];
+    }
+    if (!isRecord(prompt) || !isRecord(output)) {
+      return [];
+    }
+    let nodes;
+    try {
+      nodes = listNodes();
+    } catch {
+      return [];
+    }
+    if (!Array.isArray(nodes)) {
+      return [];
+    }
+    return nodes.filter((node) => {
+      if (!node) {
+        return false;
+      }
+      try {
+        return !isBypassed(node) && isRecord(output[String(node.id)]?.inputs);
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  /**
+   * Build a queue-only clone and a deferred live-seed commit plan. Returning
+   * null means the original prompt should pass through untouched.
+   *
+   * @param {any} prompt
+   */
+  function preparePrompt(prompt) {
+    const nodes = candidateNodes(prompt);
+    if (!nodes.length) {
+      return null;
+    }
+    let queuedPrompt;
+    try {
+      queuedPrompt = cloneJson(prompt);
+    } catch {
+      return null;
+    }
+    if (!isRecord(queuedPrompt) || !isRecord(queuedPrompt.output)) {
+      return null;
+    }
+
+    const commits = [];
+    for (const node of nodes) {
+      try {
+        const queuedInputs = queuedPrompt.output[String(node.id)]?.inputs;
+        if (!isRecord(queuedInputs)) {
+          continue;
+        }
+        const liveSettings = getSettings(node);
+        const settingsSnapshot = cloneJson(liveSettings);
+        const queuedSettings = sanitizeSettings(settingsSnapshot);
+        if (!isRecord(queuedSettings) || !isRecord(queuedSettings.sampler)) {
+          continue;
+        }
+        const inputSeed = normalizeSeedValue(
+          queuedSettings.sampler.seed,
+          specialSeedRandom,
+        );
+        const queuedSeed = resolveQueuedSeed(node, inputSeed);
+        queuedSettings.sampler.seed = queuedSeed;
+        const serializedSettings = settingsToCompactJson(queuedSettings);
+        if (typeof serializedSettings !== "string") {
+          continue;
+        }
+        queuedInputs.generation_settings = serializedSettings;
+        setWorkflowSettingsValue(
+          node,
+          findWorkflowNode(queuedPrompt.workflow, node.id),
+          serializedSettings,
+        );
+        commits.push({
+          node,
+          queuedSeed,
+          liveSeed: nextLiveSeed(
+            queuedSettings.sampler.seed_after_generate,
+            inputSeed,
+            queuedSeed,
+          ),
+        });
+      } catch {
+        // One malformed generator must not prevent unrelated prompt nodes from
+        // queueing. It remains untouched in the cloned payload.
+      }
+    }
+    return commits.length ? { prompt: queuedPrompt, commits } : null;
+  }
+
+  function hasNodeErrors(result) {
+    try {
+      const nodeErrors = result?.node_errors;
+      if (nodeErrors == null) {
+        return false;
+      }
+      if (typeof nodeErrors === "string" || Array.isArray(nodeErrors)) {
+        return nodeErrors.length > 0;
+      }
+      if (typeof nodeErrors === "object") {
+        return Object.keys(nodeErrors).length > 0;
+      }
+      return !!nodeErrors;
+    } catch {
+      // Treat malformed validation metadata conservatively without changing
+      // the original accepted queue return into a local wrapper rejection.
+      return true;
+    }
+  }
+
+  function commitPreparedSeeds(transaction) {
+    for (const commit of transaction.commits) {
+      try {
+        updateSeed(commit.node, commit.liveSeed, {
+          lastQueuedSeed: commit.queuedSeed,
+          markDirty: false,
+        });
+      } catch {
+        // A local panel/widget update cannot turn an already accepted queue
+        // response into a rejection or block another node's seed commit.
+      }
+    }
+  }
+
+  /**
+   * Wrap api.queuePrompt without owning the global hook. The original receiver,
+   * argument tail, resolved value, and thrown/rejected error are preserved.
+   *
+   * @param {(...args: any[]) => any} queuePrompt
+   */
+  function wrapQueuePrompt(queuePrompt) {
+    return async function (...args) {
+      await loadOptionalDependencies({ retryErrors: true });
+      const transaction = preparePrompt(args[1]);
+      const queueArgs = transaction ? [...args] : args;
+      if (transaction) {
+        queueArgs[1] = transaction.prompt;
+      }
+      const result = await queuePrompt.apply(this, queueArgs);
+      if (transaction && !hasNodeErrors(result)) {
+        commitPreparedSeeds(transaction);
+      }
+      return result;
+    };
+  }
+
+  return {
+    preparePrompt,
+    wrapQueuePrompt,
+  };
+}

--- a/web/js/aio/generator_queue_runtime.js
+++ b/web/js/aio/generator_queue_runtime.js
@@ -15,7 +15,8 @@
  * @property {(node: any) => any} getSettings
  * @property {(settings: any) => any} sanitizeSettings
  * @property {(node: any) => any} getLastQueuedSeed
- * @property {(node: any, seed: number, options: {lastQueuedSeed: number, markDirty: boolean}) => void} updateSeed
+ * @property {(node: any, seed: number) => void} commitLastQueuedSeed
+ * @property {(node: any, seed: number, options: {markDirty: boolean}) => void} updateSeed
  */
 
 /**
@@ -63,6 +64,7 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     getSettings,
     sanitizeSettings,
     getLastQueuedSeed,
+    commitLastQueuedSeed,
     updateSeed,
   } = nodeAdapter;
   const { loadOptionalDependencies } = queueAdapter;
@@ -135,27 +137,75 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     ) || null;
   }
 
-  function setWorkflowSettingsValue(node, workflowNode, value) {
+  function stageWorkflowSettingsValue(node, workflowNode, value) {
     if (
       !workflowNode
       || !Array.isArray(workflowNode.widgets_values)
       || !Array.isArray(node?.widgets)
     ) {
-      return;
+      return false;
     }
     const index = node.widgets.findIndex(
       (widget) => widget?.name === settingsWidgetName,
     );
     if (index < 0) {
-      return;
+      return false;
     }
-    while (workflowNode.widgets_values.length <= index) {
-      workflowNode.widgets_values.push(null);
+    const nextValues = [...workflowNode.widgets_values];
+    while (nextValues.length <= index) {
+      nextValues.push(null);
     }
-    workflowNode.widgets_values[index] = value;
+    nextValues[index] = value;
+    return {
+      workflowNode,
+      previousValues: workflowNode.widgets_values,
+      nextValues,
+    };
   }
 
-  function candidateNodes(prompt) {
+  function applyQueuedSettingsTransaction(queuedInputs, serializedSettings, workflowWrite) {
+    const hadOutputSettings = Object.prototype.hasOwnProperty.call(
+      queuedInputs,
+      "generation_settings",
+    );
+    const previousOutputSettings = queuedInputs.generation_settings;
+    try {
+      queuedInputs.generation_settings = serializedSettings;
+      workflowWrite.workflowNode.widgets_values = workflowWrite.nextValues;
+    } catch (error) {
+      try {
+        if (hadOutputSettings) {
+          queuedInputs.generation_settings = previousOutputSettings;
+        } else {
+          delete queuedInputs.generation_settings;
+        }
+      } catch {
+        // A hostile/malformed output setter may reject both apply and rollback.
+      }
+      try {
+        workflowWrite.workflowNode.widgets_values = workflowWrite.previousValues;
+      } catch {
+        // A hostile/malformed workflow setter may reject both operations.
+      }
+      throw error;
+    }
+  }
+
+  function partialExecutionTargetIds(options) {
+    if (
+      !isRecord(options)
+      || !Object.prototype.hasOwnProperty.call(options, "partialExecutionTargets")
+      || options.partialExecutionTargets == null
+    ) {
+      return null;
+    }
+    if (!Array.isArray(options.partialExecutionTargets)) {
+      return new Set();
+    }
+    return new Set(options.partialExecutionTargets.map((target) => String(target)));
+  }
+
+  function candidateNodes(prompt, options) {
     let output;
     try {
       output = prompt?.output;
@@ -174,12 +224,18 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     if (!Array.isArray(nodes)) {
       return [];
     }
+    const targetIds = partialExecutionTargetIds(options);
     return nodes.filter((node) => {
       if (!node) {
         return false;
       }
       try {
-        return !isBypassed(node) && isRecord(output[String(node.id)]?.inputs);
+        const nodeId = String(node.id);
+        return (
+          !isBypassed(node)
+          && (!targetIds || targetIds.has(nodeId))
+          && isRecord(output[nodeId]?.inputs)
+        );
       } catch {
         return false;
       }
@@ -191,9 +247,10 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
    * null means the original prompt should pass through untouched.
    *
    * @param {any} prompt
+   * @param {any} [options]
    */
-  function preparePrompt(prompt) {
-    const nodes = candidateNodes(prompt);
+  function preparePrompt(prompt, options = null) {
+    const nodes = candidateNodes(prompt, options);
     if (!nodes.length) {
       return null;
     }
@@ -230,14 +287,22 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
         if (typeof serializedSettings !== "string") {
           continue;
         }
-        queuedInputs.generation_settings = serializedSettings;
-        setWorkflowSettingsValue(
+        const workflowWrite = stageWorkflowSettingsValue(
           node,
           findWorkflowNode(queuedPrompt.workflow, node.id),
           serializedSettings,
         );
+        if (!workflowWrite) {
+          continue;
+        }
+        applyQueuedSettingsTransaction(
+          queuedInputs,
+          serializedSettings,
+          workflowWrite,
+        );
         commits.push({
           node,
+          nodeId: String(node.id),
           queuedSeed,
           liveSeed: nextLiveSeed(
             queuedSettings.sampler.seed_after_generate,
@@ -253,36 +318,59 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     return commits.length ? { prompt: queuedPrompt, commits } : null;
   }
 
-  function hasNodeErrors(result) {
+  function invalidCommitTargetIds(result) {
     try {
+      const promptId = result?.prompt_id;
+      if (promptId == null || String(promptId).trim() === "") {
+        return null;
+      }
       const nodeErrors = result?.node_errors;
       if (nodeErrors == null) {
-        return false;
+        return new Set();
       }
       if (typeof nodeErrors === "string" || Array.isArray(nodeErrors)) {
-        return nodeErrors.length > 0;
+        return nodeErrors.length > 0 ? null : new Set();
       }
       if (typeof nodeErrors === "object") {
-        return Object.keys(nodeErrors).length > 0;
+        const invalidTargets = new Set();
+        for (const [nodeId, details] of Object.entries(nodeErrors)) {
+          invalidTargets.add(String(nodeId));
+          if (Array.isArray(details?.dependent_outputs)) {
+            for (const dependentOutput of details.dependent_outputs) {
+              invalidTargets.add(String(dependentOutput));
+            }
+          }
+        }
+        return invalidTargets;
       }
-      return !!nodeErrors;
+      return nodeErrors ? null : new Set();
     } catch {
       // Treat malformed validation metadata conservatively without changing
       // the original accepted queue return into a local wrapper rejection.
-      return true;
+      return null;
     }
   }
 
-  function commitPreparedSeeds(transaction) {
+  function commitPreparedSeeds(transaction, result) {
+    const invalidTargets = invalidCommitTargetIds(result);
+    if (!invalidTargets) {
+      return;
+    }
     for (const commit of transaction.commits) {
+      if (invalidTargets.has(commit.nodeId)) {
+        continue;
+      }
       try {
-        updateSeed(commit.node, commit.liveSeed, {
-          lastQueuedSeed: commit.queuedSeed,
-          markDirty: false,
-        });
+        commitLastQueuedSeed(commit.node, commit.queuedSeed);
       } catch {
-        // A local panel/widget update cannot turn an already accepted queue
-        // response into a rejection or block another node's seed commit.
+        continue;
+      }
+      try {
+        updateSeed(commit.node, commit.liveSeed, { markDirty: false });
+      } catch {
+        // The durable last-seed reservation is already committed. A local
+        // panel/widget failure cannot reject the accepted queue result or block
+        // another node's reservation and live-seed update.
       }
     }
   }
@@ -296,14 +384,14 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
   function wrapQueuePrompt(queuePrompt) {
     return async function (...args) {
       await loadOptionalDependencies({ retryErrors: true });
-      const transaction = preparePrompt(args[1]);
+      const transaction = preparePrompt(args[1], args[2]);
       const queueArgs = transaction ? [...args] : args;
       if (transaction) {
         queueArgs[1] = transaction.prompt;
       }
       const result = await queuePrompt.apply(this, queueArgs);
-      if (transaction && !hasNodeErrors(result)) {
-        commitPreparedSeeds(transaction);
+      if (transaction) {
+        commitPreparedSeeds(transaction, result);
       }
       return result;
     };

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -19,6 +19,7 @@ import { aioCreatePreviewSettingsDialog } from "./aio/preview_settings_dialog.js
 import { createAioProfileApiClient } from "./aio/profile_api_client.js";
 import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
 import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
+import { aioCreateGeneratorQueueRuntime } from "./aio/generator_queue_runtime.js";
 import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
 import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
@@ -3387,20 +3388,6 @@ function setWidgetValueIfChanged(node, name, value) {
   setWidgetValue(node, name, value);
 }
 
-function setWorkflowWidgetValue(node, workflowNode, name, value) {
-  if (!workflowNode || !Array.isArray(workflowNode.widgets_values) || !Array.isArray(node?.widgets)) {
-    return;
-  }
-  const index = node.widgets.findIndex((widget) => widget?.name === name);
-  if (index < 0) {
-    return;
-  }
-  while (workflowNode.widgets_values.length <= index) {
-    workflowNode.widgets_values.push(null);
-  }
-  workflowNode.widgets_values[index] = value;
-}
-
 function syncGeneratorSerializedWidgets(node, serialized = null) {
   const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
   const settings = generatorSettings(node);
@@ -3557,74 +3544,12 @@ function generatorGraphNodes() {
   return Object.values(app.graph?._nodes_by_id || {}).filter(isGeneratorGraphNode);
 }
 
-function findWorkflowNode(workflow, id) {
-  const nodes = workflow?.nodes;
-  if (!Array.isArray(nodes)) {
-    return null;
-  }
-  return nodes.find((workflowNode) => String(workflowNode?.id) === String(id)) || null;
-}
-
-function resolveGeneratorSeedForQueue(node, inputSeed) {
-  const seed = normalizeSeedValue(inputSeed, GENERATOR_SPECIAL_SEED_RANDOM);
-  if (!isSpecialSeed(seed)) {
-    return seed;
-  }
-  const lastSeed = Number(node.__easyuseAnimaLastQueuedSeed);
-  if (Number.isFinite(lastSeed) && !isSpecialSeed(lastSeed)) {
-    if (seed === GENERATOR_SPECIAL_SEED_INCREMENT) {
-      return Math.min(GENERATOR_MAX_SEED, lastSeed + 1);
-    }
-    if (seed === GENERATOR_SPECIAL_SEED_DECREMENT) {
-      return Math.max(0, lastSeed - 1);
-    }
-  }
-  return randomSeed();
-}
-
-function prepareGeneratorPromptForQueue(prompt) {
-  const output = prompt?.output;
-  if (!output || typeof output !== "object") {
-    return;
-  }
-  for (const node of generatorGraphNodes()) {
-    if (node.mode === 4 || node.mode === globalThis.LiteGraph?.NEVER) {
-      continue;
-    }
-    const outputNode = output[String(node.id)];
-    const outputInputs = outputNode?.inputs;
-    if (!outputInputs) {
-      continue;
-    }
-    syncGeneratorStateFromDom(node);
-    const settings = sanitizeGeneratorSettingsForOptionalDependencies(generatorSettings(node));
-    const inputSeed = normalizeSeedValue(settings.sampler.seed, GENERATOR_SPECIAL_SEED_RANDOM);
-    const seedToUse = resolveGeneratorSeedForQueue(node, inputSeed);
-    settings.sampler.seed = seedToUse;
-    outputInputs.generation_settings = settingsToCompactJson(settings);
-
-    const workflowNode = findWorkflowNode(prompt.workflow, node.id);
-    setWorkflowWidgetValue(node, workflowNode, GENERATOR_SETTINGS_WIDGET, outputInputs.generation_settings);
-    const settingsWidget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
-    if (settingsWidget) {
-      writeSettings(node, settingsWidget, settings, false);
-    }
-
-    node.__easyuseAnimaLastQueuedSeed = seedToUse;
-    refreshGeneratorSeedButtons(node);
-  }
-}
-
 function installGeneratorQueuePromptHook() {
   if (!api?.queuePrompt || api.queuePrompt.__easyuseAnimaAioWrapped) {
     return;
   }
   const queuePrompt = api.queuePrompt;
-  api.queuePrompt = async function (number, prompt, ...args) {
-    await loadGeneratorOptionalDependencies({ retryErrors: true });
-    prepareGeneratorPromptForQueue(prompt);
-    return queuePrompt.call(this, number, prompt, ...args);
-  };
+  api.queuePrompt = generatorQueueRuntime.wrapQueuePrompt(queuePrompt);
   api.queuePrompt.__easyuseAnimaAioWrapped = true;
 }
 
@@ -4080,6 +4005,38 @@ const generatorPanelRuntime = aioCreateGeneratorPanelRuntime({
     openPostprocessSettings,
     openPreviewSettings,
   },
+});
+
+const generatorQueueRuntime = aioCreateGeneratorQueueRuntime({
+  constants: {
+    settingsWidgetName: GENERATOR_SETTINGS_WIDGET,
+    minSeed: 0,
+    maxSeed: GENERATOR_MAX_SEED,
+    specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,
+    specialSeedIncrement: GENERATOR_SPECIAL_SEED_INCREMENT,
+    specialSeedDecrement: GENERATOR_SPECIAL_SEED_DECREMENT,
+  },
+  settingsCore: {
+    normalizeSeedValue,
+    normalizeSeedControl,
+    cloneJson: clone,
+    settingsToCompactJson,
+  },
+  nodeAdapter: {
+    listNodes: generatorGraphNodes,
+    isBypassed: (node) => node.mode === 4 || node.mode === globalThis.LiteGraph?.NEVER,
+    getSettings(node) {
+      syncGeneratorStateFromDom(node);
+      return generatorSettings(node);
+    },
+    sanitizeSettings: sanitizeGeneratorSettingsForOptionalDependencies,
+    getLastQueuedSeed: (node) => node.__easyuseAnimaLastQueuedSeed,
+    updateSeed: (node, seed, options) => generatorPanelRuntime.updateSeed(node, seed, options),
+  },
+  queueAdapter: {
+    loadOptionalDependencies: loadGeneratorOptionalDependencies,
+  },
+  randomSeed,
 });
 
 function hookInputNode(node) {

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -3388,6 +3388,33 @@ function setWidgetValueIfChanged(node, name, value) {
   setWidgetValue(node, name, value);
 }
 
+function commitGeneratorSeedValue(node, seed) {
+  const seedWidget = findWidget(node, "seed");
+  const settingsWidget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
+  const settings = generatorSettings(node);
+  settings.sampler.seed = seed;
+  const serializedSettings = JSON.stringify(settings);
+
+  if (seedWidget) {
+    seedWidget.value = seed;
+  }
+  node.__easyuseAnimaGeneratorUiValues ||= {};
+  node.__easyuseAnimaGeneratorUiValues.seed = seed;
+  if (settingsWidget) {
+    settingsWidget.value = serializedSettings;
+  }
+  try {
+    seedWidget?.callback?.(seed);
+  } catch {
+    // Widget callbacks are notifications after the durable state write.
+  }
+  try {
+    settingsWidget?.callback?.(serializedSettings);
+  } catch {
+    // Hidden-widget callbacks are also best-effort notifications.
+  }
+}
+
 function syncGeneratorSerializedWidgets(node, serialized = null) {
   const widget = findWidget(node, GENERATOR_SETTINGS_WIDGET);
   const settings = generatorSettings(node);
@@ -3974,6 +4001,7 @@ const generatorPanelRuntime = aioCreateGeneratorPanelRuntime({
     widgetValue,
     widgetOptions,
     setWidgetValueIfChanged,
+    commitSeedValue: commitGeneratorSeedValue,
     markDirty: markNodeDirty,
     ensureStyle,
     suppressDefaultPreview: suppressGeneratorDefaultPreview,
@@ -4025,12 +4053,12 @@ const generatorQueueRuntime = aioCreateGeneratorQueueRuntime({
   nodeAdapter: {
     listNodes: generatorGraphNodes,
     isBypassed: (node) => node.mode === 4 || node.mode === globalThis.LiteGraph?.NEVER,
-    getSettings(node) {
-      syncGeneratorStateFromDom(node);
-      return generatorSettings(node);
-    },
+    getSettings: generatorSettings,
     sanitizeSettings: sanitizeGeneratorSettingsForOptionalDependencies,
     getLastQueuedSeed: (node) => node.__easyuseAnimaLastQueuedSeed,
+    commitLastQueuedSeed: (node, seed) => {
+      node.__easyuseAnimaLastQueuedSeed = seed;
+    },
     updateSeed: (node, seed, options) => generatorPanelRuntime.updateSeed(node, seed, options),
   },
   queueAdapter: {


### PR DESCRIPTION
## 변경 요약

Issue #54의 AiO queue/seed lifecycle 조각입니다.

- 큐 전용 prompt/workflow 복사본에서만 시드와 optional dependency를 준비합니다.
- 서버가 큐를 수락한 뒤에만 라이브 시드와 마지막 큐 시드를 커밋합니다.
- partial execution/partial-valid 응답에서는 유효한 AiO 노드만 갱신합니다.
- output/workflow 적용 실패 시 원래 상태로 롤백하고, 한 노드의 실패가 다른 노드 커밋을 막지 않게 했습니다.
- fixed/randomize/increment/decrement 및 -1/-2/-3 sentinel 처리와 범위 clamp를 전용 runtime smoke로 고정했습니다.

## 주요 파일

- `web/js/aio/generator_queue_runtime.js`
- `web/js/aio/generator_panel_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_generator_queue_runtime_smoke.mjs`
- `tests/frontend_aio_generator_panel_runtime_smoke.mjs`
- frontend runner/module wiring

## 검증

- focused syntax/runtime/module/AiO frontend smoke: 통과
- `git diff --check`: 통과
- 공식 full profile (`tools/check_project.ps1` 경유): Python unittest **380/380**, frontend **97 JavaScript files**, TypeScript 6.0.3, diff check 통과
- ComfyUI 0.27.0 legacy canvas:
  - 한 번의 batch queue에서 시드 10, 11이 순차적으로 서버 `success`
  - 마지막 큐 시드 11, 다음 라이브 시드 12
  - 저장/재열기 후 시드와 increment 제어 유지
- ComfyUI 0.27.0 Node 2.0:
  - Vue node 8개로 surface 확인
  - 서버 큐 시드 20 `success`, 다음 라이브 시드 21
  - 저장/재열기 후 시드와 increment 제어 유지
- 두 surface 종료 후 원래 시드/고정 제어와 legacy canvas를 복원
- EasyUse Anima 신규 console error 없음
- 사용자 v0.27.0 인스턴스 수동 확인: 전체 유지보수 종료 시 1회 수행 예정

## 남은 위험

다음 P3 항목은 #54 hooks/entry 후속 경계에 남깁니다.

- 다른 확장 wrapper가 함수 marker를 가리는 경우의 owner-level idempotence
- 빈/missing `prompt_id` 및 installer 이중 호출의 명시적 회귀 테스트
- 표준 ComfyUI 앱 경로 밖의 동시 direct `api.queuePrompt` 호출 reservation
