### PR TITLE
refactor: LoRA Preset 메뉴 lifecycle 분리

### DIFF
--- a/tests/frontend_lora_preset_menu_lifecycle_smoke.mjs
+++ b/tests/frontend_lora_preset_menu_lifecycle_smoke.mjs
@@ -1,0 +1,407 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  createFakeDocument,
+  descendants,
+} from "./frontend_support/fake_dom.mjs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+const menuModule = await import(
+  dataModule("../web/js/lora_preset/menu_lifecycle.js")
+);
+
+assert.deepEqual(Object.keys(menuModule), ["createLoraPresetMenuLifecycle"]);
+
+const document = createFakeDocument();
+
+function addDomCompat(element) {
+  if (element.__menuSmokeDomCompat) {
+    return element;
+  }
+  element.__menuSmokeDomCompat = true;
+  const addEventListener = element.addEventListener.bind(element);
+  element.__listenerOptions = new Map();
+  element.addEventListener = (type, handler, options = false) => {
+    const entries = element.__listenerOptions.get(type) || [];
+    entries.push(options);
+    element.__listenerOptions.set(type, entries);
+    addEventListener(type, handler, options);
+  };
+  element.appendChild = (child) => {
+    element.append(child);
+    return child;
+  };
+  element.insertBefore = (child, reference) => {
+    child.parentElement = element;
+    const index = element.children.indexOf(reference);
+    if (index < 0) {
+      element.children.push(child);
+    } else {
+      element.children.splice(index, 0, child);
+    }
+    return child;
+  };
+  Object.defineProperty(element, "firstChild", {
+    configurable: true,
+    get() {
+      return element.children[0] || null;
+    },
+  });
+  return element;
+}
+
+addDomCompat(document.body);
+document.head = addDomCompat(document.createElement("head"));
+
+function createElement(tagName, options = {}) {
+  const element = addDomCompat(document.createElement(tagName));
+  if (options.className != null) {
+    element.className = String(options.className);
+  }
+  if (options.textContent != null) {
+    element.textContent = String(options.textContent);
+  }
+  if (options.style) {
+    Object.assign(element.style, options.style);
+  }
+  if (options.innerHTML != null) {
+    element.innerHTML = String(options.innerHTML);
+    if (element.innerHTML.includes("easyuse-anima-combo-folder-arrow")) {
+      const arrow = createElement("span", {
+        className: "easyuse-anima-combo-folder-arrow",
+        textContent: "▶",
+      });
+      element.appendChild(arrow);
+    }
+  }
+  return element;
+}
+
+function validComboEntryText(value, depth = 0) {
+  if (value == null || depth > 2) {
+    return "";
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const text = String(value).trim();
+    return text && text !== "None" && text !== "[object Object]" ? text : "";
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const text = validComboEntryText(item, depth + 1);
+      if (text) {
+        return text;
+      }
+    }
+    return "";
+  }
+  if (typeof value === "object") {
+    for (const key of ["value", "content", "name", "title", "text", "label", "path", "filename"]) {
+      const text = validComboEntryText(value[key], depth + 1);
+      if (text) {
+        return text;
+      }
+    }
+  }
+  return "";
+}
+
+function installMenuSelectors(menu) {
+  const originalQuerySelectorAll = menu.querySelectorAll.bind(menu);
+  menu.querySelectorAll = (selector) => {
+    if (selector === ".litemenu-entry:not(.easyuse-anima-combo-folder)") {
+      return descendants(menu).filter(
+        (element) => element.classList.contains("litemenu-entry")
+          && !element.classList.contains("easyuse-anima-combo-folder"),
+      );
+    }
+    return originalQuerySelectorAll(selector);
+  };
+  return menu;
+}
+
+function makeMenu(entryCount, options = {}) {
+  const menu = installMenuSelectors(createElement("div", {
+    className: "litecontextmenu easyuse-anima-lora-menu",
+  }));
+  if (options.existingSearch) {
+    menu.appendChild(createElement("input", {
+      className: "comfy-context-menu-filter",
+    }));
+  }
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = createElement("div", { className: "litemenu-entry" });
+    entry.textContent = index === 0 ? "[object Object]" : "";
+    menu.appendChild(entry);
+  }
+  return menu;
+}
+
+let observer = null;
+class StubMutationObserver {
+  constructor(callback) {
+    assert.equal(observer, null, "install must create one observer");
+    this.callback = callback;
+    this.disconnected = false;
+    observer = this;
+  }
+
+  observe(target, options) {
+    this.target = target;
+    this.options = options;
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+}
+
+const animationFrames = [];
+const window = {
+  requestAnimationFrame(callback) {
+    animationFrames.push(callback);
+    callback();
+    return animationFrames.length;
+  },
+};
+
+const shownPreviews = [];
+let hiddenPreviews = 0;
+const previewLifecycle = {
+  showPreview(name, event) {
+    shownPreviews.push({ name, event });
+  },
+  hidePreview() {
+    hiddenPreviews += 1;
+  },
+};
+
+const positionCalls = [];
+let menuMode = "list";
+let currentNode = null;
+const lifecycle = menuModule.createLoraPresetMenuLifecycle({
+  document,
+  window,
+  MutationObserver: StubMutationObserver,
+  createElement,
+  validComboEntryText,
+  previewLifecycle,
+  positionMenu(menu, point) {
+    positionCalls.push({ menu, point });
+  },
+  text(key) {
+    return key === "lora.search" ? "Search LoRA" : key;
+  },
+  getMenuMode() {
+    return menuMode;
+  },
+  getCurrentNode() {
+    return currentNode;
+  },
+  nodeType: "EasyUseAnimaLoraPreset",
+  previewSize: 360,
+});
+
+assert.deepEqual(Object.keys(lifecycle).sort(), [
+  "activateMenu",
+  "createMenuItems",
+  "install",
+]);
+assert.equal(document.head.children.length, 0, "factory creation must not install DOM state");
+
+const escapedItems = lifecycle.createMenuItems([
+  "None",
+  "",
+  { value: "style/x<&\"'.safetensors" },
+]);
+assert.deepEqual(escapedItems, [{
+  content: "style/x&lt;&amp;&quot;&#39;.safetensors",
+  value: "style/x<&\"'.safetensors",
+}]);
+
+lifecycle.install();
+assert.equal(document.head.children.length, 1);
+assert.equal(document.head.children[0].tagName, "STYLE");
+assert.match(document.head.children[0].textContent, /easyuse-anima-lora-search/);
+assert.match(document.head.children[0].textContent, /easyuse-anima-lora-preview/);
+assert.ok(observer);
+assert.equal(observer.target, document.body);
+assert.deepEqual(observer.options, { childList: true, subtree: false });
+
+const listNode = {
+  comfyClass: "EasyUseAnimaLoraPreset",
+};
+currentNode = listNode;
+const listValues = [
+  "style/foo.safetensors",
+  "style/x-y.safetensors",
+];
+const listItems = lifecycle.createMenuItems(listValues);
+lifecycle.activateMenu(listNode, [140, 160], listItems);
+assert.equal(listNode.__easyuseAnimaOpeningLoraMenu, true);
+assert.deepEqual(listNode.__easyuseAnimaLoraMenuPoint, [140, 160]);
+assert.deepEqual(listNode.__easyuseAnimaLoraMenuValues, listValues);
+
+const listMenu = makeMenu(listItems.length);
+observer.callback([{ addedNodes: [listMenu], removedNodes: [] }]);
+assert.equal(listNode.__easyuseAnimaOpeningLoraMenu, false);
+assert.equal(listMenu.__easyuseAnimaListReady, true);
+
+const listEntries = listMenu.querySelectorAll(
+  ".litemenu-entry:not(.easyuse-anima-combo-folder)",
+);
+assert.equal(listEntries.length, 2);
+assert.equal(listEntries[0].textContent, listValues[0]);
+assert.equal(listEntries[0].getAttribute("data-value"), listValues[0]);
+assert.equal(listEntries[0].getAttribute("title"), listValues[0]);
+assert.equal(
+  listEntries[0].getAttribute("data-search"),
+  "style foo.safetensors style foo.safetensors",
+);
+assert.equal(listEntries[0].listenerCount("mouseover"), 1);
+assert.equal(listEntries[0].listenerCount("mousemove"), 1);
+assert.equal(listEntries[0].listenerCount("mouseout"), 1);
+for (const eventName of ["mouseover", "mousemove", "mouseout"]) {
+  assert.deepEqual(listEntries[0].__listenerOptions.get(eventName), [
+    { passive: true },
+  ]);
+}
+
+const hoverEvent = { clientX: 12, clientY: 24 };
+listEntries[0].emit("mouseover", hoverEvent);
+listEntries[0].emit("mousemove", hoverEvent);
+listEntries[0].emit("mouseout");
+assert.equal(shownPreviews.length, 2);
+assert.equal(shownPreviews[0].name, listValues[0]);
+assert.equal(shownPreviews[0].event.target, listEntries[0]);
+assert.equal(shownPreviews[0].event.clientX, 12);
+assert.equal(shownPreviews[1].name, listValues[0]);
+assert.equal(shownPreviews[1].event.clientY, 24);
+assert.equal(hiddenPreviews, 1);
+
+const listSearch = listMenu.querySelector("input");
+assert.ok(listSearch);
+assert.equal(listMenu.children[0], listSearch);
+assert.equal(listSearch.type, "search");
+assert.equal(listSearch.placeholder, "Search LoRA");
+assert.equal(listSearch.focused, true);
+
+listSearch.value = "FOO";
+listSearch.emit("input");
+assert.equal(listEntries[0].style.display, "");
+assert.equal(listEntries[1].style.display, "none");
+
+const escapeEvent = listSearch.emit("keydown", { key: "Escape" });
+assert.equal(escapeEvent.defaultPrevented, true);
+assert.equal(escapeEvent.propagationStopped, true);
+assert.equal(listSearch.value, "");
+assert.equal(listEntries[1].style.display, "");
+
+listNode.__easyuseAnimaOpeningLoraMenu = true;
+observer.callback([{ addedNodes: [listMenu], removedNodes: [] }]);
+assert.equal(listEntries[0].listenerCount("mouseover"), 1);
+assert.equal(listSearch.listenerCount("input"), 1);
+
+const removedMenu = createElement("div", { className: "litecontextmenu" });
+observer.callback([{ addedNodes: [], removedNodes: [removedMenu] }]);
+assert.equal(hiddenPreviews, 2);
+
+menuMode = "tree";
+const treeNode = {
+  comfyClass: "EasyUseAnimaLoraPreset",
+};
+currentNode = treeNode;
+const treeValues = [
+  "styles/anime/foo.safetensors",
+  "styles/real/bar.safetensors",
+  "flat.safetensors",
+];
+const treeItems = lifecycle.createMenuItems(treeValues);
+lifecycle.activateMenu(treeNode, [220, 240], treeItems);
+const treeMenu = makeMenu(treeItems.length);
+observer.callback([{ addedNodes: [treeMenu], removedNodes: [] }]);
+assert.equal(treeNode.__easyuseAnimaOpeningLoraMenu, false);
+assert.equal(treeMenu.__easyuseAnimaTreeReady, true);
+
+const treeFolders = treeMenu.querySelectorAll(".easyuse-anima-combo-folder");
+const treeContainers = treeMenu.querySelectorAll(
+  ".easyuse-anima-combo-folder-contents",
+);
+assert.equal(treeFolders.length, 3);
+assert.equal(treeContainers.length, 3);
+
+const treeEntries = treeMenu.querySelectorAll(
+  ".litemenu-entry:not(.easyuse-anima-combo-folder)",
+);
+assert.equal(treeEntries.length, 3);
+assert.equal(
+  treeEntries.filter((entry) => entry.querySelector(".easyuse-anima-combo-prefix")).length,
+  2,
+);
+
+const topFolder = treeFolders.find((folder) => folder.style.paddingLeft === "5px");
+assert.ok(topFolder);
+const topContainer = topFolder.parentElement.children[
+  topFolder.parentElement.children.indexOf(topFolder) + 1
+];
+assert.equal(topContainer.style.display, "none");
+const folderClick = topFolder.emit("click");
+assert.equal(folderClick.propagationStopped, true);
+assert.equal(topContainer.__easyuseAnimaOpen, true);
+assert.equal(topContainer.style.display, "block");
+assert.equal(
+  topFolder.querySelector(".easyuse-anima-combo-folder-arrow").textContent,
+  "▼",
+);
+
+const treeSearch = treeMenu.querySelector("input");
+treeSearch.value = "anime foo";
+treeSearch.emit("input");
+assert.ok(treeFolders.every((folder) => folder.style.display === "none"));
+assert.ok(treeContainers.every((container) => container.style.display === "block"));
+assert.equal(
+  treeEntries.filter((entry) => entry.style.display !== "none").length,
+  1,
+);
+
+treeSearch.value = "";
+treeSearch.emit("input");
+assert.ok(treeFolders.every((folder) => folder.style.display === ""));
+assert.equal(topContainer.style.display, "block");
+assert.equal(
+  treeContainers.filter((container) => container !== topContainer)
+    .every((container) => container.style.display === "none"),
+  true,
+);
+
+const existingNode = {
+  comfyClass: "EasyUseAnimaLoraPreset",
+};
+currentNode = existingNode;
+menuMode = "list";
+const existingValues = ["native/search.safetensors"];
+lifecycle.activateMenu(
+  existingNode,
+  [300, 320],
+  lifecycle.createMenuItems(existingValues),
+);
+const existingSearchMenu = makeMenu(1, { existingSearch: true });
+const existingSearch = existingSearchMenu.children[0];
+observer.callback([{ addedNodes: [existingSearchMenu], removedNodes: [] }]);
+assert.equal(existingSearchMenu.querySelectorAll("input").length, 1);
+assert.equal(existingSearch.listenerCount("input"), 1);
+assert.equal(existingSearch.focused, true);
+
+const positionCount = positionCalls.length;
+currentNode = { comfyClass: "DifferentNode" };
+observer.callback([{
+  addedNodes: [makeMenu(1)],
+  removedNodes: [removedMenu],
+}]);
+assert.equal(positionCalls.length, positionCount);
+assert.equal(hiddenPreviews, 2);
+
+console.log("LoRA preset menu lifecycle smoke passed.");

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -21,6 +21,12 @@ LORA_PRESET_PREVIEW_LIFECYCLE = (
 LORA_PRESET_PREVIEW_LIFECYCLE_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_preview_lifecycle_smoke.mjs"
 )
+LORA_PRESET_MENU_LIFECYCLE = (
+    ROOT / "web" / "js" / "lora_preset" / "menu_lifecycle.js"
+)
+LORA_PRESET_MENU_LIFECYCLE_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_menu_lifecycle_smoke.mjs"
+)
 LORA_PRESET_PROFILE_DATA = ROOT / "web" / "js" / "lora_preset" / "profile_data.js"
 LORA_PRESET_PROFILE_DATA_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_profile_data_smoke.mjs"
