### PR TITLE
fix: wildcard seed 범위 계약 통합

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -22,6 +22,7 @@ try:
     from .prompt_translation import has_prompt_translation_markers, translate_prompt_markers
     from .wildcard_engine import (
         MAX_SEED,
+        PUBLIC_MAX_SEED,
         SEED_CONTROL_DECREMENT,
         SEED_CONTROL_FIXED,
         SEED_CONTROL_INCREMENT,
@@ -50,6 +51,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from prompt_translation import has_prompt_translation_markers, translate_prompt_markers
     from wildcard_engine import (
         MAX_SEED,
+        PUBLIC_MAX_SEED,
         SEED_CONTROL_DECREMENT,
         SEED_CONTROL_FIXED,
         SEED_CONTROL_INCREMENT,
@@ -91,7 +93,15 @@ ADVANCED_FIELD_LABELS = {
 }
 ADVANCED_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_advanced_fields"
 ADVANCED_RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed"
-ADVANCED_QUEUE_MAX_SAFE_SEED = (1 << 53) - 1
+ADVANCED_QUEUE_MAX_SAFE_SEED = PUBLIC_MAX_SEED
+WILDCARD_SEED_RANGE_NOTE = (
+    f"Browser/public editing and next-seed range: 0..{PUBLIC_MAX_SEED}. The Python "
+    "backend continues accepting uint64 values for legacy workflow validation, but "
+    "values above the public maximum are best-effort in the browser because JavaScript "
+    "may already have lost integer precision. Fixed does not intentionally advance a "
+    "legacy value; increment, decrement, and randomize return the next seed to the "
+    "public range."
+)
 REGIONAL_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_regional_fields"
 REGIONAL_CONFIG_WORKFLOW_PROPERTY = "easyuse_anima_regional_config"
 REGIONAL_FIELD_TYPES = {"quality", "artist", "trigger", "general"}
@@ -8276,7 +8286,10 @@ class EasyUseAnimaWildcard:
                     "default": 0,
                     "min": 0,
                     "max": MAX_SEED,
-                    "tooltip": "Wildcard seed. Sequential mode uses seed % option_count for each wildcard.",
+                    "tooltip": (
+                        "Wildcard seed. Sequential mode uses seed % option_count for each wildcard. "
+                        f"{WILDCARD_SEED_RANGE_NOTE}"
+                    ),
                 }),
                 "seed_after_generate": (SEED_CONTROL_MODES, {
                     "default": SEED_CONTROL_FIXED,
@@ -8755,7 +8768,10 @@ class EasyUseAnimaPromptStudioAdvanced:
                     "default": 0,
                     "min": 0,
                     "max": MAX_SEED,
-                    "tooltip": "Wildcard seed used by Advanced Prompt Studio fields.",
+                    "tooltip": (
+                        "Wildcard seed used by Advanced Prompt Studio fields. "
+                        f"{WILDCARD_SEED_RANGE_NOTE}"
+                    ),
                 }),
                 "wildcard_seed_after_generate": (SEED_CONTROL_MODES, {
                     "default": SEED_CONTROL_FIXED,
@@ -10674,7 +10690,10 @@ class EasyUseAnimaPromptStudioRegional:
                     "default": 0,
                     "min": 0,
                     "max": MAX_SEED,
-                    "tooltip": "Wildcard seed used by Regional Prompt Studio fields.",
+                    "tooltip": (
+                        "Wildcard seed used by Regional Prompt Studio fields. "
+                        f"{WILDCARD_SEED_RANGE_NOTE}"
+                    ),
                 }),
                 "wildcard_seed_after_generate": (SEED_CONTROL_MODES, {
                     "default": SEED_CONTROL_FIXED,

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -14,9 +14,15 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-const queueModule = await import(
-  dataModule("../web/js/prompt_studio/advanced_queue_seed_runtime.js")
+const seedContractUrl = dataModule(
+  "../web/js/prompt_studio/wildcard_seed_contract.js",
 );
+const queueSource = readFileSync(
+  new URL("../web/js/prompt_studio/advanced_queue_seed_runtime.js", import.meta.url),
+  "utf8",
+).replace('from "./wildcard_seed_contract.js"', `from "${seedContractUrl}"`);
+const queueModule = await import(sourceModule(queueSource));
+const seedContract = await import(seedContractUrl);
 assert.deepEqual(
   Object.keys(queueModule).sort(),
   [
@@ -25,9 +31,128 @@ assert.deepEqual(
     "installAdvancedQueueSeedQueueHook",
   ],
 );
+assert.deepEqual(
+  Object.keys(seedContract).sort(),
+  [
+    "WILDCARD_SEED_MAX",
+    "bindWildcardSeedInput",
+    "nextWildcardSeed",
+    "normalizeWildcardSeed",
+    "normalizeWildcardSeedInput",
+    "optionalWildcardSeed",
+    "randomWildcardSeed",
+  ],
+);
+assert.equal(seedContract.WILDCARD_SEED_MAX, Number.MAX_SAFE_INTEGER);
+assert.equal(seedContract.optionalWildcardSeed(0), 0);
+assert.equal(
+  seedContract.optionalWildcardSeed(Number.MAX_SAFE_INTEGER),
+  Number.MAX_SAFE_INTEGER,
+);
+assert.equal(seedContract.optionalWildcardSeed(Number.MAX_SAFE_INTEGER + 1), null);
+assert.equal(seedContract.normalizeWildcardSeedInput(0), 0);
+assert.equal(seedContract.normalizeWildcardSeedInput("00042"), 42);
+assert.equal(
+  seedContract.normalizeWildcardSeedInput(String(Number.MAX_SAFE_INTEGER)),
+  Number.MAX_SAFE_INTEGER,
+);
+assert.equal(seedContract.normalizeWildcardSeedInput(-1), null);
+assert.equal(seedContract.normalizeWildcardSeedInput(12.9), null);
+assert.equal(seedContract.normalizeWildcardSeedInput("12.9"), null);
+assert.equal(seedContract.normalizeWildcardSeedInput("1e3"), null);
+assert.equal(seedContract.normalizeWildcardSeedInput("9007199254740990.9"), null);
+assert.equal(seedContract.normalizeWildcardSeedInput("9007199254740991.0"), null);
+assert.equal(seedContract.normalizeWildcardSeedInput("9007199254740992"), null);
+assert.equal(seedContract.normalizeWildcardSeedInput(Number.MAX_SAFE_INTEGER + 1), null);
+assert.equal(seedContract.nextWildcardSeed(0, "fixed"), 0);
+assert.equal(seedContract.nextWildcardSeed(Number.MAX_SAFE_INTEGER, "increment"), 0);
+assert.equal(
+  seedContract.nextWildcardSeed(0, "decrement"),
+  Number.MAX_SAFE_INTEGER,
+);
+assert.equal(
+  seedContract.nextWildcardSeed(Number.MAX_SAFE_INTEGER, "decrement"),
+  Number.MAX_SAFE_INTEGER - 1,
+);
+assert.equal(
+  seedContract.nextWildcardSeed(7, "randomize", () => Number.MAX_SAFE_INTEGER),
+  Number.MAX_SAFE_INTEGER,
+);
+assert.equal(
+  seedContract.randomWildcardSeed(() => 1),
+  Number.MAX_SAFE_INTEGER,
+);
+
+function seedInputFixture(value) {
+  const listeners = new Map();
+  return {
+    value,
+    min: "",
+    max: "",
+    step: "",
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || [];
+      current.push(listener);
+      listeners.set(type, current);
+    },
+    dispatch(type) {
+      for (const listener of listeners.get(type) || []) {
+        listener({ type, target: this });
+      }
+    },
+  };
+}
+
+for (const surface of ["Advanced", "Regional"]) {
+  const unsafeSeed = Number.MAX_SAFE_INTEGER + 1;
+  let currentSeed = unsafeSeed;
+  const published = [];
+  const afterPublish = [];
+  const input = seedInputFixture(String(unsafeSeed));
+  seedContract.bindWildcardSeedInput(
+    input,
+    () => currentSeed,
+    (seed) => {
+      currentSeed = seed;
+      published.push(seed);
+    },
+    surface === "Advanced" ? (seed) => afterPublish.push(seed) : undefined,
+  );
+  assert.equal(input.min, "0", `${surface} input minimum must use the public contract`);
+  assert.equal(
+    input.max,
+    String(Number.MAX_SAFE_INTEGER),
+    `${surface} input maximum must use the public contract`,
+  );
+  assert.equal(input.step, "1", `${surface} input step must be an exact integer`);
+
+  input.dispatch("blur");
+  assert.equal(input.value, String(unsafeSeed), `${surface} loaded unsafe seed must stay unchanged`);
+  assert.deepEqual(published, [], `${surface} unsafe blur must not publish`);
+
+  input.value = "41";
+  input.dispatch("change");
+  input.value = "42";
+  input.dispatch("blur");
+  assert.deepEqual(published, [41, 42], `${surface} change and blur must publish safe integers`);
+  assert.equal(currentSeed, 42);
+
+  for (const invalid of ["42.0", "4.2e1", "9007199254740991.1"]) {
+    input.value = invalid;
+    input.dispatch("change");
+    assert.equal(input.value, "42", `${surface} invalid edit must restore the prior seed`);
+  }
+  assert.deepEqual(published, [41, 42], `${surface} invalid edits must not publish`);
+  assert.deepEqual(
+    afterPublish,
+    surface === "Advanced" ? [41, 42] : [],
+    `${surface} post-publish hook must match successful edits`,
+  );
+}
 
 const ADVANCED = "EasyUseAnimaPromptStudioAdvanced";
 const ADVANCED_V2 = "EasyUseAnimaPromptStudioAdvancedV2";
+const WILDCARD = "EasyUseAnimaWildcard";
 const SEED_INDEX = 11;
 const RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed";
 
@@ -43,6 +168,28 @@ const nodeHooksSource = readFileSync(
   "utf8",
 ).replace('from "./constants.js"', `from "${nodeHookConstants}"`);
 const nodeHooksModule = await import(sourceModule(nodeHooksSource));
+const wildcardWidgetHelpers = sourceModule(`
+  export function findWidget(node, name) {
+    return node?.widgets?.find((widget) => widget?.name === name) || null;
+  }
+  export function findInputEl() { return null; }
+  export function firstValue(value, fallback) {
+    const first = Array.isArray(value) ? value[0] : value;
+    return first == null ? fallback : first;
+  }
+`);
+const wildcardValuesSource = readFileSync(
+  new URL("../web/js/prompt_studio/wildcard_values.js", import.meta.url),
+  "utf8",
+)
+  .replace('from "./widgets.js"', `from "${wildcardWidgetHelpers}"`)
+  .replace('from "./wildcard_seed_contract.js"', `from "${seedContractUrl}"`);
+const wildcardValuesModule = await import(sourceModule(wildcardValuesSource));
+assert.deepEqual(Object.keys(wildcardValuesModule).sort(), [
+  "applyWildcardExecutedInputs",
+  "hookWildcardSeedWidget",
+  "setRegularWidgetValue",
+]);
 
 function deferred() {
   let resolve;
@@ -282,6 +429,77 @@ function reservedSeedState(prompt, nodeId) {
 }
 
 {
+  const configureResult = Symbol("wildcard-configure-result");
+  const originalCallbackResult = Symbol("wildcard-callback-result");
+  const originalCallbackCalls = [];
+  function WildcardNodeType() {}
+  WildcardNodeType.prototype.onConfigure = function (serialized) {
+    this.widgets.find((widget) => widget.name === "seed").value = serialized.seed;
+    return configureResult;
+  };
+  const hooks = {
+    hookWildcardSeedWidget: wildcardValuesModule.hookWildcardSeedWidget,
+  };
+  assert.equal(
+    nodeHooksModule.registerPromptStudioNodeHooks(
+      WildcardNodeType,
+      { name: WILDCARD },
+      hooks,
+    ),
+    true,
+  );
+  assert.equal(
+    nodeHooksModule.registerPromptStudioNodeHooks(
+      WildcardNodeType,
+      { name: WILDCARD },
+      hooks,
+    ),
+    false,
+    "Wildcard prototype hook must install only once",
+  );
+
+  const widget = {
+    name: "seed",
+    value: 0,
+    options: { min: -10, max: 0, step: 0.5 },
+    callback(value, ...args) {
+      originalCallbackCalls.push([this, value, args]);
+      return originalCallbackResult;
+    },
+  };
+  const node = Object.assign(new WildcardNodeType(), { widgets: [widget] });
+  node.onNodeCreated();
+  assert.equal(widget.options.min, 0);
+  assert.equal(widget.options.max, Number.MAX_SAFE_INTEGER);
+  assert.equal(widget.options.step, 1);
+  const wrappedCallback = widget.callback;
+
+  const unsafeSeed = Number.MAX_SAFE_INTEGER + 1;
+  assert.equal(node.onConfigure({ seed: unsafeSeed }), configureResult);
+  assert.equal(widget.value, unsafeSeed, "configure must preserve a loaded unsafe seed");
+  assert.equal(widget.callback, wrappedCallback, "configure must not stack the callback guard");
+
+  for (const invalid of ["1.5", "1e3", "9007199254740991.1"]) {
+    widget.value = invalid;
+    assert.equal(widget.callback.call(node, invalid), undefined);
+    assert.equal(widget.value, unsafeSeed, "invalid native edit must restore the configured value");
+  }
+  assert.deepEqual(originalCallbackCalls, [], "invalid native edits must not call the original callback");
+
+  widget.value = "42";
+  assert.equal(widget.callback.call(node, "42", "tail"), originalCallbackResult);
+  assert.equal(widget.value, 42);
+  assert.deepEqual(originalCallbackCalls, [[node, 42, ["tail"]]]);
+
+  assert.equal(node.onConfigure({ seed: unsafeSeed }), configureResult);
+  assert.equal(widget.callback, wrappedCallback, "reconfigure must keep one callback guard");
+  widget.value = "2e3";
+  widget.callback.call(node, "2e3");
+  assert.equal(widget.value, unsafeSeed);
+  assert.equal(originalCallbackCalls.length, 1);
+}
+
+{
   for (const originalError of [
     new Error("original removal failure"),
     null,
@@ -470,6 +688,28 @@ function reservedSeedState(prompt, nodeId) {
 }
 
 {
+  const increment = advancedNode(10, ADVANCED, Number.MAX_SAFE_INTEGER);
+  const fixture = createFixture({ nodes: [increment] });
+  const transaction = fixture.runtime.preparePrompt(promptFor([increment]));
+  assert.ok(transaction);
+  assert.equal(queuedSeed(transaction.prompt, 10), Number.MAX_SAFE_INTEGER);
+  assert.equal(reservedNextSeed(transaction.prompt, 10), 0);
+}
+
+{
+  const randomize = advancedNode(10, ADVANCED, 7);
+  randomize.widgets[0].value = "일반 채우기";
+  randomize.widgets[2].value = "randomize";
+  const fixture = createFixture({
+    nodes: [randomize],
+    randomValues: [Number.MAX_SAFE_INTEGER],
+  });
+  const transaction = fixture.runtime.preparePrompt(promptFor([randomize]));
+  assert.ok(transaction);
+  assert.equal(reservedNextSeed(transaction.prompt, 10), Number.MAX_SAFE_INTEGER);
+}
+
+{
   const fixture = createFixture();
   let received = null;
   const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
@@ -489,6 +729,47 @@ function reservedSeedState(prompt, nodeId) {
     true,
     "an old safe-state guard must not block the backend pass-through path",
   );
+}
+
+{
+  const node = advancedNode(10, ADVANCED, 7);
+  const fixture = createFixture({ nodes: [node] });
+  const oldSafeResponse = deferred();
+  let calls = 0;
+  let unsafeReceived = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    calls += 1;
+    if (calls === 1) {
+      return oldSafeResponse.promise;
+    }
+    unsafeReceived = nextPrompt;
+    return { prompt_id: "unsafe-new", node_errors: {} };
+  });
+
+  const oldSafeQueue = wrapped(0, promptFor([node]));
+  node.widgets[1].value = Number.MAX_SAFE_INTEGER + 1;
+  const unsafePrompt = promptFor([node]);
+  await wrapped(0, unsafePrompt);
+  assert.equal(unsafeReceived, unsafePrompt, "unsafe prompt must bypass the managed clone");
+
+  oldSafeResponse.resolve({ prompt_id: "safe-old", node_errors: {} });
+  await oldSafeQueue;
+  assert.equal(
+    node.widgets[1].value,
+    Number.MAX_SAFE_INTEGER + 1,
+    "a late accepted safe response must not overwrite the unsafe live seed",
+  );
+  assert.deepEqual(fixture.commits, [], "retired safe reservations must lose publish authority");
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+
+  const unsafeBackendNext = 0;
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, unsafeBackendNext),
+    true,
+    "the unsafe backend next seed must not be filtered by retired safe state",
+  );
+  node.widgets[1].value = unsafeBackendNext;
+  assert.equal(node.widgets[1].value, 0);
 }
 
 {

--- a/tests/frontend_regional_runtime_smoke.mjs
+++ b/tests/frontend_regional_runtime_smoke.mjs
@@ -36,6 +36,9 @@ function flushFrames() {
 }
 
 const constantsUrl = dataModule("../web/js/prompt_studio/regional/constants.js");
+const wildcardSeedContractUrl = dataModule(
+  "../web/js/prompt_studio/wildcard_seed_contract.js",
+);
 const maskGeometryUrl = dataModule("../web/js/prompt_studio/regional/mask_geometry.js");
 const resolutionUrl = dataModule("../web/js/prompt_studio/regional/resolution.js", {
   "./constants.js": constantsUrl,
@@ -59,6 +62,7 @@ const fieldEditorUrl = dataModule("../web/js/prompt_studio/regional/field_editor
   "./resolution.js": resolutionUrl,
   "./schema.js": schemaUrl,
   "./lifecycle.js": lifecycleUrl,
+  "../wildcard_seed_contract.js": wildcardSeedContractUrl,
 });
 
 const lifecycle = await import(lifecycleUrl);

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -2503,6 +2503,49 @@ class FrontendModuleStructureTests(unittest.TestCase):
             frontend_check_source,
         )
 
+    def test_prompt_studio_wildcard_seed_controls_share_public_contract(self):
+        contract_source = (
+            PROMPT_STUDIO_MODULES / "wildcard_seed_contract.js"
+        ).read_text(encoding="utf-8")
+        queue_source = (
+            PROMPT_STUDIO_MODULES / "advanced_queue_seed_runtime.js"
+        ).read_text(encoding="utf-8")
+        advanced_source = (
+            PROMPT_STUDIO_MODULES / "advanced_controls.js"
+        ).read_text(encoding="utf-8")
+        regional_source = (
+            PROMPT_STUDIO_REGIONAL_MODULES / "field_editor.js"
+        ).read_text(encoding="utf-8")
+        extension_source = (
+            PROMPT_STUDIO_MODULES / "extension_runtime.js"
+        ).read_text(encoding="utf-8")
+        wildcard_values_source = (
+            PROMPT_STUDIO_MODULES / "wildcard_values.js"
+        ).read_text(encoding="utf-8")
+        node_hooks_source = (
+            PROMPT_STUDIO_MODULES / "node_hooks.js"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Number.MAX_SAFE_INTEGER", contract_source)
+        self.assertIn("BigInt(decimal)", contract_source)
+        self.assertIn("bindWildcardSeedInput", contract_source)
+        self.assertIn("normalizeWildcardSeedInput", contract_source)
+        self.assertIn("nextWildcardSeed", contract_source)
+        self.assertIn("./wildcard_seed_contract.js", queue_source)
+        self.assertIn("nextWildcardSeed", queue_source)
+        self.assertIn("./wildcard_seed_contract.js", extension_source)
+        self.assertIn("return randomWildcardSeed();", extension_source)
+        self.assertIn("hookWildcardSeedWidget,", extension_source)
+        self.assertIn("hookWildcardSeedWidget", wildcard_values_source)
+        self.assertEqual(
+            node_hooks_source.count("hooks.hookWildcardSeedWidget?.(this);"),
+            2,
+        )
+        for source in (advanced_source, regional_source):
+            with self.subTest(module="seed-control"):
+                self.assertIn("wildcard_seed_contract.js", source)
+                self.assertIn("bindWildcardSeedInput", source)
+
     def test_prompt_studio_phase_2_modules_export_expected_symbols(self):
         advanced_controls_source = (
             PROMPT_STUDIO_MODULES / "advanced_controls.js"
@@ -2923,6 +2966,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
 
         for name in (
             "applyWildcardExecutedInputs",
+            "hookWildcardSeedWidget",
             "setRegularWidgetValue",
         ):
             with self.subTest(module="wildcard_values", symbol=name):
@@ -3282,6 +3326,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "studio_resizable_input.js",
             "studio_node_ui.js",
             "studio_values.js",
+            "wildcard_seed_contract.js",
             "wildcard_values.js",
             "textarea.js",
             "wheel.js",

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -6,7 +6,11 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from nodes import EasyUseAnimaPromptStudioAdvanced, EasyUseAnimaWildcard
+from nodes import (
+    EasyUseAnimaPromptStudioAdvanced,
+    EasyUseAnimaPromptStudioRegional,
+    EasyUseAnimaWildcard,
+)
 from settings import public_settings
 import wildcard_engine
 from wildcard_engine import (
@@ -111,6 +115,119 @@ class WildcardEngineTests(unittest.TestCase):
 
         self.assertEqual(items, ["하츠"])
         self.assertEqual(result.text, "hatsune option")
+
+
+class WildcardSeedContractTests(unittest.TestCase):
+    def test_public_seed_controls_share_the_javascript_safe_range(self):
+        public_max = wildcard_engine.PUBLIC_MAX_SEED
+
+        self.assertEqual(public_max, (1 << 53) - 1)
+        self.assertEqual(wildcard_engine.next_seed(0, "fixed"), 0)
+        self.assertEqual(wildcard_engine.next_seed(public_max, "fixed"), public_max)
+        self.assertEqual(wildcard_engine.next_seed(public_max, "increment"), 0)
+        self.assertEqual(wildcard_engine.next_seed(0, "decrement"), public_max)
+        self.assertEqual(
+            wildcard_engine.next_seed(public_max, "decrement"),
+            public_max - 1,
+        )
+        with patch("wildcard_engine.random.SystemRandom") as system_random:
+            system_random.return_value.randrange.return_value = public_max
+
+            self.assertEqual(
+                wildcard_engine.next_seed(123, "randomize"),
+                public_max,
+            )
+
+            system_random.return_value.randrange.assert_called_once_with(
+                0,
+                public_max + 1,
+            )
+
+    def test_legacy_uint64_seed_is_preserved_until_a_control_advances_it(self):
+        public_max = wildcard_engine.PUBLIC_MAX_SEED
+        legacy_max = wildcard_engine.MAX_SEED
+
+        self.assertEqual(wildcard_engine.normalize_seed(legacy_max), legacy_max)
+        self.assertEqual(wildcard_engine.normalize_seed(legacy_max + 1), legacy_max)
+        self.assertEqual(wildcard_engine.next_seed(legacy_max, "fixed"), legacy_max)
+        self.assertEqual(wildcard_engine.next_seed(legacy_max + 1, "fixed"), legacy_max)
+        self.assertEqual(wildcard_engine.next_seed(legacy_max, "increment"), 0)
+        self.assertEqual(
+            wildcard_engine.next_seed(legacy_max, "decrement"),
+            public_max - 1,
+        )
+
+    def test_node_inputs_advertise_public_range_without_rejecting_legacy_workflows(self):
+        node_inputs = (
+            (EasyUseAnimaWildcard, "seed"),
+            (EasyUseAnimaPromptStudioAdvanced, "wildcard_seed"),
+            (EasyUseAnimaPromptStudioRegional, "wildcard_seed"),
+        )
+
+        for node_class, input_name in node_inputs:
+            with self.subTest(node=node_class.__name__):
+                _input_type, config = node_class.INPUT_TYPES()["required"][input_name]
+                self.assertEqual(config["max"], wildcard_engine.MAX_SEED)
+                self.assertIn(str(wildcard_engine.PUBLIC_MAX_SEED), config["tooltip"])
+                self.assertIn("legacy", config["tooltip"].lower())
+
+    def test_all_wildcard_node_surfaces_publish_the_public_decrement_wrap(self):
+        public_max = wildcard_engine.PUBLIC_MAX_SEED
+        wildcard = EasyUseAnimaWildcard().generate(
+            "",
+            "",
+            "일반 채우기",
+            0,
+            "decrement",
+        )
+        advanced = EasyUseAnimaPromptStudioAdvanced().build(
+            False,
+            True,
+            False,
+            False,
+            "[]",
+            wildcard_mode="일반 채우기",
+            wildcard_seed=0,
+            wildcard_seed_after_generate="decrement",
+        )
+        regional = EasyUseAnimaPromptStudioRegional().build(
+            "[]",
+            "{}",
+            wildcard_mode="일반 채우기",
+            wildcard_seed=0,
+            wildcard_seed_after_generate="decrement",
+        )
+
+        self.assertEqual(wildcard["ui"]["wildcard"][0]["seed"], public_max)
+        self.assertEqual(
+            advanced["ui"]["prompt_studio_advanced"][0]["wildcard_seed"],
+            public_max,
+        )
+        self.assertEqual(
+            regional["ui"]["prompt_studio_regional"][0]["wildcard_seed"],
+            public_max,
+        )
+
+    def test_legacy_current_seed_is_used_before_next_seed_reenters_public_range(self):
+        legacy_max = wildcard_engine.MAX_SEED
+        expansion = WildcardExpansionResult(
+            text="expanded style",
+            changed=True,
+            used_keys=("style",),
+            missing_keys=(),
+        )
+
+        with patch("nodes.expand_wildcards", return_value=expansion) as expand:
+            result = EasyUseAnimaWildcard().generate(
+                "__style__",
+                "",
+                "일반 채우기",
+                legacy_max,
+                "increment",
+            )
+
+        self.assertEqual(expand.call_args.kwargs["seed"], legacy_max)
+        self.assertEqual(result["result"], ("expanded style", 0))
 
 
 class WildcardNodeTests(unittest.TestCase):

--- a/web/js/prompt_studio/advanced_controls.js
+++ b/web/js/prompt_studio/advanced_controls.js
@@ -38,6 +38,9 @@ import {
   findWidget,
   isWidgetInputLinked,
 } from "./widgets.js";
+import {
+  bindWildcardSeedInput,
+} from "./wildcard_seed_contract.js";
 
 function setAdvancedControlValue(node, name, value) {
   const widget = findWidget(node, name);
@@ -540,8 +543,6 @@ function createAdvancedWildcardSettingsBody(node) {
   const seedInput = document.createElement("input");
   protectAdvancedNativeControl(seedInput);
   seedInput.type = "number";
-  seedInput.min = "0";
-  seedInput.step = "1";
   seedInput.value = String(seedWidget.value ?? "0");
   seedInput.setAttribute("aria-label", psText("advanced.wildcardSeed"));
   seedInput.title = psText("advanced.wildcardSeedTitle");
@@ -573,20 +574,18 @@ function createAdvancedWildcardSettingsBody(node) {
     controlSelect.disabled = nextMode === "순차";
     refreshSummary();
   };
-  const syncSeed = () => {
-    const seed = Math.max(0, Math.trunc(Number(seedInput.value) || 0));
-    seedInput.value = String(seed);
-    setAdvancedWidgetValue(node, "wildcard_seed", seed);
-    refreshSummary();
-  };
   const syncControl = () => {
     setAdvancedWidgetValue(node, "wildcard_seed_after_generate", normalizeAdvancedSeedControl(controlSelect.value));
     refreshSummary();
   };
 
   modeSelect.addEventListener("change", syncMode);
-  seedInput.addEventListener("change", syncSeed);
-  seedInput.addEventListener("blur", syncSeed);
+  bindWildcardSeedInput(
+    seedInput,
+    () => seedWidget.value,
+    (seed) => setAdvancedWidgetValue(node, "wildcard_seed", seed),
+    refreshSummary,
+  );
   controlSelect.addEventListener("change", syncControl);
 
   body.append(

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -1,6 +1,11 @@
 // @ts-check
 
-const MAX_SAFE_SEED = Number.MAX_SAFE_INTEGER;
+import {
+  nextWildcardSeed,
+  normalizeWildcardSeed as normalizeSeed,
+  optionalWildcardSeed as optionalSeed,
+} from "./wildcard_seed_contract.js";
+
 const ACTIVE_WILDCARD_MODES = new Set(["populate", "fixed", "sequential"]);
 const WILDCARD_MODE_ALIASES = new Map([
   ["populate", "populate"],
@@ -25,23 +30,6 @@ function isRecord(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function normalizeSeed(value) {
-  const numberValue = Number(value);
-  if (!Number.isFinite(numberValue)) {
-    return 0;
-  }
-  return Math.max(0, Math.min(MAX_SAFE_SEED, Math.trunc(numberValue)));
-}
-
-function optionalSeed(value) {
-  const numberValue = Number(value);
-  return Number.isSafeInteger(numberValue)
-    && numberValue >= 0
-    && numberValue <= MAX_SAFE_SEED
-    ? numberValue
-    : null;
-}
-
 function normalizeNodeId(value) {
   if (typeof value === "number") {
     return Number.isSafeInteger(value) && value >= 0 ? String(value) : null;
@@ -62,26 +50,9 @@ function normalizeControl(value) {
   return SEED_CONTROLS.has(normalized) ? normalized : "fixed";
 }
 
-function incrementSeed(seed) {
-  return seed >= MAX_SAFE_SEED ? 0 : seed + 1;
-}
-
-function decrementSeed(seed) {
-  return seed <= 0 ? MAX_SAFE_SEED : seed - 1;
-}
-
 function nextSeed(seed, mode, control, randomSeed) {
   const effectiveControl = mode === "sequential" ? "increment" : normalizeControl(control);
-  if (effectiveControl === "randomize") {
-    return normalizeSeed(randomSeed());
-  }
-  if (effectiveControl === "increment") {
-    return incrementSeed(seed);
-  }
-  if (effectiveControl === "decrement") {
-    return decrementSeed(seed);
-  }
-  return seed;
+  return nextWildcardSeed(seed, effectiveControl, randomSeed);
 }
 
 function workflowNode(workflow, nodeId) {
@@ -415,11 +386,13 @@ function createAdvancedQueueSeedRuntime(dependencies) {
         }
         if (optionalSeed(inputs.wildcard_seed) == null) {
           const state = nodeStates.get(nodeId);
-          if (!state?.reservations.length) {
+          if (state) {
             // Unsafe 64-bit values stay entirely on the pre-existing backend
-            // path. Drop idle managed state so its executed UI update is not
-            // filtered by a previous safe reservation or node owner.
-            nodeStates.delete(nodeId);
+            // path. Retire even pending safe reservations so a late accepted
+            // response can finish bookkeeping without publishing over the
+            // unsafe live widget or remaining authoritative for its backend
+            // onExecuted update.
+            retireState(state);
           }
           return [];
         }

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -109,7 +109,11 @@ import {
 } from "./advanced_queue_seed_runtime.js";
 import {
   applyWildcardExecutedInputs as applyWildcardExecutedInputsWithHooks,
+  hookWildcardSeedWidget,
 } from "./wildcard_values.js";
+import {
+  randomWildcardSeed,
+} from "./wildcard_seed_contract.js";
 import {
   captureAdvancedConfigure,
   pruneDisconnectedAdvancedFieldInputValues,
@@ -191,7 +195,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
         globalThis.crypto.getRandomValues(values);
         return (values[0] & 0x1fffff) * 0x100000000 + values[1];
       }
-      return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+      return randomWildcardSeed();
     },
   });
 
@@ -437,6 +441,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
         ),
         disconnectAdvancedEditorWidthObserver,
         detachAdvancedQueueSeedNode: advancedQueueSeedRuntime.detachNode,
+        hookWildcardSeedWidget,
         hookStudioNode,
         isExtendNode,
         layoutExtendPromptWidgets,

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -49,7 +49,9 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
     onNodeCreated?.apply(this, arguments);
     if (isAdvanced) {
       hooks.scheduleHookAdvancedNode(this);
-    } else if (!isWildcard) {
+    } else if (isWildcard) {
+      hooks.hookWildcardSeedWidget?.(this);
+    } else {
       hooks.hookStudioNode(this);
     }
   };
@@ -61,7 +63,9 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
       hooks.captureAdvancedConfigure(this, serialized);
       hooks.attachAdvancedQueueSeedNode?.(this);
       hooks.scheduleHookAdvancedNode(this);
-    } else if (!isWildcard) {
+    } else if (isWildcard) {
+      hooks.hookWildcardSeedWidget?.(this);
+    } else {
       hooks.hookStudioNode(this);
     }
     return result;

--- a/web/js/prompt_studio/regional/field_editor.js
+++ b/web/js/prompt_studio/regional/field_editor.js
@@ -24,6 +24,9 @@ import {
 import {
   scheduleRegionalNodeFrame,
 } from "./lifecycle.js";
+import {
+  bindWildcardSeedInput,
+} from "../wildcard_seed_contract.js";
 
 /**
  * Move a field within its current pane without changing its id or crossing the
@@ -113,8 +116,6 @@ function createRegionalFieldEditor(runtime, layout, maskEditor, hooks) {
 
     const seedInput = document.createElement("input");
     seedInput.type = "number";
-    seedInput.min = "0";
-    seedInput.step = "1";
     seedInput.value = String(seedWidget.value ?? "0");
     seedInput.setAttribute("aria-label", hooks.promptStudioText("advanced.wildcardSeed"));
 
@@ -147,11 +148,6 @@ function createRegionalFieldEditor(runtime, layout, maskEditor, hooks) {
       }
       renderRegionalEditor(node);
     };
-    const syncSeed = () => {
-      const seed = Math.max(0, Math.trunc(Number(seedInput.value) || 0));
-      seedInput.value = String(seed);
-      runtime.setRegionalWidgetValue(node, "wildcard_seed", seed);
-    };
     const syncControl = () => {
       runtime.setRegionalWidgetValue(
         node,
@@ -161,8 +157,11 @@ function createRegionalFieldEditor(runtime, layout, maskEditor, hooks) {
     };
 
     modeSelect.addEventListener("change", syncMode);
-    seedInput.addEventListener("change", syncSeed);
-    seedInput.addEventListener("blur", syncSeed);
+    bindWildcardSeedInput(
+      seedInput,
+      () => seedWidget.value,
+      (seed) => runtime.setRegionalWidgetValue(node, "wildcard_seed", seed),
+    );
     controlSelect.addEventListener("change", syncControl);
     row.append(modeSelect, seedInput, controlSelect);
     return row;

--- a/web/js/prompt_studio/wildcard_seed_contract.js
+++ b/web/js/prompt_studio/wildcard_seed_contract.js
@@ -1,0 +1,112 @@
+// @ts-check
+
+const WILDCARD_SEED_MAX = Number.MAX_SAFE_INTEGER;
+const WILDCARD_SEED_MAX_BIGINT = BigInt(WILDCARD_SEED_MAX);
+
+/** @param {any} value */
+function normalizeWildcardSeed(value) {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(WILDCARD_SEED_MAX, Math.trunc(numberValue)));
+}
+
+/** @param {any} value */
+function optionalWildcardSeed(value) {
+  const numberValue = Number(value);
+  return Number.isSafeInteger(numberValue)
+    && numberValue >= 0
+    && numberValue <= WILDCARD_SEED_MAX
+    ? numberValue
+    : null;
+}
+
+/**
+ * Normalize an editable value without silently replacing a loaded legacy
+ * uint64 seed. A null result tells the caller to restore the current widget
+ * value instead of publishing a rounded JavaScript number.
+ *
+ * @param {any} value
+ */
+function normalizeWildcardSeedInput(value) {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const decimal = value.trim();
+  if (!/^\d+$/.test(decimal)) {
+    return null;
+  }
+  try {
+    const parsed = BigInt(decimal);
+    return parsed <= WILDCARD_SEED_MAX_BIGINT ? Number(parsed) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {any} input
+ * @param {() => any} getCurrentSeed
+ * @param {(seed: number) => void} publishSeed
+ * @param {(seed: number) => void} [afterPublish]
+ */
+function bindWildcardSeedInput(input, getCurrentSeed, publishSeed, afterPublish) {
+  input.min = "0";
+  input.max = String(WILDCARD_SEED_MAX);
+  input.step = "1";
+  const syncSeed = () => {
+    const seed = normalizeWildcardSeedInput(input.value);
+    if (seed == null) {
+      input.value = String(getCurrentSeed() ?? "0");
+      return false;
+    }
+    input.value = String(seed);
+    publishSeed(seed);
+    afterPublish?.(seed);
+    return true;
+  };
+  input.addEventListener("change", syncSeed);
+  input.addEventListener("blur", syncSeed);
+  return syncSeed;
+}
+
+/**
+ * @param {number} seed
+ * @param {any} control
+ * @param {() => any} randomSeed
+ */
+function nextWildcardSeed(seed, control, randomSeed = randomWildcardSeed) {
+  const publicSeed = normalizeWildcardSeed(seed);
+  const normalizedControl = String(control || "fixed").trim();
+  if (normalizedControl === "randomize") {
+    return normalizeWildcardSeed(randomSeed());
+  }
+  if (normalizedControl === "increment") {
+    return publicSeed >= WILDCARD_SEED_MAX ? 0 : publicSeed + 1;
+  }
+  if (normalizedControl === "decrement") {
+    return publicSeed <= 0 ? WILDCARD_SEED_MAX : publicSeed - 1;
+  }
+  return publicSeed;
+}
+
+/** @param {() => number} random */
+function randomWildcardSeed(random = Math.random) {
+  return normalizeWildcardSeed(
+    Math.floor(Number(random()) * (WILDCARD_SEED_MAX + 1)),
+  );
+}
+
+export {
+  WILDCARD_SEED_MAX,
+  bindWildcardSeedInput,
+  nextWildcardSeed,
+  normalizeWildcardSeed,
+  normalizeWildcardSeedInput,
+  optionalWildcardSeed,
+  randomWildcardSeed,
+};

--- a/web/js/prompt_studio/wildcard_values.js
+++ b/web/js/prompt_studio/wildcard_values.js
@@ -5,6 +5,49 @@ import {
   findWidget,
   firstValue,
 } from "./widgets.js";
+import {
+  WILDCARD_SEED_MAX,
+  normalizeWildcardSeedInput,
+} from "./wildcard_seed_contract.js";
+
+const WILDCARD_SEED_WIDGET_STATE = "__easyuseAnimaWildcardSeedContract";
+
+function hookWildcardSeedWidget(node) {
+  const widget = findWidget(node, "seed");
+  if (!widget) {
+    return false;
+  }
+  widget.options ||= {};
+  widget.options.min = 0;
+  widget.options.max = WILDCARD_SEED_MAX;
+  widget.options.step = 1;
+
+  const existing = widget[WILDCARD_SEED_WIDGET_STATE];
+  if (existing?.wrapper === widget.callback) {
+    existing.previousValue = widget.value;
+    return false;
+  }
+
+  const state = /** @type {any} */ ({
+    originalCallback: widget.callback,
+    previousValue: widget.value,
+    wrapper: null,
+  });
+  state.wrapper = function (value, ...args) {
+    const candidate = arguments.length ? value : widget.value;
+    const normalized = normalizeWildcardSeedInput(candidate);
+    if (normalized == null) {
+      widget.value = state.previousValue;
+      return undefined;
+    }
+    widget.value = normalized;
+    state.previousValue = normalized;
+    return state.originalCallback?.apply(this, [normalized, ...args]);
+  };
+  widget[WILDCARD_SEED_WIDGET_STATE] = state;
+  widget.callback = state.wrapper;
+  return true;
+}
 
 function setRegularWidgetValue(node, name, value, hooks = {}) {
   const widget = findWidget(node, name);
@@ -39,5 +82,6 @@ function applyWildcardExecutedInputs(node, message, hooks = {}) {
 
 export {
   applyWildcardExecutedInputs,
+  hookWildcardSeedWidget,
   setRegularWidgetValue,
 };

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -69,6 +69,7 @@ SEED_CONTROL_MODES = (
 )
 
 MAX_SEED = 0xFFFFFFFFFFFFFFFF
+PUBLIC_MAX_SEED = (1 << 53) - 1
 REPLACE_DEPTH = 100
 WILDCARD_EXTENSIONS = {".txt", ".yaml", ".yml"}
 
@@ -125,14 +126,25 @@ def normalize_seed(value) -> int:
 
 
 def next_seed(seed, control: str) -> int:
+    """Return the next public wildcard seed without breaking legacy inputs.
+
+    Existing workflows may contain uint64 values that JavaScript cannot
+    represent exactly.  The current generation still consumes that legacy
+    value, and ``fixed`` preserves it.  Controls that advance the state first
+    project the value onto the public JavaScript-safe range so every returned
+    non-fixed seed uses the same inclusive range in Python and JavaScript.
+    """
     seed = normalize_seed(seed)
     control = str(control or SEED_CONTROL_FIXED).strip()
+    if control == SEED_CONTROL_FIXED:
+        return seed
     if control == SEED_CONTROL_RANDOMIZE:
-        return random.SystemRandom().randrange(0, MAX_SEED + 1)
+        return random.SystemRandom().randrange(0, PUBLIC_MAX_SEED + 1)
+    public_seed = min(seed, PUBLIC_MAX_SEED)
     if control == SEED_CONTROL_INCREMENT:
-        return (seed + 1) & MAX_SEED
+        return 0 if public_seed >= PUBLIC_MAX_SEED else public_seed + 1
     if control == SEED_CONTROL_DECREMENT:
-        return (seed - 1) & MAX_SEED
+        return PUBLIC_MAX_SEED if public_seed <= 0 else public_seed - 1
     return seed
 
 


### PR DESCRIPTION
## 변경 요약

- 브라우저에서 편집·증감하는 wildcard seed의 공개 범위를 `0..Number.MAX_SAFE_INTEGER`로 통일했습니다.
- Python backend는 기존 workflow 호환을 위해 fixed/current 값의 uint64 수용을 유지하고, increment/decrement/randomize의 다음 값은 공개 범위로 복귀시킵니다.
- Advanced/Advanced V2, Regional, native Anima Wildcard가 같은 strict decimal parser와 입력 범위를 사용하도록 연결했습니다.
- 안전 범위 예약 뒤 unsafe 상태로 바뀌는 경우 이전 queue 응답이 현재 seed를 덮거나 backend 결과를 막지 않도록 예약 상태를 폐기합니다.
- loaded legacy unsafe seed는 조용히 clamp하지 않고 load/save/reload에서 보존하며, 새 unsafe 편집은 실제 widget/직렬화 상태에 반영하지 않습니다.

## 주요 파일

- `wildcard_engine.py`, `nodes.py`: Python 공개 범위 전이와 backend uint64 호환
- `web/js/prompt_studio/wildcard_seed_contract.js`: 공용 frontend seed 계약
- `advanced_queue_seed_runtime.js`, `advanced_controls.js`: queue 예약과 Advanced 입력
- `regional/field_editor.js`: Regional 입력
- `wildcard_values.js`, `node_hooks.js`, `extension_runtime.js`: native Wildcard 생성/configure hook
- 관련 frontend/Python 회귀 테스트

## 검증

Focused:

- production JavaScript syntax 검사 통과
- `node tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs` 통과
- `node tests/frontend_regional_runtime_smoke.mjs` 통과
- wildcard 범위 회귀 unittest 5/5 통과
- frontend wiring unittest 1/1 통과
- `git diff --check` 통과

Official full runner:

```powershell
powershell -ExecutionPolicy Bypass -File tools\check_custom_node.ps1 -Project <target-worktree> -Profile full
```

- Python unittest: 390/390
- frontend smoke: 101 JavaScript files
- TypeScript: 6.0.3
- git diff check: 통과

Browser smoke — ComfyUI Codex test instance:

- Legacy canvas: 512×512, batch 1, 1 step queue 성공
  - max-safe → 0
  - 저장/reload 후 0 → 1
- Node 2.0: 512×512, batch 1, 1 step queue 성공
  - max-safe → 0
  - 저장/reload 후 0 → 1
- native Anima Wildcard loaded unsafe seed `9007199254740992`: 두 surface 모두 save/reload 보존
- EasyUse Anima 명시 browser error 없음
- 사용자 ComfyUI 인스턴스 smoke: 실행하지 않음

## 남은 위험 / 보류

- Node 2.0에서 현재 값이 max-safe일 때 max-safe+1을 입력하면 실제 widget/저장값은 max-safe로 유지되지만 raw 입력 문자열이 reload 전까지 남는 ComfyUI frontend 1.45.20 호환성 문제가 있습니다.
- callback 이전의 upstream same-value clamp 경로라 private DOM workaround는 이 PR에 넣지 않았고 #111로 분리했습니다.
- reload 시 ComfyUI 공통 `ComfyApp graph accessed before initialization` 메시지가 기록됐지만 EasyUse Anima 명시 오류는 없었습니다.

관련: #102, #111

## 라벨 후보

- `area: backend`, `area: workflow` — 현재 저장소 라벨에 없어 생성하지 않음