### PR TITLE
fix: AiO queue와 extension hook 재진입 안전성 보강

### DIFF
--- a/tests/frontend_aio_extension_runtime_smoke.mjs
+++ b/tests/frontend_aio_extension_runtime_smoke.mjs
@@ -20,6 +20,8 @@ const GENERATOR_PREVIEW_EVENT = "easyuse-anima-aio-preview";
 function createFixture(options = {}) {
   const trace = [];
   const eventRegistrations = [];
+  let samplerSetupFailures = Number(options.samplerSetupFailures || 0);
+  let userSetupFailures = Number(options.userSetupFailures || 0);
   const callbacks = {
     refreshPanels() {
       trace.push("refreshPanels");
@@ -32,13 +34,14 @@ function createFixture(options = {}) {
     clearDenoisePreviews() {},
   };
   let localeRefresh = null;
-  const runtime = extensionModule.aioCreateExtensionRuntime({
-    api: {
-      addEventListener(name, handler, capture) {
-        eventRegistrations.push({ name, handler, capture });
-        trace.push(`event:${name}:${capture === true}`);
-      },
+  const api = options.api || {
+    addEventListener(name, handler, capture) {
+      eventRegistrations.push({ name, handler, capture });
+      trace.push(`event:${name}:${capture === true}`);
     },
+  };
+  const runtime = extensionModule.aioCreateExtensionRuntime({
+    api,
     constants: {
       inputNodeType: INPUT_NODE_TYPE,
       generatorNodeType: GENERATOR_NODE_TYPE,
@@ -50,6 +53,7 @@ function createFixture(options = {}) {
       },
       installWheelForwarder() {
         trace.push("installWheelForwarder");
+        options.onInstallWheelForwarder?.();
       },
       installQueuePromptHook() {
         trace.push("installQueuePromptHook");
@@ -67,10 +71,18 @@ function createFixture(options = {}) {
       clearDenoisePreviews: callbacks.clearDenoisePreviews,
       loadSamplerOptions() {
         trace.push("loadSamplerOptions");
+        if (samplerSetupFailures > 0) {
+          samplerSetupFailures -= 1;
+          throw options.samplerSetupError;
+        }
         return Promise.resolve();
       },
       loadUserProfiles() {
         trace.push("loadUserProfiles");
+        if (userSetupFailures > 0) {
+          userSetupFailures -= 1;
+          throw options.userSetupError;
+        }
         return options.profileError
           ? Promise.reject(options.profileError)
           : Promise.resolve();
@@ -126,6 +138,7 @@ function createFixture(options = {}) {
     },
   });
   return {
+    api,
     runtime,
     trace,
     callbacks,
@@ -259,6 +272,140 @@ function createNodeType(trace, options = {}) {
   assert.equal(fixture.localeRefresh(), fixture.callbacks.refreshPanels);
   fixture.localeRefresh()();
   assert.equal(fixture.trace.filter((item) => item === "refreshPanels").length, 3);
+
+  const firstSetupTrace = [...fixture.trace];
+  const firstSetupRegistrations = [...fixture.eventRegistrations];
+  assert.equal(await fixture.runtime.setup(), undefined);
+  await Promise.resolve();
+  assert.deepEqual(
+    fixture.trace,
+    firstSetupTrace,
+    "repeated setup must not reload data or reinstall global listeners",
+  );
+  assert.deepEqual(fixture.eventRegistrations, firstSetupRegistrations);
+}
+
+{
+  const ownerFixture = createFixture();
+  await ownerFixture.runtime.setup();
+  await Promise.resolve();
+  const reentryFixture = createFixture({ api: ownerFixture.api });
+  assert.equal(await reentryFixture.runtime.setup(), undefined);
+  await Promise.resolve();
+  assert.deepEqual(
+    reentryFixture.trace,
+    [],
+    "a new runtime sharing the installed API owner must not repeat setup",
+  );
+}
+
+{
+  let reentryFixture = null;
+  let reentryPromise = null;
+  const ownerFixture = createFixture({
+    onInstallWheelForwarder() {
+      reentryPromise = reentryFixture.runtime.setup();
+    },
+  });
+  reentryFixture = createFixture({ api: ownerFixture.api });
+  assert.equal(await ownerFixture.runtime.setup(), undefined);
+  assert.equal(await reentryPromise, undefined);
+  await Promise.resolve();
+  assert.deepEqual(
+    reentryFixture.trace,
+    [],
+    "a second factory must not enter setup while the shared API state is in progress",
+  );
+  assert.equal(ownerFixture.eventRegistrations.length, 8);
+}
+
+{
+  const setupError = new Error("sampler setup failed");
+  const factoryA = createFixture({
+    samplerSetupError: setupError,
+    samplerSetupFailures: 1,
+  });
+  let caught = null;
+  try {
+    await factoryA.runtime.setup();
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, setupError, "setup must preserve the original synchronous error");
+  const factoryB = createFixture({ api: factoryA.api });
+  assert.equal(await factoryB.runtime.setup(), undefined);
+  await Promise.resolve();
+  const combinedTrace = [...factoryA.trace, ...factoryB.trace];
+  for (const completedStep of [
+    "ensureStyle",
+    "installWheelForwarder",
+    "installQueuePromptHook",
+    "watchLocale",
+  ]) {
+    assert.equal(
+      combinedTrace.filter((item) => item === completedStep).length,
+      1,
+      `${completedStep} must remain owned by factory A after the later failure`,
+    );
+  }
+  assert.equal(
+    factoryA.eventRegistrations.length,
+    8,
+    "factory B must not duplicate factory A's completed API listener steps",
+  );
+  assert.equal(
+    combinedTrace.filter((item) => item === "loadSamplerOptions").length,
+    2,
+    "only the failing sampler loader step must retry in factory B",
+  );
+  assert.equal(
+    combinedTrace.filter((item) => item === "loadUserProfiles").length,
+    1,
+    "factory B must continue with the first not-yet-run step",
+  );
+
+  const factoryC = createFixture({ api: factoryA.api });
+  assert.equal(await factoryC.runtime.setup(), undefined);
+  await Promise.resolve();
+  assert.deepEqual(
+    factoryC.trace,
+    [],
+    "the successful retry must publish durable setup ownership",
+  );
+}
+
+{
+  const setupError = new Error("user profile setup failed");
+  const factoryA = createFixture({
+    userSetupError: setupError,
+    userSetupFailures: 1,
+  });
+  let caught = null;
+  try {
+    await factoryA.runtime.setup();
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, setupError);
+  const factoryB = createFixture({ api: factoryA.api });
+  assert.equal(await factoryB.runtime.setup(), undefined);
+  await Promise.resolve();
+  const combinedTrace = [...factoryA.trace, ...factoryB.trace];
+  assert.equal(
+    combinedTrace.filter((item) => item === "loadSamplerOptions").length,
+    1,
+    "a sampler loader and its refresh tail must not restart after a later step fails",
+  );
+  assert.equal(
+    combinedTrace.filter((item) => item === "loadUserProfiles").length,
+    2,
+    "the failing user-profile loader step alone must retry",
+  );
+  assert.equal(
+    combinedTrace.filter((item) => item === "refreshPanels").length,
+    2,
+    "the sampler and successful user-profile refresh tails must each run once",
+  );
 }
 
 {
@@ -295,6 +442,59 @@ function createNodeType(trace, options = {}) {
 }
 
 {
+  const installError = new Error("prototype install failed");
+  const fixture = createFixture();
+  const { NodeType, returns } = createNodeType(fixture.trace);
+  const originalOnNodeCreated = NodeType.prototype.onNodeCreated;
+  let currentOnConfigure = NodeType.prototype.onConfigure;
+  let configureAssignmentFailures = 1;
+  Object.defineProperty(NodeType.prototype, "onConfigure", {
+    configurable: true,
+    get() {
+      return currentOnConfigure;
+    },
+    set(value) {
+      if (configureAssignmentFailures > 0) {
+        configureAssignmentFailures -= 1;
+        throw installError;
+      }
+      currentOnConfigure = value;
+    },
+  });
+
+  let caught = null;
+  try {
+    await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, installError, "prototype install must preserve its original error");
+  assert.equal(
+    NodeType.prototype.onNodeCreated,
+    originalOnNodeCreated,
+    "a partial install must roll back hooks patched before the failure",
+  );
+  assert.equal(NodeType.prototype.hideOutputImages, undefined);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      NodeType.prototype,
+      "__easyuseAnimaAioGeneratorHooksInstalled",
+    ),
+    false,
+    "a failed install must not publish prototype ownership",
+  );
+
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const node = new NodeType();
+  assert.equal(node.onNodeCreated("retry"), returns.created);
+  assert.deepEqual(fixture.trace, [
+    "suppressDefaultPreview:markDirty=false",
+    "original:onNodeCreated:retry",
+    "hookGeneratorNode",
+  ]);
+}
+
+{
   const fixture = createFixture();
   const { NodeType, returns } = createNodeType(fixture.trace);
   const generatorOnlyHooks = {
@@ -304,6 +504,14 @@ function createNodeType(trace, options = {}) {
     onRemoved: NodeType.prototype.onRemoved,
   };
   await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: INPUT_NODE_TYPE });
+  const installedHooks = {
+    onNodeCreated: NodeType.prototype.onNodeCreated,
+    onConfigure: NodeType.prototype.onConfigure,
+  };
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: INPUT_NODE_TYPE });
+  for (const [name, hook] of Object.entries(installedHooks)) {
+    assert.equal(NodeType.prototype[name], hook, `input ${name} must not be wrapped twice`);
+  }
   const node = new NodeType();
 
   assert.equal(node.onNodeCreated("a", "b"), returns.created);
@@ -327,6 +535,24 @@ function createNodeType(trace, options = {}) {
   const fixture = createFixture();
   const { NodeType, returns } = createNodeType(fixture.trace);
   await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const installedHooks = {
+    onNodeCreated: NodeType.prototype.onNodeCreated,
+    onConfigure: NodeType.prototype.onConfigure,
+    onSerialize: NodeType.prototype.onSerialize,
+    onExecuted: NodeType.prototype.onExecuted,
+    onResize: NodeType.prototype.onResize,
+    onRemoved: NodeType.prototype.onRemoved,
+  };
+  const reentryFixture = createFixture();
+  await reentryFixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  for (const [name, hook] of Object.entries(installedHooks)) {
+    assert.equal(NodeType.prototype[name], hook, `generator ${name} must not be wrapped twice`);
+  }
+  assert.deepEqual(
+    reentryFixture.trace,
+    [],
+    "a second runtime must not take ownership of an already-installed prototype",
+  );
   const node = new NodeType();
 
   assert.equal(NodeType.prototype.hideOutputImages, true);

--- a/tests/frontend_aio_generator_queue_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_queue_runtime_smoke.mjs
@@ -13,8 +13,8 @@ function clone(value) {
 const queueModule = await import(dataModule("../web/js/aio/generator_queue_runtime.js"));
 assert.deepEqual(
   Object.keys(queueModule),
-  ["aioCreateGeneratorQueueRuntime"],
-  "Generator queue runtime must expose only its factory contract",
+  ["aioCreateGeneratorQueueRuntime", "aioInstallGeneratorQueuePromptHook"],
+  "Generator queue runtime must expose only its factory and installer contracts",
 );
 
 const SPECIAL_RANDOM = -1;
@@ -390,6 +390,47 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
 }
 
 {
+  const fixture = createFixture({ seed: 10, seedControl: "increment" });
+  const host = {
+    calls: 0,
+    queuePrompt() {
+      this.calls += 1;
+      return { prompt_id: "installed", node_errors: {} };
+    },
+  };
+  assert.equal(
+    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime),
+    true,
+  );
+  const installed = host.queuePrompt;
+  assert.equal(
+    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime),
+    false,
+  );
+  assert.equal(host.queuePrompt, installed, "repeated setup must not stack AiO wrappers");
+
+  host.queuePrompt = async function (...args) {
+    return installed.apply(this, args);
+  };
+  const foreignWrapper = host.queuePrompt;
+  assert.equal(
+    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime),
+    false,
+  );
+  assert.equal(
+    host.queuePrompt,
+    foreignWrapper,
+    "the queue-owner marker must survive foreign outer wrapper composition",
+  );
+  const result = await host.queuePrompt(0, createPrompt(), "tail");
+  assert.equal(result.prompt_id, "installed");
+  assert.equal(host.calls, 1, "foreign composition must still reach the original queue once");
+  assert.deepEqual(fixture.trace, ["load:true", "sanitize", "commit:11:10:false"]);
+  assert.equal(fixture.node.lastSeed, 10);
+  assert.equal(fixture.node.settings.sampler.seed, 11);
+}
+
+{
   const skippedNode = createGeneratorNode({
     nodeId: 42,
     seed: 10,
@@ -588,6 +629,31 @@ for (const emptyNodeErrors of [undefined, null, [], "", false, 0]) {
   assert.equal(await wrapped(0, createPrompt()), result);
   assert.equal(fixture.node.settings.sampler.seed, 15);
   assert.equal(fixture.node.lastSeed, 14);
+}
+
+for (const result of [
+  { node_errors: {} },
+  { prompt_id: null, node_errors: {} },
+  { prompt_id: "", node_errors: {} },
+  { prompt_id: " \t\r\n", node_errors: {} },
+]) {
+  const fixture = createFixture({ seed: 16, seedControl: "increment" });
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  assert.equal(await wrapped(0, createPrompt()), result);
+  assert.equal(
+    fixture.node.lastSeed,
+    undefined,
+    "missing or blank prompt ids must not commit a queued seed reservation",
+  );
+  assert.equal(
+    fixture.node.settings.sampler.seed,
+    16,
+    "missing or blank prompt ids must not advance the live seed",
+  );
+  assert.equal(
+    fixture.trace.some((item) => item.startsWith("commit:")),
+    false,
+  );
 }
 
 {

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -225,7 +225,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
             ):
         ]
         start = generator_block.index("nodeType.prototype.onExecuted = function")
-        end = generator_block.index("\n        const onResize", start)
+        end = generator_block.index("const onResize = nodeType.prototype.onResize;", start)
         body = generator_block[start:end]
 
         self.assertIn("nodeType.prototype.hideOutputImages = true", extension_source)
@@ -346,7 +346,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         on_removed_start = generator_hooks.index(
             "const onRemoved = nodeType.prototype.onRemoved;"
         )
-        on_removed_end = generator_hooks.index("\n        };", on_removed_start)
+        on_removed_end = generator_hooks.index("};", on_removed_start)
         on_removed_body = generator_hooks[on_removed_start:on_removed_end]
 
         original_return = on_removed_body.index(

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -368,6 +368,18 @@ class FrontendModuleStructureTests(unittest.TestCase):
             ["aioCreateExtensionRuntime"],
         )
         self.assertIn(
+            'const EXTENSION_SETUP_HOST_MARKER = '
+            '"__easyuseAnimaAioExtensionSetupInstalled";',
+            source,
+        )
+        self.assertIn("function extensionSetupState(api)", source)
+        self.assertIn("completedSteps: new Set(),", source)
+        self.assertIn("function runExtensionSetupStep(state, step, install)", source)
+        self.assertIn("setupState.complete = true;", source)
+        self.assertIn("const originalDescriptors = new Map(", source)
+        self.assertIn("Object.defineProperty(nodeType.prototype, prototypeHookMarker", source)
+        self.assertIn("throw error;", source)
+        self.assertIn(
             'import { aioCreateExtensionRuntime } from "./aio/extension_runtime.js";',
             entry_source,
         )
@@ -674,7 +686,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertEqual(source.splitlines()[0], "// @ts-check")
         self.assertEqual(
             re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
-            ["aioCreateGeneratorQueueRuntime"],
+            [
+                "aioCreateGeneratorQueueRuntime",
+                "aioInstallGeneratorQueuePromptHook",
+            ],
         )
         self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
         self.assertNotRegex(source, r"\b(?:document|window|app)\b")
@@ -682,8 +697,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertNotIn("app.registerExtension", source)
 
         self.assertIn(
-            'import { aioCreateGeneratorQueueRuntime } from '
-            '"./aio/generator_queue_runtime.js";',
+            "  aioCreateGeneratorQueueRuntime,\n"
+            "  aioInstallGeneratorQueuePromptHook,\n"
+            '} from "./aio/generator_queue_runtime.js";',
             entry_source,
         )
         factory_match = re.search(
@@ -754,14 +770,15 @@ class FrontendModuleStructureTests(unittest.TestCase):
         install_end = entry_source.index("\nfunction ensureButton", install_start)
         install_body = entry_source[install_start:install_end]
         self.assertIn(
-            "if (!api?.queuePrompt || api.queuePrompt.__easyuseAnimaAioWrapped)",
+            "return aioInstallGeneratorQueuePromptHook(api, generatorQueueRuntime);",
             install_body,
         )
         self.assertIn(
-            "api.queuePrompt = generatorQueueRuntime.wrapQueuePrompt(queuePrompt);",
-            install_body,
+            'const QUEUE_HOST_MARKER = "__easyuseAnimaAioQueuePromptInstalled";',
+            source,
         )
-        self.assertIn("api.queuePrompt.__easyuseAnimaAioWrapped = true;", install_body)
+        self.assertIn("queueHost[QUEUE_HOST_MARKER]", source)
+        self.assertIn("wrappedQueuePrompt[QUEUE_HOOK_MARKER] = true;", source)
         self.assertIn("updateSeed: updateGeneratorSeed,", panel_source)
         self.assertLess(
             entry_source.index("const generatorPanelRuntime"),

--- a/web/js/aio/extension_runtime.js
+++ b/web/js/aio/extension_runtime.js
@@ -1,5 +1,38 @@
 // @ts-check
 
+const INPUT_PROTOTYPE_HOOK_MARKER = "__easyuseAnimaAioInputHooksInstalled";
+const GENERATOR_PROTOTYPE_HOOK_MARKER = "__easyuseAnimaAioGeneratorHooksInstalled";
+const EXTENSION_SETUP_HOST_MARKER = "__easyuseAnimaAioExtensionSetupInstalled";
+
+function extensionSetupState(api) {
+  const existing = api[EXTENSION_SETUP_HOST_MARKER];
+  if (
+    existing
+    && typeof existing === "object"
+    && existing.completedSteps instanceof Set
+  ) {
+    return existing;
+  }
+  if (existing === true) {
+    return null;
+  }
+  const state = {
+    completedSteps: new Set(),
+    inProgress: false,
+    complete: false,
+  };
+  api[EXTENSION_SETUP_HOST_MARKER] = state;
+  return state;
+}
+
+function runExtensionSetupStep(state, step, install) {
+  if (state.completedSteps.has(step)) {
+    return;
+  }
+  install();
+  state.completedSteps.add(step);
+}
+
 export function aioCreateExtensionRuntime(dependencies) {
   const {
     api,
@@ -47,79 +80,152 @@ export function aioCreateExtensionRuntime(dependencies) {
 
   return {
     async setup() {
-      ensureStyle();
-      installWheelForwarder();
-      installQueuePromptHook();
-      watchLocale(refreshPanels);
-      api.addEventListener(GENERATOR_PREVIEW_EVENT, handlePreviewEvent);
-      api.addEventListener("progress", handleProgressEvent);
-      api.addEventListener("progress_state", handleProgressStateEvent);
-      api.addEventListener("b_preview_with_metadata", handleDenoisePreviewEvent, true);
-      api.addEventListener("executing", handleExecutingEvent);
-      api.addEventListener("execution_error", clearDenoisePreviews);
-      api.addEventListener("execution_interrupted", clearDenoisePreviews);
-      api.addEventListener("execution_success", clearDenoisePreviews);
-      loadSamplerOptions().then(refreshPanels);
-      loadUserProfiles()
-        .then(refreshPanels)
-        .catch(warnUserProfiles);
+      const setupState = extensionSetupState(api);
+      if (!setupState || setupState.complete || setupState.inProgress) {
+        return;
+      }
+      setupState.inProgress = true;
+      try {
+        runExtensionSetupStep(setupState, "style", () => ensureStyle());
+        runExtensionSetupStep(setupState, "wheel-forwarder", () => {
+          installWheelForwarder();
+        });
+        runExtensionSetupStep(setupState, "queue-prompt-hook", () => {
+          installQueuePromptHook();
+        });
+        runExtensionSetupStep(setupState, "locale-watch", () => {
+          watchLocale(refreshPanels);
+        });
+        runExtensionSetupStep(setupState, "preview-listener", () => {
+          api.addEventListener(GENERATOR_PREVIEW_EVENT, handlePreviewEvent);
+        });
+        runExtensionSetupStep(setupState, "progress-listener", () => {
+          api.addEventListener("progress", handleProgressEvent);
+        });
+        runExtensionSetupStep(setupState, "progress-state-listener", () => {
+          api.addEventListener("progress_state", handleProgressStateEvent);
+        });
+        runExtensionSetupStep(setupState, "denoise-preview-listener", () => {
+          api.addEventListener("b_preview_with_metadata", handleDenoisePreviewEvent, true);
+        });
+        runExtensionSetupStep(setupState, "executing-listener", () => {
+          api.addEventListener("executing", handleExecutingEvent);
+        });
+        runExtensionSetupStep(setupState, "execution-error-listener", () => {
+          api.addEventListener("execution_error", clearDenoisePreviews);
+        });
+        runExtensionSetupStep(setupState, "execution-interrupted-listener", () => {
+          api.addEventListener("execution_interrupted", clearDenoisePreviews);
+        });
+        runExtensionSetupStep(setupState, "execution-success-listener", () => {
+          api.addEventListener("execution_success", clearDenoisePreviews);
+        });
+        runExtensionSetupStep(setupState, "sampler-options-load", () => {
+          loadSamplerOptions().then(refreshPanels);
+        });
+        runExtensionSetupStep(setupState, "user-profiles-load", () => {
+          loadUserProfiles()
+            .then(refreshPanels)
+            .catch(warnUserProfiles);
+        });
+        setupState.complete = true;
+      } finally {
+        setupState.inProgress = false;
+      }
     },
     async beforeRegisterNodeDef(nodeType, nodeData) {
       if (nodeData.name !== INPUT_NODE_TYPE && nodeData.name !== GENERATOR_NODE_TYPE) {
         return;
       }
-      if (nodeData.name === GENERATOR_NODE_TYPE) {
-        nodeType.prototype.hideOutputImages = true;
+      const prototypeHookMarker = nodeData.name === GENERATOR_NODE_TYPE
+        ? GENERATOR_PROTOTYPE_HOOK_MARKER
+        : INPUT_PROTOTYPE_HOOK_MARKER;
+      if (Object.prototype.hasOwnProperty.call(nodeType.prototype, prototypeHookMarker)) {
+        return;
       }
-      const onNodeCreated = nodeType.prototype.onNodeCreated;
-      nodeType.prototype.onNodeCreated = function () {
-        if (nodeData.name === GENERATOR_NODE_TYPE) {
-          suppressDefaultPreview(this, { markDirty: false });
-        }
-        const result = onNodeCreated?.apply(this, arguments);
-        hookNode(this, nodeData);
-        return result;
-      };
-      const onConfigure = nodeType.prototype.onConfigure;
-      nodeType.prototype.onConfigure = function () {
-        if (nodeData.name === GENERATOR_NODE_TYPE) {
-          suppressDefaultPreview(this, { markDirty: false });
-        }
-        const result = onConfigure?.apply(this, arguments);
-        hookNode(this, nodeData);
-        return result;
-      };
+      const patchedProperties = ["onNodeCreated", "onConfigure"];
       if (nodeData.name === GENERATOR_NODE_TYPE) {
-        const onSerialize = nodeType.prototype.onSerialize;
-        nodeType.prototype.onSerialize = function (serialized) {
-          const result = onSerialize?.apply(this, arguments);
-          syncSerializedWidgets(this, serialized);
-          return result;
-        };
-        nodeType.prototype.onExecuted = function (message) {
-          scheduleDefaultPreviewSuppression(this);
-          updateExecutedStatus(this, message);
-          scheduleDefaultPreviewSuppression(this, { purgeStore: false });
-          return undefined;
-        };
-        const onResize = nodeType.prototype.onResize;
-        nodeType.prototype.onResize = function () {
-          const result = onResize?.apply(this, arguments);
-          scheduleLayout(this);
-          return result;
-        };
-        const onRemoved = nodeType.prototype.onRemoved;
-        nodeType.prototype.onRemoved = function () {
-          try {
-            return onRemoved?.apply(this, arguments);
-          } finally {
-            try {
-              disposePanel(this);
-            } finally {
-              disposeNativePreviewLifecycle(this);
-            }
+        patchedProperties.push(
+          "hideOutputImages",
+          "onSerialize",
+          "onExecuted",
+          "onResize",
+          "onRemoved",
+        );
+      }
+      const originalDescriptors = new Map(patchedProperties.map((property) => [
+        property,
+        Object.getOwnPropertyDescriptor(nodeType.prototype, property),
+      ]));
+      try {
+        if (nodeData.name === GENERATOR_NODE_TYPE) {
+          nodeType.prototype.hideOutputImages = true;
+        }
+        const onNodeCreated = nodeType.prototype.onNodeCreated;
+        nodeType.prototype.onNodeCreated = function () {
+          if (nodeData.name === GENERATOR_NODE_TYPE) {
+            suppressDefaultPreview(this, { markDirty: false });
           }
+          const result = onNodeCreated?.apply(this, arguments);
+          hookNode(this, nodeData);
+          return result;
         };
+        const onConfigure = nodeType.prototype.onConfigure;
+        nodeType.prototype.onConfigure = function () {
+          if (nodeData.name === GENERATOR_NODE_TYPE) {
+            suppressDefaultPreview(this, { markDirty: false });
+          }
+          const result = onConfigure?.apply(this, arguments);
+          hookNode(this, nodeData);
+          return result;
+        };
+        if (nodeData.name === GENERATOR_NODE_TYPE) {
+          const onSerialize = nodeType.prototype.onSerialize;
+          nodeType.prototype.onSerialize = function (serialized) {
+            const result = onSerialize?.apply(this, arguments);
+            syncSerializedWidgets(this, serialized);
+            return result;
+          };
+          nodeType.prototype.onExecuted = function (message) {
+            scheduleDefaultPreviewSuppression(this);
+            updateExecutedStatus(this, message);
+            scheduleDefaultPreviewSuppression(this, { purgeStore: false });
+            return undefined;
+          };
+          const onResize = nodeType.prototype.onResize;
+          nodeType.prototype.onResize = function () {
+            const result = onResize?.apply(this, arguments);
+            scheduleLayout(this);
+            return result;
+          };
+          const onRemoved = nodeType.prototype.onRemoved;
+          nodeType.prototype.onRemoved = function () {
+            try {
+              return onRemoved?.apply(this, arguments);
+            } finally {
+              try {
+                disposePanel(this);
+              } finally {
+                disposeNativePreviewLifecycle(this);
+              }
+            }
+          };
+        }
+        Object.defineProperty(nodeType.prototype, prototypeHookMarker, { value: true });
+      } catch (error) {
+        for (const property of [...patchedProperties].reverse()) {
+          try {
+            const descriptor = originalDescriptors.get(property);
+            if (descriptor) {
+              Object.defineProperty(nodeType.prototype, property, descriptor);
+            } else {
+              delete nodeType.prototype[property];
+            }
+          } catch {
+            // Preserve the original installation error if rollback is blocked.
+          }
+        }
+        throw error;
       }
     },
   };

--- a/web/js/aio/generator_queue_runtime.js
+++ b/web/js/aio/generator_queue_runtime.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+const QUEUE_HOOK_MARKER = "__easyuseAnimaAioWrapped";
+const QUEUE_HOST_MARKER = "__easyuseAnimaAioQueuePromptInstalled";
+
 /**
  * @typedef {object} AioGeneratorQueueSettingsCore
  * @property {(value: any, fallback?: number) => number} normalizeSeedValue
@@ -401,4 +404,31 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     preparePrompt,
     wrapQueuePrompt,
   };
+}
+
+/**
+ * Install the AiO queue wrapper once per queue owner. The owner marker remains
+ * visible when another extension later wraps queuePrompt, so repeated setup
+ * cannot hide and then stack another AiO wrapper.
+ *
+ * @param {any} queueHost
+ * @param {{wrapQueuePrompt: (queuePrompt: (...args: any[]) => any) => (...args: any[]) => any}} runtime
+ */
+export function aioInstallGeneratorQueuePromptHook(queueHost, runtime) {
+  if (
+    !queueHost
+    || typeof queueHost.queuePrompt !== "function"
+    || queueHost[QUEUE_HOST_MARKER]
+  ) {
+    return false;
+  }
+  if (queueHost.queuePrompt[QUEUE_HOOK_MARKER]) {
+    queueHost[QUEUE_HOST_MARKER] = true;
+    return false;
+  }
+  const wrappedQueuePrompt = runtime.wrapQueuePrompt(queueHost.queuePrompt);
+  wrappedQueuePrompt[QUEUE_HOOK_MARKER] = true;
+  queueHost.queuePrompt = wrappedQueuePrompt;
+  queueHost[QUEUE_HOST_MARKER] = true;
+  return true;
 }

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -19,7 +19,10 @@ import { aioCreatePreviewSettingsDialog } from "./aio/preview_settings_dialog.js
 import { createAioProfileApiClient } from "./aio/profile_api_client.js";
 import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
 import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
-import { aioCreateGeneratorQueueRuntime } from "./aio/generator_queue_runtime.js";
+import {
+  aioCreateGeneratorQueueRuntime,
+  aioInstallGeneratorQueuePromptHook,
+} from "./aio/generator_queue_runtime.js";
 import { aioCreateStageSettingsDialogs } from "./aio/stage_settings_dialogs.js";
 import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.js";
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
@@ -3573,12 +3576,7 @@ function generatorGraphNodes() {
 }
 
 function installGeneratorQueuePromptHook() {
-  if (!api?.queuePrompt || api.queuePrompt.__easyuseAnimaAioWrapped) {
-    return;
-  }
-  const queuePrompt = api.queuePrompt;
-  api.queuePrompt = generatorQueueRuntime.wrapQueuePrompt(queuePrompt);
-  api.queuePrompt.__easyuseAnimaAioWrapped = true;
+  return aioInstallGeneratorQueuePromptHook(api, generatorQueueRuntime);
 }
 
 function ensureButton(node, key, label, callback) {


### PR DESCRIPTION
## 변경 요약

- AiO queue wrapper 소유권을 함수 marker가 아니라 API owner 상태에도 기록해, 다른 extension이 바깥 wrapper를 추가한 뒤 setup이 재진입해도 AiO wrapper가 중복 설치되지 않도록 했습니다.
- AiO extension setup을 API owner별 단계 상태로 관리해 listener/installer/loader가 중복 등록되지 않고, 동기 setup 실패 시 성공한 단계는 유지한 채 실패한 단계만 재시도하도록 했습니다.
- Input/Generator prototype hook에 소유 marker와 descriptor rollback을 추가해 재등록과 부분 설치 실패에 안전하게 했습니다.
- queue 응답의 `prompt_id`가 missing/null/빈 문자열/공백이면 accepted commit으로 취급하지 않는 회귀 계약을 추가했습니다.
- 기존 `onExecuted` override와 node/widget/workflow/API payload 의미는 유지했습니다.

## 주요 파일

- `web/js/aio/extension_runtime.js`: setup 및 prototype hook 재진입/rollback lifecycle
- `web/js/aio/generator_queue_runtime.js`: API owner-level queue installer와 acceptance 판정
- `web/js/easyuse_anima_aio.js`: 새 queue installer orchestration
- `tests/frontend_aio_extension_runtime_smoke.mjs`
- `tests/frontend_aio_generator_queue_runtime_smoke.mjs`
- `tests/test_aio_frontend.py`, `tests/test_frontend_modules.py`

## 검증

Focused:

- 변경 production JavaScript 3파일 `node --check` 통과
- AiO extension runtime smoke 통과
- AiO generator queue runtime smoke 통과
- 관련 unittest 35/35 통과
- 첫 병렬 focused 시도의 한 process는 테스트 본문 전에 Windows sandbox `CreateProcessAsUserW 1312`로 시작하지 못했으며, 동일 diff를 비샌드박스로 재실행해 통과했습니다.
- `git diff --check` 통과

Official full runner:

```powershell
powershell -ExecutionPolicy Bypass -File tools\check_custom_node.ps1 -Project <target-worktree> -Profile full
```

- Python unittest: 390/390
- frontend smoke: 101 JavaScript files
- TypeScript: 6.0.3
- git diff check: 통과

Browser smoke — ComfyUI Codex test instance:

- Legacy canvas
  - 8-node AiO workflow, 512×512, batch 1, 1 step
  - seed 424242 / increment queue success, final output 1개
  - live seed 424243, Last Queued 424242
  - save/close/reopen 뒤 512×512, seed/control, 단일 AiO panel 유지
- Node 2.0
  - Vue node 8개, 512×512, batch 1, 1 step
  - seed 525252 / increment queue success, final output 1개
  - live seed 525253, Last Queued 525252
  - save/close/reopen 뒤 512×512, seed/control, 단일 AiO panel 유지
- 두 surface 모두 profile/save/seed/last control 각각 1개, preview compare 2 layer + feed 2 thumb로 중복 삽입 없음
- EasyUse Anima 관련 browser error 없음
- 초기 페이지 load에서 ComfyUI 공통 `ComfyApp graph accessed before initialization` 및 `[vite:preloadError] Object` 로그가 있었으나 workflow load/queue/save-reload는 정상 완료
- 사용자 ComfyUI v0.27.0 인스턴스: 실행하지 않음

## 남은 위험 / 후속

- 표준 앱 queue 경로 밖에서 직접 동시에 `api.queuePrompt`를 호출하는 reservation/serialization 계약은 별도 behavior slice로 남깁니다.
- sampler option load 중 duplicate full render 가능성은 이번 idempotence slice에 섞지 않고 후속 조사합니다.
- 기존 `onExecuted` 미호출은 default/native preview 억제를 위한 기존 계약입니다. 다른 extension callback과의 상호운용성은 실제 충돌 증거가 있을 때 preview behavior PR로 별도 검증합니다.

관련: #54