@@ -217,8 +223,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
                     entry_source,
                     rf"\b(?:const|let|var|function|class)\s+{moved_name}\b",
                 )
-        self.assertEqual(entry_source.count("loraPreviewLifecycle.showPreview"), 4)
-        self.assertEqual(entry_source.count("loraPreviewLifecycle.hidePreview"), 6)
+        self.assertEqual(entry_source.count("loraPreviewLifecycle.showPreview"), 2)
+        self.assertEqual(entry_source.count("loraPreviewLifecycle.hidePreview"), 4)
         self.assertEqual(
             entry_source.count("loraPreviewLifecycle.forgetMissingPreview"),
             1,
@@ -237,6 +243,124 @@ class LoraPresetFrontendTests(unittest.TestCase):
 
         completed = subprocess.run(
             [node_bin, str(LORA_PRESET_PREVIEW_LIFECYCLE_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
+    def test_menu_lifecycle_module_boundary(self):
+        module_source = LORA_PRESET_MENU_LIFECYCLE.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createLoraPresetMenuLifecycle"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            r"\b(?:app|api|registerExtension)\b",
+        )
+        self.assertIn(
+            'import { createLoraPresetMenuLifecycle } from '
+            '"./lora_preset/menu_lifecycle.js";',
+            entry_source,
+        )
+
+        factory_match = re.search(
+            r"const\s+loraMenuLifecycle\s*=\s*"
+            r"createLoraPresetMenuLifecycle"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().rstrip(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "document",
+                "window",
+                "MutationObserver",
+                "createElement: createEl",
+                "validComboEntryText",
+                "previewLifecycle: loraPreviewLifecycle",
+                "positionMenu",
+                "text: lpText",
+                "getMenuMode: () => LORA_PRESET_SETTINGS.menuMode",
+                "getCurrentNode: () => app.canvas?.current_node",
+                "nodeType: NODE_TYPE",
+                "previewSize: PREVIEW_SIZE",
+            },
+        )
+
+        for moved_name in (
+            "normalizeSearchText",
+            "escapeHtml",
+            "loraMenuItems",
+            "ensureLoraMenuSearch",
+            "applyLoraMenuSearch",
+            "loraMenuElementValue",
+            "addLoraMenuEntryHandlers",
+            "normalizeLoraMenuEntries",
+            "updateLoraMenuList",
+            "updateLoraMenuTree",
+            "updateLoraMenu",
+        ):
+            with self.subTest(moved_declaration=moved_name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\b(?:const|let|var|function|class)\s+{moved_name}\b",
+                )
+
+        self.assertEqual(
+            entry_source.count("loraMenuLifecycle.createMenuItems(values)"),
+            1,
+        )
+        self.assertEqual(
+            entry_source.count(
+                "loraMenuLifecycle.activateMenu(node, clientPoint, menuItems)"
+            ),
+            1,
+        )
+        self.assertEqual(entry_source.count("loraMenuLifecycle.install()"), 1)
+        self.assertNotIn("new MutationObserver", entry_source)
+        self.assertNotIn("easyuse-anima-lora-search {", entry_source)
+        self.assertIn("new MutationObserver", module_source)
+        self.assertIn("easyuse-anima-lora-search {", module_source)
+
+        self.assertTrue(LORA_PRESET_MENU_LIFECYCLE_SMOKE.is_file())
+        self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_lora_preset_menu_lifecycle_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_menu_lifecycle_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_MENU_LIFECYCLE_SMOKE)],
             cwd=ROOT,
             text=True,
             capture_output=True,
@@ -453,6 +577,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const loraStatePath = process.argv[3];
             const apiClientPath = process.argv[4];
             const previewLifecyclePath = process.argv[5];
+            const menuLifecyclePath = process.argv[6];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -473,10 +598,15 @@ class LoraPresetFrontendTests(unittest.TestCase):
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let menuLifecycleSource = fs.readFileSync(menuLifecyclePath, "utf8");
+            menuLifecycleSource = menuLifecycleSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${source}`;
-            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, addLoraMenuEntryHandlers, applyLoraPresetSettings, loraMenuElementValue, loraMenuItems, loraPresetApi, loraPreviewLifecycle, saveProfileSet };\n";
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${source}`;
+            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
             class StubMutationObserver {
@@ -576,12 +706,10 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const {
               LoraRowWidget,
               LORA_PRESET_SETTINGS,
-              addLoraMenuEntryHandlers,
               applyLoraPresetSettings,
-              loraMenuElementValue,
-              loraMenuItems,
               loraPresetApi,
               loraPreviewLifecycle,
+              loraMenuLifecycle,
               saveProfileSet,
             } = context.__loraPresetTest;
 
@@ -654,44 +782,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
             }
 
             {
-              const listeners = new Map();
-              const item = {
-                addEventListener(type, listener, options) {
-                  listeners.set(type, { listener, options });
-                },
-              };
-              const shown = [];
-              let hidden = 0;
-              const originalShowPreview = loraPreviewLifecycle.showPreview;
-              const originalHidePreview = loraPreviewLifecycle.hidePreview;
-              loraPreviewLifecycle.showPreview = (name, event) => {
-                shown.push({ name, event });
-              };
-              loraPreviewLifecycle.hidePreview = () => {
-                hidden += 1;
-              };
-
-              addLoraMenuEntryHandlers(item, "style/menu.safetensors");
-              assert.deepStrictEqual(Array.from(listeners.keys()).sort(), ["mousemove", "mouseout", "mouseover"]);
-              for (const { options } of listeners.values()) {
-                assert.strictEqual(options.passive, true);
-              }
-              const mouseoverEvent = { type: "mouseover", clientX: 120, clientY: 80 };
-              const mousemoveEvent = { type: "mousemove", clientX: 124, clientY: 84 };
-              listeners.get("mouseover").listener(mouseoverEvent);
-              listeners.get("mousemove").listener(mousemoveEvent);
-              listeners.get("mouseout").listener({ type: "mouseout" });
-              assert.deepStrictEqual(shown, [
-                { name: "style/menu.safetensors", event: mouseoverEvent },
-                { name: "style/menu.safetensors", event: mousemoveEvent },
-              ]);
-              assert.strictEqual(hidden, 1);
-
-              loraPreviewLifecycle.showPreview = originalShowPreview;
-              loraPreviewLifecycle.hidePreview = originalHidePreview;
-            }
-
-            {
               const node = makeNode();
               context.app.canvas.current_node = node;
               let hidden = 0;
@@ -702,6 +792,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
 
               context.app.__extension.init();
               assert.strictEqual(mutationObservers.length, 1);
+              assert.ok(loraMenuLifecycle);
               const removedMenu = {
                 classList: {
                   contains(className) {
@@ -790,25 +881,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
             }
 
             {
-              const items = loraMenuItems(["style/foo.safetensors", "style/x<y.safetensors"]);
-              assert.strictEqual(items[0].content, "style/foo.safetensors");
-              assert.strictEqual(items[0].value, "style/foo.safetensors");
-              assert.strictEqual(items[1].content, "style/x&lt;y.safetensors");
-
-              const badDomItem = {
-                dataset: {},
-                textContent: "[object Object]",
-                value: null,
-                __value: null,
-                getAttribute(name) {
-                  return name === "data-value" ? "[object Object]" : null;
-                },
-              };
-              assert.strictEqual(
-                loraMenuElementValue(badDomItem, "fixed/path.safetensors"),
-                "fixed/path.safetensors",
-              );
-
               applyLoraPresetSettings({ "lora_preset.menu_mode": "list" });
               assert.strictEqual(LORA_PRESET_SETTINGS.menuMode, "list");
               applyLoraPresetSettings({ "lora_preset.menu_mode": "bad" });
@@ -861,6 +933,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_LORA_STATE),
                 str(LORA_PRESET_API_CLIENT),
                 str(LORA_PRESET_PREVIEW_LIFECYCLE),
+                str(LORA_PRESET_MENU_LIFECYCLE),
             ],
             cwd=ROOT,
             text=True,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -174,6 +174,11 @@ try {
         throw "Frontend LoRA preset preview lifecycle smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_menu_lifecycle_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset menu lifecycle smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_data_adapter_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -3,6 +3,7 @@ import { api } from "../../../scripts/api.js";
 import { easyuseAnimaEncodeRFC3986URIComponent as encodeRFC3986URIComponent, easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
 import { createLoraPresetApiClient } from "./lora_preset/api_client.js";
+import { createLoraPresetMenuLifecycle } from "./lora_preset/menu_lifecycle.js";
 import { createLoraPresetPreviewLifecycle } from "./lora_preset/preview_lifecycle.js";
 import {
   INTERNAL_WIDGET_DEFAULTS,
@@ -44,7 +45,6 @@ const DEFAULT_STRENGTH_BUTTON_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_PIXELS = 8;
 const PREVIEW_SIZE = 360;
-let activeLoraMenuNode = null;
 let activeProfileWheelTarget = null;
 let profileWheelListenerInstalled = false;
 const LORA_PRESET_SETTINGS = {
@@ -300,6 +300,20 @@ const loraPresetApi = createLoraPresetApiClient({
 const loraPreviewLifecycle = createLoraPresetPreviewLifecycle({
   document,
   encodeURIComponent: encodeRFC3986URIComponent,
+  previewSize: PREVIEW_SIZE,
+});
+const loraMenuLifecycle = createLoraPresetMenuLifecycle({
+  document,
+  window,
+  MutationObserver,
+  createElement: createEl,
+  validComboEntryText,
+  previewLifecycle: loraPreviewLifecycle,
+  positionMenu,
+  text: lpText,
+  getMenuMode: () => LORA_PRESET_SETTINGS.menuMode,
+  getCurrentNode: () => app.canvas?.current_node,
+  nodeType: NODE_TYPE,
   previewSize: PREVIEW_SIZE,
 });
 
@@ -1344,14 +1358,6 @@ function positionMenu(menu, clientPoint) {
   menu.style.top = `${top}px`;
 }
 
-function normalizeSearchText(value) {
-  return String(value || "")
-    .replace(/[\\/_-]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .toLowerCase();
-}
-
 function loraDisplayName(name) {
   const text = String(name || "");
   if (LORA_PRESET_SETTINGS.nameDisplay === "path") {
@@ -1360,38 +1366,15 @@ function loraDisplayName(name) {
   return text.replace(/\\/g, "/").split("/").pop() || text;
 }
 
-function escapeHtml(value) {
-  return String(value || "").replace(/[&<>"']/g, (char) => ({
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    "\"": "&quot;",
-    "'": "&#39;",
-  })[char]);
-}
-
-function loraMenuItems(values) {
-  return (values || [])
-    .map((value) => validComboEntryText(value))
-    .filter(Boolean)
-    .map((name) => ({
-      content: escapeHtml(name),
-      value: name,
-    }));
-}
-
 async function openLoraMenu(node, event, pos, onChoose) {
   const clientPoint = menuClientPoint(node, pos, event);
   const values = await fetchLoraNameValues(node);
-  const menuItems = loraMenuItems(values);
+  const menuItems = loraMenuLifecycle.createMenuItems(values);
   if (!menuItems.length) {
     window.alert(lpText("lora.noneFound"));
     return;
   }
-  node.__easyuseAnimaOpeningLoraMenu = true;
-  node.__easyuseAnimaLoraMenuPoint = clientPoint;
-  node.__easyuseAnimaLoraMenuValues = menuItems.map((item) => item.value);
-  activeLoraMenuNode = node;
+  loraMenuLifecycle.activateMenu(node, clientPoint, menuItems);
   new LiteGraph.ContextMenu(menuItems, {
     event: makeMenuEvent(clientPoint),
     title: lpText("lora.chooseTitle"),
@@ -1404,215 +1387,6 @@ async function openLoraMenu(node, event, pos, onChoose) {
       }
     },
   });
-}
-
-function ensureLoraMenuSearch(menu, node) {
-  if (!menu || menu.__easyuseAnimaSearchReady) {
-    return;
-  }
-  menu.__easyuseAnimaSearchReady = true;
-  const existingInput = menu.querySelector(".comfy-context-menu-filter, input[type='search'], input");
-  if (existingInput) {
-    const applyExistingSearch = () => {
-      applyLoraMenuSearch(menu, existingInput.value);
-      positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
-    };
-    existingInput.addEventListener("input", applyExistingSearch);
-    window.requestAnimationFrame(() => {
-      existingInput.focus();
-      applyExistingSearch();
-    });
-    return;
-  }
-  const input = createEl("input", {
-    className: "easyuse-anima-lora-search",
-  });
-  input.type = "search";
-  input.placeholder = lpText("lora.search");
-  input.autocomplete = "off";
-  input.spellcheck = false;
-  const stop = (event) => event.stopPropagation();
-  for (const eventName of ["pointerdown", "mousedown", "mouseup", "click", "dblclick", "keydown"]) {
-    input.addEventListener(eventName, stop);
-  }
-  input.addEventListener("keydown", (event) => {
-    if (event.key === "Escape") {
-      input.value = "";
-      applyLoraMenuSearch(menu, "");
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  });
-  input.addEventListener("input", () => {
-    applyLoraMenuSearch(menu, input.value);
-    positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
-  });
-  const firstDirectEntry = Array.from(menu.children).find((child) => child.classList?.contains("litemenu-entry"));
-  menu.insertBefore(input, firstDirectEntry || menu.firstChild);
-  window.requestAnimationFrame(() => {
-    input.focus();
-    positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
-  });
-}
-
-function applyLoraMenuSearch(menu, rawQuery) {
-  const query = normalizeSearchText(rawQuery);
-  const hasQuery = !!query;
-  const entries = Array.from(menu.querySelectorAll(".litemenu-entry:not(.easyuse-anima-combo-folder)"));
-  for (const entry of entries) {
-    const text = entry.getAttribute("data-search") || normalizeSearchText(entry.getAttribute("data-value") || entry.textContent);
-    entry.style.display = !hasQuery || text.includes(query) ? "" : "none";
-  }
-  for (const folder of menu.querySelectorAll(".easyuse-anima-combo-folder")) {
-    folder.style.display = hasQuery ? "none" : "";
-  }
-  for (const container of menu.querySelectorAll(".easyuse-anima-combo-folder-contents")) {
-    container.style.display = hasQuery ? "block" : (container.__easyuseAnimaOpen ? "block" : "none");
-  }
-}
-
-function loraMenuElementValue(item, fallbackValue) {
-  const candidates = [
-    item?.getAttribute?.("data-value"),
-    item?.dataset?.value,
-    item?.value,
-    item?.__value,
-    fallbackValue,
-    item?.textContent,
-  ];
-  for (const candidate of candidates) {
-    const text = validComboEntryText(candidate);
-    if (text) {
-      return text;
-    }
-  }
-  return "";
-}
-
-function addLoraMenuEntryHandlers(item, value) {
-  if (item.__easyuseAnimaPreviewValue === value) {
-    return;
-  }
-  item.__easyuseAnimaPreviewValue = value;
-  item.addEventListener("mouseover", (event) => loraPreviewLifecycle.showPreview(value, event), { passive: true });
-  item.addEventListener("mousemove", (event) => loraPreviewLifecycle.showPreview(value, event), { passive: true });
-  item.addEventListener("mouseout", loraPreviewLifecycle.hidePreview, { passive: true });
-}
-
-function normalizeLoraMenuEntries(menu, node, options = {}) {
-  const items = Array.from(menu.querySelectorAll(".litemenu-entry"));
-  const fallbackValues = node?.__easyuseAnimaLoraMenuValues || [];
-  const splitBy = /\/|\\/;
-  const entries = [];
-
-  items.forEach((item, index) => {
-    const value = loraMenuElementValue(item, fallbackValues[index]);
-    if (!value) {
-      item.textContent = "";
-      item.style.display = "none";
-      return;
-    }
-    item.setAttribute("data-value", value);
-    item.setAttribute("title", value);
-    const parts = value.split(splitBy).filter(Boolean);
-    item.setAttribute("data-search", normalizeSearchText([value, parts.join(" ")].join(" ")));
-    item.textContent = options.splitDisplay ? (parts[parts.length - 1] || value) : value;
-    if (options.splitDisplay && parts.length > 1) {
-      item.prepend(createEl("span", {
-        className: "easyuse-anima-combo-prefix",
-        textContent: `${parts.slice(0, -1).join("/")}/`,
-      }));
-    }
-    addLoraMenuEntryHandlers(item, value);
-    entries.push({ item, value, parts });
-  });
-
-  return entries;
-}
-
-function updateLoraMenuList(menu, node) {
-  if (!menu || menu.__easyuseAnimaListReady) {
-    return;
-  }
-  menu.__easyuseAnimaListReady = true;
-  normalizeLoraMenuEntries(menu, node, { splitDisplay: false });
-  ensureLoraMenuSearch(menu, node);
-  positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
-}
-
-function updateLoraMenuTree(menu, node) {
-  if (!menu || menu.__easyuseAnimaTreeReady) {
-    return;
-  }
-  menu.__easyuseAnimaTreeReady = true;
-  const entries = normalizeLoraMenuEntries(menu, node, { splitDisplay: true });
-  if (!entries.length) {
-    return;
-  }
-  const folderMap = new Map();
-  const itemsSymbol = Symbol("items");
-
-  for (const { item, parts } of entries) {
-    if (parts.length <= 1) {
-      continue;
-    }
-    item.remove();
-    let level = folderMap;
-    for (const folder of parts.slice(0, -1)) {
-      if (!level.has(folder)) {
-        level.set(folder, new Map());
-      }
-      level = level.get(folder);
-    }
-    if (!level.has(itemsSymbol)) {
-      level.set(itemsSymbol, []);
-    }
-    level.get(itemsSymbol).push(item);
-  }
-
-  const parent = entries[0]?.item?.parentElement || menu;
-  const insertFolders = (target, map, depth = 0) => {
-    for (const [folder, content] of map.entries()) {
-      if (folder === itemsSymbol) {
-        continue;
-      }
-      const folderEl = createEl("div", {
-        className: "litemenu-entry easyuse-anima-combo-folder",
-        innerHTML: `<span class="easyuse-anima-combo-folder-arrow">▶</span> ${folder}`,
-        style: { paddingLeft: `${depth * 10 + 5}px` },
-      });
-      const childContainer = createEl("div", {
-        className: "easyuse-anima-combo-folder-contents",
-        style: { display: "none" },
-      });
-      for (const child of content.get(itemsSymbol) || []) {
-        child.style.paddingLeft = `${(depth + 1) * 10 + 14}px`;
-        childContainer.appendChild(child);
-      }
-      insertFolders(childContainer, content, depth + 1);
-      folderEl.addEventListener("click", (event) => {
-        event.stopPropagation();
-        const open = childContainer.style.display === "none";
-        childContainer.__easyuseAnimaOpen = open;
-        childContainer.style.display = open ? "block" : "none";
-        folderEl.querySelector(".easyuse-anima-combo-folder-arrow").textContent = open ? "▼" : "▶";
-      });
-      target.appendChild(folderEl);
-      target.appendChild(childContainer);
-    }
-  };
-
-  insertFolders(parent, folderMap);
-  ensureLoraMenuSearch(menu, node);
-  positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
-}
-
-function updateLoraMenu(menu, node) {
-  if (LORA_PRESET_SETTINGS.menuMode === "list") {
-    updateLoraMenuList(menu, node);
-    return;
-  }
-  updateLoraMenuTree(menu, node);
 }
 
 class ProfileBarWidget {
@@ -2502,83 +2276,7 @@ app.registerExtension({
     });
     document.addEventListener("pointerdown", loraPreviewLifecycle.hidePreview, true);
     installProfileWheelListener();
-
-    document.head.appendChild(createEl("style", {
-      textContent: `
-        .easyuse-anima-lora-preview {
-          position: fixed;
-          width: ${PREVIEW_SIZE}px;
-          height: ${PREVIEW_SIZE}px;
-          object-fit: contain;
-          background: rgba(20, 20, 22, 0.96);
-          border: 1px solid rgba(180, 180, 185, 0.45);
-          z-index: 10000;
-          pointer-events: none;
-          display: none;
-        }
-        .easyuse-anima-lora-menu .easyuse-anima-lora-search {
-          box-sizing: border-box;
-          width: calc(100% - 10px);
-          margin: 4px 5px 6px;
-          padding: 4px 6px;
-          color: var(--input-text, #ddd);
-          background: var(--comfy-input-bg, #222);
-          border: 1px solid rgba(180, 180, 185, 0.45);
-          border-radius: 3px;
-          outline: none;
-        }
-        .easyuse-anima-lora-menu .easyuse-anima-combo-folder {
-          opacity: 0.72;
-        }
-        .easyuse-anima-lora-menu .easyuse-anima-combo-folder-arrow {
-          display: inline-block;
-          width: 15px;
-        }
-        .easyuse-anima-lora-menu .easyuse-anima-combo-folder:hover {
-          background-color: rgba(255, 255, 255, 0.1);
-        }
-        .easyuse-anima-lora-menu .easyuse-anima-combo-prefix {
-          display: none;
-        }
-        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .easyuse-anima-combo-folder-contents {
-          display: block !important;
-        }
-        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .easyuse-anima-combo-folder {
-          display: none;
-        }
-        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .easyuse-anima-combo-prefix {
-          display: inline;
-        }
-        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .litemenu-entry {
-          padding-left: 2px !important;
-        }
-      `,
-    }));
-
-    const observer = new MutationObserver((mutations) => {
-      const node = activeLoraMenuNode || app.canvas?.current_node;
-      if (!node || node.comfyClass !== NODE_TYPE) {
-        return;
-      }
-      for (const mutation of mutations) {
-        for (const removed of mutation.removedNodes) {
-          if (removed.classList?.contains("litecontextmenu")) {
-            loraPreviewLifecycle.hidePreview();
-          }
-        }
-        for (const added of mutation.addedNodes) {
-          if (!added.classList?.contains("litecontextmenu") || !node.__easyuseAnimaOpeningLoraMenu) {
-            continue;
-          }
-          window.requestAnimationFrame(() => {
-            updateLoraMenu(added, node);
-            node.__easyuseAnimaOpeningLoraMenu = false;
-            activeLoraMenuNode = null;
-          });
-        }
-      }
-    });
-    observer.observe(document.body, { childList: true, subtree: false });
+    loraMenuLifecycle.install();
   },
   setup() {
     installLoraPresetSaveSync();

--- a/web/js/lora_preset/menu_lifecycle.js
+++ b/web/js/lora_preset/menu_lifecycle.js
@@ -1,0 +1,374 @@
+// @ts-check
+
+/**
+ * @typedef {object} LoraPresetMenuDependencies
+ * @property {Document} document
+ * @property {Window} window
+ * @property {typeof MutationObserver} MutationObserver
+ * @property {(tagName: string, options?: Record<string, any>) => any} createElement
+ * @property {(value: unknown) => string} validComboEntryText
+ * @property {{showPreview: (name: string, event?: any) => void, hidePreview: () => void}} previewLifecycle
+ * @property {(menu: any, clientPoint: any) => void} positionMenu
+ * @property {(key: string) => string} text
+ * @property {() => string} getMenuMode
+ * @property {() => any} getCurrentNode
+ * @property {string} nodeType
+ * @property {number} previewSize
+ */
+
+/**
+ * Own the LoRA context-menu DOM lifecycle while the entry module keeps menu
+ * creation and selection callbacks. This preserves the existing order:
+ * prepare node state, create the LiteGraph menu, normalize its DOM on the
+ * observer frame, then release the active node.
+ *
+ * @param {LoraPresetMenuDependencies} dependencies
+ */
+export function createLoraPresetMenuLifecycle(dependencies) {
+  const {
+    document,
+    window,
+    MutationObserver,
+    createElement,
+    validComboEntryText,
+    previewLifecycle,
+    positionMenu,
+    text,
+    getMenuMode,
+    getCurrentNode,
+    nodeType,
+    previewSize,
+  } = dependencies;
+  let activeLoraMenuNode = null;
+
+  function normalizeSearchText(value) {
+    return String(value || "")
+      .replace(/[\\/_-]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase();
+  }
+
+  function escapeHtml(value) {
+    return String(value || "").replace(/[&<>"']/g, (char) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      "\"": "&quot;",
+      "'": "&#39;",
+    })[char]);
+  }
+
+  function createMenuItems(values) {
+    return (values || [])
+      .map((value) => validComboEntryText(value))
+      .filter(Boolean)
+      .map((name) => ({
+        content: escapeHtml(name),
+        value: name,
+      }));
+  }
+
+  function activateMenu(node, clientPoint, menuItems) {
+    node.__easyuseAnimaOpeningLoraMenu = true;
+    node.__easyuseAnimaLoraMenuPoint = clientPoint;
+    node.__easyuseAnimaLoraMenuValues = menuItems.map((item) => item.value);
+    activeLoraMenuNode = node;
+  }
+
+  function ensureLoraMenuSearch(menu, node) {
+    if (!menu || menu.__easyuseAnimaSearchReady) {
+      return;
+    }
+    menu.__easyuseAnimaSearchReady = true;
+    const existingInput = menu.querySelector(".comfy-context-menu-filter, input[type='search'], input");
+    if (existingInput) {
+      const applyExistingSearch = () => {
+        applyLoraMenuSearch(menu, existingInput.value);
+        positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
+      };
+      existingInput.addEventListener("input", applyExistingSearch);
+      window.requestAnimationFrame(() => {
+        existingInput.focus();
+        applyExistingSearch();
+      });
+      return;
+    }
+    const input = createElement("input", {
+      className: "easyuse-anima-lora-search",
+    });
+    input.type = "search";
+    input.placeholder = text("lora.search");
+    input.autocomplete = "off";
+    input.spellcheck = false;
+    const stop = (event) => event.stopPropagation();
+    for (const eventName of ["pointerdown", "mousedown", "mouseup", "click", "dblclick", "keydown"]) {
+      input.addEventListener(eventName, stop);
+    }
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        input.value = "";
+        applyLoraMenuSearch(menu, "");
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    });
+    input.addEventListener("input", () => {
+      applyLoraMenuSearch(menu, input.value);
+      positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
+    });
+    const firstDirectEntry = Array.from(menu.children).find((child) => child.classList?.contains("litemenu-entry"));
+    menu.insertBefore(input, firstDirectEntry || menu.firstChild);
+    window.requestAnimationFrame(() => {
+      input.focus();
+      positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
+    });
+  }
+
+  function applyLoraMenuSearch(menu, rawQuery) {
+    const query = normalizeSearchText(rawQuery);
+    const hasQuery = !!query;
+    const entries = Array.from(menu.querySelectorAll(".litemenu-entry:not(.easyuse-anima-combo-folder)"));
+    for (const entry of entries) {
+      const textValue = entry.getAttribute("data-search") || normalizeSearchText(entry.getAttribute("data-value") || entry.textContent);
+      entry.style.display = !hasQuery || textValue.includes(query) ? "" : "none";
+    }
+    for (const folder of menu.querySelectorAll(".easyuse-anima-combo-folder")) {
+      folder.style.display = hasQuery ? "none" : "";
+    }
+    for (const container of menu.querySelectorAll(".easyuse-anima-combo-folder-contents")) {
+      container.style.display = hasQuery ? "block" : (container.__easyuseAnimaOpen ? "block" : "none");
+    }
+  }
+
+  function loraMenuElementValue(item, fallbackValue) {
+    const candidates = [
+      item?.getAttribute?.("data-value"),
+      item?.dataset?.value,
+      item?.value,
+      item?.__value,
+      fallbackValue,
+      item?.textContent,
+    ];
+    for (const candidate of candidates) {
+      const textValue = validComboEntryText(candidate);
+      if (textValue) {
+        return textValue;
+      }
+    }
+    return "";
+  }
+
+  function addLoraMenuEntryHandlers(item, value) {
+    if (item.__easyuseAnimaPreviewValue === value) {
+      return;
+    }
+    item.__easyuseAnimaPreviewValue = value;
+    item.addEventListener("mouseover", (event) => previewLifecycle.showPreview(value, event), { passive: true });
+    item.addEventListener("mousemove", (event) => previewLifecycle.showPreview(value, event), { passive: true });
+    item.addEventListener("mouseout", previewLifecycle.hidePreview, { passive: true });
+  }
+
+  function normalizeLoraMenuEntries(menu, node, options = {}) {
+    const items = Array.from(menu.querySelectorAll(".litemenu-entry"));
+    const fallbackValues = node?.__easyuseAnimaLoraMenuValues || [];
+    const splitBy = /\/|\\/;
+    const entries = [];
+
+    items.forEach((item, index) => {
+      const value = loraMenuElementValue(item, fallbackValues[index]);
+      if (!value) {
+        item.textContent = "";
+        item.style.display = "none";
+        return;
+      }
+      item.setAttribute("data-value", value);
+      item.setAttribute("title", value);
+      const parts = value.split(splitBy).filter(Boolean);
+      item.setAttribute("data-search", normalizeSearchText([value, parts.join(" ")].join(" ")));
+      item.textContent = options.splitDisplay ? (parts[parts.length - 1] || value) : value;
+      if (options.splitDisplay && parts.length > 1) {
+        item.prepend(createElement("span", {
+          className: "easyuse-anima-combo-prefix",
+          textContent: `${parts.slice(0, -1).join("/")}/`,
+        }));
+      }
+      addLoraMenuEntryHandlers(item, value);
+      entries.push({ item, value, parts });
+    });
+
+    return entries;
+  }
+
+  function updateLoraMenuList(menu, node) {
+    if (!menu || menu.__easyuseAnimaListReady) {
+      return;
+    }
+    menu.__easyuseAnimaListReady = true;
+    normalizeLoraMenuEntries(menu, node, { splitDisplay: false });
+    ensureLoraMenuSearch(menu, node);
+    positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
+  }
+
+  function updateLoraMenuTree(menu, node) {
+    if (!menu || menu.__easyuseAnimaTreeReady) {
+      return;
+    }
+    menu.__easyuseAnimaTreeReady = true;
+    const entries = normalizeLoraMenuEntries(menu, node, { splitDisplay: true });
+    if (!entries.length) {
+      return;
+    }
+    const folderMap = new Map();
+    const itemsSymbol = Symbol("items");
+
+    for (const { item, parts } of entries) {
+      if (parts.length <= 1) {
+        continue;
+      }
+      item.remove();
+      let level = folderMap;
+      for (const folder of parts.slice(0, -1)) {
+        if (!level.has(folder)) {
+          level.set(folder, new Map());
+        }
+        level = level.get(folder);
+      }
+      if (!level.has(itemsSymbol)) {
+        level.set(itemsSymbol, []);
+      }
+      level.get(itemsSymbol).push(item);
+    }
+
+    const parent = entries[0]?.item?.parentElement || menu;
+    const insertFolders = (target, map, depth = 0) => {
+      for (const [folder, content] of map.entries()) {
+        if (folder === itemsSymbol) {
+          continue;
+        }
+        const folderEl = createElement("div", {
+          className: "litemenu-entry easyuse-anima-combo-folder",
+          innerHTML: `<span class="easyuse-anima-combo-folder-arrow">▶</span> ${folder}`,
+          style: { paddingLeft: `${depth * 10 + 5}px` },
+        });
+        const childContainer = createElement("div", {
+          className: "easyuse-anima-combo-folder-contents",
+          style: { display: "none" },
+        });
+        for (const child of content.get(itemsSymbol) || []) {
+          child.style.paddingLeft = `${(depth + 1) * 10 + 14}px`;
+          childContainer.appendChild(child);
+        }
+        insertFolders(childContainer, content, depth + 1);
+        folderEl.addEventListener("click", (event) => {
+          event.stopPropagation();
+          const open = childContainer.style.display === "none";
+          childContainer.__easyuseAnimaOpen = open;
+          childContainer.style.display = open ? "block" : "none";
+          folderEl.querySelector(".easyuse-anima-combo-folder-arrow").textContent = open ? "▼" : "▶";
+        });
+        target.appendChild(folderEl);
+        target.appendChild(childContainer);
+      }
+    };
+
+    insertFolders(parent, folderMap);
+    ensureLoraMenuSearch(menu, node);
+    positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
+  }
+
+  function updateLoraMenu(menu, node) {
+    if (getMenuMode() === "list") {
+      updateLoraMenuList(menu, node);
+      return;
+    }
+    updateLoraMenuTree(menu, node);
+  }
+
+  function install() {
+    document.head.appendChild(createElement("style", {
+      textContent: `
+        .easyuse-anima-lora-preview {
+          position: fixed;
+          width: ${previewSize}px;
+          height: ${previewSize}px;
+          object-fit: contain;
+          background: rgba(20, 20, 22, 0.96);
+          border: 1px solid rgba(180, 180, 185, 0.45);
+          z-index: 10000;
+          pointer-events: none;
+          display: none;
+        }
+        .easyuse-anima-lora-menu .easyuse-anima-lora-search {
+          box-sizing: border-box;
+          width: calc(100% - 10px);
+          margin: 4px 5px 6px;
+          padding: 4px 6px;
+          color: var(--input-text, #ddd);
+          background: var(--comfy-input-bg, #222);
+          border: 1px solid rgba(180, 180, 185, 0.45);
+          border-radius: 3px;
+          outline: none;
+        }
+        .easyuse-anima-lora-menu .easyuse-anima-combo-folder {
+          opacity: 0.72;
+        }
+        .easyuse-anima-lora-menu .easyuse-anima-combo-folder-arrow {
+          display: inline-block;
+          width: 15px;
+        }
+        .easyuse-anima-lora-menu .easyuse-anima-combo-folder:hover {
+          background-color: rgba(255, 255, 255, 0.1);
+        }
+        .easyuse-anima-lora-menu .easyuse-anima-combo-prefix {
+          display: none;
+        }
+        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .easyuse-anima-combo-folder-contents {
+          display: block !important;
+        }
+        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .easyuse-anima-combo-folder {
+          display: none;
+        }
+        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .easyuse-anima-combo-prefix {
+          display: inline;
+        }
+        .easyuse-anima-lora-menu:has(input:not(:placeholder-shown)) .litemenu-entry {
+          padding-left: 2px !important;
+        }
+      `,
+    }));
+
+    const observer = new MutationObserver((mutations) => {
+      const node = activeLoraMenuNode || getCurrentNode();
+      if (!node || node.comfyClass !== nodeType) {
+        return;
+      }
+      for (const mutation of mutations) {
+        for (const removed of mutation.removedNodes) {
+          const removedElement = /** @type {Element} */ (removed);
+          if (removedElement.classList?.contains("litecontextmenu")) {
+            previewLifecycle.hidePreview();
+          }
+        }
+        for (const added of mutation.addedNodes) {
+          const addedElement = /** @type {Element} */ (added);
+          if (!addedElement.classList?.contains("litecontextmenu") || !node.__easyuseAnimaOpeningLoraMenu) {
+            continue;
+          }
+          window.requestAnimationFrame(() => {
+            updateLoraMenu(addedElement, node);
+            node.__easyuseAnimaOpeningLoraMenu = false;
+            activeLoraMenuNode = null;
+          });
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: false });
+  }
+
+  return {
+    activateMenu,
+    createMenuItems,
+    install,
+  };
+}


### PR DESCRIPTION
## 변경 요약

- LoRA Preset의 menu/search/MutationObserver lifecycle을 `lora_preset/menu_lifecycle.js`로 분리했습니다.
- list/tree 정규화, 검색 입력·Escape·filter, folder toggle, hover preview handler, context menu 제거 cleanup과 관련 CSS의 소유 경계를 한 모듈로 모았습니다.
- entry는 menu item 생성, 활성 node 전달, lifecycle 설치만 위임하도록 축소했습니다.
- 기존 profile 형식, LoRA 선택 callback, preview API, canvas/serialization 동작은 변경하지 않았습니다.

## 주요 파일

- `web/js/lora_preset/menu_lifecycle.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_menu_lifecycle_smoke.mjs`
- 관련 source/runtime 테스트와 frontend runner

## 검증

- 변경 JavaScript syntax 검사 통과
- 신규 menu lifecycle smoke 통과
- focused unittest 11/11 통과
- 최종 official full:
  - Python compile 통과
  - `unittest` 384/384 통과
  - frontend 100개 JavaScript 파일 검사 통과
  - TypeScript 6.0.3 통과
  - diff check 통과

검증 재실행 사유:

- 최신 `dev` rebase 후 첫 focused 실행은 Windows sandbox 로그온 세션 오류로 테스트 본문 전에 실패해 동일 frozen diff를 비샌드박스로 재실행했습니다.
- 첫 official full은 모든 Python/smoke가 통과했지만 새 `@ts-check` 모듈에서 MutationRecord의 일반 `Node` 2건에 대한 `classList` 타입 오류로 실패했습니다. JSDoc `Element` cast만 추가해 production diff가 바뀐 뒤 focused smoke/TypeScript와 full을 1회 재실행했습니다.

이번 조각은 기존 lifecycle의 기계적 이동이므로 legacy canvas / Node 2.0 browser smoke는 반복하지 않았습니다. 사용자 v0.27.0 인스턴스 수동 확인은 전체 유지보수 작업 종료 시점까지 보류합니다.

## 후속 범위

- canvas drawing, hit testing, strength drag와 canvas widget lifecycle
- profile mutation 및 node initialize/configure/serialize runtime
- save sync, wheel listener와 extension entry
- 최종 dual-canvas load/edit/FIX/queue/save-reload matrix
