### PR TITLE
fix: native Wildcard 연속 queue seed 예약

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -92,8 +92,8 @@ ADVANCED_FIELD_LABELS = {
     "naia": "NAIA Prompt",
 }
 ADVANCED_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_advanced_fields"
-ADVANCED_RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed"
-ADVANCED_QUEUE_MAX_SAFE_SEED = PUBLIC_MAX_SEED
+WILDCARD_RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed"
+WILDCARD_QUEUE_MAX_SAFE_SEED = PUBLIC_MAX_SEED
 WILDCARD_SEED_RANGE_NOTE = (
     f"Browser/public editing and next-seed range: 0..{PUBLIC_MAX_SEED}. The Python "
     "backend continues accepting uint64 values for legacy workflow validation, but "
@@ -7753,25 +7753,25 @@ def _get_workflow_node(extra_pnginfo, node_id: str):
     return found
 
 
-def _consume_advanced_reserved_next_seed(
-    field_inputs,
+def _consume_reserved_wildcard_next_seed(
+    reservation_inputs,
     workflow_prompt,
     node_id,
     current_seed,
     wildcard_mode,
     seed_control,
 ):
-    if not isinstance(field_inputs, dict):
+    if not isinstance(reservation_inputs, dict):
         return None
     raw_reservation = _single_value(
-        field_inputs.pop(ADVANCED_RESERVED_NEXT_SEED_INPUT, None)
+        reservation_inputs.pop(WILDCARD_RESERVED_NEXT_SEED_INPUT, None)
     )
     node_id = _single_value(node_id)
     if isinstance(workflow_prompt, dict) and node_id is not None:
         prompt_node = workflow_prompt.get(str(node_id))
         prompt_inputs = prompt_node.get("inputs") if isinstance(prompt_node, dict) else None
         if isinstance(prompt_inputs, dict):
-            prompt_inputs.pop(ADVANCED_RESERVED_NEXT_SEED_INPUT, None)
+            prompt_inputs.pop(WILDCARD_RESERVED_NEXT_SEED_INPUT, None)
     if not isinstance(raw_reservation, str):
         return None
     try:
@@ -7791,7 +7791,7 @@ def _consume_advanced_reserved_next_seed(
     def reserved_seed(value):
         if isinstance(value, bool) or not isinstance(value, int):
             return None
-        return value if 0 <= value <= ADVANCED_QUEUE_MAX_SAFE_SEED else None
+        return value if 0 <= value <= WILDCARD_QUEUE_MAX_SAFE_SEED else None
 
     reservation_current_seed = reserved_seed(reservation.get("current_seed"))
     reservation_next_seed = reserved_seed(reservation.get("next_seed"))
@@ -7820,12 +7820,12 @@ def _consume_advanced_reserved_next_seed(
     elif reservation_control == SEED_CONTROL_INCREMENT:
         expected_next_seed = (
             0
-            if reservation_current_seed >= ADVANCED_QUEUE_MAX_SAFE_SEED
+            if reservation_current_seed >= WILDCARD_QUEUE_MAX_SAFE_SEED
             else reservation_current_seed + 1
         )
     elif reservation_control == SEED_CONTROL_DECREMENT:
         expected_next_seed = (
-            ADVANCED_QUEUE_MAX_SAFE_SEED
+            WILDCARD_QUEUE_MAX_SAFE_SEED
             if reservation_current_seed <= 0
             else reservation_current_seed - 1
         )
@@ -8301,6 +8301,7 @@ class EasyUseAnimaWildcard:
                 "extra_pnginfo": "EXTRA_PNGINFO",
                 "unique_id": "UNIQUE_ID",
             },
+            "optional": _FlexibleOptionalInputType("STRING"),
         }
 
     RETURN_TYPES = ("STRING", "INT")
@@ -8400,6 +8401,7 @@ class EasyUseAnimaWildcard:
         workflow_prompt=None,
         extra_pnginfo=None,
         unique_id=None,
+        **reservation_inputs,
     ):
         mode_key = normalize_wildcard_mode(mode)
         seed_value = normalize_seed(seed)
@@ -8423,7 +8425,19 @@ class EasyUseAnimaWildcard:
             if mode_key == WILDCARD_MODE_SEQUENTIAL
             else seed_after_generate
         )
-        next_seed_value = next_seed(seed_value, effective_seed_control)
+        reserved_next_seed = _consume_reserved_wildcard_next_seed(
+            reservation_inputs,
+            workflow_prompt,
+            unique_id,
+            seed_value,
+            mode_key,
+            effective_seed_control,
+        )
+        next_seed_value = (
+            reserved_next_seed
+            if reserved_next_seed is not None
+            else next_seed(seed_value, effective_seed_control)
+        )
         self._update_metadata_cache(
             workflow_prompt,
             extra_pnginfo,
@@ -8976,7 +8990,7 @@ class EasyUseAnimaPromptStudioAdvanced:
             if wildcard_mode_key == WILDCARD_MODE_SEQUENTIAL
             else str(wildcard_seed_after_generate or SEED_CONTROL_FIXED)
         )
