### PR TITLE
fix: Prompt Studio queue seed 상태 lifecycle 정리

### DIFF
--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -6,6 +6,10 @@ function dataModule(relativePath) {
   return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
 }
 
+function sourceModule(source) {
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -17,6 +21,7 @@ assert.deepEqual(
   Object.keys(queueModule).sort(),
   [
     "createAdvancedQueueSeedRuntime",
+    "installAdvancedQueueSeedGraphCleanup",
     "installAdvancedQueueSeedQueueHook",
   ],
 );
@@ -25,6 +30,19 @@ const ADVANCED = "EasyUseAnimaPromptStudioAdvanced";
 const ADVANCED_V2 = "EasyUseAnimaPromptStudioAdvancedV2";
 const SEED_INDEX = 11;
 const RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed";
+
+const nodeHookConstants = sourceModule(`
+  export const NODE_TYPE = "EasyUseAnimaPromptStudio";
+  export const ADVANCED_NODE_TYPE = "${ADVANCED}";
+  export const ADVANCED_V2_NODE_TYPE = "${ADVANCED_V2}";
+  export const EXTEND_NODE_TYPE = "EasyUseAnimaPromptStudioExtend";
+  export const WILDCARD_NODE_TYPE = "EasyUseAnimaWildcard";
+`);
+const nodeHooksSource = readFileSync(
+  new URL("../web/js/prompt_studio/node_hooks.js", import.meta.url),
+  "utf8",
+).replace('from "./constants.js"', `from "${nodeHookConstants}"`);
+const nodeHooksModule = await import(sourceModule(nodeHooksSource));
 
 function deferred() {
   let resolve;
@@ -166,6 +184,149 @@ function reservedNextSeed(prompt, nodeId) {
 function reservedSeedState(prompt, nodeId) {
   const raw = prompt.output[String(nodeId)].inputs[RESERVED_NEXT_SEED_INPUT];
   return raw == null ? undefined : JSON.parse(raw);
+}
+
+{
+  const events = [];
+  const clearResult = { cleared: true };
+  const firstArg = { first: true };
+  const secondArg = { second: true };
+  const graph = {
+    clear(...args) {
+      events.push(["clear", this, args]);
+      return clearResult;
+    },
+  };
+  const owner = { graphOwner: true };
+  const runtime = {
+    clearGraphNodes() {
+      events.push(["cleanup"]);
+    },
+  };
+  assert.equal(queueModule.installAdvancedQueueSeedGraphCleanup(graph, runtime), true);
+  const installed = graph.clear;
+  assert.equal(queueModule.installAdvancedQueueSeedGraphCleanup(graph, runtime), false);
+  assert.equal(graph.clear, installed, "graph cleanup wrapper must install only once");
+  assert.equal(graph.clear.call(owner, firstArg, secondArg), clearResult);
+  assert.deepEqual(events, [
+    ["clear", owner, [firstArg, secondArg]],
+    ["cleanup"],
+  ]);
+
+  const clearError = new Error("graph clear failed");
+  let failedCleanupCalls = 0;
+  const failingGraph = {
+    clear() {
+      throw clearError;
+    },
+  };
+  queueModule.installAdvancedQueueSeedGraphCleanup(failingGraph, {
+    clearGraphNodes() {
+      failedCleanupCalls += 1;
+    },
+  });
+  assert.throws(() => failingGraph.clear(), (error) => error === clearError);
+  assert.equal(
+    failedCleanupCalls,
+    0,
+    "a failed original graph clear must preserve managed owners for the still-live graph",
+  );
+}
+
+{
+  const events = [];
+  const configureResult = Symbol("configure-result");
+  const removeResult = Symbol("remove-result");
+  const serialized = { workflow: true };
+  const configureTail = { extra: true };
+  const removeArg = { reason: "test" };
+  function AdvancedNodeType() {}
+  AdvancedNodeType.prototype.onConfigure = function (...args) {
+    events.push(["configure", this, args]);
+    return configureResult;
+  };
+  AdvancedNodeType.prototype.onRemoved = function (...args) {
+    events.push(["remove", this, args]);
+    return removeResult;
+  };
+  const hooks = {
+    captureAdvancedConfigure: (node, value) => events.push(["capture", node, value]),
+    attachAdvancedQueueSeedNode: (node) => events.push(["attach", node]),
+    scheduleHookAdvancedNode: (node) => events.push(["schedule", node]),
+    disconnectAdvancedEditorWidthObserver: (node) => {
+      events.push(["disconnect", node]);
+      throw new Error("isolated observer cleanup failure");
+    },
+    detachAdvancedQueueSeedNode: (node) => events.push(["detach", node]),
+  };
+  assert.equal(
+    nodeHooksModule.registerPromptStudioNodeHooks(
+      AdvancedNodeType,
+      { name: ADVANCED },
+      hooks,
+    ),
+    true,
+  );
+  const node = new AdvancedNodeType();
+  assert.equal(node.onConfigure(serialized, configureTail), configureResult);
+  assert.equal(node.onRemoved(removeArg), removeResult);
+  assert.deepEqual(events, [
+    ["configure", node, [serialized, configureTail]],
+    ["capture", node, serialized],
+    ["attach", node],
+    ["schedule", node],
+    ["remove", node, [removeArg]],
+    ["disconnect", node],
+    ["detach", node],
+  ]);
+}
+
+{
+  for (const originalError of [
+    new Error("original removal failure"),
+    null,
+    undefined,
+    0,
+    false,
+  ]) {
+    const events = [];
+    function FailingAdvancedNodeType() {}
+    FailingAdvancedNodeType.prototype.onRemoved = function () {
+      events.push(["remove", this]);
+      throw originalError;
+    };
+    nodeHooksModule.registerPromptStudioNodeHooks(
+      FailingAdvancedNodeType,
+      { name: ADVANCED_V2 },
+      {
+        captureAdvancedConfigure() {},
+        scheduleHookAdvancedNode() {},
+        disconnectAdvancedEditorWidthObserver(node) {
+          events.push(["disconnect", node]);
+          throw new Error("secondary disconnect failure");
+        },
+        detachAdvancedQueueSeedNode(node) {
+          events.push(["detach", node]);
+          throw new Error("secondary state cleanup failure");
+        },
+      },
+    );
+    const node = new FailingAdvancedNodeType();
+    const notThrown = Symbol("not-thrown");
+    let caught = notThrown;
+    try {
+      node.onRemoved();
+    } catch (error) {
+      caught = error;
+    }
+    assert.notEqual(caught, notThrown, "the original removal throw must not be swallowed");
+    assert.equal(caught, originalError, "cleanup must preserve the original throw identity");
+    assert.deepEqual(events, [
+      ["remove", node],
+      ["disconnect", node],
+      ["detach", node],
+    ]);
+  }
 }
 
 {
@@ -554,6 +715,147 @@ function reservedSeedState(prompt, nodeId) {
   }
   assert.equal(fixture.nodes[0].widgets[1].value, 7);
   assert.equal(fixture.cloneCalls(), 0);
+}
+
+{
+  const fixture = createFixture();
+  const gate = deferred();
+  const node = fixture.nodes[0];
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => gate.promise);
+  const pending = wrapped(0, promptFor([node]));
+  assert.equal(fixture.runtime.trackedStateCount(), 1);
+  assert.equal(
+    fixture.runtime.attachNode(node),
+    true,
+    "reconfiguring the same object must attach a new lifecycle epoch",
+  );
+  assert.equal(fixture.runtime.trackedStateCount(), 2);
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, 8),
+    false,
+    "the new same-object epoch must block the old epoch's executed seed",
+  );
+  gate.resolve({ prompt_id: "same-object-old-epoch", node_errors: {} });
+  await pending;
+  assert.deepEqual(fixture.commits, []);
+  assert.equal(node.widgets[1].value, 7, "late settlement must not publish across epochs");
+  assert.equal(fixture.runtime.trackedStateCount(), 1);
+  fixture.runtime.detachNode(node);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+}
+
+{
+  for (const invalidId of [
+    null,
+    undefined,
+    "",
+    "   ",
+    -1,
+    "-1",
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+    Number.NaN,
+    Infinity,
+    -Infinity,
+  ]) {
+    const node = advancedNode(invalidId, ADVANCED, 7);
+    const fixture = createFixture({ nodes: [node] });
+    const prompt = promptFor([node]);
+    assert.equal(fixture.runtime.attachNode(node), false);
+    assert.equal(fixture.runtime.trackedStateCount(), 0);
+    assert.equal(fixture.runtime.preparePrompt(prompt), null);
+    assert.equal(fixture.runtime.trackedStateCount(), 0);
+    let received = null;
+    const result = { prompt_id: "invalid-node-id-pass-through", node_errors: {} };
+    const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+      received = nextPrompt;
+      return result;
+    });
+    assert.equal(await wrapped(0, prompt), result);
+    assert.equal(received, prompt, "invalid node ids must remain on the unmanaged pass-through path");
+    assert.equal(fixture.runtime.trackedStateCount(), 0);
+    assert.equal(fixture.runtime.detachNode(node), false);
+    assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 8), true);
+  }
+}
+
+{
+  const fixture = createFixture();
+  const node = fixture.nodes[0];
+  assert.equal(fixture.runtime.attachNode(node), true);
+  assert.equal(fixture.runtime.trackedStateCount(), 1);
+  assert.equal(fixture.runtime.detachNode(node), true);
+  assert.equal(
+    fixture.runtime.trackedStateCount(),
+    0,
+    "removing an idle node must release its managed state immediately",
+  );
+}
+
+{
+  const fixture = createFixture();
+  let current = fixture.nodes[0];
+  fixture.runtime.attachNode(current);
+  for (let index = 0; index < 50; index += 1) {
+    assert.equal(fixture.runtime.detachNode(current), true);
+    current = advancedNode(1000 + index, ADVANCED, index);
+    fixture.nodes.splice(0, 1, current);
+    assert.equal(fixture.runtime.attachNode(current), true);
+    assert.equal(
+      fixture.runtime.trackedStateCount(),
+      1,
+      "repeated workflow replacement must retain only the live idle owner",
+    );
+  }
+  fixture.runtime.clearGraphNodes();
+  assert.equal(
+    fixture.runtime.trackedStateCount(),
+    0,
+    "graph clear must release every idle managed owner",
+  );
+}
+
+{
+  const fixture = createFixture();
+  const gate = deferred();
+  const oldNode = fixture.nodes[0];
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => gate.promise);
+  const pending = wrapped(0, promptFor([oldNode]));
+  assert.equal(fixture.runtime.trackedStateCount(), 1);
+
+  fixture.runtime.clearGraphNodes();
+  assert.equal(
+    fixture.runtime.trackedStateCount(),
+    1,
+    "graph clear must retain a detached state until its queue settles",
+  );
+
+  const replacement = advancedNode(10, ADVANCED, 100);
+  fixture.nodes.splice(0, 1, replacement);
+  assert.equal(fixture.runtime.attachNode(replacement), true);
+  assert.equal(
+    fixture.runtime.trackedStateCount(),
+    2,
+    "a pending retired owner and its same-id replacement must have separate identities",
+  );
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(replacement, 8),
+    false,
+    "a configured same-id replacement must reject the retired owner's executed seed",
+  );
+
+  gate.resolve({ prompt_id: "retired-owner", node_errors: {} });
+  await pending;
+  assert.equal(oldNode.widgets[1].value, 7, "late settlement must not publish to a removed owner");
+  assert.equal(replacement.widgets[1].value, 100, "late settlement must not publish to a new owner");
+  assert.deepEqual(fixture.commits, []);
+  assert.equal(
+    fixture.runtime.trackedStateCount(),
+    1,
+    "settlement must release the retired state and retain only the live owner",
+  );
+  fixture.runtime.detachNode(replacement);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
 }
 
 {

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -2174,6 +2174,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         studio_node_ui_source = (
             PROMPT_STUDIO_MODULES / "studio_node_ui.js"
         ).read_text(encoding="utf-8")
+        node_hooks_source = (
+            PROMPT_STUDIO_MODULES / "node_hooks.js"
+        ).read_text(encoding="utf-8")
         advanced_node_ui_source = (
             PROMPT_STUDIO_MODULES / "advanced_node_ui.js"
         ).read_text(encoding="utf-8")
@@ -2190,6 +2193,17 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("./advanced_queue_seed_runtime.js", extension_runtime_source)
         self.assertIn("installAdvancedQueueSeedQueueHook", extension_runtime_source)
         self.assertIn("advancedQueueSeedRuntime.shouldApplyExecutedSeed", extension_runtime_source)
+        self.assertIn("installAdvancedQueueSeedGraphCleanup", extension_runtime_source)
+        self.assertIn(
+            "attachAdvancedQueueSeedNode: advancedQueueSeedRuntime.attachNode",
+            extension_runtime_source,
+        )
+        self.assertIn(
+            "detachAdvancedQueueSeedNode: advancedQueueSeedRuntime.detachNode",
+            extension_runtime_source,
+        )
+        self.assertIn("hooks.attachAdvancedQueueSeedNode?.(this);", node_hooks_source)
+        self.assertIn("hooks.detachAdvancedQueueSeedNode?.(this);", node_hooks_source)
         self.assertTrue(PROMPT_STUDIO_ADVANCED_QUEUE_SEED_RUNTIME_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs"',

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -18,6 +18,7 @@ const WILDCARD_MODE_ALIASES = new Map([
 const SEED_CONTROLS = new Set(["fixed", "randomize", "increment", "decrement"]);
 const QUEUE_HOOK_MARKER = "__easyuseAnimaAdvancedQueueSeedWrapped";
 const QUEUE_HOST_MARKER = "__easyuseAnimaAdvancedQueueSeedInstalled";
+const GRAPH_CLEANUP_MARKER = "__easyuseAnimaAdvancedQueueSeedCleanup";
 const RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed";
 
 function isRecord(value) {
@@ -39,6 +40,17 @@ function optionalSeed(value) {
     && numberValue <= MAX_SAFE_SEED
     ? numberValue
     : null;
+}
+
+function normalizeNodeId(value) {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized && normalized !== "-1" ? normalized : null;
 }
 
 function normalizeMode(value) {
@@ -76,19 +88,20 @@ function workflowNode(workflow, nodeId) {
   if (!Array.isArray(workflow?.nodes)) {
     return null;
   }
-  return workflow.nodes.find((node) => String(node?.id) === String(nodeId)) || null;
+  return workflow.nodes.find((node) => normalizeNodeId(node?.id) === nodeId) || null;
 }
 
 function inputSourceIds(value, output, result = new Set()) {
   if (!Array.isArray(value)) {
     return result;
   }
+  const sourceId = normalizeNodeId(value[0]);
   if (
     value.length >= 2
-    && (typeof value[0] === "string" || typeof value[0] === "number")
-    && Object.prototype.hasOwnProperty.call(output, String(value[0]))
+    && sourceId != null
+    && Object.prototype.hasOwnProperty.call(output, sourceId)
   ) {
-    result.add(String(value[0]));
+    result.add(sourceId);
     return result;
   }
   for (const item of value) {
@@ -151,8 +164,10 @@ function partialExecutionTargets(options, output) {
     return [];
   }
   return rawTargets
-    .map((target) => String(target))
-    .filter((target) => Object.prototype.hasOwnProperty.call(output, target));
+    .map((target) => normalizeNodeId(target))
+    .filter((target) => (
+      target != null && Object.prototype.hasOwnProperty.call(output, target)
+    ));
 }
 
 function queueResultPromptId(result) {
@@ -238,23 +253,53 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     randomSeed,
   } = dependencies;
   const nodeStates = new Map();
+  const retiredStates = new Set();
   let reservationId = 0;
 
-  function stateForNode(node, inputSeed) {
-    const nodeId = String(node.id);
+  function forgetState(state) {
+    if (nodeStates.get(state.nodeId) === state) {
+      nodeStates.delete(state.nodeId);
+    }
+    retiredStates.delete(state);
+  }
+
+  function retireState(state) {
+    state.attached = false;
+    if (state.reservations.length) {
+      if (nodeStates.get(state.nodeId) === state) {
+        nodeStates.delete(state.nodeId);
+      }
+      retiredStates.add(state);
+      return;
+    }
+    forgetState(state);
+  }
+
+  function createState(node, nodeId, inputSeed, blockUnknownExecuted) {
+    return {
+      node,
+      nodeId,
+      attached: true,
+      committedSeed: normalizeSeed(inputSeed),
+      authoritative: false,
+      blockUnknownExecuted,
+      publishFailed: false,
+      reservations: [],
+    };
+  }
+
+  function stateForNode(node, nodeId, inputSeed) {
     let state = nodeStates.get(nodeId);
     if (!state || state.node !== node) {
-      state = {
-        node,
-        committedSeed: normalizeSeed(inputSeed),
-        authoritative: false,
-        blockUnknownExecuted: !!state,
-        publishFailed: false,
-        reservations: [],
-      };
+      const replacedState = state;
+      if (replacedState) {
+        retireState(replacedState);
+      }
+      state = createState(node, nodeId, inputSeed, !!replacedState);
       nodeStates.set(nodeId, state);
       return state;
     }
+    state.attached = true;
     if (!state.reservations.length) {
       if (state.publishFailed) {
         try {
@@ -289,13 +334,21 @@ function createAdvancedQueueSeedRuntime(dependencies) {
         committed = true;
       }
     }
-    if (committed) {
+    if (
+      committed
+      && state.attached
+      && state.node === node
+      && nodeStates.get(state.nodeId) === state
+    ) {
       try {
         updateSeed(node, state.committedSeed);
         state.publishFailed = false;
       } catch {
         state.publishFailed = true;
       }
+    }
+    if (!state.reservations.length && !state.attached) {
+      forgetState(state);
     }
   }
 
@@ -334,7 +387,10 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (targets == null) {
       targets = nodes.flatMap((node) => {
         try {
-          const nodeId = String(node?.id);
+          const nodeId = normalizeNodeId(node?.id);
+          if (nodeId == null) {
+            return [];
+          }
           return node && isOutputNode(node) && isRecord(output[nodeId]) ? [nodeId] : [];
         } catch {
           return [];
@@ -347,16 +403,17 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     const memo = new Map();
     return nodes.flatMap((node) => {
       try {
-        const inputs = output[String(node?.id)]?.inputs;
+        const nodeId = normalizeNodeId(node?.id);
+        const inputs = nodeId == null ? null : output[nodeId]?.inputs;
         if (
           !node
+          || nodeId == null
           || !isAdvancedNode(node)
           || !isRecord(inputs)
         ) {
           return [];
         }
         if (optionalSeed(inputs.wildcard_seed) == null) {
-          const nodeId = String(node.id);
           const state = nodeStates.get(nodeId);
           if (!state?.reservations.length) {
             // Unsafe 64-bit values stay entirely on the pre-existing backend
@@ -367,9 +424,9 @@ function createAdvancedQueueSeedRuntime(dependencies) {
           return [];
         }
         const targetIds = targets.filter(
-          (targetId) => isUpstreamOf(output, node.id, targetId, memo),
+          (targetId) => isUpstreamOf(output, nodeId, targetId, memo),
         );
-        return targetIds.length ? [{ node, targetIds }] : [];
+        return targetIds.length ? [{ node, nodeId, targetIds }] : [];
       } catch {
         return [];
       }
@@ -392,10 +449,10 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     }
 
     const reservations = [];
-    for (const { node, targetIds } of candidates) {
+    for (const { node, nodeId, targetIds } of candidates) {
       try {
-        const inputs = queuedPrompt.output[String(node.id)]?.inputs;
-        const workflow = workflowNode(queuedPrompt.workflow, node.id);
+        const inputs = queuedPrompt.output[nodeId]?.inputs;
+        const workflow = workflowNode(queuedPrompt.workflow, nodeId);
         if (!isRecord(inputs) || !workflow || !Array.isArray(workflow.widgets_values)) {
           continue;
         }
@@ -409,7 +466,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
           // precision. Preserve the original queue payload for those values.
           continue;
         }
-        const state = stateForNode(node, inputSeed);
+        const state = stateForNode(node, nodeId, inputSeed);
         const queuedSeed = reservedCurrentSeed(state);
         const effectiveControl = mode === "sequential"
           ? "increment"
@@ -437,7 +494,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
         const reservation = {
           id: ++reservationId,
           node,
-          nodeId: String(node.id),
+          nodeId,
           state,
           targetIds,
           queuedSeed,
@@ -495,8 +552,73 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     };
   }
 
+  function attachNode(node) {
+    if (!node || !isAdvancedNode(node)) {
+      return false;
+    }
+    const nodeId = normalizeNodeId(node.id);
+    if (nodeId == null) {
+      return false;
+    }
+    const inputSeed = optionalSeed(getSeed(node));
+    const existing = nodeStates.get(nodeId);
+    if (inputSeed == null) {
+      if (existing) {
+        retireState(existing);
+      }
+      return false;
+    }
+    if (existing?.node === node) {
+      if (existing.reservations.length) {
+        retireState(existing);
+        const state = createState(node, nodeId, inputSeed, true);
+        nodeStates.set(nodeId, state);
+        return true;
+      }
+      existing.attached = true;
+      existing.committedSeed = inputSeed;
+      existing.authoritative = false;
+      existing.blockUnknownExecuted = true;
+      existing.publishFailed = false;
+      return true;
+    }
+    if (existing) {
+      retireState(existing);
+    }
+    const state = createState(node, nodeId, inputSeed, true);
+    nodeStates.set(nodeId, state);
+    return true;
+  }
+
+  function detachNode(node) {
+    const nodeId = normalizeNodeId(node?.id);
+    if (nodeId == null) {
+      return false;
+    }
+    const state = nodeStates.get(nodeId);
+    if (!state || state.node !== node) {
+      return false;
+    }
+    retireState(state);
+    return true;
+  }
+
+  function clearGraphNodes() {
+    for (const state of [...nodeStates.values()]) {
+      retireState(state);
+    }
+  }
+
+  function trackedStateCount() {
+    return nodeStates.size + retiredStates.size;
+  }
+
   function shouldApplyExecutedSeed(node, value) {
-    const state = nodeStates.get(String(node?.id));
+    const nodeId = normalizeNodeId(node?.id);
+    if (nodeId == null) {
+      return true;
+    }
+    const state = nodeStates.get(nodeId);
     if (!state) {
       return true;
     }
@@ -521,10 +643,33 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   }
 
   return {
+    attachNode,
+    clearGraphNodes,
+    detachNode,
     preparePrompt,
     shouldApplyExecutedSeed,
+    trackedStateCount,
     wrapQueuePrompt,
   };
+}
+
+function installAdvancedQueueSeedGraphCleanup(graph, runtime) {
+  if (
+    !graph
+    || typeof graph.clear !== "function"
+    || graph.clear[GRAPH_CLEANUP_MARKER]
+  ) {
+    return false;
+  }
+  const clear = graph.clear;
+  const wrappedClear = function () {
+    const result = clear.apply(this, arguments);
+    runtime.clearGraphNodes();
+    return result;
+  };
+  wrappedClear[GRAPH_CLEANUP_MARKER] = true;
+  graph.clear = wrappedClear;
+  return true;
 }
 
 function installAdvancedQueueSeedQueueHook(queueHost, runtime) {
@@ -545,5 +690,6 @@ function installAdvancedQueueSeedQueueHook(queueHost, runtime) {
 
 export {
   createAdvancedQueueSeedRuntime,
+  installAdvancedQueueSeedGraphCleanup,
   installAdvancedQueueSeedQueueHook,
 };

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -104,6 +104,7 @@ import {
 } from "./advanced_values.js";
 import {
   createAdvancedQueueSeedRuntime,
+  installAdvancedQueueSeedGraphCleanup,
   installAdvancedQueueSeedQueueHook,
 } from "./advanced_queue_seed_runtime.js";
 import {
@@ -396,6 +397,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
       installAdvancedWheelForwarder();
       installMiddlePanForwarder();
       installAdvancedSaveSync(app, syncAllAdvancedNodes);
+      installAdvancedQueueSeedGraphCleanup(app.graph, advancedQueueSeedRuntime);
       installAdvancedQueueSeedQueueHook(api, advancedQueueSeedRuntime);
       installPromptHighlightOverlayRefresh(app, applyPromptStudioTextStyle);
       await loadPromptStudioSettings({
@@ -425,6 +427,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
     },
     async beforeRegisterNodeDef(nodeType, nodeData) {
       registerPromptStudioNodeHooks(nodeType, nodeData, {
+        attachAdvancedQueueSeedNode: advancedQueueSeedRuntime.attachNode,
         applyAdvancedExecutedInputs,
         applyExecutedInputs,
         applyExtendSlotVisibility,
@@ -433,6 +436,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
           captureAdvancedConfigure(node, serialized, advancedWidget(node))
         ),
         disconnectAdvancedEditorWidthObserver,
+        detachAdvancedQueueSeedNode: advancedQueueSeedRuntime.detachNode,
         hookStudioNode,
         isExtendNode,
         layoutExtendPromptWidgets,

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -56,13 +56,15 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
 
   const onConfigure = nodeType.prototype.onConfigure;
   nodeType.prototype.onConfigure = function (serialized) {
-    onConfigure?.apply(this, arguments);
+    const result = onConfigure?.apply(this, arguments);
     if (isAdvanced) {
       hooks.captureAdvancedConfigure(this, serialized);
+      hooks.attachAdvancedQueueSeedNode?.(this);
       hooks.scheduleHookAdvancedNode(this);
     } else if (!isWildcard) {
       hooks.hookStudioNode(this);
     }
+    return result;
   };
 
   const onResize = nodeType.prototype.onResize;
@@ -97,9 +99,29 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
 
   const onRemoved = nodeType.prototype.onRemoved;
   nodeType.prototype.onRemoved = function () {
-    const result = onRemoved?.apply(this, arguments);
+    let result;
+    let didThrow = false;
+    let originalError;
+    try {
+      result = onRemoved?.apply(this, arguments);
+    } catch (error) {
+      didThrow = true;
+      originalError = error;
+    }
     if (isAdvanced) {
-      hooks.disconnectAdvancedEditorWidthObserver?.(this);
+      try {
+        hooks.disconnectAdvancedEditorWidthObserver?.(this);
+      } catch {
+        // Cleanup failures must not replace the node's original lifecycle result.
+      }
+      try {
+        hooks.detachAdvancedQueueSeedNode?.(this);
+      } catch {
+        // State cleanup remains isolated from other node removal handlers.
+      }
+    }
+    if (didThrow) {
+      throw originalError;
     }
     return result;
   };


### PR DESCRIPTION
## 변경 요약

- Prompt Studio Advanced V2의 queue seed 상태를 active/retired lifecycle로 분리해 노드 제거·graph clear·재구성 뒤에도 이전 epoch가 새 노드에 값을 게시하지 못하게 했습니다.
- 같은 객체 재구성과 같은 ID의 다른 객체 교체를 별도 epoch로 처리하고, pending 작업 정산 뒤 retired 상태를 해제합니다.
- 미할당/유효하지 않은 node ID(`-1`, 공백, 비정수, unsafe integer, NaN/Infinity)를 상태 key로 추적하지 않습니다.
- `onConfigure`, `onRemoved`, graph clear wrapper의 원래 반환값·인자·receiver·예외 의미를 보존하고 cleanup 오류를 격리했습니다.
- 반복 교체, late settlement, hook 예외, graph clear 성공/실패 경계를 frontend smoke로 고정했습니다.

## 주요 파일

- `web/js/prompt_studio/advanced_queue_seed_runtime.js`
- `web/js/prompt_studio/extension_runtime.js`
- `web/js/prompt_studio/node_hooks.js`
- `tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs`
- `tests/test_frontend_modules.py`

## 검증

- focused: 변경 JS syntax 검사, queue seed/runtime smoke, 관련 unittest 45/45, `git diff --check`
- official full runner: Python unittest 384/384, frontend smoke 100 files, TypeScript 6.0.3, diff check 통과
- ComfyUI Codex test instance:
  - 레거시 캔버스: 512×512 queue 성공 → graph clear → workflow 재진입 → 512×512 queue 성공
  - Nodes 2.0: 512×512 queue 성공 → graph clear → workflow 재진입 → 512×512 queue 성공
  - EasyUse Anima 관련 browser error 없음
- 첫 focused 실행의 Windows sandbox `CreateProcessAsUserW 1312` 실패는 테스트 본문 진입 전 환경 오류였고, 동일 diff를 비샌드박스에서 재실행해 통과했습니다.
- ComfyUI v0.27.0 user instance: 전체 유지보수 종료 시 수동 확인 예정

## 남은 위험

- graph clear 성공 뒤 내부 state collection 정리 자체가 예외를 던질 경우 성공한 clear가 오류로 바뀔 수 있으나, 현재 cleanup은 외부 callback 없는 Map/Set 정리만 수행합니다.

Closes #105