### PR TITLE
fix: reserve Prompt Studio subgraph queue seeds

### DIFF
--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -161,6 +161,7 @@ const ADVANCED_QUEUE_SEED_CONTRACT = Object.freeze({
   seedInputName: "wildcard_seed",
   controlInputName: "wildcard_seed_after_generate",
   seedWidgetIndex: SEED_INDEX,
+  supportsSubgraph: true,
 });
 const WILDCARD_QUEUE_SEED_CONTRACT = Object.freeze({
   modeInputName: "mode",
@@ -363,6 +364,169 @@ function createFixture(options = {}) {
   };
 }
 
+function seedPromptInputs(node) {
+  const contract = queueSeedContract(node);
+  const mode = node.widgets.find((widget) => widget.name === contract.modeInputName).value;
+  const seed = node.widgets.find((widget) => widget.name === contract.seedInputName).value;
+  const control = node.widgets.find((widget) => widget.name === contract.controlInputName).value;
+  return node.type === WILDCARD
+    ? {
+        text: "__style__",
+        populated_text: "",
+        mode,
+        seed,
+        seed_after_generate: control,
+      }
+    : {
+        advanced_fields: "[]",
+        wildcard_mode: mode,
+        wildcard_seed: seed,
+        wildcard_seed_after_generate: control,
+      };
+}
+
+function seedWorkflowNode(node) {
+  const inputs = seedPromptInputs(node);
+  return {
+    id: node.id,
+    type: node.type,
+    widgets_values: node.type === WILDCARD
+      ? wildcardWidgetValues(inputs.seed, inputs.mode, inputs.seed_after_generate)
+      : widgetValues(
+          inputs.wildcard_seed,
+          inputs.wildcard_mode,
+          inputs.wildcard_seed_after_generate,
+        ),
+  };
+}
+
+function createSubgraphFixture(options = {}) {
+  const nodes = options.nodes || [advancedNode(10)];
+  const definition = {
+    id: options.definitionId || "advanced-subgraph-definition",
+    name: "Advanced seed subgraph",
+    _nodes: nodes,
+  };
+  for (const node of nodes) {
+    node.graph = definition;
+  }
+  const containers = (options.containerIds || [50]).map((id) => ({
+    id,
+    type: definition.id,
+    subgraph: definition,
+  }));
+  const outputNodes = options.outputNodes || [{ id: 20, outputNode: true }];
+  const rootGraph = {
+    id: "root-graph",
+    isRootGraph: true,
+    _nodes: [...containers, ...outputNodes],
+  };
+  for (const node of rootGraph._nodes) {
+    node.graph = rootGraph;
+  }
+
+  const randomValues = [...(options.randomValues || [41, 42, 43, 44])];
+  const commits = [];
+  let randomCalls = 0;
+  let cloneCalls = 0;
+  const runtime = queueModule.createAdvancedQueueSeedRuntime({
+    listNodes: () => rootGraph._nodes,
+    rootGraph,
+    getNodeContract: queueSeedContract,
+    isOutputNode: (node) => node?.outputNode === true,
+    getSeed(node, contract) {
+      return node.widgets.find((widget) => widget.name === contract.seedInputName)?.value;
+    },
+    updateSeed(node, seed, contract) {
+      commits.push([definition.id, node.id, seed]);
+      node.widgets.find((widget) => widget.name === contract.seedInputName).value = seed;
+    },
+    clonePrompt(value) {
+      cloneCalls += 1;
+      return clone(value);
+    },
+    randomSeed() {
+      randomCalls += 1;
+      return randomValues.shift() ?? 0;
+    },
+  });
+  return {
+    commits,
+    containers,
+    definition,
+    nodes,
+    outputNodes,
+    rootGraph,
+    runtime,
+    cloneCalls: () => cloneCalls,
+    randomCalls: () => randomCalls,
+  };
+}
+
+function subgraphPromptFor(fixture, options = {}) {
+  const omittedContainerIds = new Set(
+    (options.omittedContainerIds || []).map((value) => String(value)),
+  );
+  const output = {};
+  for (const container of fixture.containers) {
+    if (omittedContainerIds.has(String(container.id))) {
+      continue;
+    }
+    for (const node of fixture.nodes) {
+      output[`${container.id}:${node.id}`] = {
+        class_type: node.type,
+        inputs: seedPromptInputs(node),
+      };
+    }
+  }
+
+  const connections = options.connections || [{
+    executionId: `${fixture.containers[0].id}:${fixture.nodes[0].id}`,
+    targetId: fixture.outputNodes[0].id,
+  }];
+  for (const outputNode of fixture.outputNodes) {
+    const inputs = {};
+    connections
+      .filter((connection) => String(connection.targetId) === String(outputNode.id))
+      .forEach((connection, index) => {
+        inputs[`source_${index}`] = [String(connection.executionId), 0];
+      });
+    output[String(outputNode.id)] = {
+      class_type: "PreviewImage",
+      inputs,
+    };
+  }
+
+  return {
+    output,
+    workflow: {
+      nodes: [
+        ...fixture.containers.map((container) => ({
+          id: container.id,
+          type: fixture.definition.id,
+          mode: omittedContainerIds.has(String(container.id)) ? 4 : 0,
+          widgets_values: [],
+        })),
+        ...fixture.outputNodes.map((node) => ({
+          id: node.id,
+          type: "PreviewImage",
+          widgets_values: [],
+        })),
+      ],
+      definitions: {
+        subgraphs: [{
+          id: fixture.definition.id,
+          name: fixture.definition.name,
+          inputNode: { id: -10 },
+          outputNode: { id: -20 },
+          nodes: fixture.nodes.map(seedWorkflowNode),
+        }],
+      },
+      links: [],
+    },
+  };
+}
+
 function registerWildcardRuntimeHooks(nodeType, runtime) {
   return nodeHooksModule.registerPromptStudioNodeHooks(
     nodeType,
@@ -391,8 +555,23 @@ function workflowSeed(prompt, nodeId) {
   const contract = promptNode.class_type === WILDCARD
     ? WILDCARD_QUEUE_SEED_CONTRACT
     : ADVANCED_QUEUE_SEED_CONTRACT;
-  return prompt.workflow.nodes.find((node) => String(node.id) === String(nodeId))
-    .widgets_values[contract.seedWidgetIndex];
+  const nodeIds = String(nodeId).split(":");
+  const definitions = new Map(
+    (prompt.workflow.definitions?.subgraphs || []).map((definition) => [
+      String(definition.id),
+      definition,
+    ]),
+  );
+  let nodes = prompt.workflow.nodes;
+  let workflowNodeValue = null;
+  for (let index = 0; index < nodeIds.length; index += 1) {
+    workflowNodeValue = nodes.find((node) => String(node.id) === nodeIds[index]) || null;
+    if (!workflowNodeValue || index === nodeIds.length - 1) {
+      break;
+    }
+    nodes = definitions.get(String(workflowNodeValue.type))?.nodes || [];
+  }
+  return workflowNodeValue.widgets_values[contract.seedWidgetIndex];
 }
 
 function reservedNextSeed(prompt, nodeId) {
@@ -1140,6 +1319,244 @@ function reservedSeedState(prompt, nodeId) {
   assert.equal(reservedSeedState(received, 16), undefined);
   assert.equal(queuedSeed(received, 16), 30);
   assert.equal(workflowSeed(received, 16), 30);
+}
+
+{
+  const nodes = [advancedNode(10, ADVANCED, 7), advancedNode(11, ADVANCED_V2, 30)];
+  const fixture = createSubgraphFixture({ nodes });
+  const prompt = subgraphPromptFor(fixture, {
+    connections: [{ executionId: "50:10", targetId: 20 }],
+  });
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "subgraph-connected-only", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.notEqual(received, prompt);
+  assert.equal(queuedSeed(received, "50:10"), 7);
+  assert.equal(workflowSeed(received, "50:10"), 7);
+  assert.deepEqual(reservedSeedState(received, "50:10"), {
+    version: 1,
+    current_seed: 7,
+    next_seed: 8,
+    mode: "sequential",
+    control: "increment",
+  });
+  assert.equal(nodes[0].widgets[1].value, 8);
+  assert.equal(
+    nodes[1].widgets[1].value,
+    30,
+    "a disconnected Advanced V2 node in the same definition must not reserve",
+  );
+  assert.equal(reservedSeedState(received, "50:11"), undefined);
+  assert.equal(workflowSeed(received, "50:11"), 30);
+  assert.equal(reservedSeedState(prompt, "50:10"), undefined, "the caller prompt stays immutable");
+  assert.equal(workflowSeed(prompt, "50:10"), 7);
+}
+
+{
+  const node = advancedNode(10, ADVANCED_V2, 7);
+  node.widgets[0].value = "일반 채우기";
+  node.widgets[2].value = "randomize";
+  const fixture = createSubgraphFixture({ nodes: [node], randomValues: [41, 42, 43] });
+  const queued = [];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queued.push({
+      current: queuedSeed(prompt, "50:10"),
+      workflow: workflowSeed(prompt, "50:10"),
+      next: reservedNextSeed(prompt, "50:10"),
+    });
+    return { prompt_id: `subgraph-rapid-${queued.length}`, node_errors: {} };
+  });
+  await Promise.all([
+    wrapped(0, subgraphPromptFor(fixture)),
+    wrapped(0, subgraphPromptFor(fixture)),
+    wrapped(0, subgraphPromptFor(fixture)),
+  ]);
+  assert.deepEqual(queued, [
+    { current: 7, workflow: 7, next: 41 },
+    { current: 41, workflow: 41, next: 42 },
+    { current: 42, workflow: 42, next: 43 },
+  ]);
+  assert.equal(node.widgets[1].value, 43);
+  assert.equal(fixture.randomCalls(), 3);
+}
+
+{
+  const node = advancedNode(10, ADVANCED, 7);
+  node.widgets[0].value = "일반 채우기";
+  node.widgets[2].value = "randomize";
+  const fixture = createSubgraphFixture({
+    nodes: [node],
+    containerIds: [50, 51],
+    randomValues: [41, 42],
+  });
+  const prompt = subgraphPromptFor(fixture, {
+    connections: [
+      { executionId: "50:10", targetId: 20 },
+      { executionId: "51:10", targetId: 20 },
+    ],
+  });
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "shared-subgraph-definition", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  for (const executionId of ["50:10", "51:10"]) {
+    assert.equal(queuedSeed(received, executionId), 7);
+    assert.equal(reservedNextSeed(received, executionId), 41);
+  }
+  assert.equal(workflowSeed(received, "50:10"), 7);
+  assert.equal(node.widgets[1].value, 41);
+  assert.equal(fixture.randomCalls(), 1, "one shared live definition reserves one next seed");
+  assert.deepEqual(fixture.commits, [[fixture.definition.id, 10, 41]]);
+}
+
+{
+  const node = advancedNode(10, ADVANCED_V2, 7);
+  const fixture = createSubgraphFixture({
+    nodes: [node],
+    definitionId: "inner-advanced-definition",
+    containerIds: [60],
+  });
+  const innerDefinition = fixture.definition;
+  const innerContainer = {
+    id: 50,
+    type: innerDefinition.id,
+    subgraph: innerDefinition,
+  };
+  const outerDefinition = {
+    id: "outer-advanced-definition",
+    name: "Outer Advanced seed subgraph",
+    _nodes: [innerContainer],
+  };
+  innerContainer.graph = outerDefinition;
+  fixture.containers[0].type = outerDefinition.id;
+  fixture.containers[0].subgraph = outerDefinition;
+  const prompt = {
+    output: {
+      "60:50:10": {
+        class_type: node.type,
+        inputs: seedPromptInputs(node),
+      },
+      20: {
+        class_type: "PreviewImage",
+        inputs: { source: ["60:50:10", 0] },
+      },
+    },
+    workflow: {
+      nodes: [
+        { id: 60, type: outerDefinition.id, widgets_values: [] },
+        { id: 20, type: "PreviewImage", widgets_values: [] },
+      ],
+      definitions: {
+        subgraphs: [
+          {
+            id: outerDefinition.id,
+            name: outerDefinition.name,
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            nodes: [{ id: 50, type: innerDefinition.id, widgets_values: [] }],
+          },
+          {
+            id: innerDefinition.id,
+            name: innerDefinition.name,
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            nodes: [seedWorkflowNode(node)],
+          },
+        ],
+      },
+      links: [],
+    },
+  };
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "nested-subgraph", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.equal(queuedSeed(received, "60:50:10"), 7);
+  assert.equal(workflowSeed(received, "60:50:10"), 7);
+  assert.equal(reservedNextSeed(received, "60:50:10"), 8);
+  assert.equal(node.widgets[1].value, 8);
+}
+
+{
+  const node = advancedNode(10, ADVANCED, 7);
+  node.widgets[0].value = "일반 채우기";
+  node.widgets[2].value = "randomize";
+  const fixture = createSubgraphFixture({ nodes: [node], randomValues: [41] });
+  const prompt = subgraphPromptFor(fixture, {
+    omittedContainerIds: [50],
+    connections: [],
+  });
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "bypassed-subgraph", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.equal(received, prompt, "a bypassed subgraph stays on the unmanaged queue path");
+  assert.equal(fixture.cloneCalls(), 0);
+  assert.equal(fixture.randomCalls(), 0);
+  assert.deepEqual(fixture.commits, []);
+  assert.equal(node.widgets[1].value, 7);
+}
+
+{
+  const node = wildcardNode(15, 7);
+  const fixture = createSubgraphFixture({ nodes: [node] });
+  const prompt = subgraphPromptFor(fixture, {
+    connections: [{ executionId: "50:15", targetId: 20 }],
+  });
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "native-wildcard-subgraph-pass-through", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.equal(received, prompt, "#103 native Wildcard support remains top-level only");
+  assert.equal(reservedSeedState(received, "50:15"), undefined);
+  assert.equal(node.widgets.find((widget) => widget.name === "seed").value, 7);
+  assert.equal(fixture.cloneCalls(), 0);
+}
+
+{
+  const node = advancedNode(10, ADVANCED, 7);
+  node.widgets[0].value = "일반 채우기";
+  node.widgets[2].value = "randomize";
+  const fixture = createSubgraphFixture({
+    nodes: [node],
+    containerIds: [50, 51],
+    randomValues: [41],
+  });
+  const prompt = subgraphPromptFor(fixture, {
+    connections: [
+      { executionId: "50:10", targetId: 20 },
+      { executionId: "51:10", targetId: 20 },
+    ],
+  });
+  prompt.output["51:10"].inputs.wildcard_seed = 99;
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "promoted-seed-mismatch", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.equal(received, prompt, "different per-instance seeds cannot share one workflow value");
+  assert.equal(fixture.cloneCalls(), 0);
+  assert.equal(fixture.randomCalls(), 0);
+  assert.deepEqual(fixture.commits, []);
+  assert.equal(node.widgets[1].value, 7);
 }
 
 {

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -1370,24 +1370,33 @@ function reservedSeedState(prompt, nodeId) {
     nodes: [node],
     delayedRootGraph: true,
   });
-  const prompt = subgraphPromptFor(fixture, {
-    connections: [{ executionId: "50:10", targetId: 20 }],
-  });
   fixture.setRootGraph(fixture.rootGraph);
 
-  let received = null;
+  const queued = [];
   const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
-    received = nextPrompt;
-    return { prompt_id: "delayed-root-graph", node_errors: {} };
+    queued.push({
+      current: queuedSeed(nextPrompt, "50:10"),
+      workflow: workflowSeed(nextPrompt, "50:10"),
+      next: reservedNextSeed(nextPrompt, "50:10"),
+    });
+    return {
+      prompt_id: `delayed-root-graph-rapid-${queued.length}`,
+      node_errors: {},
+    };
   });