-        reserved_next_wildcard_seed = _consume_advanced_reserved_next_seed(
+        reserved_next_wildcard_seed = _consume_reserved_wildcard_next_seed(
             field_inputs,
             workflow_prompt,
             unique_id,

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -154,7 +154,20 @@ const ADVANCED = "EasyUseAnimaPromptStudioAdvanced";
 const ADVANCED_V2 = "EasyUseAnimaPromptStudioAdvancedV2";
 const WILDCARD = "EasyUseAnimaWildcard";
 const SEED_INDEX = 11;
+const WILDCARD_SEED_INDEX = 3;
 const RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed";
+const ADVANCED_QUEUE_SEED_CONTRACT = Object.freeze({
+  modeInputName: "wildcard_mode",
+  seedInputName: "wildcard_seed",
+  controlInputName: "wildcard_seed_after_generate",
+  seedWidgetIndex: SEED_INDEX,
+});
+const WILDCARD_QUEUE_SEED_CONTRACT = Object.freeze({
+  modeInputName: "mode",
+  seedInputName: "seed",
+  controlInputName: "seed_after_generate",
+  seedWidgetIndex: WILDCARD_SEED_INDEX,
+});
 
 const nodeHookConstants = sourceModule(`
   export const NODE_TYPE = "EasyUseAnimaPromptStudio";
@@ -209,6 +222,10 @@ function widgetValues(seed, mode = "순차", control = "increment") {
   return values;
 }
 
+function wildcardWidgetValues(seed, mode = "순차", control = "increment") {
+  return ["__style__", "", mode, seed, control];
+}
+
 function advancedNode(id, type = ADVANCED, seed = 7) {
   return {
     id,
@@ -222,28 +239,60 @@ function advancedNode(id, type = ADVANCED, seed = 7) {
   };
 }
 
+function wildcardNode(id, seed = 7) {
+  return {
+    id,
+    type: WILDCARD,
+    comfyClass: WILDCARD,
+    widgets: [
+      { name: "text", value: "__style__" },
+      { name: "populated_text", value: "" },
+      { name: "mode", value: "순차" },
+      { name: "seed", value: seed },
+      { name: "seed_after_generate", value: "increment" },
+    ],
+  };
+}
+
+function queueSeedContract(node) {
+  if ([ADVANCED, ADVANCED_V2].includes(node?.type)) {
+    return ADVANCED_QUEUE_SEED_CONTRACT;
+  }
+  return node?.type === WILDCARD ? WILDCARD_QUEUE_SEED_CONTRACT : null;
+}
+
 function promptFor(nodes, options = {}) {
   const output = {};
   const workflowNodes = [];
   for (const node of nodes) {
-    const mode = node.widgets.find((widget) => widget.name === "wildcard_mode").value;
-    const seed = node.widgets.find((widget) => widget.name === "wildcard_seed").value;
-    const control = node.widgets.find(
-      (widget) => widget.name === "wildcard_seed_after_generate",
-    ).value;
+    const contract = queueSeedContract(node);
+    const mode = node.widgets.find((widget) => widget.name === contract.modeInputName).value;
+    const seed = node.widgets.find((widget) => widget.name === contract.seedInputName).value;
+    const control = node.widgets.find((widget) => widget.name === contract.controlInputName).value;
+    const inputs = node.type === WILDCARD
+      ? {
+          text: "__style__",
+          populated_text: "",
+          mode,
+          seed,
+          seed_after_generate: control,
+        }
+      : {
+          advanced_fields: "[]",
+          wildcard_mode: mode,
+          wildcard_seed: seed,
+          wildcard_seed_after_generate: control,
+        };
     output[String(node.id)] = {
       class_type: node.type,
-      inputs: {
-        advanced_fields: "[]",
-        wildcard_mode: mode,
-        wildcard_seed: seed,
-        wildcard_seed_after_generate: control,
-      },
+      inputs,
     };
     workflowNodes.push({
       id: node.id,
       type: node.type,
-      widgets_values: widgetValues(seed, mode, control),
+      widgets_values: node.type === WILDCARD
+        ? wildcardWidgetValues(seed, mode, control)
+        : widgetValues(seed, mode, control),
     });
   }
   const consumers = Object.prototype.hasOwnProperty.call(options, "consumers")
@@ -279,20 +328,19 @@ function createFixture(options = {}) {
   let cloneCalls = 0;
   let updateFailures = Number(options.updateFailures || 0);
   const runtime = queueModule.createAdvancedQueueSeedRuntime({
-    seedWidgetIndex: SEED_INDEX,
     listNodes: () => [...nodes, ...outputNodes],
-    isAdvancedNode: (node) => [ADVANCED, ADVANCED_V2].includes(node?.type),
+    getNodeContract: queueSeedContract,
     isOutputNode: (node) => node?.outputNode === true,
-    getSeed(node) {
-      return node.widgets.find((widget) => widget.name === "wildcard_seed")?.value;
+    getSeed(node, contract) {
+      return node.widgets.find((widget) => widget.name === contract.seedInputName)?.value;
     },
-    updateSeed(node, seed) {
+    updateSeed(node, seed, contract) {
       if (updateFailures > 0) {
         updateFailures -= 1;
         throw new Error("seed publish failed");
       }
       commits.push([node.id, seed]);
-      node.widgets.find((widget) => widget.name === "wildcard_seed").value = seed;
+      node.widgets.find((widget) => widget.name === contract.seedInputName).value = seed;
     },
     clonePrompt(value) {
       cloneCalls += 1;
@@ -316,12 +364,20 @@ function createFixture(options = {}) {
 }
 
 function queuedSeed(prompt, nodeId) {
-  return prompt.output[String(nodeId)].inputs.wildcard_seed;
+  const promptNode = prompt.output[String(nodeId)];
+  const contract = promptNode.class_type === WILDCARD
+    ? WILDCARD_QUEUE_SEED_CONTRACT
+    : ADVANCED_QUEUE_SEED_CONTRACT;
+  return promptNode.inputs[contract.seedInputName];
 }
 
 function workflowSeed(prompt, nodeId) {
+  const promptNode = prompt.output[String(nodeId)];
+  const contract = promptNode.class_type === WILDCARD
+    ? WILDCARD_QUEUE_SEED_CONTRACT
+    : ADVANCED_QUEUE_SEED_CONTRACT;
   return prompt.workflow.nodes.find((node) => String(node.id) === String(nodeId))
-    .widgets_values[SEED_INDEX];
+    .widgets_values[contract.seedWidgetIndex];
 }
 
 function reservedNextSeed(prompt, nodeId) {
@@ -432,6 +488,7 @@ function reservedSeedState(prompt, nodeId) {
   const configureResult = Symbol("wildcard-configure-result");
   const originalCallbackResult = Symbol("wildcard-callback-result");
   const originalCallbackCalls = [];
+  const queueLifecycleCalls = [];
   function WildcardNodeType() {}
   WildcardNodeType.prototype.onConfigure = function (serialized) {
     this.widgets.find((widget) => widget.name === "seed").value = serialized.seed;
@@ -439,6 +496,8 @@ function reservedSeedState(prompt, nodeId) {
   };
   const hooks = {
     hookWildcardSeedWidget: wildcardValuesModule.hookWildcardSeedWidget,
+    attachAdvancedQueueSeedNode: (node) => queueLifecycleCalls.push(["attach", node]),
+    detachAdvancedQueueSeedNode: (node) => queueLifecycleCalls.push(["detach", node]),
   };
   assert.equal(
     nodeHooksModule.registerPromptStudioNodeHooks(
@@ -497,6 +556,29 @@ function reservedSeedState(prompt, nodeId) {
   widget.callback.call(node, "2e3");
   assert.equal(widget.value, unsafeSeed);
   assert.equal(originalCallbackCalls.length, 1);
+  assert.equal(node.onRemoved(), undefined);
+  assert.deepEqual(queueLifecycleCalls, [
+    ["attach", node],
+    ["attach", node],
+    ["detach", node],
+  ]);
+}
+
+{
+  const node = wildcardNode(15, 30);
+  const seedWidget = node.widgets.find((widget) => widget.name === "seed");
+  wildcardValuesModule.applyWildcardExecutedInputs(
+    node,
+    { wildcard: [{ seed: 8 }] },
+    { shouldApplyExecutedSeed: () => false },
+  );
+  assert.equal(seedWidget.value, 30, "stale native onExecuted seed must not replace a reservation");
+  wildcardValuesModule.applyWildcardExecutedInputs(
+    node,
+    { wildcard: [{ seed: 31 }] },
+    { shouldApplyExecutedSeed: () => true },
+  );
+  assert.equal(seedWidget.value, 31, "an allowed native onExecuted seed remains publishable");
 }
 
 {
@@ -653,6 +735,36 @@ function reservedSeedState(prompt, nodeId) {
     { current: 42, next: 43 },
   ]);
   assert.equal(node.widgets[1].value, 43);
+  assert.equal(fixture.randomCalls(), 3);
+}
+
+{
+  const node = wildcardNode(15, 7);
+  node.widgets.find((widget) => widget.name === "mode").value = "일반 채우기";
+  node.widgets.find((widget) => widget.name === "seed_after_generate").value = "randomize";
+  const fixture = createFixture({ nodes: [node], randomValues: [41, 42, 43] });
+  const queued = [];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queued.push({
+      current: queuedSeed(prompt, 15),
+      workflow: workflowSeed(prompt, 15),
+      next: reservedNextSeed(prompt, 15),
+    });
+    return { prompt_id: `native-wildcard-${queued.length}`, node_errors: {} };
+  });
+  await Promise.all([
+    wrapped(0, promptFor([node])),
+    wrapped(0, promptFor([node])),
+    wrapped(0, promptFor([node])),
+  ]);
+  assert.deepEqual(queued, [
+    { current: 7, workflow: 7, next: 41 },
+    { current: 41, workflow: 41, next: 42 },
+    { current: 42, workflow: 42, next: 43 },
+  ]);
+  assert.equal(node.widgets.find((widget) => widget.name === "seed").value, 43);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 41), false);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 43), true);
   assert.equal(fixture.randomCalls(), 3);
 }
 
@@ -906,6 +1018,28 @@ function reservedSeedState(prompt, nodeId) {
   assert.equal(nodes[1].widgets[1].value, 30, "disconnected Advanced nodes must not reserve seeds");
   assert.equal(reservedNextSeed(received, 10), 8);
   assert.equal(reservedSeedState(received, 11), undefined);
+}
+
+{
+  const nodes = [wildcardNode(15, 7), wildcardNode(16, 30)];
+  const fixture = createFixture({ nodes });
+  const prompt = promptFor(nodes, { consumers: [{ id: 20, source: 15 }] });
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "connected-native-only", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+  assert.equal(nodes[0].widgets.find((widget) => widget.name === "seed").value, 8);
+  assert.equal(
+    nodes[1].widgets.find((widget) => widget.name === "seed").value,
+    30,
+    "a disconnected native Wildcard must not reserve a seed",
+  );
+  assert.equal(reservedNextSeed(received, 15), 8);
+  assert.equal(reservedSeedState(received, 16), undefined);
+  assert.equal(queuedSeed(received, 16), 30);
+  assert.equal(workflowSeed(received, 16), 30);
 }
 
 {

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -363,6 +363,21 @@ function createFixture(options = {}) {
   };
 }
 
+function registerWildcardRuntimeHooks(nodeType, runtime) {
+  return nodeHooksModule.registerPromptStudioNodeHooks(
+    nodeType,
+    { name: WILDCARD },
+    {
+      hookWildcardSeedWidget() {},
+      attachAdvancedQueueSeedNode: (node) => runtime.attachNode(node),
+      detachAdvancedQueueSeedNode: (node) => runtime.detachNode(node),
+      applyWildcardExecutedInputs(node, message) {
+        wildcardValuesModule.applyWildcardExecutedInputs(node, message, runtime);
+      },
+    },
+  );
+}
+
 function queuedSeed(prompt, nodeId) {
   const promptNode = prompt.output[String(nodeId)];
   const contract = promptNode.class_type === WILDCARD
@@ -922,6 +937,91 @@ function reservedSeedState(prompt, nodeId) {
 }
 
 {
+  for (const { control, backendNextSeed } of [
+    { control: "increment", backendNextSeed: 8 },
+    { control: "randomize", backendNextSeed: 41 },
+  ]) {
+    function ConfiguredWildcardNodeType() {}
+    ConfiguredWildcardNodeType.prototype.onConfigure = function (serialized) {
+      for (const name of ["mode", "seed", "seed_after_generate"]) {
+        this.widgets.find((widget) => widget.name === name).value = serialized[name];
+      }
+    };
+    const node = Object.assign(new ConfiguredWildcardNodeType(), wildcardNode(15, 0));
+    const fixture = createFixture({ nodes: [node], randomValues: [99] });
+    assert.equal(registerWildcardRuntimeHooks(ConfiguredWildcardNodeType, fixture.runtime), true);
+
+    node.onConfigure({ mode: "재현", seed: 7, seed_after_generate: control });
+    assert.equal(
+      fixture.runtime.shouldApplyExecutedSeed(node, backendNextSeed),
+      false,
+      "configure must initially guard native Wildcard against an unknown executed seed",
+    );
+    const prompt = promptFor([node]);
+    let received = null;
+    const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+      received = nextPrompt;
+      return { prompt_id: `native-reproduce-${control}`, node_errors: {} };
+    });
+    await wrapped(0, prompt);
+
+    assert.equal(received, prompt, "native reproduce must stay on the backend pass-through path");
+    assert.equal(fixture.runtime.trackedStateCount(), 0);
+    assert.equal(
+      fixture.runtime.shouldApplyExecutedSeed(node, backendNextSeed),
+      true,
+      "an unmanaged reproduce queue must release the configured executed-seed guard",
+    );
+    node.onExecuted({ wildcard: [{ seed: backendNextSeed }] });
+    assert.equal(
+      node.widgets.find((widget) => widget.name === "seed").value,
+      backendNextSeed,
+      `native reproduce ${control} must publish the backend next seed`,
+    );
+    assert.equal(fixture.randomCalls(), 0, "reproduce randomization remains backend-owned");
+  }
+}
+
+{
+  const node = wildcardNode(15, 7);
+  const fixture = createFixture({ nodes: [node] });
+  assert.equal(fixture.runtime.attachNode(node), true);
+  const gate = deferred();
+  const received = [];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    received.push(prompt);
+    return received.length === 1
+      ? gate.promise
+      : { prompt_id: "native-reproduce-after-pending", node_errors: {} };
+  });
+  const managedPrompt = promptFor([node]);
+  const pending = wrapped(0, managedPrompt);
+
+  node.widgets.find((widget) => widget.name === "mode").value = "재현";
+  const reproducePrompt = promptFor([node]);
+  await wrapped(0, reproducePrompt);
+  assert.notEqual(received[0], managedPrompt, "the first managed queue must keep its clone");
+  assert.equal(received[1], reproducePrompt, "the reproduce queue must pass through unchanged");
+  assert.equal(
+    fixture.runtime.trackedStateCount(),
+    1,
+    "the retired pending reservation must remain tracked until settlement",
+  );
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 50), true);
+  wildcardValuesModule.applyWildcardExecutedInputs(
+    node,
+    { wildcard: [{ seed: 50 }] },
+    fixture.runtime,
+  );
+
+  gate.resolve({ prompt_id: "managed-before-reproduce", node_errors: {} });
+  await pending;
+  assert.deepEqual(fixture.commits, [], "retired managed work must lose live publish authority");
+  assert.equal(node.widgets.find((widget) => widget.name === "seed").value, 50);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+}
+
+{
   const fixture = createFixture();
   const failure = new Error("queue rejected");
   let attempts = 0;
@@ -1353,6 +1453,60 @@ function reservedSeedState(prompt, nodeId) {
   assert.equal(received, prompt);
   assert.equal(fixture.nodes[0].widgets[1].value, 7);
   assert.equal(fixture.cloneCalls(), 1);
+}
+
+{
+  const node = wildcardNode(15, 7);
+  const cloneError = new Error("native clone failed");
+  const fixture = createFixture({ nodes: [node], cloneError });
+  assert.equal(fixture.runtime.attachNode(node), true);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 8), false);
+  const prompt = promptFor([node]);
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "native-clone-pass-through", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.equal(received, prompt);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, 8),
+    true,
+    "clone failure must not leave a configured guard on the backend pass-through queue",
+  );
+  wildcardValuesModule.applyWildcardExecutedInputs(
+    node,
+    { wildcard: [{ seed: 8 }] },
+    fixture.runtime,
+  );
+  assert.equal(node.widgets.find((widget) => widget.name === "seed").value, 8);
+}
+
+{
+  const node = wildcardNode(15, 7);
+  const fixture = createFixture({ nodes: [node] });
+  assert.equal(fixture.runtime.attachNode(node), true);
+  const prompt = promptFor([node]);
+  prompt.workflow.nodes = prompt.workflow.nodes.filter(
+    (workflowNodeValue) => String(workflowNodeValue.id) !== String(node.id),
+  );
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "native-workflow-pass-through", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.equal(received, prompt);
+  assert.equal(fixture.cloneCalls(), 1);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, 8),
+    true,
+    "missing workflow seed storage must release the unmanaged queue guard",
+  );
 }
 
 {

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -231,6 +231,69 @@ class WildcardSeedContractTests(unittest.TestCase):
 
 
 class WildcardNodeTests(unittest.TestCase):
+    def test_native_wildcard_consumes_reserved_queue_seed_and_scrubs_token(self):
+        reservation = json.dumps({
+            "version": 1,
+            "current_seed": 2,
+            "next_seed": 47,
+            "mode": "populate",
+            "control": "randomize",
+        })
+        workflow_prompt = {
+            "7": {
+                "inputs": {
+                    "text": "__style__",
+                    "populated_text": "",
+                    "mode": "일반 채우기",
+                    "seed": 2,
+                    "seed_after_generate": "randomize",
+                    "easyuse_anima_reserved_wildcard_next_seed": reservation,
+                }
+            }
+        }
+        extra_pnginfo = {
+            "workflow": {
+                "nodes": [{
+                    "id": 7,
+                    "widgets_values": ["__style__", "", "일반 채우기", 2, "randomize"],
+                }]
+            }
+        }
+
+        with (
+            patch(
+                "nodes.expand_wildcards",
+                return_value=WildcardExpansionResult(
+                    text="expanded style",
+                    changed=True,
+                    used_keys=("style",),
+                    missing_keys=(),
+                ),
+            ),
+            patch("nodes.next_seed") as backend_next_seed,
+        ):
+            result = EasyUseAnimaWildcard().generate(
+                "__style__",
+                "",
+                "일반 채우기",
+                2,
+                "randomize",
+                workflow_prompt=workflow_prompt,
+                extra_pnginfo=extra_pnginfo,
+                unique_id="7",
+                easyuse_anima_reserved_wildcard_next_seed=reservation,
+            )
+
+        backend_next_seed.assert_not_called()
+        self.assertEqual(result["result"], ("expanded style", 47))
+        self.assertEqual(result["ui"]["wildcard"][0]["seed"], 47)
+        self.assertNotIn(
+            "easyuse_anima_reserved_wildcard_next_seed",
+            workflow_prompt["7"]["inputs"],
+        )
+        self.assertEqual(workflow_prompt["7"]["inputs"]["seed"], 2)
+        self.assertEqual(extra_pnginfo["workflow"]["nodes"][0]["widgets_values"][3], 2)
+
     def test_node_stores_reproduce_metadata_for_saved_workflow(self):
         workflow_prompt = {
             "7": {

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -195,28 +195,34 @@ function reservationWasAccepted(result, reservation, prompt) {
 }
 
 /**
- * @typedef {object} AdvancedQueueSeedDependencies
+ * @typedef {object} WildcardQueueSeedContract
+ * @property {string} modeInputName
+ * @property {string} seedInputName
+ * @property {string} controlInputName
  * @property {number} seedWidgetIndex
+ */
+
+/**
+ * @typedef {object} AdvancedQueueSeedDependencies
  * @property {() => any[]} listNodes
- * @property {(node: any) => boolean} isAdvancedNode
+ * @property {(node: any) => WildcardQueueSeedContract | null} getNodeContract
  * @property {(node: any) => boolean} isOutputNode
- * @property {(node: any) => any} getSeed
- * @property {(node: any, seed: number) => void} updateSeed
+ * @property {(node: any, contract: WildcardQueueSeedContract) => any} getSeed
+ * @property {(node: any, seed: number, contract: WildcardQueueSeedContract) => void} updateSeed
  * @property {(value: any) => any} clonePrompt
  * @property {() => number} randomSeed
  */
 
 /**
- * Reserve Prompt Studio Advanced wildcard seeds in queue-only prompt clones.
+ * Reserve top-level wildcard seeds in queue-only prompt clones.
  * Live widgets advance only after ComfyUI accepts the corresponding queue.
  *
  * @param {AdvancedQueueSeedDependencies} dependencies
  */
 function createAdvancedQueueSeedRuntime(dependencies) {
   const {
-    seedWidgetIndex,
     listNodes,
-    isAdvancedNode,
+    getNodeContract,
     isOutputNode,
     getSeed,
     updateSeed,
@@ -246,10 +252,11 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     forgetState(state);
   }
 
-  function createState(node, nodeId, inputSeed, blockUnknownExecuted) {
+  function createState(node, nodeId, inputSeed, contract, blockUnknownExecuted) {
     return {
       node,
       nodeId,
+      contract,
       attached: true,
       committedSeed: normalizeSeed(inputSeed),
       authoritative: false,
@@ -259,14 +266,14 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     };
   }
 
-  function stateForNode(node, nodeId, inputSeed) {
+  function stateForNode(node, nodeId, inputSeed, contract) {
     let state = nodeStates.get(nodeId);
     if (!state || state.node !== node) {
       const replacedState = state;
       if (replacedState) {
         retireState(replacedState);
       }
-      state = createState(node, nodeId, inputSeed, !!replacedState);
+      state = createState(node, nodeId, inputSeed, contract, !!replacedState);
       nodeStates.set(nodeId, state);
       return state;
     }
@@ -274,13 +281,13 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (!state.reservations.length) {
       if (state.publishFailed) {
         try {
-          updateSeed(node, state.committedSeed);
+          updateSeed(node, state.committedSeed, state.contract);
           state.publishFailed = false;
         } catch {
           return state;
         }
       }
-      const liveSeed = optionalSeed(getSeed(node));
+      const liveSeed = optionalSeed(getSeed(node, state.contract));
       if (liveSeed != null && liveSeed !== state.committedSeed) {
         state.committedSeed = liveSeed;
         state.authoritative = false;
@@ -312,7 +319,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
       && nodeStates.get(state.nodeId) === state
     ) {
       try {
-        updateSeed(node, state.committedSeed);
+        updateSeed(node, state.committedSeed, state.contract);
         state.publishFailed = false;
       } catch {
         state.publishFailed = true;
@@ -376,15 +383,16 @@ function createAdvancedQueueSeedRuntime(dependencies) {
       try {
         const nodeId = normalizeNodeId(node?.id);
         const inputs = nodeId == null ? null : output[nodeId]?.inputs;
+        const contract = node ? getNodeContract(node) : null;
         if (
           !node
           || nodeId == null
-          || !isAdvancedNode(node)
+          || !contract
           || !isRecord(inputs)
         ) {
           return [];
         }
-        if (optionalSeed(inputs.wildcard_seed) == null) {
+        if (optionalSeed(inputs[contract.seedInputName]) == null) {
           const state = nodeStates.get(nodeId);
           if (state) {
             // Unsafe 64-bit values stay entirely on the pre-existing backend
@@ -399,7 +407,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
         const targetIds = targets.filter(
           (targetId) => isUpstreamOf(output, nodeId, targetId, memo),
         );
-        return targetIds.length ? [{ node, nodeId, targetIds }] : [];
+        return targetIds.length ? [{ node, nodeId, targetIds, contract }] : [];
       } catch {
         return [];
       }
@@ -422,28 +430,28 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     }
 
     const reservations = [];
-    for (const { node, nodeId, targetIds } of candidates) {
+    for (const { node, nodeId, targetIds, contract } of candidates) {
       try {
         const inputs = queuedPrompt.output[nodeId]?.inputs;
         const workflow = workflowNode(queuedPrompt.workflow, nodeId);
         if (!isRecord(inputs) || !workflow || !Array.isArray(workflow.widgets_values)) {
           continue;
         }
-        const mode = normalizeMode(inputs.wildcard_mode);
+        const mode = normalizeMode(inputs[contract.modeInputName]);
         if (!ACTIVE_WILDCARD_MODES.has(mode)) {
           continue;
         }
-        const inputSeed = optionalSeed(inputs.wildcard_seed);
+        const inputSeed = optionalSeed(inputs[contract.seedInputName]);
         if (inputSeed == null) {
           // JavaScript cannot reserve 64-bit backend seeds without losing
           // precision. Preserve the original queue payload for those values.
           continue;
         }
-        const state = stateForNode(node, nodeId, inputSeed);
+        const state = stateForNode(node, nodeId, inputSeed, contract);
         const queuedSeed = reservedCurrentSeed(state);
         const effectiveControl = mode === "sequential"
           ? "increment"
-          : normalizeControl(inputs.wildcard_seed_after_generate);
+          : normalizeControl(inputs[contract.controlInputName]);
         const reservedNextSeed = nextSeed(
           queuedSeed,
           mode,
@@ -451,10 +459,10 @@ function createAdvancedQueueSeedRuntime(dependencies) {
           randomSeed,
         );
         const workflowValues = [...workflow.widgets_values];
-        while (workflowValues.length <= seedWidgetIndex) {
+        while (workflowValues.length <= contract.seedWidgetIndex) {
           workflowValues.push(null);
         }
-        workflowValues[seedWidgetIndex] = queuedSeed;
+        workflowValues[contract.seedWidgetIndex] = queuedSeed;
         workflow.widgets_values = workflowValues;
         inputs[RESERVED_NEXT_SEED_INPUT] = JSON.stringify({
           version: 1,
@@ -463,7 +471,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
           mode,
           control: effectiveControl,
         });
-        inputs.wildcard_seed = queuedSeed;
+        inputs[contract.seedInputName] = queuedSeed;
         const reservation = {
           id: ++reservationId,
           node,
@@ -526,14 +534,15 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   }
 
   function attachNode(node) {
-    if (!node || !isAdvancedNode(node)) {
+    const contract = node ? getNodeContract(node) : null;
+    if (!node || !contract) {
       return false;
     }
     const nodeId = normalizeNodeId(node.id);
     if (nodeId == null) {
       return false;
     }
-    const inputSeed = optionalSeed(getSeed(node));
+    const inputSeed = optionalSeed(getSeed(node, contract));
     const existing = nodeStates.get(nodeId);
     if (inputSeed == null) {
       if (existing) {
@@ -544,7 +553,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (existing?.node === node) {
       if (existing.reservations.length) {
         retireState(existing);
-        const state = createState(node, nodeId, inputSeed, true);
+        const state = createState(node, nodeId, inputSeed, contract, true);
         nodeStates.set(nodeId, state);
         return true;
       }
@@ -558,7 +567,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (existing) {
       retireState(existing);
     }
-    const state = createState(node, nodeId, inputSeed, true);
+    const state = createState(node, nodeId, inputSeed, contract, true);
     nodeStates.set(nodeId, state);
     return true;
   }
@@ -609,7 +618,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
       state.publishFailed = false;
       return true;
     }
-    const liveSeed = optionalSeed(getSeed(node));
+    const liveSeed = optionalSeed(getSeed(node, state.contract));
     return liveSeed != null
       && liveSeed === state.committedSeed
       && executedSeed === state.committedSeed;

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -252,6 +252,19 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     forgetState(state);
   }
 
+  function retireCandidateState(candidate) {
+    const state = nodeStates.get(candidate.nodeId);
+    if (state) {
+      retireState(state);
+    }
+  }
+
+  function retireCandidateStates(candidates) {
+    for (const candidate of candidates) {
+      retireCandidateState(candidate);
+    }
+  }
+
   function createState(node, nodeId, inputSeed, contract, blockUnknownExecuted) {
     return {
       node,
@@ -423,28 +436,34 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     try {
       queuedPrompt = clonePrompt(prompt);
     } catch {
+      retireCandidateStates(candidates);
       return null;
     }
     if (!isRecord(queuedPrompt) || !isRecord(queuedPrompt.output)) {
+      retireCandidateStates(candidates);
       return null;
     }
 
     const reservations = [];
-    for (const { node, nodeId, targetIds, contract } of candidates) {
+    for (const candidate of candidates) {
+      const { node, nodeId, targetIds, contract } = candidate;
       try {
         const inputs = queuedPrompt.output[nodeId]?.inputs;
         const workflow = workflowNode(queuedPrompt.workflow, nodeId);
         if (!isRecord(inputs) || !workflow || !Array.isArray(workflow.widgets_values)) {
+          retireCandidateState(candidate);
           continue;
         }
         const mode = normalizeMode(inputs[contract.modeInputName]);
         if (!ACTIVE_WILDCARD_MODES.has(mode)) {
+          retireCandidateState(candidate);
           continue;
         }
         const inputSeed = optionalSeed(inputs[contract.seedInputName]);
         if (inputSeed == null) {
           // JavaScript cannot reserve 64-bit backend seeds without losing
           // precision. Preserve the original queue payload for those values.
+          retireCandidateState(candidate);
           continue;
         }
         const state = stateForNode(node, nodeId, inputSeed, contract);
@@ -485,7 +504,9 @@ function createAdvancedQueueSeedRuntime(dependencies) {
         state.reservations.push(reservation);
         reservations.push(reservation);
       } catch {
-        // One malformed Advanced node must not block unrelated prompt nodes.
+        // One malformed wildcard-seed node must not block unrelated prompt
+        // nodes or leave its configured guard attached to an unmanaged queue.
+        retireCandidateState(candidate);
       }
     }
     return reservations.length ? { prompt: queuedPrompt, reservations } : null;

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -29,6 +29,7 @@ import {
 import {
   isAdvancedNode,
   isExtendNode,
+  isWildcardNode,
   installAdvancedSaveSync,
   registerPromptStudioNodeHooks,
   syncAdvancedNodes,
@@ -110,6 +111,7 @@ import {
 import {
   applyWildcardExecutedInputs as applyWildcardExecutedInputsWithHooks,
   hookWildcardSeedWidget,
+  setRegularWidgetValue,
 } from "./wildcard_values.js";
 import {
   randomWildcardSeed,
@@ -124,6 +126,19 @@ import {
   markNodeDirty as markNodeDirtyWithApp,
   refreshNodeSize as refreshNodeSizeWithApp,
 } from "./runtime_canvas.js";
+
+const ADVANCED_QUEUE_SEED_CONTRACT = Object.freeze({
+  modeInputName: "wildcard_mode",
+  seedInputName: "wildcard_seed",
+  controlInputName: "wildcard_seed_after_generate",
+  seedWidgetIndex: ADVANCED_WIDGET_INDEX.wildcard_seed,
+});
+const WILDCARD_QUEUE_SEED_CONTRACT = Object.freeze({
+  modeInputName: "mode",
+  seedInputName: "seed",
+  controlInputName: "seed_after_generate",
+  seedWidgetIndex: 3,
+});
 
 function createPromptStudioExtensionRuntime(app, api = null) {
   function markNodeDirty(node) {
@@ -171,17 +186,30 @@ function createPromptStudioExtensionRuntime(app, api = null) {
   }
 
   function applyWildcardExecutedInputs(node, message) {
-    applyWildcardExecutedInputsWithHooks(node, message, { markNodeDirty });
+    applyWildcardExecutedInputsWithHooks(node, message, {
+      markNodeDirty,
+      shouldApplyExecutedSeed: advancedQueueSeedRuntime.shouldApplyExecutedSeed,
+    });
   }
 
   const advancedQueueSeedRuntime = createAdvancedQueueSeedRuntime({
-    seedWidgetIndex: ADVANCED_WIDGET_INDEX.wildcard_seed,
     listNodes: () => app.graph?._nodes || [],
-    isAdvancedNode,
+    getNodeContract(node) {
+      if (isAdvancedNode(node)) {
+        return ADVANCED_QUEUE_SEED_CONTRACT;
+      }
+      return isWildcardNode(node) ? WILDCARD_QUEUE_SEED_CONTRACT : null;
+    },
     isOutputNode: (node) => node?.constructor?.nodeData?.output_node === true,
-    getSeed: (node) => findWidget(node, "wildcard_seed")?.value,
-    updateSeed(node, seed) {
-      const widget = findWidget(node, "wildcard_seed");
+    getSeed: (node, contract) => findWidget(node, contract.seedInputName)?.value,
+    updateSeed(node, seed, contract) {
+      if (contract === WILDCARD_QUEUE_SEED_CONTRACT) {
+        if (!setRegularWidgetValue(node, "seed", seed, { markNodeDirty })) {
+          throw new Error("Anima Wildcard seed widget is unavailable.");
+        }
+        return;
+      }
+      const widget = findWidget(node, contract.seedInputName);
       if (!widget) {
         throw new Error("Prompt Studio wildcard_seed widget is unavailable.");
       }

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -65,6 +65,7 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
       hooks.scheduleHookAdvancedNode(this);
     } else if (isWildcard) {
       hooks.hookWildcardSeedWidget?.(this);
+      hooks.attachAdvancedQueueSeedNode?.(this);
     } else {
       hooks.hookStudioNode(this);
     }
@@ -118,6 +119,12 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
       } catch {
         // Cleanup failures must not replace the node's original lifecycle result.
       }
+      try {
+        hooks.detachAdvancedQueueSeedNode?.(this);
+      } catch {
+        // State cleanup remains isolated from other node removal handlers.
+      }
+    } else if (isWildcard) {
       try {
         hooks.detachAdvancedQueueSeedNode?.(this);
       } catch {

--- a/web/js/prompt_studio/wildcard_values.js
+++ b/web/js/prompt_studio/wildcard_values.js
@@ -75,7 +75,10 @@ function applyWildcardExecutedInputs(node, message, hooks = {}) {
   if (payload.mode != null) {
     setRegularWidgetValue(node, "mode", String(payload.mode), hooks);
   }
-  if (payload.seed != null) {
+  if (
+    payload.seed != null
+    && hooks.shouldApplyExecutedSeed?.(node, payload.seed) !== false
+  ) {
     setRegularWidgetValue(node, "seed", Number(payload.seed), hooks);
   }
 }


### PR DESCRIPTION
## 변경 요약

- top-level `EasyUseAnimaWildcard` 노드가 빠른 연속 queue에서 서로 다른 seed를 예약하도록 기존 Prompt Studio queue transaction 경계를 확장했습니다.
- queue용 prompt/workflow clone에 현재 seed와 다음 seed 계약을 기록하고, backend가 예약값을 검증·소비한 뒤 transient token을 제거하도록 했습니다.
- accepted/rejected/disconnected queue 정산과 unmanaged native queue의 retired-state 전환을 보강해 stale `onExecuted`가 이후 정상 결과를 막지 않도록 했습니다.
- Regional Prompt Studio와 subgraph 예약 경계는 이 PR에 포함하지 않습니다.

Refs #103

## 주요 파일

- `web/js/prompt_studio/advanced_queue_seed_runtime.js`
- `web/js/prompt_studio/extension_runtime.js`
- `web/js/prompt_studio/node_hooks.js`
- `web/js/prompt_studio/wildcard_values.js`
- `nodes.py`
- 관련 frontend/Python regression tests

## 검증

- focused syntax/runtime smoke: PASS
- 관련 Python unittest: 66/66 PASS
- official full runner:
  - Python unittest 391/391
  - frontend smoke 101 JavaScript files
  - TypeScript 6.0.3
  - git diff check
- ComfyUI Codex test instance browser smoke:
  - Legacy canvas: 512×512, batch 1, 1 step, rapid queue 3회 PASS
  - Node 2.0: 512×512, batch 1, 1 step, rapid queue 3회 PASS
  - 양쪽 모두 prompt seed `7, 8, 9`, 예약 next seed `8, 9, 10`, 서로 다른 prompt_id 3개, 출력 3개 success
  - Node 2.0 live widget seed가 queue 직후 `10`으로 갱신됨
  - 유효 검증 구간의 EasyUse Anima 관련 browser error 없음
- 최초 browser 시도는 테스트 런처의 닫힌 stderr에서 발생한 `OSError [Errno 22]`로 generation이 실패해 증거에서 제외했고, 동일 diff를 지속 로그 launcher로 재실행한 결과는 위와 같이 통과했습니다.

## 남은 범위

- Regional Prompt Studio 연속 queue 중복 경계는 #103의 후속 slice로 남깁니다.
- subgraph 내부 Advanced node 예약 경계는 #104에서 다룹니다.
- 사용자 ComfyUI 인스턴스 반영은 아직 수행하지 않았습니다.
