### PR TITLE
refactor: AiO extension lifecycle 경계 분리

### DIFF
--- a/tests/frontend_aio_extension_runtime_smoke.mjs
+++ b/tests/frontend_aio_extension_runtime_smoke.mjs
@@ -1,0 +1,502 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const extensionModule = await import(dataModule("../web/js/aio/extension_runtime.js"));
+assert.deepEqual(
+  Object.keys(extensionModule),
+  ["aioCreateExtensionRuntime"],
+  "AiO extension runtime must expose only its factory contract",
+);
+
+const INPUT_NODE_TYPE = "EasyUseAnimaInput";
+const GENERATOR_NODE_TYPE = "EasyUseAnimaAIOGenerator";
+const GENERATOR_PREVIEW_EVENT = "easyuse-anima-aio-preview";
+
+function createFixture(options = {}) {
+  const trace = [];
+  const eventRegistrations = [];
+  const callbacks = {
+    refreshPanels() {
+      trace.push("refreshPanels");
+    },
+    handlePreviewEvent() {},
+    handleProgressEvent() {},
+    handleProgressStateEvent() {},
+    handleDenoisePreviewEvent() {},
+    handleExecutingEvent() {},
+    clearDenoisePreviews() {},
+  };
+  let localeRefresh = null;
+  const runtime = extensionModule.aioCreateExtensionRuntime({
+    api: {
+      addEventListener(name, handler, capture) {
+        eventRegistrations.push({ name, handler, capture });
+        trace.push(`event:${name}:${capture === true}`);
+      },
+    },
+    constants: {
+      inputNodeType: INPUT_NODE_TYPE,
+      generatorNodeType: GENERATOR_NODE_TYPE,
+      generatorPreviewEvent: GENERATOR_PREVIEW_EVENT,
+    },
+    setup: {
+      ensureStyle() {
+        trace.push("ensureStyle");
+      },
+      installWheelForwarder() {
+        trace.push("installWheelForwarder");
+      },
+      installQueuePromptHook() {
+        trace.push("installQueuePromptHook");
+      },
+      watchLocale(callback) {
+        trace.push("watchLocale");
+        localeRefresh = callback;
+      },
+      refreshPanels: callbacks.refreshPanels,
+      handlePreviewEvent: callbacks.handlePreviewEvent,
+      handleProgressEvent: callbacks.handleProgressEvent,
+      handleProgressStateEvent: callbacks.handleProgressStateEvent,
+      handleDenoisePreviewEvent: callbacks.handleDenoisePreviewEvent,
+      handleExecutingEvent: callbacks.handleExecutingEvent,
+      clearDenoisePreviews: callbacks.clearDenoisePreviews,
+      loadSamplerOptions() {
+        trace.push("loadSamplerOptions");
+        return Promise.resolve();
+      },
+      loadUserProfiles() {
+        trace.push("loadUserProfiles");
+        return options.profileError
+          ? Promise.reject(options.profileError)
+          : Promise.resolve();
+      },
+      warnUserProfiles(error) {
+        trace.push(`warnUserProfiles:${error.message}`);
+      },
+    },
+    nodes: {
+      suppressDefaultPreview(_node, suppressOptions) {
+        trace.push(
+          suppressOptions?.markDirty === false
+            ? "suppressDefaultPreview:markDirty=false"
+            : suppressOptions?.purgeStore === false
+              ? "suppressDefaultPreview:purgeStore=false"
+              : "suppressDefaultPreview",
+        );
+      },
+      hookInputNode() {
+        trace.push("hookInputNode");
+      },
+      hookGeneratorNode() {
+        trace.push("hookGeneratorNode");
+      },
+      syncSerializedWidgets(_node, serialized) {
+        trace.push(`syncSerializedWidgets:${serialized.marker}`);
+      },
+      scheduleDefaultPreviewSuppression(_node, suppressOptions) {
+        trace.push(
+          suppressOptions?.purgeStore === false
+            ? "scheduleDefaultPreviewSuppression:purgeStore=false"
+            : "scheduleDefaultPreviewSuppression",
+        );
+      },
+      updateExecutedStatus(_node, message) {
+        trace.push(`updateExecutedStatus:${message.marker}`);
+      },
+      scheduleLayout() {
+        trace.push("scheduleLayout");
+      },
+      disposePanel() {
+        trace.push("disposePanel");
+        if (options.panelError) {
+          throw options.panelError;
+        }
+      },
+      disposeNativePreviewLifecycle() {
+        trace.push("disposeNativePreviewLifecycle");
+        if (options.nativeError) {
+          throw options.nativeError;
+        }
+      },
+    },
+  });
+  return {
+    runtime,
+    trace,
+    callbacks,
+    eventRegistrations,
+    localeRefresh: () => localeRefresh,
+  };
+}
+
+function createNodeType(trace, options = {}) {
+  const returns = {
+    created: { hook: "created" },
+    configured: { hook: "configured" },
+    serialized: { hook: "serialized" },
+    executed: { hook: "executed" },
+    resized: { hook: "resized" },
+    removed: { hook: "removed" },
+  };
+  function NodeType() {}
+  NodeType.prototype.onNodeCreated = function (...args) {
+    trace.push(`original:onNodeCreated:${args.join(",")}`);
+    if (options.createdError) {
+      throw options.createdError;
+    }
+    return returns.created;
+  };
+  NodeType.prototype.onConfigure = function (...args) {
+    trace.push(`original:onConfigure:${args.join(",")}`);
+    if (options.configuredError) {
+      throw options.configuredError;
+    }
+    return returns.configured;
+  };
+  NodeType.prototype.onSerialize = function (serialized) {
+    trace.push(`original:onSerialize:${serialized.marker}`);
+    if (options.serializedError) {
+      throw options.serializedError;
+    }
+    return returns.serialized;
+  };
+  NodeType.prototype.onExecuted = function (message) {
+    trace.push(`original:onExecuted:${message.marker}`);
+    return returns.executed;
+  };
+  NodeType.prototype.onResize = function (...args) {
+    trace.push(`original:onResize:${args.join(",")}`);
+    if (options.resizedError) {
+      throw options.resizedError;
+    }
+    return returns.resized;
+  };
+  NodeType.prototype.onRemoved = function (...args) {
+    trace.push(`original:onRemoved:${args.join(",")}`);
+    if (options.removedError) {
+      throw options.removedError;
+    }
+    return returns.removed;
+  };
+  return { NodeType, returns };
+}
+
+{
+  const fixture = createFixture();
+  assert.equal(
+    await fixture.runtime.setup(),
+    undefined,
+    "setup must preserve the extension hook's undefined result",
+  );
+  await Promise.resolve();
+
+  assert.deepEqual(fixture.trace.slice(0, 14), [
+    "ensureStyle",
+    "installWheelForwarder",
+    "installQueuePromptHook",
+    "watchLocale",
+    `event:${GENERATOR_PREVIEW_EVENT}:false`,
+    "event:progress:false",
+    "event:progress_state:false",
+    "event:b_preview_with_metadata:true",
+    "event:executing:false",
+    "event:execution_error:false",
+    "event:execution_interrupted:false",
+    "event:execution_success:false",
+    "loadSamplerOptions",
+    "loadUserProfiles",
+  ]);
+  assert.deepEqual(
+    fixture.eventRegistrations.map(({ name }) => name),
+    [
+      GENERATOR_PREVIEW_EVENT,
+      "progress",
+      "progress_state",
+      "b_preview_with_metadata",
+      "executing",
+      "execution_error",
+      "execution_interrupted",
+      "execution_success",
+    ],
+  );
+  assert.equal(
+    fixture.eventRegistrations.find(({ name }) => name === GENERATOR_PREVIEW_EVENT).handler,
+    fixture.callbacks.handlePreviewEvent,
+  );
+  assert.equal(
+    fixture.eventRegistrations.find(({ name }) => name === "progress").handler,
+    fixture.callbacks.handleProgressEvent,
+  );
+  assert.equal(
+    fixture.eventRegistrations.find(({ name }) => name === "progress_state").handler,
+    fixture.callbacks.handleProgressStateEvent,
+  );
+  assert.equal(
+    fixture.eventRegistrations.find(({ name }) => name === "b_preview_with_metadata").handler,
+    fixture.callbacks.handleDenoisePreviewEvent,
+  );
+  assert.equal(
+    fixture.eventRegistrations.find(({ name }) => name === "b_preview_with_metadata").capture,
+    true,
+  );
+  assert.equal(
+    fixture.eventRegistrations.find(({ name }) => name === "executing").handler,
+    fixture.callbacks.handleExecutingEvent,
+  );
+  for (const name of ["execution_error", "execution_interrupted", "execution_success"]) {
+    assert.equal(
+      fixture.eventRegistrations.find((registration) => registration.name === name).handler,
+      fixture.callbacks.clearDenoisePreviews,
+      `${name} must keep the shared preview cleanup handler`,
+    );
+  }
+  assert.equal(fixture.trace.filter((item) => item === "refreshPanels").length, 2);
+  assert.equal(fixture.localeRefresh(), fixture.callbacks.refreshPanels);
+  fixture.localeRefresh()();
+  assert.equal(fixture.trace.filter((item) => item === "refreshPanels").length, 3);
+}
+
+{
+  const profileError = new Error("profile load failed");
+  const fixture = createFixture({ profileError });
+  await fixture.runtime.setup();
+  await Promise.resolve();
+  assert.ok(
+    fixture.trace.includes("warnUserProfiles:profile load failed"),
+    "the user-profile rejection must reach the entry warning adapter",
+  );
+}
+
+{
+  const fixture = createFixture();
+  const originalTrace = [];
+  const { NodeType } = createNodeType(originalTrace);
+  const originalHooks = {
+    onNodeCreated: NodeType.prototype.onNodeCreated,
+    onConfigure: NodeType.prototype.onConfigure,
+    onSerialize: NodeType.prototype.onSerialize,
+    onExecuted: NodeType.prototype.onExecuted,
+    onResize: NodeType.prototype.onResize,
+    onRemoved: NodeType.prototype.onRemoved,
+  };
+  assert.equal(
+    await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: "OtherNode" }),
+    undefined,
+  );
+  for (const [name, hook] of Object.entries(originalHooks)) {
+    assert.equal(NodeType.prototype[name], hook, `unrelated ${name} must stay untouched`);
+  }
+  assert.equal(NodeType.prototype.hideOutputImages, undefined);
+}
+
+{
+  const fixture = createFixture();
+  const { NodeType, returns } = createNodeType(fixture.trace);
+  const generatorOnlyHooks = {
+    onSerialize: NodeType.prototype.onSerialize,
+    onExecuted: NodeType.prototype.onExecuted,
+    onResize: NodeType.prototype.onResize,
+    onRemoved: NodeType.prototype.onRemoved,
+  };
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: INPUT_NODE_TYPE });
+  const node = new NodeType();
+
+  assert.equal(node.onNodeCreated("a", "b"), returns.created);
+  assert.deepEqual(fixture.trace, [
+    "original:onNodeCreated:a,b",
+    "hookInputNode",
+  ]);
+  fixture.trace.length = 0;
+  assert.equal(node.onConfigure("saved"), returns.configured);
+  assert.deepEqual(fixture.trace, [
+    "original:onConfigure:saved",
+    "hookInputNode",
+  ]);
+  for (const [name, hook] of Object.entries(generatorOnlyHooks)) {
+    assert.equal(NodeType.prototype[name], hook, `input ${name} must stay untouched`);
+  }
+  assert.equal(NodeType.prototype.hideOutputImages, undefined);
+}
+
+{
+  const fixture = createFixture();
+  const { NodeType, returns } = createNodeType(fixture.trace);
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const node = new NodeType();
+
+  assert.equal(NodeType.prototype.hideOutputImages, true);
+  assert.equal(node.onNodeCreated("new"), returns.created);
+  assert.deepEqual(fixture.trace, [
+    "suppressDefaultPreview:markDirty=false",
+    "original:onNodeCreated:new",
+    "hookGeneratorNode",
+  ]);
+
+  fixture.trace.length = 0;
+  assert.equal(node.onConfigure("saved"), returns.configured);
+  assert.deepEqual(fixture.trace, [
+    "suppressDefaultPreview:markDirty=false",
+    "original:onConfigure:saved",
+    "hookGeneratorNode",
+  ]);
+
+  fixture.trace.length = 0;
+  assert.equal(node.onSerialize({ marker: "workflow" }), returns.serialized);
+  assert.deepEqual(fixture.trace, [
+    "original:onSerialize:workflow",
+    "syncSerializedWidgets:workflow",
+  ]);
+
+  fixture.trace.length = 0;
+  assert.equal(node.onExecuted({ marker: "done" }), undefined);
+  assert.deepEqual(fixture.trace, [
+    "scheduleDefaultPreviewSuppression",
+    "updateExecutedStatus:done",
+    "scheduleDefaultPreviewSuppression:purgeStore=false",
+  ]);
+
+  fixture.trace.length = 0;
+  assert.equal(node.onResize(512, 640), returns.resized);
+  assert.deepEqual(fixture.trace, [
+    "original:onResize:512,640",
+    "scheduleLayout",
+  ]);
+
+  fixture.trace.length = 0;
+  assert.equal(node.onRemoved("delete"), returns.removed);
+  assert.deepEqual(fixture.trace, [
+    "original:onRemoved:delete",
+    "disposePanel",
+    "disposeNativePreviewLifecycle",
+  ]);
+}
+
+for (const hookCase of [
+  {
+    method: "onNodeCreated",
+    option: "createdError",
+    args: ["new"],
+    expectedTrace: [
+      "suppressDefaultPreview:markDirty=false",
+      "original:onNodeCreated:new",
+    ],
+  },
+  {
+    method: "onConfigure",
+    option: "configuredError",
+    args: ["saved"],
+    expectedTrace: [
+      "suppressDefaultPreview:markDirty=false",
+      "original:onConfigure:saved",
+    ],
+  },
+  {
+    method: "onSerialize",
+    option: "serializedError",
+    args: [{ marker: "workflow" }],
+    expectedTrace: ["original:onSerialize:workflow"],
+  },
+  {
+    method: "onResize",
+    option: "resizedError",
+    args: [512, 640],
+    expectedTrace: ["original:onResize:512,640"],
+  },
+]) {
+  const originalError = new Error(`${hookCase.method} failed`);
+  const fixture = createFixture();
+  const { NodeType } = createNodeType(fixture.trace, {
+    [hookCase.option]: originalError,
+  });
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const node = new NodeType();
+  let caught = null;
+  try {
+    node[hookCase.method](...hookCase.args);
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(
+    caught,
+    originalError,
+    `${hookCase.method} must preserve the original error identity`,
+  );
+  assert.deepEqual(
+    fixture.trace,
+    hookCase.expectedTrace,
+    `${hookCase.method} must not run its tail adapter after the original hook fails`,
+  );
+}
+
+{
+  const removedError = new Error("original removal failed");
+  const fixture = createFixture();
+  const { NodeType } = createNodeType(fixture.trace, { removedError });
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const node = new NodeType();
+  let caught = null;
+  try {
+    node.onRemoved("delete");
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, removedError, "the original removal error identity must be preserved");
+  assert.deepEqual(fixture.trace, [
+    "original:onRemoved:delete",
+    "disposePanel",
+    "disposeNativePreviewLifecycle",
+  ]);
+}
+
+{
+  const panelError = new Error("panel disposal failed");
+  const fixture = createFixture({ panelError });
+  const { NodeType } = createNodeType(fixture.trace);
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const node = new NodeType();
+  let caught = null;
+  try {
+    node.onRemoved("delete");
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, panelError, "the panel disposal error identity must be preserved");
+  assert.deepEqual(fixture.trace, [
+    "original:onRemoved:delete",
+    "disposePanel",
+    "disposeNativePreviewLifecycle",
+  ]);
+}
+
+{
+  const removedError = new Error("original removal failed");
+  const panelError = new Error("panel disposal failed");
+  const nativeError = new Error("native preview disposal failed");
+  const fixture = createFixture({ panelError, nativeError });
+  const { NodeType } = createNodeType(fixture.trace, { removedError });
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const node = new NodeType();
+  let caught = null;
+  try {
+    node.onRemoved("delete");
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(
+    caught,
+    nativeError,
+    "the innermost cleanup error must preserve nested-finally precedence",
+  );
+  assert.deepEqual(fixture.trace, [
+    "original:onRemoved:delete",
+    "disposePanel",
+    "disposeNativePreviewLifecycle",
+  ]);
+}
+
+console.log("Frontend AiO extension runtime smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -21,6 +21,9 @@ AIO_GENERATOR_PANEL_RUNTIME_JS = (
 AIO_GENERATOR_QUEUE_RUNTIME_JS = (
     ROOT / "web" / "js" / "aio" / "generator_queue_runtime.js"
 )
+AIO_EXTENSION_RUNTIME_JS = (
+    ROOT / "web" / "js" / "aio" / "extension_runtime.js"
+)
 AIO_NATIVE_PREVIEW_RUNTIME_JS = (
     ROOT / "web" / "js" / "aio" / "native_preview_runtime.js"
 )
@@ -171,6 +174,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_generator_wheel_router_decides_scroll_ownership_before_canvas(self):
         source = AIO_JS.read_text(encoding="utf-8")
+        extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
         panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         wheel_source = AIO_WHEEL_JS.read_text(encoding="utf-8")
         forward_start = source.index("function forwardGeneratorPanelWheel")
@@ -179,9 +183,11 @@ class AIOFrontendSourceTests(unittest.TestCase):
         install_start = forward_end + 1
         install_end = source.index("\nfunction generatorSettings", install_start)
         install_body = source[install_start:install_end]
-        setup_start = source.index("  async setup() {")
-        setup_end = source.index("\n  async beforeRegisterNodeDef", setup_start)
-        setup_body = source[setup_start:setup_end]
+        setup_start = extension_source.index("    async setup() {")
+        setup_end = extension_source.index(
+            "\n    async beforeRegisterNodeDef", setup_start
+        )
+        setup_body = extension_source[setup_start:setup_end]
 
         self.assertIn('from "./aio/wheel.js"', source)
         self.assertIn(
@@ -198,23 +204,31 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('window.addEventListener("wheel", forwardGeneratorPanelWheel', install_body)
         self.assertIn("capture: true", install_body)
         self.assertIn("passive: false", install_body)
-        self.assertIn("installGeneratorWheelForwarder();", setup_body)
+        self.assertIn("installWheelForwarder();", setup_body)
+        self.assertIn(
+            "installWheelForwarder: installGeneratorWheelForwarder,", source
+        )
         self.assertIn("owns the wheel even at either boundary", wheel_source)
         self.assertIn("Canvas zoom is allowed only when neither intended scrollbar exists", wheel_source)
 
     def test_generator_keeps_native_output_preview_suppressed_after_execution(self):
         source = AIO_JS.read_text(encoding="utf-8")
+        extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
         native_preview_source = AIO_NATIVE_PREVIEW_RUNTIME_JS.read_text(
             encoding="utf-8"
         )
         preview_source = AIO_PREVIEW_JS.read_text(encoding="utf-8")
-        registration_start = source.index("async beforeRegisterNodeDef")
-        generator_block = source[source.index("if (nodeData.name === GENERATOR_NODE_TYPE)", registration_start):]
+        registration_start = extension_source.index("async beforeRegisterNodeDef")
+        generator_block = extension_source[
+            extension_source.index(
+                "if (nodeData.name === GENERATOR_NODE_TYPE)", registration_start
+            ):
+        ]
         start = generator_block.index("nodeType.prototype.onExecuted = function")
-        end = generator_block.index("\n      const onResize", start)
+        end = generator_block.index("\n        const onResize", start)
         body = generator_block[start:end]
 
-        self.assertIn("nodeType.prototype.hideOutputImages = true", source)
+        self.assertIn("nodeType.prototype.hideOutputImages = true", extension_source)
         for store_alias in (
             "module?.useNodeOutputStore,",
             "module?.cn,",
@@ -247,28 +261,36 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("aioSuppressDefaultPreview", native_preview_source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .text-node-component-header-text", source)
         self.assertIn(".lg-node:has(.easyuse-anima-aio-node-panel) .pt-2.text-center.text-xs.text-base-foreground", source)
-        self.assertIn("scheduleGeneratorDefaultPreviewSuppression(this);", body)
-        self.assertIn("updateGeneratorExecutedStatus(this, message);", body)
+        self.assertIn("scheduleDefaultPreviewSuppression(this);", body)
+        self.assertIn("updateExecutedStatus(this, message);", body)
         self.assertIn(
-            "scheduleGeneratorDefaultPreviewSuppression(this, { purgeStore: false });",
+            "scheduleDefaultPreviewSuppression(this, { purgeStore: false });",
             body,
         )
         self.assertEqual(
-            body.count("scheduleGeneratorDefaultPreviewSuppression(this"),
+            body.count("scheduleDefaultPreviewSuppression(this"),
             2,
         )
         self.assertLess(
-            body.index("scheduleGeneratorDefaultPreviewSuppression(this);"),
-            body.index("updateGeneratorExecutedStatus(this, message);"),
+            body.index("scheduleDefaultPreviewSuppression(this);"),
+            body.index("updateExecutedStatus(this, message);"),
         )
         self.assertLess(
-            body.index("updateGeneratorExecutedStatus(this, message);"),
+            body.index("updateExecutedStatus(this, message);"),
             body.index(
-                "scheduleGeneratorDefaultPreviewSuppression(this, "
+                "scheduleDefaultPreviewSuppression(this, "
                 "{ purgeStore: false });"
             ),
         )
         self.assertNotIn("onExecuted?.apply", body)
+        self.assertIn(
+            "scheduleDefaultPreviewSuppression: "
+            "scheduleGeneratorDefaultPreviewSuppression,",
+            source,
+        )
+        self.assertIn(
+            "updateExecutedStatus: updateGeneratorExecutedStatus,", source
+        )
 
         suppression_start = native_preview_source.index(
             "function scheduleGeneratorDefaultPreviewSuppression"
@@ -293,33 +315,38 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_generator_native_preview_lifecycle_disposes_on_generator_removal(self):
         source = AIO_JS.read_text(encoding="utf-8")
-        registration_start = source.index("async beforeRegisterNodeDef")
-        configure_start = source.index(
+        extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
+        registration_start = extension_source.index("async beforeRegisterNodeDef")
+        configure_start = extension_source.index(
             "const onConfigure = nodeType.prototype.onConfigure;",
             registration_start,
         )
-        generator_hooks_start = source.index(
-            "    if (nodeData.name === GENERATOR_NODE_TYPE) {",
+        generator_hooks_start = extension_source.index(
+            "      if (nodeData.name === GENERATOR_NODE_TYPE) {",
             configure_start,
         )
-        generator_hooks_end = source.index(
-            "\n    }\n  },\n});",
+        generator_hooks_end = extension_source.index(
+            "\n      }\n    },\n  };",
             generator_hooks_start,
         )
-        generator_hooks = source[generator_hooks_start:generator_hooks_end]
+        generator_hooks = extension_source[
+            generator_hooks_start:generator_hooks_end
+        ]
 
         self.assertNotIn(
             "const onRemoved = nodeType.prototype.onRemoved;",
-            source[registration_start:generator_hooks_start],
+            extension_source[registration_start:generator_hooks_start],
         )
         self.assertEqual(
-            source.count("const onRemoved = nodeType.prototype.onRemoved;"),
+            extension_source.count(
+                "const onRemoved = nodeType.prototype.onRemoved;"
+            ),
             1,
         )
         on_removed_start = generator_hooks.index(
             "const onRemoved = nodeType.prototype.onRemoved;"
         )
-        on_removed_end = generator_hooks.index("\n      };", on_removed_start)
+        on_removed_end = generator_hooks.index("\n        };", on_removed_start)
         on_removed_body = generator_hooks[on_removed_start:on_removed_end]
 
         original_return = on_removed_body.index(
@@ -327,12 +354,12 @@ class AIOFrontendSourceTests(unittest.TestCase):
         )
         outer_finally = on_removed_body.index("finally", original_return)
         panel_cleanup = on_removed_body.index(
-            "disposeGeneratorPanel(this);",
+            "disposePanel(this);",
             outer_finally,
         )
         nested_finally = on_removed_body.index("finally", panel_cleanup)
         native_cleanup = on_removed_body.index(
-            "disposeGeneratorNativePreviewLifecycle(this);",
+            "disposeNativePreviewLifecycle(this);",
             nested_finally,
         )
 
@@ -341,10 +368,16 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertLess(outer_finally, panel_cleanup)
         self.assertLess(panel_cleanup, nested_finally)
         self.assertLess(nested_finally, native_cleanup)
-        self.assertEqual(on_removed_body.count("disposeGeneratorPanel(this);"), 1)
+        self.assertEqual(on_removed_body.count("disposePanel(this);"), 1)
         self.assertEqual(
-            on_removed_body.count("disposeGeneratorNativePreviewLifecycle(this);"),
+            on_removed_body.count("disposeNativePreviewLifecycle(this);"),
             1,
+        )
+        self.assertIn("disposePanel: disposeGeneratorPanel,", source)
+        self.assertIn(
+            "disposeNativePreviewLifecycle: "
+            "disposeGeneratorNativePreviewLifecycle,",
+            source,
         )
 
     def test_generator_panel_runtime_exposes_cancellable_lifecycle_facades(self):
@@ -496,6 +529,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_generator_panel_lifecycle_keeps_entry_behavior_boundaries(self):
         source = AIO_JS.read_text(encoding="utf-8")
+        extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
         panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         queue_source = AIO_GENERATOR_QUEUE_RUNTIME_JS.read_text(encoding="utf-8")
 
@@ -526,11 +560,19 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("resolveGeneratorSeedForQueue", source)
         self.assertNotIn("prepareGeneratorPromptForQueue", source)
 
-        setup_start = source.index("  async setup() {")
-        setup_end = source.index("\n  async beforeRegisterNodeDef", setup_start)
-        setup_body = source[setup_start:setup_end]
-        self.assertIn("installGeneratorWheelForwarder();", setup_body)
-        self.assertIn("installGeneratorQueuePromptHook();", setup_body)
+        setup_start = extension_source.index("    async setup() {")
+        setup_end = extension_source.index(
+            "\n    async beforeRegisterNodeDef", setup_start
+        )
+        setup_body = extension_source[setup_start:setup_end]
+        self.assertIn("installWheelForwarder();", setup_body)
+        self.assertIn("installQueuePromptHook();", setup_body)
+        self.assertIn(
+            "installWheelForwarder: installGeneratorWheelForwarder,", source
+        )
+        self.assertIn(
+            "installQueuePromptHook: installGeneratorQueuePromptHook,", source
+        )
 
         for unchanged_adapter in (
             "specialSeedRandom: GENERATOR_SPECIAL_SEED_RANDOM,",

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -54,6 +54,10 @@ AIO_GENERATOR_QUEUE_RUNTIME_JS = AIO_MODULES / "generator_queue_runtime.js"
 AIO_GENERATOR_QUEUE_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_generator_queue_runtime_smoke.mjs"
 )
+AIO_EXTENSION_RUNTIME_JS = AIO_MODULES / "extension_runtime.js"
+AIO_EXTENSION_RUNTIME_SMOKE = (
+    ROOT / "tests" / "frontend_aio_extension_runtime_smoke.mjs"
+)
 AIO_NATIVE_PREVIEW_RUNTIME_JS = AIO_MODULES / "native_preview_runtime.js"
 AIO_NATIVE_PREVIEW_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_native_preview_runtime_smoke.mjs"
@@ -209,6 +213,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
     def test_aio_profile_settings_runtime_has_closed_controller_boundary(self):
         source = AIO_PROFILE_SETTINGS_RUNTIME_JS.read_text(encoding="utf-8")
         entry_source = AIO_JS.read_text(encoding="utf-8")
+        extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
         self.assertEqual(source.splitlines()[0], "// @ts-check")
@@ -329,16 +334,103 @@ class FrontendModuleStructureTests(unittest.TestCase):
                     rf"\bfunction\s+{local_function}\(",
                 )
 
-        setup_start = entry_source.index("  async setup() {")
-        setup_end = entry_source.index("\n  async beforeRegisterNodeDef", setup_start)
-        setup_body = entry_source[setup_start:setup_end]
-        self.assertEqual(setup_body.count("loadGeneratorUserProfiles()"), 1)
-        self.assertIn(".then(refreshGeneratorPanels)", setup_body)
+        setup_start = extension_source.index("    async setup() {")
+        setup_end = extension_source.index(
+            "\n    async beforeRegisterNodeDef", setup_start
+        )
+        setup_body = extension_source[setup_start:setup_end]
+        self.assertEqual(setup_body.count("loadSamplerOptions()"), 1)
+        self.assertEqual(setup_body.count("loadUserProfiles()"), 1)
+        self.assertEqual(setup_body.count(".then(refreshPanels)"), 2)
+        self.assertIn("loadSamplerOptions: loadGeneratorSamplerOptions,", entry_source)
+        self.assertIn("loadUserProfiles: loadGeneratorUserProfiles,", entry_source)
+        self.assertIn("refreshPanels: refreshGeneratorPanels,", entry_source)
         self.assertNotIn("__easyuseAnimaGeneratorProfileValue", source[source.index("return {"):])
 
         self.assertTrue(AIO_PROFILE_SETTINGS_RUNTIME_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_profile_settings_runtime_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_extension_runtime_owns_registration_lifecycle(self):
+        source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
+        entry_source = AIO_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertNotIn("app.registerExtension", source)
+        self.assertEqual(
+            re.findall(
+                r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE
+            ),
+            ["aioCreateExtensionRuntime"],
+        )
+        self.assertIn(
+            'import { aioCreateExtensionRuntime } from "./aio/extension_runtime.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+aioExtensionRuntime\s*=\s*"
+            r"aioCreateExtensionRuntime\(\{(?P<dependencies>.*?)\n\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependencies = factory_match.group("dependencies")
+        for expected_wiring in (
+            "api,",
+            "inputNodeType: INPUT_NODE_TYPE,",
+            "generatorNodeType: GENERATOR_NODE_TYPE,",
+            "generatorPreviewEvent: GENERATOR_PREVIEW_EVENT,",
+            "installWheelForwarder: installGeneratorWheelForwarder,",
+            "installQueuePromptHook: installGeneratorQueuePromptHook,",
+            "watchLocale: easyuseAnimaWatchLocale,",
+            "refreshPanels: refreshGeneratorPanels,",
+            "handlePreviewEvent: handleGeneratorPreviewEvent,",
+            "handleProgressEvent: handleGeneratorProgressEvent,",
+            "handleProgressStateEvent: handleGeneratorProgressStateEvent,",
+            "handleDenoisePreviewEvent: handleGeneratorDenoisePreviewEvent,",
+            "handleExecutingEvent: handleGeneratorExecutingEvent,",
+            "clearDenoisePreviews: clearGeneratorDenoisePreviews,",
+            "loadSamplerOptions: loadGeneratorSamplerOptions,",
+            "loadUserProfiles: loadGeneratorUserProfiles,",
+            "suppressDefaultPreview: suppressGeneratorDefaultPreview,",
+            "hookInputNode,",
+            "hookGeneratorNode,",
+            "syncSerializedWidgets: syncGeneratorSerializedWidgets,",
+            "scheduleDefaultPreviewSuppression: scheduleGeneratorDefaultPreviewSuppression,",
+            "updateExecutedStatus: updateGeneratorExecutedStatus,",
+            "scheduleLayout: scheduleGeneratorLayout,",
+            "disposePanel: disposeGeneratorPanel,",
+            "disposeNativePreviewLifecycle: disposeGeneratorNativePreviewLifecycle,",
+        ):
+            with self.subTest(factory_wiring=expected_wiring):
+                self.assertIn(expected_wiring, dependencies)
+
+        for entry_forbidden_lifecycle in (
+            "async setup()",
+            "beforeRegisterNodeDef",
+            "api.addEventListener",
+            "nodeType.prototype",
+        ):
+            with self.subTest(entry_forbidden_lifecycle=entry_forbidden_lifecycle):
+                self.assertNotIn(entry_forbidden_lifecycle, entry_source)
+        self.assertEqual(entry_source.count("app.registerExtension("), 1)
+        self.assertRegex(
+            entry_source,
+            re.compile(
+                r'app\.registerExtension\(\{\s*'
+                r'name:\s*"easyuse-anima\.aio",\s*'
+                r'\.\.\.aioExtensionRuntime,\s*'
+                r'\}\);\s*$',
+                re.DOTALL,
+            ),
+        )
+        self.assertTrue(AIO_EXTENSION_RUNTIME_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_extension_runtime_smoke.mjs"',
             frontend_check_source,
         )
 
@@ -688,6 +780,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
     def test_aio_native_preview_runtime_owns_dom_store_scheduler_and_event_lifecycle(self):
         source = AIO_NATIVE_PREVIEW_RUNTIME_JS.read_text(encoding="utf-8")
         entry_source = AIO_JS.read_text(encoding="utf-8")
+        extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
         panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
         preview_source = AIO_PREVIEW_JS.read_text(encoding="utf-8")
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
@@ -980,18 +1073,19 @@ class FrontendModuleStructureTests(unittest.TestCase):
 
         self.assertIn("app.registerExtension({", entry_source)
         for listener_registration in (
-            "api.addEventListener(GENERATOR_PREVIEW_EVENT, handleGeneratorPreviewEvent);",
-            'api.addEventListener("progress", handleGeneratorProgressEvent);',
-            'api.addEventListener("progress_state", handleGeneratorProgressStateEvent);',
+            "api.addEventListener(GENERATOR_PREVIEW_EVENT, handlePreviewEvent);",
+            'api.addEventListener("progress", handleProgressEvent);',
+            'api.addEventListener("progress_state", handleProgressStateEvent);',
             'api.addEventListener("b_preview_with_metadata", '
-            "handleGeneratorDenoisePreviewEvent, true);",
-            'api.addEventListener("executing", handleGeneratorExecutingEvent);',
-            'api.addEventListener("execution_error", clearGeneratorDenoisePreviews);',
-            'api.addEventListener("execution_interrupted", clearGeneratorDenoisePreviews);',
-            'api.addEventListener("execution_success", clearGeneratorDenoisePreviews);',
+            "handleDenoisePreviewEvent, true);",
+            'api.addEventListener("executing", handleExecutingEvent);',
+            'api.addEventListener("execution_error", clearDenoisePreviews);',
+            'api.addEventListener("execution_interrupted", clearDenoisePreviews);',
+            'api.addEventListener("execution_success", clearDenoisePreviews);',
         ):
-            with self.subTest(entry_owned_listener_registration=listener_registration):
-                self.assertIn(listener_registration, entry_source)
+            with self.subTest(runtime_owned_listener_registration=listener_registration):
+                self.assertIn(listener_registration, extension_source)
+        self.assertNotIn("api.addEventListener", entry_source)
         for prototype_hook in (
             "onNodeCreated",
             "onConfigure",
@@ -1000,8 +1094,11 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "onResize",
             "onRemoved",
         ):
-            with self.subTest(entry_owned_prototype_hook=prototype_hook):
-                self.assertIn(f"nodeType.prototype.{prototype_hook}", entry_source)
+            with self.subTest(runtime_owned_prototype_hook=prototype_hook):
+                self.assertIn(
+                    f"nodeType.prototype.{prototype_hook}", extension_source
+                )
+                self.assertNotIn(f"nodeType.prototype.{prototype_hook}", entry_source)
                 self.assertNotIn(f"nodeType.prototype.{prototype_hook}", source)
 
         self.assertTrue(AIO_NATIVE_PREVIEW_RUNTIME_SMOKE.is_file())

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -64,6 +64,11 @@ try {
         throw "Frontend AiO generator queue runtime smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_extension_runtime_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO extension runtime smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_stage_settings_dialogs_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO stage settings dialogs smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/extension_runtime.js
+++ b/web/js/aio/extension_runtime.js
@@ -1,0 +1,126 @@
+// @ts-check
+
+export function aioCreateExtensionRuntime(dependencies) {
+  const {
+    api,
+    constants: {
+      inputNodeType: INPUT_NODE_TYPE,
+      generatorNodeType: GENERATOR_NODE_TYPE,
+      generatorPreviewEvent: GENERATOR_PREVIEW_EVENT,
+    },
+    setup: {
+      ensureStyle,
+      installWheelForwarder,
+      installQueuePromptHook,
+      watchLocale,
+      refreshPanels,
+      handlePreviewEvent,
+      handleProgressEvent,
+      handleProgressStateEvent,
+      handleDenoisePreviewEvent,
+      handleExecutingEvent,
+      clearDenoisePreviews,
+      loadSamplerOptions,
+      loadUserProfiles,
+      warnUserProfiles,
+    },
+    nodes: {
+      suppressDefaultPreview,
+      hookInputNode,
+      hookGeneratorNode,
+      syncSerializedWidgets,
+      scheduleDefaultPreviewSuppression,
+      updateExecutedStatus,
+      scheduleLayout,
+      disposePanel,
+      disposeNativePreviewLifecycle,
+    },
+  } = dependencies;
+
+  function hookNode(node, nodeData) {
+    if (nodeData.name === INPUT_NODE_TYPE) {
+      hookInputNode(node);
+    } else if (nodeData.name === GENERATOR_NODE_TYPE) {
+      hookGeneratorNode(node);
+    }
+  }
+
+  return {
+    async setup() {
+      ensureStyle();
+      installWheelForwarder();
+      installQueuePromptHook();
+      watchLocale(refreshPanels);
+      api.addEventListener(GENERATOR_PREVIEW_EVENT, handlePreviewEvent);
+      api.addEventListener("progress", handleProgressEvent);
+      api.addEventListener("progress_state", handleProgressStateEvent);
+      api.addEventListener("b_preview_with_metadata", handleDenoisePreviewEvent, true);
+      api.addEventListener("executing", handleExecutingEvent);
+      api.addEventListener("execution_error", clearDenoisePreviews);
+      api.addEventListener("execution_interrupted", clearDenoisePreviews);
+      api.addEventListener("execution_success", clearDenoisePreviews);
+      loadSamplerOptions().then(refreshPanels);
+      loadUserProfiles()
+        .then(refreshPanels)
+        .catch(warnUserProfiles);
+    },
+    async beforeRegisterNodeDef(nodeType, nodeData) {
+      if (nodeData.name !== INPUT_NODE_TYPE && nodeData.name !== GENERATOR_NODE_TYPE) {
+        return;
+      }
+      if (nodeData.name === GENERATOR_NODE_TYPE) {
+        nodeType.prototype.hideOutputImages = true;
+      }
+      const onNodeCreated = nodeType.prototype.onNodeCreated;
+      nodeType.prototype.onNodeCreated = function () {
+        if (nodeData.name === GENERATOR_NODE_TYPE) {
+          suppressDefaultPreview(this, { markDirty: false });
+        }
+        const result = onNodeCreated?.apply(this, arguments);
+        hookNode(this, nodeData);
+        return result;
+      };
+      const onConfigure = nodeType.prototype.onConfigure;
+      nodeType.prototype.onConfigure = function () {
+        if (nodeData.name === GENERATOR_NODE_TYPE) {
+          suppressDefaultPreview(this, { markDirty: false });
+        }
+        const result = onConfigure?.apply(this, arguments);
+        hookNode(this, nodeData);
+        return result;
+      };
+      if (nodeData.name === GENERATOR_NODE_TYPE) {
+        const onSerialize = nodeType.prototype.onSerialize;
+        nodeType.prototype.onSerialize = function (serialized) {
+          const result = onSerialize?.apply(this, arguments);
+          syncSerializedWidgets(this, serialized);
+          return result;
+        };
+        nodeType.prototype.onExecuted = function (message) {
+          scheduleDefaultPreviewSuppression(this);
+          updateExecutedStatus(this, message);
+          scheduleDefaultPreviewSuppression(this, { purgeStore: false });
+          return undefined;
+        };
+        const onResize = nodeType.prototype.onResize;
+        nodeType.prototype.onResize = function () {
+          const result = onResize?.apply(this, arguments);
+          scheduleLayout(this);
+          return result;
+        };
+        const onRemoved = nodeType.prototype.onRemoved;
+        nodeType.prototype.onRemoved = function () {
+          try {
+            return onRemoved?.apply(this, arguments);
+          } finally {
+            try {
+              disposePanel(this);
+            } finally {
+              disposeNativePreviewLifecycle(this);
+            }
+          }
+        };
+      }
+    },
+  };
+}

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -26,6 +26,7 @@ import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js
 import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";
 import { aioCreateAdvancedSettingsDialog } from "./aio/advanced_settings_dialog.js";
 import { aioCreateNativePreviewRuntime } from "./aio/native_preview_runtime.js";
+import { aioCreateExtensionRuntime } from "./aio/extension_runtime.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -4167,92 +4168,45 @@ function updateGeneratorExecutedStatus(node, message) {
   updateGeneratorDomSummary(node);
 }
 
-function hookNode(node, nodeData) {
-  if (nodeData.name === INPUT_NODE_TYPE) {
-    hookInputNode(node);
-  } else if (nodeData.name === GENERATOR_NODE_TYPE) {
-    hookGeneratorNode(node);
-  }
-}
+const aioExtensionRuntime = aioCreateExtensionRuntime({
+  api,
+  constants: {
+    inputNodeType: INPUT_NODE_TYPE,
+    generatorNodeType: GENERATOR_NODE_TYPE,
+    generatorPreviewEvent: GENERATOR_PREVIEW_EVENT,
+  },
+  setup: {
+    ensureStyle,
+    installWheelForwarder: installGeneratorWheelForwarder,
+    installQueuePromptHook: installGeneratorQueuePromptHook,
+    watchLocale: easyuseAnimaWatchLocale,
+    refreshPanels: refreshGeneratorPanels,
+    handlePreviewEvent: handleGeneratorPreviewEvent,
+    handleProgressEvent: handleGeneratorProgressEvent,
+    handleProgressStateEvent: handleGeneratorProgressStateEvent,
+    handleDenoisePreviewEvent: handleGeneratorDenoisePreviewEvent,
+    handleExecutingEvent: handleGeneratorExecutingEvent,
+    clearDenoisePreviews: clearGeneratorDenoisePreviews,
+    loadSamplerOptions: loadGeneratorSamplerOptions,
+    loadUserProfiles: loadGeneratorUserProfiles,
+    warnUserProfiles(error) {
+      console.warn("[EasyUseAnima] Failed to load AiO user profiles.", error);
+    },
+  },
+  nodes: {
+    suppressDefaultPreview: suppressGeneratorDefaultPreview,
+    hookInputNode,
+    hookGeneratorNode,
+    syncSerializedWidgets: syncGeneratorSerializedWidgets,
+    scheduleDefaultPreviewSuppression: scheduleGeneratorDefaultPreviewSuppression,
+    updateExecutedStatus: updateGeneratorExecutedStatus,
+    scheduleLayout: scheduleGeneratorLayout,
+    disposePanel: disposeGeneratorPanel,
+    disposeNativePreviewLifecycle: disposeGeneratorNativePreviewLifecycle,
+  },
+});
 
 app.registerExtension({
   name: "easyuse-anima.aio",
-  async setup() {
-    ensureStyle();
-    installGeneratorWheelForwarder();
-    installGeneratorQueuePromptHook();
-    easyuseAnimaWatchLocale(refreshGeneratorPanels);
-    api.addEventListener(GENERATOR_PREVIEW_EVENT, handleGeneratorPreviewEvent);
-    api.addEventListener("progress", handleGeneratorProgressEvent);
-    api.addEventListener("progress_state", handleGeneratorProgressStateEvent);
-    api.addEventListener("b_preview_with_metadata", handleGeneratorDenoisePreviewEvent, true);
-    api.addEventListener("executing", handleGeneratorExecutingEvent);
-    api.addEventListener("execution_error", clearGeneratorDenoisePreviews);
-    api.addEventListener("execution_interrupted", clearGeneratorDenoisePreviews);
-    api.addEventListener("execution_success", clearGeneratorDenoisePreviews);
-    loadGeneratorSamplerOptions().then(refreshGeneratorPanels);
-    loadGeneratorUserProfiles()
-      .then(refreshGeneratorPanels)
-      .catch((error) => {
-        console.warn("[EasyUseAnima] Failed to load AiO user profiles.", error);
-      });
-  },
-  async beforeRegisterNodeDef(nodeType, nodeData) {
-    if (nodeData.name !== INPUT_NODE_TYPE && nodeData.name !== GENERATOR_NODE_TYPE) {
-      return;
-    }
-    if (nodeData.name === GENERATOR_NODE_TYPE) {
-      nodeType.prototype.hideOutputImages = true;
-    }
-    const onNodeCreated = nodeType.prototype.onNodeCreated;
-    nodeType.prototype.onNodeCreated = function () {
-      if (nodeData.name === GENERATOR_NODE_TYPE) {
-        suppressGeneratorDefaultPreview(this, { markDirty: false });
-      }
-      const result = onNodeCreated?.apply(this, arguments);
-      hookNode(this, nodeData);
-      return result;
-    };
-    const onConfigure = nodeType.prototype.onConfigure;
-    nodeType.prototype.onConfigure = function () {
-      if (nodeData.name === GENERATOR_NODE_TYPE) {
-        suppressGeneratorDefaultPreview(this, { markDirty: false });
-      }
-      const result = onConfigure?.apply(this, arguments);
-      hookNode(this, nodeData);
-      return result;
-    };
-    if (nodeData.name === GENERATOR_NODE_TYPE) {
-      const onSerialize = nodeType.prototype.onSerialize;
-      nodeType.prototype.onSerialize = function (serialized) {
-        const result = onSerialize?.apply(this, arguments);
-        syncGeneratorSerializedWidgets(this, serialized);
-        return result;
-      };
-      nodeType.prototype.onExecuted = function (message) {
-        scheduleGeneratorDefaultPreviewSuppression(this);
-        updateGeneratorExecutedStatus(this, message);
-        scheduleGeneratorDefaultPreviewSuppression(this, { purgeStore: false });
-        return undefined;
-      };
-      const onResize = nodeType.prototype.onResize;
-      nodeType.prototype.onResize = function () {
-        const result = onResize?.apply(this, arguments);
-        scheduleGeneratorLayout(this);
-        return result;
-      };
-      const onRemoved = nodeType.prototype.onRemoved;
-      nodeType.prototype.onRemoved = function () {
-        try {
-          return onRemoved?.apply(this, arguments);
-        } finally {
-          try {
-            disposeGeneratorPanel(this);
-          } finally {
-            disposeGeneratorNativePreviewLifecycle(this);
-          }
-        }
-      };
-    }
-  },
+  ...aioExtensionRuntime,
 });


### PR DESCRIPTION
## 변경 요약

- AiO extension의 `setup`과 node prototype hook lifecycle을 `aio/extension_runtime.js`로 분리했습니다.
- entry 파일은 dependency adapter 조립과 `registerExtension` 등록만 소유하도록 축소했습니다.
- setup event/listener 순서, 원 hook 호출·반환·예외, `onExecuted` override, `onRemoved`의 nested cleanup `finally` 동작을 그대로 유지했습니다.
- queue wrapper의 receiver, 추가 인자, 반환값·예외 보존 계약을 focused smoke로 함께 고정했습니다.

## 주요 파일

- `web/js/aio/extension_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_extension_runtime_smoke.mjs`
- 관련 source-structure 테스트와 frontend runner

## 검증

- 변경 JavaScript syntax 검사 통과
- 신규 AiO extension lifecycle smoke 통과
- 기존 AiO generator queue runtime smoke 통과
- focused unittest:
  - `test_aio_frontend.py` 33/33 통과
  - `test_frontend_modules.py` 45/45 통과
- 최종 official full:
  - Python compile 통과
  - `unittest` 382/382 통과
  - frontend 99개 JavaScript 파일 검사 통과
  - TypeScript 6.0.3 통과
  - diff check 통과

첫 official full은 추출된 setup/listener/prototype hook을 기존 entry 본문에서 찾던 source-structure 계약 15건 때문에 실패했습니다. Production 코드는 변경하지 않고 테스트 소유권을 새 runtime으로 갱신한 뒤 final diff가 바뀌어 full을 1회 재실행했습니다.

이번 조각은 기계적인 lifecycle 이동이며 관찰 가능한 동작을 변경하지 않아 legacy canvas / Node 2.0 browser smoke는 반복하지 않았습니다. 사용자 v0.27.0 인스턴스 수동 확인은 전체 유지보수 작업 종료 시점까지 보류합니다.

## 후속 범위

- API owner-level queue hook idempotence와 installer 재호출 방어
- missing/empty `prompt_id` no-commit 회귀 고정
- sampler option load 시 중복 full render 정리
- 비표준 동시 direct `api.queuePrompt` 지원 계약 결정