-  await wrapped(0, prompt);
+  await Promise.all([
+    wrapped(0, subgraphPromptFor(fixture)),
+    wrapped(0, subgraphPromptFor(fixture)),
+    wrapped(0, subgraphPromptFor(fixture)),
+  ]);
 
-  assert.notEqual(received, prompt);
-  assert.equal(queuedSeed(received, "50:10"), 7);
-  assert.equal(workflowSeed(received, "50:10"), 7);
-  assert.equal(reservedNextSeed(received, "50:10"), 8);
-  assert.equal(node.widgets[1].value, 8);
-  assert.equal(fixture.cloneCalls(), 1);
+  assert.deepEqual(queued, [
+    { current: 7, workflow: 7, next: 8 },
+    { current: 8, workflow: 8, next: 9 },
+    { current: 9, workflow: 9, next: 10 },
+  ]);
+  assert.equal(node.widgets[1].value, 10);
+  assert.equal(fixture.cloneCalls(), 3);
 }
 
 {

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -429,9 +429,14 @@ function createSubgraphFixture(options = {}) {
   const commits = [];
   let randomCalls = 0;
   let cloneCalls = 0;
+  const graphHolder = {
+    current: options.delayedRootGraph ? undefined : rootGraph,
+  };
   const runtime = queueModule.createAdvancedQueueSeedRuntime({
-    listNodes: () => rootGraph._nodes,
-    rootGraph,
+    listNodes: () => graphHolder.current?._nodes || [],
+    ...(options.delayedRootGraph
+      ? { getRootGraph: () => graphHolder.current }
+      : { rootGraph }),
     getNodeContract: queueSeedContract,
     isOutputNode: (node) => node?.outputNode === true,
     getSeed(node, contract) {
@@ -458,6 +463,9 @@ function createSubgraphFixture(options = {}) {
     outputNodes,
     rootGraph,
     runtime,
+    setRootGraph(graph) {
+      graphHolder.current = graph;
+    },
     cloneCalls: () => cloneCalls,
     randomCalls: () => randomCalls,
   };
@@ -1354,6 +1362,32 @@ function reservedSeedState(prompt, nodeId) {
   assert.equal(workflowSeed(received, "50:11"), 30);
   assert.equal(reservedSeedState(prompt, "50:10"), undefined, "the caller prompt stays immutable");
   assert.equal(workflowSeed(prompt, "50:10"), 7);
+}
+
+{
+  const node = advancedNode(10, ADVANCED_V2, 7);
+  const fixture = createSubgraphFixture({
+    nodes: [node],
+    delayedRootGraph: true,
+  });
+  const prompt = subgraphPromptFor(fixture, {
+    connections: [{ executionId: "50:10", targetId: 20 }],
+  });
+  fixture.setRootGraph(fixture.rootGraph);
+
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "delayed-root-graph", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+
+  assert.notEqual(received, prompt);
+  assert.equal(queuedSeed(received, "50:10"), 7);
+  assert.equal(workflowSeed(received, "50:10"), 7);
+  assert.equal(reservedNextSeed(received, "50:10"), 8);
+  assert.equal(node.widgets[1].value, 8);
+  assert.equal(fixture.cloneCalls(), 1);
 }
 
 {

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -2211,6 +2211,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("installAdvancedQueueSeedQueueHook", extension_runtime_source)
         self.assertIn("advancedQueueSeedRuntime.shouldApplyExecutedSeed", extension_runtime_source)
         self.assertIn("installAdvancedQueueSeedGraphCleanup", extension_runtime_source)
+        self.assertIn("getRootGraph: () => app.graph,", extension_runtime_source)
+        self.assertNotIn("rootGraph: app.graph,", extension_runtime_source)
         self.assertIn(
             "attachAdvancedQueueSeedNode: advancedQueueSeedRuntime.attachNode",
             extension_runtime_source,

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -55,11 +55,102 @@ function nextSeed(seed, mode, control, randomSeed) {
   return nextWildcardSeed(seed, effectiveControl, randomSeed);
 }
 
-function workflowNode(workflow, nodeId) {
+function workflowSubgraphDefinitions(workflow) {
+  const definitions = new Map();
+  const pending = Array.isArray(workflow?.definitions?.subgraphs)
+    ? [...workflow.definitions.subgraphs]
+    : [];
+  while (pending.length) {
+    const definition = pending.shift();
+    const definitionId = normalizeNodeId(definition?.id);
+    if (definitionId == null || definitions.has(definitionId)) {
+      continue;
+    }
+    definitions.set(definitionId, definition);
+    if (Array.isArray(definition?.definitions?.subgraphs)) {
+      pending.push(...definition.definitions.subgraphs);
+    }
+  }
+  return definitions;
+}
+
+function workflowNode(workflow, executionId) {
   if (!Array.isArray(workflow?.nodes)) {
     return null;
   }
-  return workflow.nodes.find((node) => normalizeNodeId(node?.id) === nodeId) || null;
+  const nodeIds = String(executionId || "")
+    .split(":")
+    .map((value) => normalizeNodeId(value));
+  if (!nodeIds.length || nodeIds.some((value) => value == null)) {
+    return null;
+  }
+  const definitions = workflowSubgraphDefinitions(workflow);
+  let nodes = workflow.nodes;
+  let found = null;
+  for (let index = 0; index < nodeIds.length; index += 1) {
+    found = nodes.find((node) => normalizeNodeId(node?.id) === nodeIds[index]) || null;
+    if (!found || index === nodeIds.length - 1) {
+      break;
+    }
+    const definition = definitions.get(normalizeNodeId(found.type));
+    if (!Array.isArray(definition?.nodes)) {
+      return null;
+    }
+    nodes = definition.nodes;
+  }
+  return found;
+}
+
+function graphNodeEntries(rootGraph) {
+  if (!Array.isArray(rootGraph?._nodes)) {
+    return [];
+  }
+  const entries = new Map();
+
+  function visit(graph, parentPath, ancestors) {
+    if (!Array.isArray(graph?._nodes)) {
+      return;
+    }
+    for (const node of graph._nodes) {
+      const nodeId = normalizeNodeId(node?.id);
+      if (!node || nodeId == null) {
+        continue;
+      }
+      const executionId = [...parentPath, nodeId].join(":");
+      let entry = entries.get(node);
+      if (!entry) {
+        entry = { node, executionIds: [] };
+        entries.set(node, entry);
+      }
+      if (!entry.executionIds.includes(executionId)) {
+        entry.executionIds.push(executionId);
+      }
+
+      const subgraph = node.subgraph;
+      if (!Array.isArray(subgraph?._nodes) || ancestors.has(node)) {
+        continue;
+      }
+      const nestedAncestors = new Set(ancestors);
+      nestedAncestors.add(node);
+      visit(subgraph, [...parentPath, nodeId], nestedAncestors);
+    }
+  }
+
+  visit(rootGraph, [], new Set());
+  return [...entries.values()];
+}
+
+function nodeStateKey(rootGraph, node) {
+  const nodeId = normalizeNodeId(node?.id);
+  if (nodeId == null) {
+    return null;
+  }
+  const graph = node?.graph;
+  if (!rootGraph || !graph || graph === rootGraph || graph.isRootGraph === true) {
+    return nodeId;
+  }
+  const graphId = normalizeNodeId(graph.id);
+  return graphId == null ? nodeId : `${graphId}:${nodeId}`;
 }
 
 function inputSourceIds(value, output, result = new Set()) {
@@ -200,11 +291,13 @@ function reservationWasAccepted(result, reservation, prompt) {
  * @property {string} seedInputName
  * @property {string} controlInputName
  * @property {number} seedWidgetIndex
+ * @property {boolean} [supportsSubgraph]
  */
 
 /**
  * @typedef {object} AdvancedQueueSeedDependencies
  * @property {() => any[]} listNodes
+ * @property {any} [rootGraph]
  * @property {(node: any) => WildcardQueueSeedContract | null} getNodeContract
  * @property {(node: any) => boolean} isOutputNode
  * @property {(node: any, contract: WildcardQueueSeedContract) => any} getSeed
@@ -214,7 +307,7 @@ function reservationWasAccepted(result, reservation, prompt) {
  */
 
 /**
- * Reserve top-level wildcard seeds in queue-only prompt clones.
+ * Reserve eligible wildcard seeds upstream of root output targets in queue-only prompt clones.
  * Live widgets advance only after ComfyUI accepts the corresponding queue.
  *
  * @param {AdvancedQueueSeedDependencies} dependencies
@@ -222,6 +315,7 @@ function reservationWasAccepted(result, reservation, prompt) {
 function createAdvancedQueueSeedRuntime(dependencies) {
   const {
     listNodes,
+    rootGraph = null,
     getNodeContract,
     isOutputNode,
     getSeed,
@@ -234,8 +328,8 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   let reservationId = 0;
 
   function forgetState(state) {
-    if (nodeStates.get(state.nodeId) === state) {
-      nodeStates.delete(state.nodeId);
+    if (nodeStates.get(state.stateKey) === state) {
+      nodeStates.delete(state.stateKey);
     }
     retiredStates.delete(state);
   }
@@ -243,8 +337,8 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   function retireState(state) {
     state.attached = false;
     if (state.reservations.length) {
-      if (nodeStates.get(state.nodeId) === state) {
-        nodeStates.delete(state.nodeId);
+      if (nodeStates.get(state.stateKey) === state) {
+        nodeStates.delete(state.stateKey);
       }
       retiredStates.add(state);
       return;
@@ -253,7 +347,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   }
 
   function retireCandidateState(candidate) {
-    const state = nodeStates.get(candidate.nodeId);
+    const state = nodeStates.get(candidate.stateKey);
     if (state) {
       retireState(state);
     }
@@ -265,10 +359,10 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     }
   }
 
-  function createState(node, nodeId, inputSeed, contract, blockUnknownExecuted) {
+  function createState(node, stateKey, inputSeed, contract, blockUnknownExecuted) {
     return {
       node,
-      nodeId,
+      stateKey,
       contract,
       attached: true,
       committedSeed: normalizeSeed(inputSeed),
@@ -279,15 +373,15 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     };
   }
 
-  function stateForNode(node, nodeId, inputSeed, contract) {
-    let state = nodeStates.get(nodeId);
+  function stateForNode(node, stateKey, inputSeed, contract) {
+    let state = nodeStates.get(stateKey);
     if (!state || state.node !== node) {
       const replacedState = state;
       if (replacedState) {
         retireState(replacedState);
       }
-      state = createState(node, nodeId, inputSeed, contract, !!replacedState);
-      nodeStates.set(nodeId, state);
+      state = createState(node, stateKey, inputSeed, contract, !!replacedState);
+      nodeStates.set(stateKey, state);
       return state;
     }
     state.attached = true;
@@ -329,7 +423,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
       committed
       && state.attached
       && state.node === node
-      && nodeStates.get(state.nodeId) === state
+      && nodeStates.get(state.stateKey) === state
     ) {
       try {
         updateSeed(node, state.committedSeed, state.contract);
@@ -365,18 +459,32 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (!isRecord(prompt) || !isRecord(output)) {
       return [];
     }
-    let nodes;
+    let entries;
+    let rootNodes;
     try {
-      nodes = listNodes();
+      if (rootGraph) {
+        entries = graphNodeEntries(rootGraph);
+        rootNodes = Array.isArray(rootGraph?._nodes) ? rootGraph._nodes : [];
+      } else {
+        const nodes = listNodes();
+        if (!Array.isArray(nodes)) {
+          return [];
+        }
+        rootNodes = nodes;
+        entries = nodes.map((node) => ({
+          node,
+          executionIds: [normalizeNodeId(node?.id)].filter((value) => value != null),
+        }));
+      }
     } catch {
       return [];
     }
-    if (!Array.isArray(nodes)) {
+    if (!Array.isArray(entries) || !Array.isArray(rootNodes)) {
       return [];
     }
     let targets = partialExecutionTargets(options, output);
     if (targets == null) {
-      targets = nodes.flatMap((node) => {
+      targets = rootNodes.flatMap((node) => {
         try {
           const nodeId = normalizeNodeId(node?.id);
           if (nodeId == null) {
@@ -392,35 +500,49 @@ function createAdvancedQueueSeedRuntime(dependencies) {
       return [];
     }
     const memo = new Map();
-    return nodes.flatMap((node) => {
+    return entries.flatMap((entry) => {
       try {
-        const nodeId = normalizeNodeId(node?.id);
-        const inputs = nodeId == null ? null : output[nodeId]?.inputs;
+        const node = entry?.node;
         const contract = node ? getNodeContract(node) : null;
-        if (
-          !node
-          || nodeId == null
-          || !contract
-          || !isRecord(inputs)
-        ) {
+        const stateKey = nodeStateKey(rootGraph, node);
+        if (!node || !contract || stateKey == null || !Array.isArray(entry.executionIds)) {
           return [];
         }
-        if (optionalSeed(inputs[contract.seedInputName]) == null) {
-          const state = nodeStates.get(nodeId);
+        const executionIds = entry.executionIds.filter((nodeId) => (
+          contract.supportsSubgraph === true || !String(nodeId).includes(":")
+        ));
+        const executions = executionIds.flatMap((nodeId) => {
+          const inputs = output[nodeId]?.inputs;
+          if (!isRecord(inputs)) {
+            return [];
+          }
+          const targetIds = targets.filter(
+            (targetId) => isUpstreamOf(output, nodeId, targetId, memo),
+          );
+          return targetIds.length ? [{ nodeId, inputs, targetIds }] : [];
+        });
+        if (!executions.length) {
+          return [];
+        }
+        const inputSeeds = executions.map(
+          ({ inputs }) => optionalSeed(inputs[contract.seedInputName]),
+        );
+        if (
+          inputSeeds.some((value) => value == null)
+          || inputSeeds.some((value) => value !== inputSeeds[0])
+        ) {
+          const state = nodeStates.get(stateKey);
           if (state) {
             // Unsafe 64-bit values stay entirely on the pre-existing backend
-            // path. Retire even pending safe reservations so a late accepted
-            // response can finish bookkeeping without publishing over the
-            // unsafe live widget or remaining authoritative for its backend
-            // onExecuted update.
+            // path. Multiple live instances that resolve the same definition
+            // node to different seeds are also backend-owned because one
+            // workflow definition cannot persist distinct current values.
             retireState(state);
           }
           return [];
         }
-        const targetIds = targets.filter(
-          (targetId) => isUpstreamOf(output, nodeId, targetId, memo),
-        );
-        return targetIds.length ? [{ node, nodeId, targetIds, contract }] : [];
+        const targetIds = [...new Set(executions.flatMap((value) => value.targetIds))];
+        return [{ node, stateKey, executions, targetIds, contract }];
       } catch {
         return [];
       }
@@ -446,31 +568,48 @@ function createAdvancedQueueSeedRuntime(dependencies) {
 
     const reservations = [];
     for (const candidate of candidates) {
-      const { node, nodeId, targetIds, contract } = candidate;
+      const { node, stateKey, executions, targetIds, contract } = candidate;
       try {
-        const inputs = queuedPrompt.output[nodeId]?.inputs;
-        const workflow = workflowNode(queuedPrompt.workflow, nodeId);
-        if (!isRecord(inputs) || !workflow || !Array.isArray(workflow.widgets_values)) {
+        const preparedExecutions = executions.map(({ nodeId }) => {
+          const inputs = queuedPrompt.output[nodeId]?.inputs;
+          const workflow = workflowNode(queuedPrompt.workflow, nodeId);
+          if (!isRecord(inputs) || !workflow || !Array.isArray(workflow.widgets_values)) {
+            return null;
+          }
+          const mode = normalizeMode(inputs[contract.modeInputName]);
+          const inputSeed = optionalSeed(inputs[contract.seedInputName]);
+          const effectiveControl = mode === "sequential"
+            ? "increment"
+            : normalizeControl(inputs[contract.controlInputName]);
+          return { nodeId, inputs, workflow, mode, inputSeed, effectiveControl };
+        });
+        if (preparedExecutions.some((value) => value == null)) {
           retireCandidateState(candidate);
           continue;
         }
-        const mode = normalizeMode(inputs[contract.modeInputName]);
+        const first = preparedExecutions[0];
+        const { workflow, mode, inputSeed, effectiveControl } = first;
         if (!ACTIVE_WILDCARD_MODES.has(mode)) {
           retireCandidateState(candidate);
           continue;
         }
-        const inputSeed = optionalSeed(inputs[contract.seedInputName]);
-        if (inputSeed == null) {
+        if (
+          inputSeed == null
+          || preparedExecutions.some((value) => (
+            value.workflow !== workflow
+            || value.mode !== mode
+            || value.inputSeed !== inputSeed
+            || value.effectiveControl !== effectiveControl
+          ))
+        ) {
           // JavaScript cannot reserve 64-bit backend seeds without losing
-          // precision. Preserve the original queue payload for those values.
+          // precision. Per-instance promoted values also stay backend-owned
+          // when one shared definition cannot persist one coherent state.
           retireCandidateState(candidate);
           continue;
         }
-        const state = stateForNode(node, nodeId, inputSeed, contract);
+        const state = stateForNode(node, stateKey, inputSeed, contract);
         const queuedSeed = reservedCurrentSeed(state);
-        const effectiveControl = mode === "sequential"
-          ? "increment"
-          : normalizeControl(inputs[contract.controlInputName]);
         const reservedNextSeed = nextSeed(
           queuedSeed,
           mode,
@@ -483,18 +622,22 @@ function createAdvancedQueueSeedRuntime(dependencies) {
         }
         workflowValues[contract.seedWidgetIndex] = queuedSeed;
         workflow.widgets_values = workflowValues;
-        inputs[RESERVED_NEXT_SEED_INPUT] = JSON.stringify({
+        const reservationInput = JSON.stringify({
           version: 1,
           current_seed: queuedSeed,
           next_seed: reservedNextSeed,
           mode,
           control: effectiveControl,
         });
-        inputs[contract.seedInputName] = queuedSeed;
+        for (const { inputs } of preparedExecutions) {
+          inputs[RESERVED_NEXT_SEED_INPUT] = reservationInput;
+          inputs[contract.seedInputName] = queuedSeed;
+        }
         const reservation = {
           id: ++reservationId,
           node,
-          nodeId,
+          nodeId: first.nodeId,
+          nodeIds: preparedExecutions.map((value) => value.nodeId),
           state,
           targetIds,
           queuedSeed,
@@ -559,12 +702,12 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (!node || !contract) {
       return false;
     }
-    const nodeId = normalizeNodeId(node.id);
-    if (nodeId == null) {
+    const stateKey = nodeStateKey(rootGraph, node);
+    if (stateKey == null) {
       return false;
     }
     const inputSeed = optionalSeed(getSeed(node, contract));
-    const existing = nodeStates.get(nodeId);
+    const existing = nodeStates.get(stateKey);
     if (inputSeed == null) {
       if (existing) {
         retireState(existing);
@@ -574,8 +717,8 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (existing?.node === node) {
       if (existing.reservations.length) {
         retireState(existing);
-        const state = createState(node, nodeId, inputSeed, contract, true);
-        nodeStates.set(nodeId, state);
+        const state = createState(node, stateKey, inputSeed, contract, true);
+        nodeStates.set(stateKey, state);
         return true;
       }
       existing.attached = true;
@@ -588,17 +731,17 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (existing) {
       retireState(existing);
     }
-    const state = createState(node, nodeId, inputSeed, contract, true);
-    nodeStates.set(nodeId, state);
+    const state = createState(node, stateKey, inputSeed, contract, true);
+    nodeStates.set(stateKey, state);
     return true;
   }
 
   function detachNode(node) {
-    const nodeId = normalizeNodeId(node?.id);
-    if (nodeId == null) {
+    const stateKey = nodeStateKey(rootGraph, node);
+    if (stateKey == null) {
       return false;
     }
-    const state = nodeStates.get(nodeId);
+    const state = nodeStates.get(stateKey);
     if (!state || state.node !== node) {
       return false;
     }
@@ -617,11 +760,11 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   }
 
   function shouldApplyExecutedSeed(node, value) {
-    const nodeId = normalizeNodeId(node?.id);
-    if (nodeId == null) {
+    const stateKey = nodeStateKey(rootGraph, node);
+    if (stateKey == null) {
       return true;
     }
-    const state = nodeStates.get(nodeId);
+    const state = nodeStates.get(stateKey);
     if (!state) {
       return true;
     }

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -146,7 +146,7 @@ function nodeStateKey(rootGraph, node) {
     return null;
   }
   const graph = node?.graph;
-  if (!rootGraph || !graph || graph === rootGraph || graph.isRootGraph === true) {
+  if (!graph || graph === rootGraph || graph.isRootGraph === true) {
     return nodeId;
   }
   const graphId = normalizeNodeId(graph.id);
@@ -297,6 +297,7 @@ function reservationWasAccepted(result, reservation, prompt) {
 /**
  * @typedef {object} AdvancedQueueSeedDependencies
  * @property {() => any[]} listNodes
+ * @property {() => any} [getRootGraph]
  * @property {any} [rootGraph]
  * @property {(node: any) => WildcardQueueSeedContract | null} getNodeContract
  * @property {(node: any) => boolean} isOutputNode
@@ -315,7 +316,8 @@ function reservationWasAccepted(result, reservation, prompt) {
 function createAdvancedQueueSeedRuntime(dependencies) {
   const {
     listNodes,
-    rootGraph = null,
+    getRootGraph = null,
+    rootGraph: initialRootGraph = null,
     getNodeContract,
     isOutputNode,
     getSeed,
@@ -326,6 +328,17 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   const nodeStates = new Map();
   const retiredStates = new Set();
   let reservationId = 0;
+
+  function resolveRootGraph() {
+    if (typeof getRootGraph === "function") {
+      try {
+        return getRootGraph() || initialRootGraph;
+      } catch {
+        return initialRootGraph;
+      }
+    }
+    return initialRootGraph;
+  }
 
   function forgetState(state) {
     if (nodeStates.get(state.stateKey) === state) {
@@ -459,6 +472,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (!isRecord(prompt) || !isRecord(output)) {
       return [];
     }
+    const rootGraph = resolveRootGraph();
     let entries;
     let rootNodes;
     try {
@@ -702,7 +716,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     if (!node || !contract) {
       return false;
     }
-    const stateKey = nodeStateKey(rootGraph, node);
+    const stateKey = nodeStateKey(resolveRootGraph(), node);
     if (stateKey == null) {
       return false;
     }
@@ -737,7 +751,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   }
 
   function detachNode(node) {
-    const stateKey = nodeStateKey(rootGraph, node);
+    const stateKey = nodeStateKey(resolveRootGraph(), node);
     if (stateKey == null) {
       return false;
     }
@@ -760,7 +774,7 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   }
 
   function shouldApplyExecutedSeed(node, value) {
-    const stateKey = nodeStateKey(rootGraph, node);
+    const stateKey = nodeStateKey(resolveRootGraph(), node);
     if (stateKey == null) {
       return true;
     }

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -132,6 +132,7 @@ const ADVANCED_QUEUE_SEED_CONTRACT = Object.freeze({
   seedInputName: "wildcard_seed",
   controlInputName: "wildcard_seed_after_generate",
   seedWidgetIndex: ADVANCED_WIDGET_INDEX.wildcard_seed,
+  supportsSubgraph: true,
 });
 const WILDCARD_QUEUE_SEED_CONTRACT = Object.freeze({
   modeInputName: "mode",
@@ -194,6 +195,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
 
   const advancedQueueSeedRuntime = createAdvancedQueueSeedRuntime({
     listNodes: () => app.graph?._nodes || [],
+    rootGraph: app.graph,
     getNodeContract(node) {
       if (isAdvancedNode(node)) {
         return ADVANCED_QUEUE_SEED_CONTRACT;

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -195,7 +195,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
 
   const advancedQueueSeedRuntime = createAdvancedQueueSeedRuntime({
     listNodes: () => app.graph?._nodes || [],
-    rootGraph: app.graph,
+    getRootGraph: () => app.graph,
     getNodeContract(node) {
       if (isAdvancedNode(node)) {
         return ADVANCED_QUEUE_SEED_CONTRACT;


### PR DESCRIPTION
## 변경 요약

- top-level output에 실제로 연결된 native subgraph 내부 `EasyUseAnimaPromptStudioAdvanced` / `AdvancedV2`의 queue seed를 colon execution ID 기준으로 예약합니다.
- 연속 queue에서 current/workflow seed가 서로 중복되지 않도록 예약하고, ComfyUI가 queue를 수락한 뒤에만 live widget seed를 commit합니다.
- disconnected/BYPASS/NEVER subgraph node, native Wildcard pass-through, shared definition 및 기존 Prompt Studio lifecycle을 보존합니다.
- ComfyUI extension 로드가 root graph 생성보다 먼저 일어나는 초기화 순서에 맞춰 `app.graph`를 lazy getter로 해석합니다.
- production wiring과 delayed-root native subgraph의 rapid 3 queue 계약을 자동 회귀 테스트로 고정합니다.

Closes #104

## 주요 파일

- `web/js/prompt_studio/advanced_queue_seed_runtime.js`
- `web/js/prompt_studio/extension_runtime.js`
- `tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs`
- `tests/test_frontend_modules.py`

## 검증

Focused:

- 변경 JS 및 smoke `node --check`: 통과
- Prompt Studio Advanced queue-seed runtime smoke: 통과
- Regional lifecycle smoke: 통과
- `test_frontend_modules.py`: 46/46
- reserved queue-next seed backend focused test: 1/1
- 독립 correctness/regression 감사: blocker/P1/P2 없음
- `git diff --check`: 통과

Official full runner:

- Python unittest: 393/393
- frontend smoke: 102 JavaScript files
- TypeScript: 6.0.3
- git diff check: 통과

Live browser smoke — ComfyUI 0.27.0 / frontend 1.45.20:

- Legacy canvas: native subgraph `50:10`, batch 3 모두 success/completed
  - input/workflow seed: `7, 8, 9`
  - backend output next seed: `8, 9, 10`
  - queue 완료 후 live widget seed: `10`
- Node 2.0: 동일 matrix 통과
- 두 표면 모두 EasyUse Anima browser error 없음
- 알려진 ComfyUI core의 `ComfyApp graph accessed before initialization` 1건씩만 관찰

초기 Legacy gate에서는 기존 구현이 module load 시 `app.graph`의 undefined 값을 영구 캡처해 세 queue가 모두 seed 7을 사용했습니다. 해당 증거는 폐기했고, lazy graph 수정 및 회귀 테스트 보강 후 최종 diff에서 official full/Legacy/Node 2.0을 모두 다시 실행했습니다.

## 남은 위험 / 비차단 gap

- colon execution ID와 `partialExecutionTargets` + non-empty `node_errors`를 함께 다루는 direct settlement test
- subgraph detach/clear의 direct lifecycle test
- 서로 다른 definition이 같은 local node ID를 쓰는 direct lifecycle test

위 항목은 현재 production correctness blocker로 판단되지 않았습니다.