### PR TITLE
fix: LoRA Preset menu lifecycle hardening

### DIFF
--- a/tests/frontend_lora_preset_menu_lifecycle_smoke.mjs
+++ b/tests/frontend_lora_preset_menu_lifecycle_smoke.mjs
@@ -57,6 +57,7 @@ function addDomCompat(element) {
 addDomCompat(document.body);
 document.head = addDomCompat(document.createElement("head"));
 
+let innerHtmlOptionUses = 0;
 function createElement(tagName, options = {}) {
   const element = addDomCompat(document.createElement(tagName));
   if (options.className != null) {
@@ -69,6 +70,7 @@ function createElement(tagName, options = {}) {
     Object.assign(element.style, options.style);
   }
   if (options.innerHTML != null) {
+    innerHtmlOptionUses += 1;
     element.innerHTML = String(options.innerHTML);
     if (element.innerHTML.includes("easyuse-anima-combo-folder-arrow")) {
       const arrow = createElement("span", {
@@ -141,48 +143,76 @@ function makeMenu(entryCount, options = {}) {
 }
 
 let observer = null;
+const observers = [];
+let observerConstructionError = null;
+let observerObserveError = null;
+let observerDisconnectError = null;
 class StubMutationObserver {
   constructor(callback) {
-    assert.equal(observer, null, "install must create one observer");
+    if (observerConstructionError) {
+      const error = observerConstructionError;
+      observerConstructionError = null;
+      throw error;
+    }
     this.callback = callback;
     this.disconnected = false;
     observer = this;
+    observers.push(this);
   }
 
   observe(target, options) {
     this.target = target;
     this.options = options;
+    if (observerObserveError) {
+      const error = observerObserveError;
+      observerObserveError = null;
+      throw error;
+    }
   }
 
   disconnect() {
     this.disconnected = true;
+    if (observerDisconnectError) {
+      const error = observerDisconnectError;
+      observerDisconnectError = null;
+      throw error;
+    }
   }
 }
 
 const animationFrames = [];
+let runAnimationFramesImmediately = true;
 const window = {
   requestAnimationFrame(callback) {
     animationFrames.push(callback);
-    callback();
+    if (runAnimationFramesImmediately) {
+      callback();
+    }
     return animationFrames.length;
   },
 };
 
 const shownPreviews = [];
 let hiddenPreviews = 0;
+let hidePreviewError = null;
 const previewLifecycle = {
   showPreview(name, event) {
     shownPreviews.push({ name, event });
   },
   hidePreview() {
     hiddenPreviews += 1;
+    if (hidePreviewError) {
+      const error = hidePreviewError;
+      hidePreviewError = null;
+      throw error;
+    }
   },
 };
 
 const positionCalls = [];
 let menuMode = "list";
 let currentNode = null;
-const lifecycle = menuModule.createLoraPresetMenuLifecycle({
+const lifecycleDependencies = {
   document,
   window,
   MutationObserver: StubMutationObserver,
@@ -203,11 +233,13 @@ const lifecycle = menuModule.createLoraPresetMenuLifecycle({
   },
   nodeType: "EasyUseAnimaLoraPreset",
   previewSize: 360,
-});
+};
+const lifecycle = menuModule.createLoraPresetMenuLifecycle(lifecycleDependencies);
 
 assert.deepEqual(Object.keys(lifecycle).sort(), [
   "activateMenu",
   "createMenuItems",
+  "dispose",
   "install",
 ]);
 assert.equal(document.head.children.length, 0, "factory creation must not install DOM state");
@@ -222,14 +254,25 @@ assert.deepEqual(escapedItems, [{
   value: "style/x<&\"'.safetensors",
 }]);
 
-lifecycle.install();
+const lifecycleDispose = lifecycle.install();
+assert.equal(lifecycleDispose, lifecycle.dispose);
 assert.equal(document.head.children.length, 1);
 assert.equal(document.head.children[0].tagName, "STYLE");
 assert.match(document.head.children[0].textContent, /easyuse-anima-lora-search/);
 assert.match(document.head.children[0].textContent, /easyuse-anima-lora-preview/);
+assert.match(
+  document.head.children[0].textContent,
+  /easyuse-anima-combo-folder-label\s*\{[^}]*margin-left:\s*0\.25em;/,
+);
 assert.ok(observer);
 assert.equal(observer.target, document.body);
 assert.deepEqual(observer.options, { childList: true, subtree: false });
+const firstObserver = observer;
+const firstStyle = document.head.children[0];
+assert.equal(lifecycle.install(), lifecycleDispose);
+assert.equal(observers.length, 1, "repeated install must reuse the current observer");
+assert.equal(document.head.children.length, 1, "repeated install must reuse the current style");
+assert.equal(firstObserver.disconnected, false);
 
 const listNode = {
   comfyClass: "EasyUseAnimaLoraPreset",
@@ -305,8 +348,13 @@ observer.callback([{ addedNodes: [listMenu], removedNodes: [] }]);
 assert.equal(listEntries[0].listenerCount("mouseover"), 1);
 assert.equal(listSearch.listenerCount("input"), 1);
 
-const removedMenu = createElement("div", { className: "litecontextmenu" });
-observer.callback([{ addedNodes: [], removedNodes: [removedMenu] }]);
+const unrelatedRemovedMenu = createElement("div", { className: "litecontextmenu" });
+observer.callback([{ addedNodes: [], removedNodes: [unrelatedRemovedMenu] }]);
+assert.equal(hiddenPreviews, 1, "unrelated context-menu removal must not hide the preview");
+const ownedRemovedMenu = createElement("div", {
+  className: "litecontextmenu easyuse-anima-lora-menu",
+});
+observer.callback([{ addedNodes: [], removedNodes: [ownedRemovedMenu] }]);
 assert.equal(hiddenPreviews, 2);
 
 menuMode = "tree";
@@ -317,6 +365,7 @@ currentNode = treeNode;
 const treeValues = [
   "styles/anime/foo.safetensors",
   "styles/real/bar.safetensors",
+  "unsafe/<img src=x onerror=alert(1)>/baz.safetensors",
   "flat.safetensors",
 ];
 const treeItems = lifecycle.createMenuItems(treeValues);
@@ -330,16 +379,23 @@ const treeFolders = treeMenu.querySelectorAll(".easyuse-anima-combo-folder");
 const treeContainers = treeMenu.querySelectorAll(
   ".easyuse-anima-combo-folder-contents",
 );
-assert.equal(treeFolders.length, 3);
-assert.equal(treeContainers.length, 3);
+assert.equal(treeFolders.length, 5);
+assert.equal(treeContainers.length, 5);
+assert.equal(innerHtmlOptionUses, 0, "folder rendering must not use innerHTML");
+const folderLabels = treeMenu.querySelectorAll(".easyuse-anima-combo-folder-label");
+assert.equal(folderLabels.length, treeFolders.length);
+assert.ok(
+  folderLabels.some((label) => label.textContent === "<img src=x onerror=alert(1)>"),
+);
+assert.equal(treeMenu.querySelector("img"), null, "folder text must not create markup nodes");
 
 const treeEntries = treeMenu.querySelectorAll(
   ".litemenu-entry:not(.easyuse-anima-combo-folder)",
 );
-assert.equal(treeEntries.length, 3);
+assert.equal(treeEntries.length, 4);
 assert.equal(
   treeEntries.filter((entry) => entry.querySelector(".easyuse-anima-combo-prefix")).length,
-  2,
+  3,
 );
 
 const topFolder = treeFolders.find((folder) => folder.style.paddingLeft === "5px");
@@ -399,9 +455,191 @@ const positionCount = positionCalls.length;
 currentNode = { comfyClass: "DifferentNode" };
 observer.callback([{
   addedNodes: [makeMenu(1)],
-  removedNodes: [removedMenu],
+  removedNodes: [unrelatedRemovedMenu],
 }]);
 assert.equal(positionCalls.length, positionCount);
-assert.equal(hiddenPreviews, 2);
+assert.equal(hiddenPreviews, 2, "unrelated removal must remain inert after node selection changes");
+const selectedAwayOwnedMenu = createElement("div", {
+  className: "litecontextmenu easyuse-anima-lora-menu",
+});
+observer.callback([{ addedNodes: [], removedNodes: [selectedAwayOwnedMenu] }]);
+assert.equal(hiddenPreviews, 3, "removed menus must hide previews after node selection changes");
+
+observerConstructionError = new Error("observer construction failed");
+const constructionFailureLifecycle = menuModule.createLoraPresetMenuLifecycle(
+  lifecycleDependencies,
+);
+assert.throws(() => constructionFailureLifecycle.install(), /observer construction failed/);
+assert.equal(firstObserver.disconnected, false, "failed replacement must retain the old owner");
+assert.equal(document.head.children.length, 1);
+assert.equal(document.head.children[0], firstStyle);
+assert.equal(
+  document.createdElements.filter((element) => element.tagName === "STYLE").at(-1).removed,
+  true,
+  "constructor failure must clean its detached style",
+);
+assert.equal(hiddenPreviews, 3);
+
+observerObserveError = new Error("observer observe failed");
+const observeFailureLifecycle = menuModule.createLoraPresetMenuLifecycle(
+  lifecycleDependencies,
+);
+assert.throws(() => observeFailureLifecycle.install(), /observer observe failed/);
+const failedObserver = observers.at(-1);
+assert.equal(failedObserver.disconnected, true, "observe failure must disconnect its observer");
+assert.equal(firstObserver.disconnected, false);
+assert.equal(document.head.children.length, 1);
+assert.equal(document.head.children[0], firstStyle);
+assert.equal(
+  document.createdElements.filter((element) => element.tagName === "STYLE").at(-1).removed,
+  true,
+  "observe failure must remove its appended style",
+);
+assert.equal(hiddenPreviews, 3, "failed replacement must not dispose the active owner");
+
+runAnimationFramesImmediately = false;
+menuMode = "list";
+const nestedFrameNode = {
+  comfyClass: "EasyUseAnimaLoraPreset",
+};
+currentNode = nestedFrameNode;
+const nestedFrameItems = lifecycle.createMenuItems(["nested/frame.safetensors"]);
+lifecycle.activateMenu(nestedFrameNode, [360, 380], nestedFrameItems);
+const nestedFrameMenu = makeMenu(nestedFrameItems.length);
+const menuFrameIndex = animationFrames.length;
+firstObserver.callback([{ addedNodes: [nestedFrameMenu], removedNodes: [] }]);
+assert.equal(nestedFrameMenu.__easyuseAnimaListReady, undefined);
+animationFrames[menuFrameIndex]();
+assert.equal(nestedFrameMenu.__easyuseAnimaListReady, true);
+const nestedSearch = nestedFrameMenu.querySelector("input");
+assert.equal(nestedSearch.focused, false);
+const nestedSearchFrameIndex = animationFrames.length - 1;
+const nestedPositionCount = positionCalls.length;
+
+const staleNode = {
+  comfyClass: "EasyUseAnimaLoraPreset",
+};
+currentNode = staleNode;
+const staleItems = lifecycle.createMenuItems(["stale/menu.safetensors"]);
+lifecycle.activateMenu(staleNode, [400, 420], staleItems);
+const staleMenu = makeMenu(staleItems.length);
+const staleFrameIndex = animationFrames.length;
+firstObserver.callback([{ addedNodes: [staleMenu], removedNodes: [] }]);
+assert.equal(staleMenu.__easyuseAnimaListReady, undefined);
+
+const replacementLifecycle = menuModule.createLoraPresetMenuLifecycle(lifecycleDependencies);
+assert.equal(document.head.children.length, 1, "factory creation must not replace the owner");
+const replacementDispose = replacementLifecycle.dispose;
+const previousOwnerError = new Error("previous owner preview cleanup failed");
+hidePreviewError = previousOwnerError;
+assert.throws(
+  () => replacementLifecycle.install(),
+  (error) => error === previousOwnerError,
+  "owner replacement must preserve the prior teardown error",
+);
+assert.equal(firstObserver.disconnected, true, "owner replacement must disconnect the old observer");
+assert.equal(firstStyle.removed, true, "owner replacement must remove the old style");
+assert.equal(staleNode.__easyuseAnimaOpeningLoraMenu, false);
+assert.equal(hiddenPreviews, 4, "owner replacement must clean up an active preview");
+assert.equal(document.head.children.length, 1);
+assert.equal(observers.length, 3);
+const replacementObserver = observer;
+const replacementStyle = document.head.children[0];
+replacementObserver.callback([{ addedNodes: [], removedNodes: [listMenu] }]);
+assert.equal(hiddenPreviews, 4, "replacement owners must ignore stale owned-menu removal");
+
+animationFrames[nestedSearchFrameIndex]();
+assert.equal(nestedSearch.focused, false, "disposed nested search frames must stay inert");
+assert.equal(positionCalls.length, nestedPositionCount);
+animationFrames[staleFrameIndex]();
+assert.equal(staleMenu.__easyuseAnimaListReady, undefined, "disposed owner frames must stay inert");
+runAnimationFramesImmediately = true;
+
+const disposedShownPreviewCount = shownPreviews.length;
+const disposedHiddenPreviewCount = hiddenPreviews;
+const disposedPositionCount = positionCalls.length;
+listSearch.value = "FOO";
+listSearch.emit("input");
+assert.equal(listEntries[0].style.display, "");
+assert.equal(listEntries[1].style.display, "");
+assert.equal(positionCalls.length, disposedPositionCount);
+const disposedEscape = listSearch.emit("keydown", { key: "Escape" });
+assert.equal(listSearch.value, "FOO");
+assert.equal(disposedEscape.defaultPrevented, false);
+assert.equal(disposedEscape.propagationStopped, false);
+listEntries[0].emit("mouseover", { clientX: 50, clientY: 60 });
+listEntries[0].emit("mousemove", { clientX: 70, clientY: 80 });
+listEntries[0].emit("mouseout");
+assert.equal(shownPreviews.length, disposedShownPreviewCount);
+assert.equal(hiddenPreviews, disposedHiddenPreviewCount);
+const disposedFolderDisplay = topContainer.style.display;
+const disposedFolderOpen = topContainer.__easyuseAnimaOpen;
+const disposedFolderArrow = topFolder.querySelector(
+  ".easyuse-anima-combo-folder-arrow",
+).textContent;
+const disposedFolderClick = topFolder.emit("click");
+assert.equal(disposedFolderClick.propagationStopped, false);
+assert.equal(topContainer.style.display, disposedFolderDisplay);
+assert.equal(topContainer.__easyuseAnimaOpen, disposedFolderOpen);
+assert.equal(
+  topFolder.querySelector(".easyuse-anima-combo-folder-arrow").textContent,
+  disposedFolderArrow,
+);
+
+assert.equal(lifecycle.dispose(), false, "disposing a replaced owner must be idempotent");
+assert.equal(replacementObserver.disconnected, false);
+assert.equal(document.head.children[0], replacementStyle);
+assert.equal(hiddenPreviews, 4);
+assert.equal(replacementLifecycle.install(), replacementDispose);
+assert.equal(observers.length, 3, "replacement install must also be idempotent");
+
+assert.equal(replacementLifecycle.dispose(), true);
+assert.equal(replacementObserver.disconnected, true);
+assert.equal(replacementStyle.removed, true);
+assert.equal(document.head.children.length, 0);
+assert.equal(hiddenPreviews, 5);
+assert.equal(replacementLifecycle.dispose(), false);
+assert.equal(hiddenPreviews, 5, "repeated dispose must not repeat preview cleanup");
+
+assert.equal(replacementLifecycle.install(), replacementDispose);
+assert.equal(document.head.children.length, 1);
+assert.equal(observers.length, 4, "install after dispose must create a fresh observer");
+assert.notEqual(observer, replacementObserver);
+const disconnectFailure = new Error("observer disconnect failed");
+observerDisconnectError = disconnectFailure;
+assert.throws(
+  () => replacementLifecycle.dispose(),
+  (error) => error === disconnectFailure,
+  "dispose must preserve the first cleanup error",
+);
+assert.equal(observer.disconnected, true);
+assert.equal(document.head.children.length, 0);
+assert.equal(hiddenPreviews, 6);
+assert.equal(
+  replacementLifecycle.dispose(),
+  false,
+  "failed cleanup must still leave the lifecycle disposed",
+);
+
+const ownerKey = Symbol.for("easyuse-anima.lora-preset.menu-lifecycle-owner");
+let refusingOwnerCalls = 0;
+const refusingOwner = () => {
+  refusingOwnerCalls += 1;
+};
+document[ownerKey] = refusingOwner;
+const refusedLifecycle = menuModule.createLoraPresetMenuLifecycle(lifecycleDependencies);
+const observerCountBeforeRefusal = observers.length;
+assert.throws(
+  () => refusedLifecycle.install(),
+  /previous LoRA preset menu lifecycle did not release ownership/,
+);
+assert.equal(refusingOwnerCalls, 1);
+assert.equal(document[ownerKey], refusingOwner, "install must not steal retained ownership");
+assert.equal(observers.length, observerCountBeforeRefusal + 1);
+assert.equal(observers.at(-1).disconnected, true);
+assert.equal(document.head.children.length, 0);
+assert.equal(hiddenPreviews, 6, "failed owner replacement must not clean unrelated preview state");
+assert.equal(refusedLifecycle.dispose(), false);
+delete document[ownerKey];
 
 console.log("LoRA preset menu lifecycle smoke passed.");

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -796,7 +796,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
               const removedMenu = {
                 classList: {
                   contains(className) {
-                    return className === "litecontextmenu";
+                    return className === "litecontextmenu"
+                      || className === "easyuse-anima-lora-menu";
                   },
                 },
               };

--- a/web/js/lora_preset/menu_lifecycle.js
+++ b/web/js/lora_preset/menu_lifecycle.js
@@ -1,5 +1,9 @@
 // @ts-check
 
+const LORA_PRESET_MENU_LIFECYCLE_OWNER = Symbol.for(
+  "easyuse-anima.lora-preset.menu-lifecycle-owner",
+);
+
 /**
  * @typedef {object} LoraPresetMenuDependencies
  * @property {Document} document
@@ -39,7 +43,35 @@ export function createLoraPresetMenuLifecycle(dependencies) {
     nodeType,
     previewSize,
   } = dependencies;
+  const ownerHost = /** @type {any} */ (document);
   let activeLoraMenuNode = null;
+  let installed = false;
+  let installRevision = 0;
+  let observer = /** @type {MutationObserver | null} */ (null);
+  let styleElement = /** @type {HTMLElement | null} */ (null);
+
+  function ownsRevision(revision) {
+    return installed
+      && revision === installRevision
+      && ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER] === dispose;
+  }
+
+  function ownsMenu(menu, revision) {
+    return ownsRevision(revision)
+      && menu?.__easyuseAnimaLoraMenuOwner === dispose
+      && menu?.__easyuseAnimaLoraMenuRevision === revision;
+  }
+
+  function ownsRemovedMenu(menu) {
+    if (!menu?.classList?.contains("easyuse-anima-lora-menu")) {
+      return false;
+    }
+    const menuOwner = menu.__easyuseAnimaLoraMenuOwner;
+    return !menuOwner || (
+      menuOwner === dispose
+      && menu.__easyuseAnimaLoraMenuRevision === installRevision
+    );
+  }
 
   function normalizeSearchText(value) {
     return String(value || "")
@@ -76,19 +108,26 @@ export function createLoraPresetMenuLifecycle(dependencies) {
     activeLoraMenuNode = node;
   }
 
-  function ensureLoraMenuSearch(menu, node) {
+  function ensureLoraMenuSearch(menu, node, revision) {
     if (!menu || menu.__easyuseAnimaSearchReady) {
       return;
     }
     menu.__easyuseAnimaSearchReady = true;
+    const isLive = () => ownsMenu(menu, revision);
     const existingInput = menu.querySelector(".comfy-context-menu-filter, input[type='search'], input");
     if (existingInput) {
       const applyExistingSearch = () => {
+        if (!isLive()) {
+          return;
+        }
         applyLoraMenuSearch(menu, existingInput.value);
         positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
       };
       existingInput.addEventListener("input", applyExistingSearch);
       window.requestAnimationFrame(() => {
+        if (!isLive()) {
+          return;
+        }
         existingInput.focus();
         applyExistingSearch();
       });
@@ -101,12 +140,16 @@ export function createLoraPresetMenuLifecycle(dependencies) {
     input.placeholder = text("lora.search");
     input.autocomplete = "off";
     input.spellcheck = false;
-    const stop = (event) => event.stopPropagation();
+    const stop = (event) => {
+      if (isLive()) {
+        event.stopPropagation();
+      }
+    };
     for (const eventName of ["pointerdown", "mousedown", "mouseup", "click", "dblclick", "keydown"]) {
       input.addEventListener(eventName, stop);
     }
     input.addEventListener("keydown", (event) => {
-      if (event.key === "Escape") {
+      if (isLive() && event.key === "Escape") {
         input.value = "";
         applyLoraMenuSearch(menu, "");
         event.preventDefault();
@@ -114,12 +157,18 @@ export function createLoraPresetMenuLifecycle(dependencies) {
       }
     });
     input.addEventListener("input", () => {
+      if (!isLive()) {
+        return;
+      }
       applyLoraMenuSearch(menu, input.value);
       positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
     });
     const firstDirectEntry = Array.from(menu.children).find((child) => child.classList?.contains("litemenu-entry"));
     menu.insertBefore(input, firstDirectEntry || menu.firstChild);
     window.requestAnimationFrame(() => {
+      if (!isLive()) {
+        return;
+      }
       input.focus();
       positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
     });
@@ -159,17 +208,33 @@ export function createLoraPresetMenuLifecycle(dependencies) {
     return "";
   }
 
-  function addLoraMenuEntryHandlers(item, value) {
-    if (item.__easyuseAnimaPreviewValue === value) {
+  function addLoraMenuEntryHandlers(item, value, menu, revision) {
+    if (
+      item.__easyuseAnimaPreviewValue === value
+      && item.__easyuseAnimaPreviewOwner === dispose
+      && item.__easyuseAnimaPreviewRevision === revision
+    ) {
       return;
     }
     item.__easyuseAnimaPreviewValue = value;
-    item.addEventListener("mouseover", (event) => previewLifecycle.showPreview(value, event), { passive: true });
-    item.addEventListener("mousemove", (event) => previewLifecycle.showPreview(value, event), { passive: true });
-    item.addEventListener("mouseout", previewLifecycle.hidePreview, { passive: true });
+    item.__easyuseAnimaPreviewOwner = dispose;
+    item.__easyuseAnimaPreviewRevision = revision;
+    const showPreview = (event) => {
+      if (ownsMenu(menu, revision)) {
+        previewLifecycle.showPreview(value, event);
+      }
+    };
+    const hidePreview = () => {
+      if (ownsMenu(menu, revision)) {
+        previewLifecycle.hidePreview();
+      }
+    };
+    item.addEventListener("mouseover", showPreview, { passive: true });
+    item.addEventListener("mousemove", showPreview, { passive: true });
+    item.addEventListener("mouseout", hidePreview, { passive: true });
   }
 
-  function normalizeLoraMenuEntries(menu, node, options = {}) {
+  function normalizeLoraMenuEntries(menu, node, revision, options = {}) {
     const items = Array.from(menu.querySelectorAll(".litemenu-entry"));
     const fallbackValues = node?.__easyuseAnimaLoraMenuValues || [];
     const splitBy = /\/|\\/;
@@ -193,29 +258,29 @@ export function createLoraPresetMenuLifecycle(dependencies) {
           textContent: `${parts.slice(0, -1).join("/")}/`,
         }));
       }
-      addLoraMenuEntryHandlers(item, value);
+      addLoraMenuEntryHandlers(item, value, menu, revision);
       entries.push({ item, value, parts });
     });
 
     return entries;
   }
 
-  function updateLoraMenuList(menu, node) {
+  function updateLoraMenuList(menu, node, revision) {
     if (!menu || menu.__easyuseAnimaListReady) {
       return;
     }
     menu.__easyuseAnimaListReady = true;
-    normalizeLoraMenuEntries(menu, node, { splitDisplay: false });
-    ensureLoraMenuSearch(menu, node);
+    normalizeLoraMenuEntries(menu, node, revision, { splitDisplay: false });
+    ensureLoraMenuSearch(menu, node, revision);
     positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
   }
 
-  function updateLoraMenuTree(menu, node) {
+  function updateLoraMenuTree(menu, node, revision) {
     if (!menu || menu.__easyuseAnimaTreeReady) {
       return;
     }
     menu.__easyuseAnimaTreeReady = true;
-    const entries = normalizeLoraMenuEntries(menu, node, { splitDisplay: true });
+    const entries = normalizeLoraMenuEntries(menu, node, revision, { splitDisplay: true });
     if (!entries.length) {
       return;
     }
@@ -248,9 +313,18 @@ export function createLoraPresetMenuLifecycle(dependencies) {
         }
         const folderEl = createElement("div", {
           className: "litemenu-entry easyuse-anima-combo-folder",
-          innerHTML: `<span class="easyuse-anima-combo-folder-arrow">▶</span> ${folder}`,
           style: { paddingLeft: `${depth * 10 + 5}px` },
         });
+        folderEl.append(
+          createElement("span", {
+            className: "easyuse-anima-combo-folder-arrow",
+            textContent: "▶",
+          }),
+          createElement("span", {
+            className: "easyuse-anima-combo-folder-label",
+            textContent: folder,
+          }),
+        );
         const childContainer = createElement("div", {
           className: "easyuse-anima-combo-folder-contents",
           style: { display: "none" },
@@ -261,6 +335,9 @@ export function createLoraPresetMenuLifecycle(dependencies) {
         }
         insertFolders(childContainer, content, depth + 1);
         folderEl.addEventListener("click", (event) => {
+          if (!ownsMenu(menu, revision)) {
+            return;
+          }
           event.stopPropagation();
           const open = childContainer.style.display === "none";
           childContainer.__easyuseAnimaOpen = open;
@@ -273,20 +350,75 @@ export function createLoraPresetMenuLifecycle(dependencies) {
     };
 
     insertFolders(parent, folderMap);
-    ensureLoraMenuSearch(menu, node);
+    ensureLoraMenuSearch(menu, node, revision);
     positionMenu(menu, node?.__easyuseAnimaLoraMenuPoint);
   }
 
-  function updateLoraMenu(menu, node) {
+  function updateLoraMenu(menu, node, revision) {
     if (getMenuMode() === "list") {
-      updateLoraMenuList(menu, node);
+      updateLoraMenuList(menu, node, revision);
       return;
     }
-    updateLoraMenuTree(menu, node);
+    updateLoraMenuTree(menu, node, revision);
+  }
+
+  function dispose() {
+    if (!installed) {
+      if (ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER] === dispose) {
+        delete ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER];
+      }
+      return false;
+    }
+
+    installed = false;
+    installRevision += 1;
+    const currentObserver = observer;
+    const currentStyleElement = styleElement;
+    observer = null;
+    styleElement = null;
+    if (activeLoraMenuNode) {
+      activeLoraMenuNode.__easyuseAnimaOpeningLoraMenu = false;
+    }
+    activeLoraMenuNode = null;
+
+    let cleanupFailed = false;
+    let firstCleanupError;
+    const runCleanup = (callback) => {
+      try {
+        callback();
+      } catch (error) {
+        if (!cleanupFailed) {
+          cleanupFailed = true;
+          firstCleanupError = error;
+        }
+      }
+    };
+    if (ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER] === dispose) {
+      runCleanup(() => {
+        delete ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER];
+      });
+    }
+    runCleanup(() => currentObserver?.disconnect());
+    runCleanup(() => currentStyleElement?.remove());
+    runCleanup(() => previewLifecycle.hidePreview());
+    if (cleanupFailed) {
+      throw firstCleanupError;
+    }
+    return true;
   }
 
   function install() {
-    document.head.appendChild(createElement("style", {
+    if (installed && ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER] === dispose) {
+      return dispose;
+    }
+
+    if (installed) {
+      dispose();
+    }
+
+    const previousOwner = ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER];
+    const revision = ++installRevision;
+    const nextStyleElement = createElement("style", {
       textContent: `
         .easyuse-anima-lora-preview {
           position: fixed;
@@ -317,6 +449,9 @@ export function createLoraPresetMenuLifecycle(dependencies) {
           display: inline-block;
           width: 15px;
         }
+        .easyuse-anima-lora-menu .easyuse-anima-combo-folder-label {
+          margin-left: 0.25em;
+        }
         .easyuse-anima-lora-menu .easyuse-anima-combo-folder:hover {
           background-color: rgba(255, 255, 255, 0.1);
         }
@@ -336,39 +471,106 @@ export function createLoraPresetMenuLifecycle(dependencies) {
           padding-left: 2px !important;
         }
       `,
-    }));
+    });
 
-    const observer = new MutationObserver((mutations) => {
-      const node = activeLoraMenuNode || getCurrentNode();
-      if (!node || node.comfyClass !== nodeType) {
+    /** @param {MutationRecord[]} mutations */
+    const handleMutations = (mutations) => {
+      if (!ownsRevision(revision)) {
         return;
       }
       for (const mutation of mutations) {
         for (const removed of mutation.removedNodes) {
           const removedElement = /** @type {Element} */ (removed);
-          if (removedElement.classList?.contains("litecontextmenu")) {
+          if (ownsRemovedMenu(removedElement)) {
             previewLifecycle.hidePreview();
           }
         }
+      }
+
+      const node = activeLoraMenuNode || getCurrentNode();
+      if (!node || node.comfyClass !== nodeType) {
+        return;
+      }
+      for (const mutation of mutations) {
         for (const added of mutation.addedNodes) {
-          const addedElement = /** @type {Element} */ (added);
-          if (!addedElement.classList?.contains("litecontextmenu") || !node.__easyuseAnimaOpeningLoraMenu) {
+          const addedElement = /** @type {any} */ (added);
+          if (
+            !addedElement.classList?.contains("litecontextmenu")
+            || !addedElement.classList?.contains("easyuse-anima-lora-menu")
+            || !node.__easyuseAnimaOpeningLoraMenu
+          ) {
             continue;
           }
+          addedElement.__easyuseAnimaLoraMenuOwner = dispose;
+          addedElement.__easyuseAnimaLoraMenuRevision = revision;
           window.requestAnimationFrame(() => {
-            updateLoraMenu(addedElement, node);
+            if (!ownsMenu(addedElement, revision)) {
+              return;
+            }
+            updateLoraMenu(addedElement, node, revision);
             node.__easyuseAnimaOpeningLoraMenu = false;
             activeLoraMenuNode = null;
           });
         }
       }
-    });
-    observer.observe(document.body, { childList: true, subtree: false });
+    };
+
+    let nextObserver = /** @type {MutationObserver | null} */ (null);
+    const cleanupPreparedResources = () => {
+      try {
+        nextObserver?.disconnect();
+      } catch {
+        // Preserve the error that caused installation to fail.
+      }
+      try {
+        nextStyleElement.remove();
+      } catch {
+        // Preserve the error that caused installation to fail.
+      }
+    };
+    try {
+      nextObserver = new MutationObserver(handleMutations);
+      document.head.appendChild(nextStyleElement);
+      nextObserver.observe(document.body, { childList: true, subtree: false });
+    } catch (error) {
+      installRevision += 1;
+      cleanupPreparedResources();
+      throw error;
+    }
+
+    let previousOwnerThrew = false;
+    let previousOwnerError;
+    if (typeof previousOwner === "function" && previousOwner !== dispose) {
+      try {
+        previousOwner();
+      } catch (error) {
+        previousOwnerThrew = true;
+        previousOwnerError = error;
+      }
+      if (typeof ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER] === "function") {
+        installRevision += 1;
+        cleanupPreparedResources();
+        if (previousOwnerThrew) {
+          throw previousOwnerError;
+        }
+        throw new Error("The previous LoRA preset menu lifecycle did not release ownership.");
+      }
+    }
+
+    styleElement = nextStyleElement;
+    observer = nextObserver;
+    installed = true;
+    ownerHost[LORA_PRESET_MENU_LIFECYCLE_OWNER] = dispose;
+    if (previousOwnerThrew) {
+      throw previousOwnerError;
+    }
+    return dispose;
   }
 
   return {
     activateMenu,
     createMenuItems,
+    dispose,
     install,
   };
 }


### PR DESCRIPTION
## 변경 요약

- LoRA 폴더 라벨을 `textContent` 기반 span으로 렌더링해 경로 문자열이 HTML로 해석되지 않도록 했습니다.
- 메뉴를 연 뒤 current node가 바뀌어도 기존 preview를 숨기도록 cleanup 순서를 보강했습니다.
- 메뉴 lifecycle에 owner/revision 기반 install·dispose idempotence와 실패 rollback을 추가했습니다.
- 폐기된 listener와 예약된 animation frame이 새 owner 상태를 건드리지 않도록 guard를 추가했습니다.

## 주요 파일

- `web/js/lora_preset/menu_lifecycle.js`
- `tests/frontend_lora_preset_menu_lifecycle_smoke.mjs`
- `tests/test_frontend_lora_preset.py`

## 검증

- `node --check`: production/test JavaScript 통과
- focused lifecycle smoke: 통과
- `python -m unittest tests.test_frontend_lora_preset`: 11/11 통과
- official full runner:
  - Python unittest 391/391
  - frontend smoke 101 JavaScript files
  - TypeScript 6.0.3
  - git diff check
- ComfyUI Codex test instance, Legacy canvas:
  - 메뉴·검색 입력 단일 생성
  - `zhi100m` 검색 결과와 전체 LoRA 경로 확인
  - 실제 preview 이미지 로드(`naturalWidth=480`)
  - current node 변경 후 menu 제거·preview 숨김
  - 재진입 후 menu/input/style owner 단일성 확인
- ComfyUI Codex test instance, Node 2.0:
  - 위와 동일한 menu/search/preview/cleanup/re-entry 표면 통과
- EasyUse Anima 관련 새 browser error 없음
- 첫 focused sandbox 시도는 테스트 본문 전 Windows `CreateProcessAsUserW 1312` 환경 오류였고, 동일 최종 diff의 비샌드박스 재실행은 통과했습니다.

## 남은 범위

- Issue #55의 save sync, wheel listener, extension entry 및 profile/node serialization 경계는 후속 slice로 남깁니다.
- ComfyUI v0.27.0 사용자 인스턴스 수동 확인은 아직 실행하지 않았습니다.

Closes #109
Refs #55