### PR TITLE
fix: stabilize autocomplete input lifecycle

### DIFF
--- a/tests/frontend_autocomplete_input_controller_smoke.mjs
+++ b/tests/frontend_autocomplete_input_controller_smoke.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createScheduler() {
+  let nextHandle = 1;
+  const frames = new Map();
+  const timers = new Map();
+  return {
+    requestFrame(callback) {
+      const handle = nextHandle++;
+      frames.set(handle, callback);
+      return handle;
+    },
+    cancelFrame(handle) {
+      frames.delete(handle);
+    },
+    setTimer(callback, delay) {
+      const handle = nextHandle++;
+      timers.set(handle, { callback, delay });
+      return handle;
+    },
+    clearTimer(handle) {
+      timers.delete(handle);
+    },
+    frameCount() {
+      return frames.size;
+    },
+    timerCount() {
+      return timers.size;
+    },
+    timerDelays() {
+      return [...timers.values()].map((entry) => entry.delay);
+    },
+    async flushFrames() {
+      const callbacks = [...frames.values()];
+      frames.clear();
+      for (const callback of callbacks) {
+        await callback();
+      }
+    },
+    async flushTimers() {
+      const callbacks = [...timers.values()].map((entry) => entry.callback);
+      timers.clear();
+      for (const callback of callbacks) {
+        await callback();
+      }
+    },
+  };
+}
+
+const controllerModule = await import(
+  dataModule("../web/js/autocomplete/input_controller.js")
+);
+assert.deepEqual(Object.keys(controllerModule), ["createAutocompleteInputController"]);
+
+const { createAutocompleteInputController } = controllerModule;
+
+{
+  const scheduler = createScheduler();
+  let updateCount = 0;
+  const controller = createAutocompleteInputController({
+    ...scheduler,
+    async onUpdate() {
+      updateCount += 1;
+    },
+    onError(error) {
+      throw error;
+    },
+  });
+
+  controller.scheduleCaretUpdate();
+  controller.scheduleCaretUpdate();
+  controller.scheduleCaretUpdate();
+  controller.scheduleCaretUpdate();
+  assert.equal(scheduler.frameCount(), 1, "caret event bursts must coalesce to one frame");
+  await scheduler.flushFrames();
+  assert.equal(updateCount, 1);
+
+  controller.scheduleUpdate();
+  controller.scheduleUpdate();
+  controller.scheduleUpdate();
+  assert.equal(scheduler.timerCount(), 1, "input event bursts must keep one debounce timer");
+  assert.deepEqual(scheduler.timerDelays(), [120]);
+  await scheduler.flushTimers();
+  assert.equal(updateCount, 2);
+
+  controller.scheduleUpdate();
+  await controller.updateNow();
+  assert.equal(scheduler.timerCount(), 0, "an immediate refresh must cancel pending debounce work");
+  assert.equal(updateCount, 3);
+
+  controller.beginComposition();
+  assert.equal(controller.isComposing({}), true);
+  assert.equal(controller.isComposing({ isComposing: true }), true);
+  assert.equal(controller.isComposing({ keyCode: 229 }), true);
+  controller.scheduleUpdate();
+  assert.equal(scheduler.timerCount(), 1, "composition updates must retain debounced searching");
+  controller.endComposition();
+  assert.equal(controller.isComposing({}), false);
+  assert.equal(controller.isCompositionEndUpdatePending(), true);
+  assert.equal(scheduler.timerCount(), 0);
+  assert.equal(scheduler.frameCount(), 1, "composition end must own one final caret refresh");
+  controller.scheduleUpdate();
+  assert.equal(
+    scheduler.timerCount(),
+    0,
+    "the final input after compositionend must not downgrade the frame to debounce",
+  );
+  assert.equal(scheduler.frameCount(), 1);
+  await scheduler.flushFrames();
+  assert.equal(controller.isCompositionEndUpdatePending(), false);
+  assert.equal(updateCount, 4);
+
+  controller.scheduleUpdate();
+  controller.invalidate();
+  assert.equal(scheduler.timerCount(), 0, "close/invalidate must cancel scheduled input work");
+  await scheduler.flushTimers();
+  assert.equal(updateCount, 4);
+
+  controller.scheduleCaretUpdate();
+  controller.dispose();
+  assert.equal(scheduler.frameCount(), 0, "dispose must cancel scheduled caret work");
+  controller.scheduleCaretUpdate();
+  await controller.updateNow();
+  assert.equal(scheduler.frameCount(), 0);
+  assert.equal(updateCount, 4, "disposed controllers must ignore future updates");
+}
+
+{
+  const scheduler = createScheduler();
+  const pending = new Map();
+  const loaderCalls = new Map();
+  const applied = [];
+  const errors = [];
+  let requestKey = "same";
+
+  const controller = createAutocompleteInputController({
+    ...scheduler,
+    async onUpdate(context) {
+      const key = requestKey;
+      const result = await context.request(key, () => {
+        loaderCalls.set(key, (loaderCalls.get(key) || 0) + 1);
+        const request = deferred();
+        pending.set(key, request);
+        return request.promise;
+      });
+      if (context.isCurrent()) {
+        applied.push(result);
+      }
+    },
+    onError(error) {
+      errors.push(error.message);
+    },
+  });
+
+  const sameFirst = controller.updateNow();
+  const sameSecond = controller.updateNow();
+  assert.equal(loaderCalls.get("same"), 1, "same-signature in-flight requests must be shared");
+  pending.get("same").resolve("same-result");
+  await Promise.all([sameFirst, sameSecond]);
+  assert.deepEqual(applied, ["same-result"], "only the latest waiter may publish shared results");
+
+  requestKey = "old";
+  const oldUpdate = controller.updateNow();
+  requestKey = "new";
+  const newUpdate = controller.updateNow();
+  pending.get("new").resolve("new-result");
+  await newUpdate;
+  pending.get("old").reject(new Error("stale failure"));
+  await oldUpdate;
+  assert.deepEqual(applied, ["same-result", "new-result"]);
+  assert.deepEqual(errors, [], "a stale rejection must not mutate the current popup state");
+
+  requestKey = "current-failure";
+  const currentFailure = controller.updateNow();
+  pending.get("current-failure").reject(new Error("current failure"));
+  await currentFailure;
+  assert.deepEqual(errors, ["current failure"], "the current request must retain error handling");
+
+  requestKey = "closed";
+  const closedUpdate = controller.updateNow();
+  controller.invalidate();
+  pending.get("closed").resolve("closed-result");
+  await closedUpdate;
+  assert.deepEqual(
+    applied,
+    ["same-result", "new-result"],
+    "close/invalidate must prevent late results from reopening autocomplete",
+  );
+
+  requestKey = "disposed";
+  const disposedUpdate = controller.updateNow();
+  controller.dispose();
+  pending.get("disposed").resolve("disposed-result");
+  await disposedUpdate;
+  assert.deepEqual(applied, ["same-result", "new-result"]);
+}
+
+console.log("Autocomplete input controller smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -47,6 +47,9 @@ AUTOCOMPLETE_JS = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
 AUTOCOMPLETE_DATA_ADAPTER_JS = (
     ROOT / "web" / "js" / "autocomplete" / "data_adapter.js"
 )
+AUTOCOMPLETE_INPUT_CONTROLLER_JS = (
+    ROOT / "web" / "js" / "autocomplete" / "input_controller.js"
+)
 AUTOCOMPLETE_TEXT_MODEL_JS = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -791,23 +794,46 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_autocomplete_refreshes_during_ime_composition_without_committing(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
-        start = source.index("  const updateNow = async () => {")
-        end = source.index("  const update = debounce(updateNow);", start)
-        update_body = source[start:end]
+        controller_source = AUTOCOMPLETE_INPUT_CONTROLLER_JS.read_text(
+            encoding="utf-8"
+        )
+        hook_start = source.index("function hookInput")
+        hook_end = source.index("\nfunction hookWidget", hook_start)
+        hook_body = source[hook_start:hook_end]
 
-        self.assertIn("document.activeElement !== input", update_body)
-        self.assertNotIn("composing || document.activeElement", update_body)
-        self.assertIn('input.addEventListener("compositionupdate", update);', source)
+        self.assertIn("document.activeElement !== input", hook_body)
+        self.assertIn(
+            'input.addEventListener("compositionstart", '
+            "controller.beginComposition);",
+            hook_body,
+        )
+        self.assertIn(
+            'input.addEventListener("compositionupdate", '
+            "controller.scheduleUpdate);",
+            hook_body,
+        )
+        self.assertIn(
+            'input.addEventListener("compositionend", controller.endComposition);',
+            hook_body,
+        )
+        self.assertIn("function beginComposition()", controller_source)
+        self.assertIn("function endComposition()", controller_source)
+        self.assertIn("function scheduleUpdate()", controller_source)
+        self.assertIn("function isComposing(event = null)", controller_source)
+        self.assertIn(
+            "if (!controller.isComposing(event) "
+            "&& handleBracketPreviewKeydown(state, event))",
+            hook_body,
+        )
 
         autocomplete_done = source.index("  input.__easyuseAnimaAutocompleteHooked = true;")
         keydown_start = source.rindex('  input.addEventListener("keydown", (event) => {', 0, autocomplete_done)
         keydown_end = source.index("  });", keydown_start)
         keydown_body = source[keydown_start:keydown_end]
 
-        self.assertIn("event.isComposing", keydown_body)
-        self.assertIn("event.keyCode === 229", keydown_body)
+        self.assertIn("controller.isComposing(event)", keydown_body)
         self.assertLess(
-            keydown_body.index("event.isComposing"),
+            keydown_body.index("controller.isComposing(event)"),
             keydown_body.index("!activeState"),
         )
 
@@ -864,6 +890,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         hide_body = source[start:end]
 
         self.assertIn("markAutocompleteInputInactive(input);", hide_body)
+        self.assertIn("controller?.invalidate();", hide_body)
         self.assertIn("resetAutocompleteMenuToTop(popup);", hide_body)
         self.assertLess(hide_body.index("popup.replaceChildren();"), hide_body.index("resetAutocompleteMenuToTop(popup);"))
         self.assertLess(hide_body.index("resetAutocompleteMenuToTop(popup);"), hide_body.index('popup.classList.add("hidden");'))
@@ -900,7 +927,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("resetActiveAutocompleteMenu(menu);", visible_reset_body)
 
         start = source.index("function renderResults")
-        end = source.index("\nfunction debounce", start)
+        end = source.index("\nfunction isTextEditingShortcut", start)
         body = source[start:end]
 
         self.assertIn("resetAutocompleteMenuToTop(menu);", body)
@@ -915,8 +942,8 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertLess(body.index('menu.classList.remove("hidden");'), body.index("resetVisibleAutocompleteMenuSoon(menu, state.input);"))
         self.assertLess(body.index("resetVisibleAutocompleteMenuSoon(menu, state.input);"), body.index("updateAutocompletePreview();"))
 
-        start = source.index("  const updateNow = async () => {")
-        end = source.index("    const seq = ++updateSeq;", start)
+        start = source.index("    onUpdate: async ({ isCurrent, request }) => {")
+        end = source.index("      const results = await request(", start)
         update_body = source[start:end]
 
         self.assertIn("lastAutocompleteSignature: undefined", source)

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -16,6 +16,12 @@ AUTOCOMPLETE_DATA_ADAPTER = (
 AUTOCOMPLETE_DATA_ADAPTER_SMOKE = (
     ROOT / "tests" / "frontend_autocomplete_data_adapter_smoke.mjs"
 )
+AUTOCOMPLETE_INPUT_CONTROLLER = (
+    ROOT / "web" / "js" / "autocomplete" / "input_controller.js"
+)
+AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE = (
+    ROOT / "tests" / "frontend_autocomplete_input_controller_smoke.mjs"
+)
 AUTOCOMPLETE_TEXT_MODEL = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -33,6 +39,94 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class AutocompleteFrontendBoundaryTests(unittest.TestCase):
+    def test_input_controller_has_exact_lifecycle_boundary(self):
+        module_source = AUTOCOMPLETE_INPUT_CONTROLLER.read_text(encoding="utf-8")
+        entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createAutocompleteInputController"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|registerExtension|"
+                r"addEventListener|removeEventListener|MutationObserver|"
+                r"HTMLElement|HTMLInputElement|HTMLTextAreaElement)\b"
+            ),
+        )
+        self.assertIn(
+            'import { createAutocompleteInputController } from '
+            '"./autocomplete/input_controller.js";',
+            entry_source,
+        )
+        self.assertEqual(
+            entry_source.count("createAutocompleteInputController({"),
+            1,
+        )
+
+        hook_start = entry_source.index("function hookInput")
+        hook_end = entry_source.index("\nfunction hookWidget", hook_start)
+        hook_body = entry_source[hook_start:hook_end]
+        self.assertNotIn("let composing", hook_body)
+        self.assertNotIn("let updateSeq", hook_body)
+        self.assertNotIn("requestAnimationFrame(updateNow)", hook_body)
+        self.assertNotIn("setTimeout(updateNow, 0)", hook_body)
+        self.assertIn("const controller = createAutocompleteInputController({", hook_body)
+        self.assertIn(
+            'input.addEventListener("compositionstart", controller.beginComposition);',
+            hook_body,
+        )
+        self.assertIn(
+            'input.addEventListener("compositionupdate", controller.scheduleUpdate);',
+            hook_body,
+        )
+        self.assertIn(
+            'input.addEventListener("compositionend", controller.endComposition);',
+            hook_body,
+        )
+        self.assertIn("const results = await request(", hook_body)
+        self.assertIn("isCurrent()", hook_body)
+        self.assertIn("controller.invalidate();", hook_body)
+        self.assertIn("controller.isComposing(event)", hook_body)
+        self.assertIn("state?.controller?.invalidate();", entry_source)
+
+        keydown_start = hook_body.rindex(
+            'input.addEventListener("keydown", (event) => {'
+        )
+        keydown_body = hook_body[keydown_start:]
+        self.assertLess(
+            keydown_body.index('event.key === "Escape"'),
+            keydown_body.index("!activeState"),
+        )
+
+    def test_input_controller_module_semantics(self):
+        self.assertTrue(AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE.is_file())
+
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_popup_geometry_has_exact_dom_free_boundary(self):
         module_source = AUTOCOMPLETE_POPUP_GEOMETRY.read_text(encoding="utf-8")
         entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -184,6 +184,11 @@ try {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_autocomplete_input_controller_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend autocomplete input controller smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_popup_geometry_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete popup geometry smoke failed with exit code $LASTEXITCODE."

--- a/web/js/autocomplete/input_controller.js
+++ b/web/js/autocomplete/input_controller.js
@@ -1,0 +1,194 @@
+// @ts-check
+
+/**
+ * @typedef {object} AutocompleteInputUpdateContext
+ * @property {() => boolean} isCurrent
+ * @property {(key: string, loader: () => Promise<any>) => Promise<any>} request
+ */
+
+/**
+ * @typedef {object} AutocompleteInputControllerDependencies
+ * @property {(context: AutocompleteInputUpdateContext) => Promise<void>} onUpdate
+ * @property {(error: unknown, context: AutocompleteInputUpdateContext) => void | Promise<void>} onError
+ * @property {(callback: () => unknown) => any} requestFrame
+ * @property {(handle: any) => void} cancelFrame
+ * @property {(callback: () => unknown, delay: number) => any} setTimer
+ * @property {(handle: any) => void} clearTimer
+ * @property {number} [debounceDelay]
+ */
+
+/**
+ * Own one autocomplete input's scheduled updates, composition state, and
+ * asynchronous request authority. DOM listeners and popup rendering stay in
+ * the entry module; this controller only decides which update is current.
+ *
+ * @param {AutocompleteInputControllerDependencies} dependencies
+ */
+export function createAutocompleteInputController(dependencies) {
+  const {
+    onUpdate,
+    onError,
+    requestFrame,
+    cancelFrame,
+    setTimer,
+    clearTimer,
+    debounceDelay = 120,
+  } = dependencies;
+  let disposed = false;
+  let composing = false;
+  let generation = 0;
+  let pendingTimer = null;
+  let pendingFrame = null;
+  let compositionEndFramePending = false;
+  const inFlight = new Map();
+
+  function cancelScheduledUpdate() {
+    if (pendingTimer != null) {
+      clearTimer(pendingTimer);
+      pendingTimer = null;
+    }
+    if (pendingFrame != null) {
+      cancelFrame(pendingFrame);
+      pendingFrame = null;
+    }
+    compositionEndFramePending = false;
+  }
+
+  function supersedeCurrentUpdate() {
+    generation += 1;
+  }
+
+  function request(key, loader) {
+    if (disposed) {
+      return Promise.resolve(undefined);
+    }
+    const requestKey = String(key);
+    const pending = inFlight.get(requestKey);
+    if (pending) {
+      return pending;
+    }
+    let promise;
+    try {
+      promise = Promise.resolve(loader());
+    } catch (error) {
+      promise = Promise.reject(error);
+    }
+    inFlight.set(requestKey, promise);
+    const release = () => {
+      if (inFlight.get(requestKey) === promise) {
+        inFlight.delete(requestKey);
+      }
+    };
+    promise.then(release, release);
+    return promise;
+  }
+
+  async function updateNow() {
+    if (disposed) {
+      return;
+    }
+    cancelScheduledUpdate();
+    const updateGeneration = ++generation;
+    const context = {
+      isCurrent: () => !disposed && updateGeneration === generation,
+      request,
+    };
+    try {
+      await onUpdate(context);
+    } catch (error) {
+      if (context.isCurrent()) {
+        await onError(error, context);
+      }
+    }
+  }
+
+  function scheduleUpdate() {
+    if (disposed) {
+      return;
+    }
+    if (isCompositionEndUpdatePending()) {
+      return;
+    }
+    supersedeCurrentUpdate();
+    cancelScheduledUpdate();
+    pendingTimer = setTimer(() => {
+      pendingTimer = null;
+      return updateNow();
+    }, debounceDelay);
+  }
+
+  function scheduleFrameUpdate(fromCompositionEnd) {
+    if (disposed) {
+      return;
+    }
+    supersedeCurrentUpdate();
+    cancelScheduledUpdate();
+    compositionEndFramePending = fromCompositionEnd;
+    pendingFrame = requestFrame(() => {
+      pendingFrame = null;
+      compositionEndFramePending = false;
+      return updateNow();
+    });
+  }
+
+  function scheduleCaretUpdate() {
+    scheduleFrameUpdate(false);
+  }
+
+  function isCompositionEndUpdatePending() {
+    return !disposed && compositionEndFramePending && pendingFrame != null;
+  }
+
+  function beginComposition() {
+    if (disposed) {
+      return;
+    }
+    composing = true;
+    supersedeCurrentUpdate();
+    cancelScheduledUpdate();
+  }
+
+  function endComposition() {
+    if (disposed) {
+      return;
+    }
+    composing = false;
+    scheduleFrameUpdate(true);
+  }
+
+  function isComposing(event = null) {
+    return composing || !!event?.isComposing || event?.keyCode === 229;
+  }
+
+  function invalidate() {
+    if (disposed) {
+      return;
+    }
+    supersedeCurrentUpdate();
+    cancelScheduledUpdate();
+    inFlight.clear();
+  }
+
+  function dispose() {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    generation += 1;
+    composing = false;
+    cancelScheduledUpdate();
+    inFlight.clear();
+  }
+
+  return {
+    beginComposition,
+    dispose,
+    endComposition,
+    invalidate,
+    isComposing,
+    isCompositionEndUpdatePending,
+    scheduleCaretUpdate,
+    scheduleUpdate,
+    updateNow,
+  };
+}

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -6,6 +6,7 @@ import {
 import { easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText } from "./easyuse_anima_i18n.js";
 import { createAutocompleteDataAdapter } from "./autocomplete/data_adapter.js";
+import { createAutocompleteInputController } from "./autocomplete/input_controller.js";
 import {
   calculateAutocompletePopupGeometry,
   calculateCaretMirrorGeometry,
@@ -331,6 +332,9 @@ function syncAutocompleteInputFlag(input, state = input?.__easyuseAnimaAutocompl
     return;
   }
   input.__easyuseAnimaAutocomplete = autocompleteEnabledForState(state);
+  if (!input.__easyuseAnimaAutocomplete) {
+    state?.controller?.invalidate();
+  }
 }
 
 function syncAutocompleteInputFlags() {
@@ -433,8 +437,11 @@ function ensurePopup() {
   return popup;
 }
 
-function hidePopup() {
+function hidePopup(options = {}) {
   const input = activeState?.input;
+  if (!options.preserveController) {
+    input?.__easyuseAnimaAutocompleteState?.controller?.invalidate();
+  }
   markAutocompleteInputInactive(input);
   if (popup) {
     popup.replaceChildren();
@@ -1311,16 +1318,6 @@ function renderResults(state, results, signature = "") {
   updateAutocompletePreview();
 }
 
-function debounce(fn, delay = 120) {
-  let timer = null;
-  const wrapped = (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => fn(...args), delay);
-  };
-  wrapped.cancel = () => clearTimeout(timer);
-  return wrapped;
-}
-
 function isTextEditingShortcut(event) {
   if (!(event.ctrlKey || event.metaKey) || event.altKey) {
     return false;
@@ -1345,8 +1342,6 @@ function hookInput(input, options = {}) {
     return;
   }
 
-  let composing = false;
-  let updateSeq = 0;
   const state = {
     node: options.node || null,
     widget: options.widget || null,
@@ -1361,95 +1356,102 @@ function hookInput(input, options = {}) {
     state.lastAutocompleteSignature = "";
   };
 
-  const updateNow = async () => {
-    if (document.activeElement !== input || !autocompleteEnabledForState(state)) {
-      if (activeState?.input === input) {
+  const controller = createAutocompleteInputController({
+    requestFrame: (callback) => requestAnimationFrame(callback),
+    cancelFrame: (handle) => cancelAnimationFrame(handle),
+    setTimer: (callback, delay) => setTimeout(callback, delay),
+    clearTimer: (handle) => clearTimeout(handle),
+    onUpdate: async ({ isCurrent, request }) => {
+      if (document.activeElement !== input || !autocompleteEnabledForState(state)) {
+        if (activeState?.input === input) {
+          hidePopup();
+        }
+        return;
+      }
+      if (shouldSuppressAutocomplete(input)) {
+        markAutocompleteInactive();
+        if (activeState?.input === input) {
+          hidePopup();
+        }
+        return;
+      }
+      if (isCaretInComment(input.value || "", input.selectionStart ?? 0)) {
+        markAutocompleteInactive();
         hidePopup();
+        return;
       }
-      return;
-    }
-    if (shouldSuppressAutocomplete(input)) {
-      markAutocompleteInactive();
-      if (activeState?.input === input) {
+      if (isCaretInPromptTranslationMarker(input)) {
+        markAutocompleteInactive();
         hidePopup();
+        return;
       }
-      return;
-    }
-    if (isCaretInComment(input.value || "", input.selectionStart ?? 0)) {
-      markAutocompleteInactive();
-      hidePopup();
-      return;
-    }
-    if (isCaretInPromptTranslationMarker(input)) {
-      markAutocompleteInactive();
-      hidePopup();
-      return;
-    }
-    const wildcardToken = currentWildcardToken(input);
-    const token = wildcardToken || currentToken(input);
-    if (!token?.active) {
-      markAutocompleteInactive();
-      hidePopup();
-      return;
-    }
-    const context = wildcardToken
-      ? wildcardAutocompleteQuery(wildcardToken)
-      : autocompleteQuery(token, state.forceArtistOnly);
-    if (context.kind !== "wildcard" && context.query.length < MIN_QUERY_LENGTH) {
-      markAutocompleteInactive();
-      hidePopup();
-      return;
-    }
-    const signature = autocompleteStateSignature(token, context, state);
-    const previousSignature = state.lastAutocompleteSignature;
-    state.lastAutocompleteSignature = signature;
-    if (activeState?.input === input && activeState.signature === signature) {
-      if (previousSignature !== undefined && previousSignature !== signature) {
-        resetActiveAutocompleteMenu(ensurePopup());
+      const wildcardToken = currentWildcardToken(input);
+      const token = wildcardToken || currentToken(input);
+      if (!token?.active) {
+        markAutocompleteInactive();
+        hidePopup();
+        return;
       }
-      positionPopup(input);
-      updateAutocompletePreview();
-      return;
-    }
-    const seq = ++updateSeq;
-    try {
-      const results = context.kind === "wildcard"
-        ? await autocompleteData.searchWildcards(context.query)
-        : await autocompleteData.search(context.query, context.category);
-      if (document.activeElement === input && seq === updateSeq && !shouldSuppressAutocomplete(input)) {
+      const context = wildcardToken
+        ? wildcardAutocompleteQuery(wildcardToken)
+        : autocompleteQuery(token, state.forceArtistOnly);
+      if (context.kind !== "wildcard" && context.query.length < MIN_QUERY_LENGTH) {
+        markAutocompleteInactive();
+        hidePopup();
+        return;
+      }
+      const signature = autocompleteStateSignature(token, context, state);
+      const previousSignature = state.lastAutocompleteSignature;
+      state.lastAutocompleteSignature = signature;
+      if (activeState?.input === input && activeState.signature === signature) {
+        if (previousSignature !== undefined && previousSignature !== signature) {
+          resetActiveAutocompleteMenu(ensurePopup());
+        }
+        positionPopup(input);
+        updateAutocompletePreview();
+        return;
+      }
+      const results = await request(
+        signature,
+        () => context.kind === "wildcard"
+          ? autocompleteData.searchWildcards(context.query)
+          : autocompleteData.search(context.query, context.category),
+      );
+      if (
+        isCurrent()
+        && document.activeElement === input
+        && autocompleteEnabledForState(state)
+        && !shouldSuppressAutocomplete(input)
+      ) {
         renderResults(state, strictAutocompleteResults(context, token, state, results), signature);
       }
-    } catch {
-      hidePopup();
-    }
-  };
-  const update = debounce(updateNow);
-  const updateFromCaret = () => {
-    update.cancel();
-    updateNow();
-  };
-  const updateAfterCaretMove = () => {
-    update.cancel();
-    requestAnimationFrame(updateNow);
-    setTimeout(updateNow, 0);
-  };
-  state.refresh = updateFromCaret;
+    },
+    onError: () => {
+      if (document.activeElement === input && (!activeState || activeState.input === input)) {
+        hidePopup();
+      }
+    },
+  });
+  state.controller = controller;
+  state.refresh = controller.updateNow;
   state.reposition = () => positionPopup(input);
+  const scheduleInputUpdate = () => {
+    const preserveController = controller.isCompositionEndUpdatePending();
+    if (activeState?.input === input) {
+      hidePopup({ preserveController });
+    }
+    controller.scheduleUpdate();
+  };
 
-  input.addEventListener("compositionstart", () => {
-    composing = true;
-  });
-  input.addEventListener("compositionupdate", update);
-  input.addEventListener("compositionend", () => {
-    composing = false;
-    updateAfterCaretMove();
-  });
-  input.addEventListener("input", update);
-  input.addEventListener("focus", updateFromCaret);
-  input.addEventListener("click", updateAfterCaretMove);
-  input.addEventListener("mousedown", updateAfterCaretMove);
-  input.addEventListener("mouseup", updateAfterCaretMove);
-  input.addEventListener("pointerup", updateAfterCaretMove);
+  input.addEventListener("compositionstart", controller.beginComposition);
+  input.addEventListener("compositionupdate", controller.scheduleUpdate);
+  input.addEventListener("compositionend", controller.endComposition);
+  input.addEventListener("input", scheduleInputUpdate);
+  input.addEventListener("focus", controller.updateNow);
+  input.addEventListener("click", controller.scheduleCaretUpdate);
+  input.addEventListener("mousedown", controller.scheduleCaretUpdate);
+  input.addEventListener("mouseup", controller.scheduleCaretUpdate);
+  input.addEventListener("pointerup", controller.scheduleCaretUpdate);
   input.addEventListener("pointerdown", (event) => {
     if (forwardMiddlePanFromAutocompleteInput(event)) {
       hidePopup();
@@ -1468,11 +1470,12 @@ function hookInput(input, options = {}) {
   }, true);
   input.addEventListener("keyup", (event) => {
     if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"].includes(event.key)) {
-      updateAfterCaretMove();
+      controller.scheduleCaretUpdate();
     }
   });
-  input.addEventListener("select", updateAfterCaretMove);
+  input.addEventListener("select", controller.scheduleCaretUpdate);
   input.addEventListener("blur", () => {
+    controller.invalidate();
     setTimeout(() => {
       if (activeState?.input === input) {
         hidePopup();
@@ -1485,12 +1488,20 @@ function hookInput(input, options = {}) {
     }
   });
   input.addEventListener("keydown", (event) => {
-    if (handleBracketPreviewKeydown(state, event)) {
-      updateAfterCaretMove();
+    if (!controller.isComposing(event) && handleBracketPreviewKeydown(state, event)) {
+      controller.scheduleCaretUpdate();
     }
   });
   input.addEventListener("keydown", (event) => {
-    if (composing || event.isComposing || event.keyCode === 229) {
+    if (controller.isComposing(event)) {
+      return;
+    }
+    if (event.key === "Escape") {
+      controller.invalidate();
+      if (activeState?.input === input) {
+        event.preventDefault();
+        hidePopup();
+      }
       return;
     }
     if (!activeState || activeState.input !== input) {
@@ -1513,9 +1524,6 @@ function hookInput(input, options = {}) {
       commitSuggestion(activeState, activeState.results[activeState.index], {
         suppressPopup: true,
       });
-    } else if (event.key === "Escape") {
-      event.preventDefault();
-      hidePopup();
     }
   });
 


### PR DESCRIPTION
## 변경 요약

- autocomplete 입력 상태를 전담하는 `input_controller`를 추가해 debounce, caret frame, composition 종료, in-flight 요청과 generation 권한을 한 곳에서 관리합니다.
- 같은 signature 요청은 공유하고, blur/Escape/input 변경 뒤 도착한 stale 성공·실패가 최신 popup을 닫거나 다시 열지 못하게 했습니다.
- entry 연결에서 IME 조합 중 commit/bracket 처리를 차단하고, 동일 DOM input 재진입 시 기존 state를 갱신하도록 정리했습니다.
- 새 controller smoke를 공용 frontend runner에 등록했습니다.

## 주요 파일

- `web/js/autocomplete/input_controller.js`
- `web/js/easyuse_anima_autocomplete.js`
- `tests/frontend_autocomplete_input_controller_smoke.mjs`
- `tests/test_autocomplete_frontend.py`
- `tests/test_aio_frontend.py`
- `tools/check_frontend.ps1`

## 검증

- `node --check`: controller, entry, controller smoke 통과
- autocomplete input controller smoke: 통과
- autocomplete data adapter smoke: 통과
- 관련 unittest: 42/42
- official full runner:
  - Python unittest 393/393
  - frontend smoke 102 JavaScript files
  - TypeScript 6.0.3
  - git diff check
- ComfyUI Codex test instance, Legacy canvas:
  - `hats` 입력 후 popup 1개, 결과 20개, active `hatsune miku`
  - ArrowDown/ArrowUp active 이동·복귀
  - Enter commit 후 값 `hatsune miku`, popup cleanup
  - `miku` 입력 직후 Escape 시 값 보존·popup 재개방 차단
  - outside click cleanup과 focus 재진입 singleton
- ComfyUI Codex test instance, Node 2.0:
  - 위와 동일한 input/popup/keyboard/Escape/outside-close/re-entry 표면 통과
- Unicode `하츠네` 입력은 두 캔버스에서 값이 보존되고 오류 없이 닫혔지만, Browser API 제약상 실제 composition event 증거로는 사용하지 않았습니다.
- EasyUse Anima 관련 새 browser error 없음
- 일부 focused sandbox 시도는 테스트 본문 전 Windows `CreateProcessAsUserW 1312` 환경 오류였고, 동일 최종 diff의 비샌드박스 재실행은 통과했습니다.

## 남은 범위

- Issue #98의 중첩 괄호·가중치·artist 접두사 replacement syntax
- Issue #99의 source/adapter epoch invalidation
- Issue #100의 backend 51~100 결과 제한
- external DOM hook/listener installer와 extension entry lifecycle
- 최종 Legacy/Node 2.0 input/select/close/save-reload matrix
- ComfyUI v0.27.0 사용자 인스턴스 수동 확인은 아직 실행하지 않았습니다.

Refs #56
Refs #99