### PR TITLE
fix: reserve Regional Prompt Studio queue seeds

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -10890,6 +10890,14 @@ class EasyUseAnimaPromptStudioRegional:
             if wildcard_mode_key == WILDCARD_MODE_SEQUENTIAL
             else str(wildcard_seed_after_generate or SEED_CONTROL_FIXED)
         )
+        reserved_next_wildcard_seed = _consume_reserved_wildcard_next_seed(
+            field_inputs,
+            workflow_prompt,
+            unique_id,
+            wildcard_seed_value,
+            wildcard_mode_key,
+            wildcard_effective_seed_control,
+        )
         ui_updates: dict[str, Any] = {}
         metadata_updates: dict[str, Any] = {}
 
@@ -10906,7 +10914,11 @@ class EasyUseAnimaPromptStudioRegional:
         effective_fields = _translate_prompt_fields(effective_fields)
         wildcard_changed = bool(saved_wildcard["changed"] or effective_wildcard["changed"])
         if wildcard_mode_key in {WILDCARD_MODE_POPULATE, WILDCARD_MODE_FIXED, WILDCARD_MODE_SEQUENTIAL}:
-            next_wildcard_seed = next_seed(wildcard_seed_value, wildcard_effective_seed_control)
+            next_wildcard_seed = (
+                reserved_next_wildcard_seed
+                if reserved_next_wildcard_seed is not None
+                else next_seed(wildcard_seed_value, wildcard_effective_seed_control)
+            )
             ui_updates.update({
                 "wildcard_mode": str(wildcard_mode or WILDCARD_MODE_LABELS[1]),
                 "wildcard_seed": next_wildcard_seed,

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -153,8 +153,10 @@ for (const surface of ["Advanced", "Regional"]) {
 const ADVANCED = "EasyUseAnimaPromptStudioAdvanced";
 const ADVANCED_V2 = "EasyUseAnimaPromptStudioAdvancedV2";
 const WILDCARD = "EasyUseAnimaWildcard";
+const REGIONAL = "EasyUseAnimaPromptStudioRegional";
 const SEED_INDEX = 11;
 const WILDCARD_SEED_INDEX = 3;
+const REGIONAL_SEED_INDEX = 7;
 const RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed";
 const ADVANCED_QUEUE_SEED_CONTRACT = Object.freeze({
   modeInputName: "wildcard_mode",
@@ -168,6 +170,13 @@ const WILDCARD_QUEUE_SEED_CONTRACT = Object.freeze({
   seedInputName: "seed",
   controlInputName: "seed_after_generate",
   seedWidgetIndex: WILDCARD_SEED_INDEX,
+});
+const REGIONAL_QUEUE_SEED_CONTRACT = Object.freeze({
+  modeInputName: "wildcard_mode",
+  seedInputName: "wildcard_seed",
+  controlInputName: "wildcard_seed_after_generate",
+  seedWidgetIndex: REGIONAL_SEED_INDEX,
+  supportsSubgraph: false,
 });
 
 const nodeHookConstants = sourceModule(`
@@ -227,6 +236,10 @@ function wildcardWidgetValues(seed, mode = "순차", control = "increment") {
   return ["__style__", "", mode, seed, control];
 }
 
+function regionalWidgetValues(seed, mode = "순차", control = "increment") {
+  return ["[]", "{}", "1024", "1024 * 1024 (1:1)", 1024, 1024, mode, seed, control];
+}
+
 function advancedNode(id, type = ADVANCED, seed = 7) {
   return {
     id,
@@ -255,9 +268,25 @@ function wildcardNode(id, seed = 7) {
   };
 }
 
+function regionalNode(id, seed = 7) {
+  return {
+    id,
+    type: REGIONAL,
+    comfyClass: REGIONAL,
+    widgets: [
+      { name: "wildcard_mode", value: "순차" },
+      { name: "wildcard_seed", value: seed },
+      { name: "wildcard_seed_after_generate", value: "increment" },
+    ],
+  };
+}
+
 function queueSeedContract(node) {
   if ([ADVANCED, ADVANCED_V2].includes(node?.type)) {
     return ADVANCED_QUEUE_SEED_CONTRACT;
+  }
+  if (node?.type === REGIONAL) {
+    return REGIONAL_QUEUE_SEED_CONTRACT;
   }
   return node?.type === WILDCARD ? WILDCARD_QUEUE_SEED_CONTRACT : null;
 }
@@ -270,20 +299,31 @@ function promptFor(nodes, options = {}) {
     const mode = node.widgets.find((widget) => widget.name === contract.modeInputName).value;
     const seed = node.widgets.find((widget) => widget.name === contract.seedInputName).value;
     const control = node.widgets.find((widget) => widget.name === contract.controlInputName).value;
-    const inputs = node.type === WILDCARD
-      ? {
+    let inputs;
+    if (node.type === WILDCARD) {
+      inputs = {
           text: "__style__",
           populated_text: "",
           mode,
           seed,
           seed_after_generate: control,
-        }
-      : {
+        };
+    } else if (node.type === REGIONAL) {
+      inputs = {
+          regional_fields: "[]",
+          regional_config: "{}",
+          wildcard_mode: mode,
+          wildcard_seed: seed,
+          wildcard_seed_after_generate: control,
+        };
+    } else {
+      inputs = {
           advanced_fields: "[]",
           wildcard_mode: mode,
           wildcard_seed: seed,
           wildcard_seed_after_generate: control,
         };
+    }
     output[String(node.id)] = {
       class_type: node.type,
       inputs,
@@ -293,7 +333,9 @@ function promptFor(nodes, options = {}) {
       type: node.type,
       widgets_values: node.type === WILDCARD
         ? wildcardWidgetValues(seed, mode, control)
-        : widgetValues(seed, mode, control),
+        : (node.type === REGIONAL
+          ? regionalWidgetValues(seed, mode, control)
+          : widgetValues(seed, mode, control)),
     });
   }
   const consumers = Object.prototype.hasOwnProperty.call(options, "consumers")
@@ -369,15 +411,25 @@ function seedPromptInputs(node) {
   const mode = node.widgets.find((widget) => widget.name === contract.modeInputName).value;
   const seed = node.widgets.find((widget) => widget.name === contract.seedInputName).value;
   const control = node.widgets.find((widget) => widget.name === contract.controlInputName).value;
-  return node.type === WILDCARD
-    ? {
+  if (node.type === WILDCARD) {
+    return {
         text: "__style__",
         populated_text: "",
         mode,
         seed,
         seed_after_generate: control,
-      }
-    : {
+      };
+  }
+  if (node.type === REGIONAL) {
+    return {
+        regional_fields: "[]",
+        regional_config: "{}",
+        wildcard_mode: mode,
+        wildcard_seed: seed,
+        wildcard_seed_after_generate: control,
+      };
+  }
+  return {
         advanced_fields: "[]",
         wildcard_mode: mode,
         wildcard_seed: seed,
@@ -392,11 +444,17 @@ function seedWorkflowNode(node) {
     type: node.type,
     widgets_values: node.type === WILDCARD
       ? wildcardWidgetValues(inputs.seed, inputs.mode, inputs.seed_after_generate)
-      : widgetValues(
+      : (node.type === REGIONAL
+        ? regionalWidgetValues(
           inputs.wildcard_seed,
           inputs.wildcard_mode,
           inputs.wildcard_seed_after_generate,
-        ),
+        )
+        : widgetValues(
+          inputs.wildcard_seed,
+          inputs.wildcard_mode,
+          inputs.wildcard_seed_after_generate,
+        )),
   };
 }
 
@@ -552,17 +610,13 @@ function registerWildcardRuntimeHooks(nodeType, runtime) {
 
 function queuedSeed(prompt, nodeId) {
   const promptNode = prompt.output[String(nodeId)];
-  const contract = promptNode.class_type === WILDCARD
-    ? WILDCARD_QUEUE_SEED_CONTRACT
-    : ADVANCED_QUEUE_SEED_CONTRACT;
+  const contract = queueSeedContract({ type: promptNode.class_type });
   return promptNode.inputs[contract.seedInputName];
 }
 
 function workflowSeed(prompt, nodeId) {
   const promptNode = prompt.output[String(nodeId)];
-  const contract = promptNode.class_type === WILDCARD
-    ? WILDCARD_QUEUE_SEED_CONTRACT
-    : ADVANCED_QUEUE_SEED_CONTRACT;
+  const contract = queueSeedContract({ type: promptNode.class_type });
   const nodeIds = String(nodeId).split(":");
   const definitions = new Map(
     (prompt.workflow.definitions?.subgraphs || []).map((definition) => [
@@ -1999,6 +2053,208 @@ function reservedSeedState(prompt, nodeId) {
   const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
   assert.equal(await wrapped(0, promptFor(fixture.nodes)), result);
   assert.equal(fixture.nodes[0].widgets[1].value, 7);
+}
+
+{
+  const node = regionalNode(30, 7);
+  const fixture = createFixture({ nodes: [node] });
+  const gates = [deferred(), deferred(), deferred()];
+  const queued = [];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queued.push({
+      current: queuedSeed(prompt, node.id),
+      workflow: workflowSeed(prompt, node.id),
+      next: reservedNextSeed(prompt, node.id),
+    });
+    return gates[queued.length - 1].promise;
+  });
+  const pending = [
+    wrapped(0, promptFor([node])),
+    wrapped(0, promptFor([node])),
+    wrapped(0, promptFor([node])),
+  ];
+
+  assert.deepEqual(queued, [
+    { current: 7, workflow: 7, next: 8 },
+    { current: 8, workflow: 8, next: 9 },
+    { current: 9, workflow: 9, next: 10 },
+  ]);
+  assert.equal(node.widgets[1].value, 7, "Regional live seed changes only after acceptance");
+
+  gates[1].resolve({ prompt_id: "regional-second", node_errors: {} });
+  await pending[1];
+  assert.equal(node.widgets[1].value, 7, "Regional out-of-order settlement must wait for FIFO");
+  gates[0].resolve({ node_errors: {} });
+  await pending[0];
+  assert.equal(node.widgets[1].value, 9, "a missing prompt_id rolls back only its reservation");
+  gates[2].resolve({ prompt_id: "regional-third", node_errors: {} });
+  await pending[2];
+  assert.equal(node.widgets[1].value, 10);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 8), false);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 10), true);
+}
+
+{
+  const node = regionalNode(30, 7);
+  const fixture = createFixture({ nodes: [node] });
+  const seen = [];
+  const results = [
+    { prompt_id: "   ", node_errors: {} },
+    { prompt_id: "regional-retry", node_errors: {} },
+  ];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    seen.push(queuedSeed(prompt, node.id));
+    return results.shift();
+  });
+  await wrapped(0, promptFor([node]));
+  assert.equal(node.widgets[1].value, 7, "an empty Regional prompt_id must not advance live state");
+  await wrapped(0, promptFor([node]));
+  assert.deepEqual(seen, [7, 7], "a rejected Regional seed must remain reusable");
+  assert.equal(node.widgets[1].value, 8);
+}
+
+{
+  const nodes = [regionalNode(30, 7), regionalNode(31, 30)];
+  const outputNodes = [{ id: 40, outputNode: true }, { id: 41, outputNode: true }];
+  const fixture = createFixture({ nodes, outputNodes });
+  const prompt = promptFor(nodes, {
+    consumers: [
+      { id: 40, source: 30 },
+      { id: 41, source: 31 },
+    ],
+  });
+  let received = null;
+  const rejected = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return {
+      prompt_id: "regional-partial-error",
+      node_errors: {
+        30: { dependent_outputs: ["40"] },
+      },
+    };
+  });
+  await rejected(0, prompt, { partialExecutionTargets: [40] });
+  assert.equal(reservedNextSeed(received, 30), 8);
+  assert.equal(reservedSeedState(received, 31), undefined);
+  assert.equal(nodes[0].widgets[1].value, 7, "a related Regional node_error must rollback");
+  assert.equal(nodes[1].widgets[1].value, 30, "a disjoint partial target must not consume seed");
+
+  const accepted = fixture.runtime.wrapQueuePrompt(() => ({
+    prompt_id: "regional-partial-valid",
+    node_errors: {},
+  }));
+  await accepted(0, promptFor(nodes, {
+    consumers: [
+      { id: 40, source: 30 },
+      { id: 41, source: 31 },
+    ],
+  }), { partialExecutionTargets: [40] });
+  assert.equal(nodes[0].widgets[1].value, 8);
+  assert.equal(nodes[1].widgets[1].value, 30);
+}
+
+{
+  const nodes = [regionalNode(30, 7), regionalNode(31, 30)];
+  const fixture = createFixture({
+    nodes,
+    outputNodes: [{ id: 40, outputNode: true }],
+  });
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    received = prompt;
+    return { prompt_id: "regional-connected-only", node_errors: {} };
+  });
+  await wrapped(0, promptFor(nodes, {
+    consumers: [{ id: 40, source: 30 }],
+  }));
+  assert.equal(nodes[0].widgets[1].value, 8);
+  assert.equal(nodes[1].widgets[1].value, 30, "a disconnected Regional node must not consume seed");
+  assert.equal(reservedNextSeed(received, 30), 8);
+  assert.equal(reservedSeedState(received, 31), undefined);
+}
+
+{
+  const node = regionalNode(30, 7);
+  const fixture = createFixture({ nodes: [node] });
+  const failure = new Error("Regional queue rejected");
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => Promise.reject(failure));
+  await assert.rejects(wrapped(0, promptFor([node])), (error) => error === failure);
+  assert.equal(node.widgets[1].value, 7, "a thrown Regional queue must rollback its reservation");
+}
+
+{
+  const node = regionalNode(30, 7);
+  const fixture = createFixture({ nodes: [node], cloneError: new Error("Regional clone failed") });
+  assert.equal(fixture.runtime.attachNode(node), true);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 8), false);
+  const prompt = promptFor([node]);
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "regional-clone-pass-through", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+  assert.equal(received, prompt);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, 8),
+    true,
+    "Regional clone failure must release the configured authority guard",
+  );
+}
+
+{
+  const node = regionalNode(30, 7);
+  const fixture = createFixture({ nodes: [node] });
+  assert.equal(fixture.runtime.attachNode(node), true);
+  const prompt = promptFor([node]);
+  prompt.workflow.nodes = prompt.workflow.nodes.filter(
+    (workflowNodeValue) => String(workflowNodeValue.id) !== String(node.id),
+  );
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "regional-workflow-pass-through", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+  assert.equal(received, prompt);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, 8),
+    true,
+    "Regional workflow preparation failure must release the unmanaged guard",
+  );
+}
+
+{
+  const node = regionalNode(30, 7);
+  const fixture = createSubgraphFixture({ nodes: [node] });
+  const prompt = subgraphPromptFor(fixture, {
+    connections: [{ executionId: "50:30", targetId: 20 }],
+  });
+  let received = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, nextPrompt) => {
+    received = nextPrompt;
+    return { prompt_id: "regional-colon-pass-through", node_errors: {} };
+  });
+  await wrapped(0, prompt);
+  assert.equal(received, prompt, "Regional colon execution ids must remain backend-owned");
+  assert.equal(fixture.cloneCalls(), 0);
+  assert.equal(node.widgets[1].value, 7);
+  assert.equal(reservedSeedState(prompt, "50:30"), undefined);
+}
+
+{
+  const node = regionalNode(30, 7);
+  const fixture = createFixture({ nodes: [node] });
+  const gate = deferred();
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => gate.promise);
+  const pending = wrapped(0, promptFor([node]));
+  fixture.runtime.clearGraphNodes();
+  gate.resolve({ prompt_id: "regional-retired-on-clear", node_errors: {} });
+  await pending;
+  assert.equal(node.widgets[1].value, 7, "graph clear must retire Regional publish authority");
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
 }
 
 console.log("Frontend Prompt Studio Advanced queue seed runtime smoke passed.");

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -1610,6 +1610,8 @@ function reservedSeedState(prompt, nodeId) {
 {
   const node = wildcardNode(15, 7);
   const fixture = createSubgraphFixture({ nodes: [node] });
+  assert.equal(fixture.runtime.attachNode(node), true);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 8), false);
   const prompt = subgraphPromptFor(fixture, {
     connections: [{ executionId: "50:15", targetId: 20 }],
   });
@@ -1624,6 +1626,18 @@ function reservedSeedState(prompt, nodeId) {
   assert.equal(reservedSeedState(received, "50:15"), undefined);
   assert.equal(node.widgets.find((widget) => widget.name === "seed").value, 7);
   assert.equal(fixture.cloneCalls(), 0);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, 8),
+    true,
+    "native Wildcard colon pass-through must release the configured guard",
+  );
+  wildcardValuesModule.applyWildcardExecutedInputs(
+    node,
+    { wildcard: [{ seed: 8 }] },
+    fixture.runtime,
+  );
+  assert.equal(node.widgets.find((widget) => widget.name === "seed").value, 8);
 }
 
 {
@@ -2229,6 +2243,8 @@ function reservedSeedState(prompt, nodeId) {
 {
   const node = regionalNode(30, 7);
   const fixture = createSubgraphFixture({ nodes: [node] });
+  assert.equal(fixture.runtime.attachNode(node), true);
+  assert.equal(fixture.runtime.shouldApplyExecutedSeed(node, 8), false);
   const prompt = subgraphPromptFor(fixture, {
     connections: [{ executionId: "50:30", targetId: 20 }],
   });
@@ -2242,6 +2258,12 @@ function reservedSeedState(prompt, nodeId) {
   assert.equal(fixture.cloneCalls(), 0);
   assert.equal(node.widgets[1].value, 7);
   assert.equal(reservedSeedState(prompt, "50:30"), undefined);
+  assert.equal(fixture.runtime.trackedStateCount(), 0);
+  assert.equal(
+    fixture.runtime.shouldApplyExecutedSeed(node, 8),
+    true,
+    "Regional colon pass-through must release the configured guard",
+  );
 }
 
 {

--- a/tests/frontend_regional_runtime_smoke.mjs
+++ b/tests/frontend_regional_runtime_smoke.mjs
@@ -48,6 +48,11 @@ const schemaUrl = dataModule("../web/js/prompt_studio/regional/schema.js", {
   "./mask_geometry.js": maskGeometryUrl,
   "./resolution.js": resolutionUrl,
 });
+const serializationUrl = dataModule("../web/js/prompt_studio/regional/serialization.js", {
+  "./constants.js": constantsUrl,
+  "./schema.js": schemaUrl,
+});
+const queueSeedBridgeUrl = dataModule("../web/js/prompt_studio/queue_seed_bridge.js");
 const lifecycleUrl = dataModule("../web/js/prompt_studio/regional/lifecycle.js");
 const layoutUrl = dataModule("../web/js/prompt_studio/regional/layout.js", {
   "./lifecycle.js": lifecycleUrl,
@@ -56,6 +61,13 @@ const extensionUrl = dataModule("../web/js/prompt_studio/regional/extension.js",
   "./constants.js": constantsUrl,
   "./lifecycle.js": lifecycleUrl,
   "./layout.js": layoutUrl,
+  "../queue_seed_bridge.js": queueSeedBridgeUrl,
+});
+const regionalRuntimeUrl = dataModule("../web/js/prompt_studio/regional/runtime.js", {
+  "./constants.js": constantsUrl,
+  "./resolution.js": resolutionUrl,
+  "./schema.js": schemaUrl,
+  "./serialization.js": serializationUrl,
 });
 const fieldEditorUrl = dataModule("../web/js/prompt_studio/regional/field_editor.js", {
   "./constants.js": constantsUrl,
@@ -68,6 +80,8 @@ const fieldEditorUrl = dataModule("../web/js/prompt_studio/regional/field_editor
 const lifecycle = await import(lifecycleUrl);
 const extension = await import(extensionUrl);
 const fieldEditor = await import(fieldEditorUrl);
+const queueSeedBridgeModule = await import(queueSeedBridgeUrl);
+const regionalRuntimeModule = await import(regionalRuntimeUrl);
 
 const lifecycleNode = {};
 lifecycle.activateRegionalNodeLifecycle(lifecycleNode);
@@ -148,6 +162,7 @@ for (const [name, value] of Object.entries({
 
 const hookCalls = [];
 const hooks = {
+  attachQueueSeedNode: (node) => hookCalls.push(["attach", node]),
   applyRegionalExecutedInputs: (node) => hookCalls.push(["executed", node]),
   captureRegionalConfigure: (node) => hookCalls.push(["configure", node]),
   disposeRegionalNode: (node) => {
@@ -176,7 +191,178 @@ assert(node.onRemoved() === returns.removed, "onRemoved return value changed");
 assert(originalThis.every(([, value]) => value === node), "A Regional wrapper changed original this");
 flushFrames();
 assert(!hookCalls.some(([name]) => name === "render"), "Connection callback ran after node removal");
+assert(hookCalls.filter(([name]) => name === "attach").length === 1, "Configure did not attach Regional queue state");
 assert(hookCalls.filter(([name]) => name === "dispose").length === 1, "Node removal cleanup count changed");
+
+const runtimeApp = {
+  graph: {
+    links: {},
+    setDirtyCanvas() {},
+  },
+};
+const regionalRuntime = regionalRuntimeModule.createRegionalRuntime(runtimeApp);
+const guardedNode = {
+  widgets: [
+    { name: "regional_fields", value: "[]" },
+    { name: "regional_config", value: "{}" },
+    { name: "resolution_bucket", value: "1024" },
+    { name: "resolution_size", value: "1024 * 1024 (1:1)" },
+    { name: "resolution_custom_width", value: 1024 },
+    { name: "resolution_custom_height", value: 1024 },
+    { name: "wildcard_mode", value: "고정" },
+    { name: "wildcard_seed", value: 30 },
+    { name: "wildcard_seed_after_generate", value: "fixed" },
+  ],
+  inputs: [],
+  properties: {},
+  addInput(name, type) {
+    this.inputs.push({ name, type, link: null });
+  },
+  removeInput(index) {
+    this.inputs.splice(index, 1);
+  },
+  setDirtyCanvas() {},
+};
+const executedPayload = {
+  prompt_studio_regional: [{
+    regional_fields: [{
+      id: "p1",
+      pane: "positive",
+      type: "general",
+      label: "General",
+      text: "queued field",
+      enabled: true,
+    }],
+    regional_config: { masks: [], next_mask_id: 1 },
+    field_inputs: { field_p1: "linked field" },
+    wildcard_mode: "일반 채우기",
+    wildcard_seed: 8,
+    wildcard_seed_after_generate: "randomize",
+  }],
+};
+assert(
+  regionalRuntime.applyRegionalExecutedInputs(guardedNode, executedPayload, {
+    shouldApplyExecutedSeed: () => false,
+  }),
+  "Regional executed payload was not applied",
+);
+assert(
+  regionalRuntime.findWidget(guardedNode, "wildcard_seed").value === 30,
+  "A stale Regional executed seed replaced shared runtime authority",
+);
+assert(
+  regionalRuntime.findWidget(guardedNode, "wildcard_mode").value === "일반 채우기",
+  "Regional executed mode was blocked with the stale seed",
+);
+assert(
+  regionalRuntime.findWidget(guardedNode, "wildcard_seed_after_generate").value === "randomize",
+  "Regional executed control was blocked with the stale seed",
+);
+assert(
+  guardedNode.__easyuseAnimaRegionalFieldInputValues.field_p1 === "linked field",
+  "Regional executed field inputs were blocked with the stale seed",
+);
+assert(
+  regionalRuntime.applyRegionalExecutedInputs(
+    guardedNode,
+    { prompt_studio_regional: [{ wildcard_seed: 31 }] },
+    { shouldApplyExecutedSeed: () => true },
+  ),
+  "An authoritative Regional executed seed payload was not applied",
+);
+assert(
+  regionalRuntime.findWidget(guardedNode, "wildcard_seed").value === 31,
+  "An authoritative Regional executed seed stayed blocked",
+);
+
+const bridgeApp = { graph: { _nodes: [] } };
+const bridge = queueSeedBridgeModule.promptStudioQueueSeedBridge(bridgeApp);
+const bridgeCalls = [];
+bridge.bindRuntime({
+  attachNode(node) {
+    bridgeCalls.push(["attach", node]);
+    return true;
+  },
+  detachNode(node) {
+    bridgeCalls.push(["detach", node]);
+    return true;
+  },
+  shouldApplyExecutedSeed(node, value) {
+    bridgeCalls.push(["guard", node, value]);
+    return false;
+  },
+});
+const bridgeRuntime = {
+  applyRegionalExecutedInputs(node, message, options) {
+    bridgeCalls.push([
+      "executed",
+      node,
+      message,
+      options.shouldApplyExecutedSeed(node, message.seed),
+    ]);
+    return true;
+  },
+  captureRegionalConfigure() {},
+  isRegionalNode: (node) => node?.type === "EasyUseAnimaPromptStudioRegional",
+  pruneDisconnectedRegionalFieldInputValues() {},
+  removeRegionalInternalInputSockets() {},
+  repairRegionalConditioningWidgets() {},
+  setRegionalWidgetValue(node, name, value) {
+    bridgeCalls.push(["publish", node, name, value]);
+    return true;
+  },
+  syncRegionalValues() {},
+};
+const bridgeFieldEditor = {
+  collectRegionalEditorFields: () => [],
+  renderRegionalEditor: (node) => bridgeCalls.push(["render", node]),
+};
+const bridgeExtension = extension.createRegionalExtensionRuntime(
+  bridgeApp,
+  bridgeRuntime,
+  {
+    regionalEditorMinimumHeight: () => 0,
+    regionalEditorWidgetHeight: () => 0,
+    scheduleRegionalLayout() {},
+  },
+  bridgeFieldEditor,
+  {
+    ensureRegionalStyle() {},
+    installRegionalAdapter() {},
+  },
+);
+function BridgeRegionalNodeType() {}
+await bridgeExtension.beforeRegisterNodeDef(BridgeRegionalNodeType, {
+  name: "EasyUseAnimaPromptStudioRegional",
+});
+const bridgeNode = Object.assign(new BridgeRegionalNodeType(), {
+  type: "EasyUseAnimaPromptStudioRegional",
+});
+bridgeNode.onConfigure({});
+bridgeNode.onExecuted({ seed: 8 });
+assert(bridge.publishRegionalSeed(bridgeNode, 9), "Regional live seed publisher was not bound");
+bridgeNode.onRemoved();
+assert(
+  bridgeCalls.some(([name, target]) => name === "attach" && target === bridgeNode),
+  "Regional configure did not reach the shared runtime owner",
+);
+assert(
+  bridgeCalls.some(([name, target, value]) => name === "guard" && target === bridgeNode && value === 8),
+  "Regional onExecuted did not use the shared authority guard",
+);
+assert(
+  bridgeCalls.some(([name, target]) => name === "detach" && target === bridgeNode),
+  "Regional removal did not detach shared queue state",
+);
+assert(
+  bridgeCalls.some(([name, target, widgetName, value]) => (
+    name === "publish"
+    && target === bridgeNode
+    && widgetName === "wildcard_seed"
+    && value === 9
+  )),
+  "Accepted Regional seed did not publish through the Regional runtime",
+);
 
 function ConditioningNodeType() {}
 const conditioningReturn = Symbol("conditioning");

--- a/tests/test_prompt_studio_regional.py
+++ b/tests/test_prompt_studio_regional.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from unittest.mock import patch
 
 import nodes as easy_nodes
 from nodes import (
@@ -253,6 +254,97 @@ class PromptStudioRegionalTests(unittest.TestCase):
             result["ui"]["prompt_studio_regional"][0]["field_inputs"],
             {"field_masked_general": "blue hair girl"},
         )
+
+    def test_build_consumes_reserved_queue_seed_and_scrubs_token(self):
+        reservation_key = easy_nodes.WILDCARD_RESERVED_NEXT_SEED_INPUT
+        reservation = json.dumps({
+            "version": 1,
+            "current_seed": 2,
+            "next_seed": 47,
+            "mode": "populate",
+            "control": "randomize",
+        })
+        workflow_prompt = {
+            "42": {
+                "inputs": {
+                    "wildcard_mode": "일반 채우기",
+                    "wildcard_seed": 2,
+                    "wildcard_seed_after_generate": "randomize",
+                    reservation_key: reservation,
+                }
+            }
+        }
+        extra_pnginfo = {
+            "workflow": {
+                "nodes": [{
+                    "id": 42,
+                    "type": "EasyUseAnimaPromptStudioRegional",
+                    "widgets_values": [
+                        "[]",
+                        "{}",
+                        "1024",
+                        "1024 * 1024 (1:1)",
+                        1024,
+                        1024,
+                        "일반 채우기",
+                        2,
+                        "randomize",
+                    ],
+                    "properties": {},
+                }]
+            }
+        }
+
+        with patch("nodes.next_seed") as fallback_next_seed:
+            result = EasyUseAnimaPromptStudioRegional().build(
+                "",
+                "",
+                wildcard_mode="일반 채우기",
+                wildcard_seed=2,
+                wildcard_seed_after_generate="randomize",
+                workflow_prompt=workflow_prompt,
+                extra_pnginfo=extra_pnginfo,
+                unique_id="42",
+                **{reservation_key: reservation},
+            )
+
+        fallback_next_seed.assert_not_called()
+        payload = result["ui"]["prompt_studio_regional"][0]
+        self.assertEqual(payload["wildcard_seed"], 47)
+        self.assertNotIn(reservation_key, payload["field_inputs"])
+        self.assertNotIn(reservation_key, workflow_prompt["42"]["inputs"])
+        self.assertEqual(extra_pnginfo["workflow"]["nodes"][0]["widgets_values"][7], 2)
+
+    def test_invalid_reserved_queue_seed_scrubs_token_and_uses_fallback(self):
+        reservation_key = easy_nodes.WILDCARD_RESERVED_NEXT_SEED_INPUT
+        mismatched_reservation = json.dumps({
+            "version": 1,
+            "current_seed": 2,
+            "next_seed": 47,
+            "mode": "populate",
+            "control": "randomize",
+        })
+        workflow_prompt = {
+            "42": {"inputs": {reservation_key: mismatched_reservation}}
+        }
+
+        with patch("nodes.next_seed", return_value=3) as fallback_next_seed:
+            result = EasyUseAnimaPromptStudioRegional().build(
+                "",
+                "",
+                wildcard_mode="순차",
+                wildcard_seed=2,
+                wildcard_seed_after_generate="increment",
+                workflow_prompt=workflow_prompt,
+                unique_id="42",
+                **{reservation_key: mismatched_reservation},
+            )
+
+        fallback_next_seed.assert_called_once_with(2, "increment")
+        payload = result["ui"]["prompt_studio_regional"][0]
+        self.assertEqual(payload["wildcard_seed"], 3)
+        self.assertNotIn(reservation_key, payload["field_inputs"])
+        self.assertNotIn(reservation_key, workflow_prompt["42"]["inputs"])
 
 
 if __name__ == "__main__":

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -525,6 +525,17 @@ function createAdvancedQueueSeedRuntime(dependencies) {
         const executionIds = entry.executionIds.filter((nodeId) => (
           contract.supportsSubgraph === true || !String(nodeId).includes(":")
         ));
+        if (!executionIds.length && entry.executionIds.length) {
+          const state = nodeStates.get(stateKey);
+          if (state) {
+            // Top-level-only contracts remain backend-owned when their only
+            // executions are colon-qualified subgraph instances. Release the
+            // configured authority guard so backend next-seed metadata can
+            // settle the live widget after the unmanaged queue completes.
+            retireState(state);
+          }
+          return [];
+        }
         const executions = executionIds.flatMap((nodeId) => {
           const inputs = output[nodeId]?.inputs;
           if (!isRecord(inputs)) {

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -109,6 +109,13 @@ import {
   installAdvancedQueueSeedQueueHook,
 } from "./advanced_queue_seed_runtime.js";
 import {
+  promptStudioQueueSeedBridge,
+} from "./queue_seed_bridge.js";
+import {
+  REGIONAL_NODE_TYPE,
+  REGIONAL_WIDGET_INDEX,
+} from "./regional/constants.js";
+import {
   applyWildcardExecutedInputs as applyWildcardExecutedInputsWithHooks,
   hookWildcardSeedWidget,
   setRegularWidgetValue,
@@ -140,8 +147,21 @@ const WILDCARD_QUEUE_SEED_CONTRACT = Object.freeze({
   controlInputName: "seed_after_generate",
   seedWidgetIndex: 3,
 });
+const REGIONAL_QUEUE_SEED_CONTRACT = Object.freeze({
+  modeInputName: "wildcard_mode",
+  seedInputName: "wildcard_seed",
+  controlInputName: "wildcard_seed_after_generate",
+  seedWidgetIndex: REGIONAL_WIDGET_INDEX.wildcard_seed,
+  supportsSubgraph: false,
+});
+
+function isRegionalQueueSeedNode(node) {
+  return node?.type === REGIONAL_NODE_TYPE || node?.comfyClass === REGIONAL_NODE_TYPE;
+}
 
 function createPromptStudioExtensionRuntime(app, api = null) {
+  const queueSeedBridge = promptStudioQueueSeedBridge(app);
+
   function markNodeDirty(node) {
     markNodeDirtyWithApp(app, node);
   }
@@ -200,6 +220,9 @@ function createPromptStudioExtensionRuntime(app, api = null) {
       if (isAdvancedNode(node)) {
         return ADVANCED_QUEUE_SEED_CONTRACT;
       }
+      if (isRegionalQueueSeedNode(node)) {
+        return REGIONAL_QUEUE_SEED_CONTRACT;
+      }
       return isWildcardNode(node) ? WILDCARD_QUEUE_SEED_CONTRACT : null;
     },
     isOutputNode: (node) => node?.constructor?.nodeData?.output_node === true,
@@ -209,6 +232,19 @@ function createPromptStudioExtensionRuntime(app, api = null) {
         if (!setRegularWidgetValue(node, "seed", seed, { markNodeDirty })) {
           throw new Error("Anima Wildcard seed widget is unavailable.");
         }
+        return;
+      }
+      if (contract === REGIONAL_QUEUE_SEED_CONTRACT) {
+        if (queueSeedBridge.publishRegionalSeed(node, seed)) {
+          return;
+        }
+        const widget = findWidget(node, contract.seedInputName);
+        if (!widget) {
+          throw new Error("Prompt Studio Regional wildcard_seed widget is unavailable.");
+        }
+        widget.value = seed;
+        widget.callback?.(widget.value);
+        markNodeDirty(node);
         return;
       }
       const widget = findWidget(node, contract.seedInputName);
@@ -228,6 +264,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
       return randomWildcardSeed();
     },
   });
+  queueSeedBridge.bindRuntime(advancedQueueSeedRuntime);
 
   function refreshNodeSize(node, options = {}) {
     refreshNodeSizeWithApp(app, node, options);

--- a/web/js/prompt_studio/queue_seed_bridge.js
+++ b/web/js/prompt_studio/queue_seed_bridge.js
@@ -1,0 +1,49 @@
+// @ts-check
+
+const QUEUE_SEED_BRIDGES = new WeakMap();
+
+/**
+ * Keep the Prompt Studio queue hook owned by one runtime while allowing the
+ * independently registered Regional extension to share its node lifecycle and
+ * visible seed publisher.
+ *
+ * @param {object} app
+ */
+function promptStudioQueueSeedBridge(app) {
+  const existing = QUEUE_SEED_BRIDGES.get(app);
+  if (existing) {
+    return existing;
+  }
+
+  let runtime = null;
+  let regionalSeedPublisher = null;
+  const bridge = Object.freeze({
+    bindRuntime(value) {
+      runtime = value;
+    },
+    bindRegionalSeedPublisher(value) {
+      regionalSeedPublisher = typeof value === "function" ? value : null;
+    },
+    attachNode(node) {
+      return runtime?.attachNode?.(node) === true;
+    },
+    detachNode(node) {
+      return runtime?.detachNode?.(node) === true;
+    },
+    publishRegionalSeed(node, seed) {
+      if (typeof regionalSeedPublisher !== "function") {
+        return false;
+      }
+      return regionalSeedPublisher(node, seed) !== false;
+    },
+    shouldApplyExecutedSeed(node, value) {
+      return runtime?.shouldApplyExecutedSeed?.(node, value) !== false;
+    },
+  });
+  QUEUE_SEED_BRIDGES.set(app, bridge);
+  return bridge;
+}
+
+export {
+  promptStudioQueueSeedBridge,
+};

--- a/web/js/prompt_studio/regional/extension.js
+++ b/web/js/prompt_studio/regional/extension.js
@@ -14,6 +14,9 @@ import {
   REGIONAL_NODE_DEFAULT_WIDTH,
   REGIONAL_NODE_MIN_WIDTH,
 } from "./layout.js";
+import {
+  promptStudioQueueSeedBridge,
+} from "../queue_seed_bridge.js";
 
 /**
  * @param {any} nodeType
@@ -79,6 +82,7 @@ function installRegionalSaveSync(app, syncAllRegionalNodes, graph = null) {
 /**
  * @param {any} nodeType
  * @param {{
+ *   attachQueueSeedNode?: (node: any) => void,
  *   applyRegionalExecutedInputs: (node: any, message: any) => void,
  *   captureRegionalConfigure: (node: any, serialized: any) => void,
  *   disposeRegionalNode: (node: any) => void,
@@ -108,6 +112,7 @@ function registerRegionalNodeHooks(nodeType, hooks) {
     const result = onConfigure?.apply(this, arguments);
     hooks.captureRegionalConfigure(this, serialized);
     hooks.removeRegionalInternalInputSockets(this);
+    hooks.attachQueueSeedNode?.(this);
     hooks.scheduleHookRegionalNode(this);
     return result;
   };
@@ -176,6 +181,18 @@ function registerRegionalNodeHooks(nodeType, hooks) {
  * }} hooks
  */
 function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks) {
+  const queueSeedBridge = promptStudioQueueSeedBridge(app);
+  queueSeedBridge.bindRegionalSeedPublisher((node, seed) => {
+    if (!runtime.isRegionalNode(node)) {
+      return false;
+    }
+    if (!runtime.setRegionalWidgetValue(node, "wildcard_seed", seed)) {
+      throw new Error("Prompt Studio Regional wildcard_seed widget is unavailable.");
+    }
+    fieldEditor.renderRegionalEditor(node);
+    return true;
+  });
+
   /** @param {any} node */
   function cleanupRegionalEditor(node) {
     const editor = node?.__easyuseAnimaRegionalEditorEl;
@@ -209,6 +226,11 @@ function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks
 
   /** @param {any} node */
   function disposeRegionalNode(node) {
+    try {
+      queueSeedBridge.detachNode(node);
+    } catch {
+      // Queue state cleanup remains isolated from the Regional DOM lifecycle.
+    }
     disposeRegionalNodeLifecycle(node);
     node.__easyuseAnimaRegionalApplyingLayout = false;
     node.__easyuseAnimaRegionalHandlingConnectionsChange = false;
@@ -295,7 +317,11 @@ function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks
   }
 
   function applyRegionalExecutedInputs(node, message) {
-    if (runtime.applyRegionalExecutedInputs(node, message)) {
+    if (runtime.applyRegionalExecutedInputs(node, message, {
+      shouldApplyExecutedSeed: (target, value) => (
+        queueSeedBridge.shouldApplyExecutedSeed(target, value)
+      ),
+    })) {
       fieldEditor.renderRegionalEditor(node);
     }
   }
@@ -317,6 +343,7 @@ function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks
         return;
       }
       registerRegionalNodeHooks(nodeType, {
+        attachQueueSeedNode: queueSeedBridge.attachNode,
         applyRegionalExecutedInputs,
         captureRegionalConfigure: runtime.captureRegionalConfigure,
         disposeRegionalNode,

--- a/web/js/prompt_studio/regional/runtime.js
+++ b/web/js/prompt_studio/regional/runtime.js
@@ -494,8 +494,12 @@ function createRegionalRuntime(app, hooks = {}) {
     }
   }
 
-  /** @param {any} node @param {any} message */
-  function applyRegionalExecutedInputs(node, message) {
+  /**
+   * @param {any} node
+   * @param {any} message
+   * @param {{ shouldApplyExecutedSeed?: (node: any, value: any) => boolean }} [options]
+   */
+  function applyRegionalExecutedInputs(node, message, options = {}) {
     const payload = firstRegionalValue(message?.prompt_studio_regional, null);
     if (!payload || typeof payload !== "object") {
       return false;
@@ -518,9 +522,21 @@ function createRegionalRuntime(app, hooks = {}) {
     }
     for (const name of ["wildcard_mode", "wildcard_seed", "wildcard_seed_after_generate"]) {
       const widget = findWidget(node, name);
-      if (widget && payload[name] != null) {
-        widget.value = payload[name];
+      if (!widget || payload[name] == null) {
+        continue;
       }
+      if (name === "wildcard_seed" && typeof options.shouldApplyExecutedSeed === "function") {
+        let shouldApply = false;
+        try {
+          shouldApply = options.shouldApplyExecutedSeed(node, payload[name]) !== false;
+        } catch {
+          // A failed authority check must not let stale execution metadata win.
+        }
+        if (!shouldApply) {
+          continue;
+        }
+      }
+      widget.value = payload[name];
     }
     ensureRegionalWidgetValues(node);
     const fields = node.__easyuseAnimaRegionalFields || createDefaultRegionalFields();


### PR DESCRIPTION
## 변경 요약

- 기존 Prompt Studio API queue hook owner에 Regional seed 계약을 등록해 빠른 연속 queue를 `7 → 8 → 9`로 예약합니다.
- accepted queue만 live seed를 진행시키고, reject/throw/missing `prompt_id`/부분 실행 경계에서는 기존 transaction 수명주기를 유지합니다.
- Python Regional 실행부가 검증된 reserved next seed를 소비하고 workflow prompt에서 예약 토큰을 제거하며, 유효하지 않은 예약은 기존 fallback을 사용합니다.
- `supportsSubgraph: false`인 Regional/native Wildcard의 colon execution pass-through에서 남던 configured seed guard를 retire해 backend-owned 갱신을 허용합니다.

## 주요 파일

- `nodes.py`
- `web/js/prompt_studio/advanced_queue_seed_runtime.js`
- `web/js/prompt_studio/extension_runtime.js`
- `web/js/prompt_studio/queue_seed_bridge.js`
- `web/js/prompt_studio/regional/extension.js`
- `web/js/prompt_studio/regional/runtime.js`
- 관련 frontend smoke 및 Python unittest

## 검증

- focused Node syntax/smoke: 통과
  - Advanced queue seed runtime
  - Regional runtime
  - native Wildcard / Advanced / Regional 회귀
- Python focused unittest: Regional 8/8, reserved-seed 관련 3/3, frontend module structure 46/46
- quick runner: Python compile, JavaScript 103 files, TypeScript 6.0.3, diff check 통과
- official full runner:
  - Python unittest 395/395
  - frontend smoke 103 JavaScript files
  - TypeScript 6.0.3
  - git diff check
- ComfyUI 0.27.0 / frontend 1.45.20 live smoke:
  - Legacy canvas: 512×512 batch 1, rapid queue 3회, current seed 7/8/9, next seed 8/9/10, live seed 10, 3/3 success
  - Node 2.0: 동일 조건과 결과, 3/3 success
  - 각 실행 이미지의 실제 PNG 크기 512×512 확인
  - EasyUse Anima browser error 0건
- 독립 감사 3관점(frontend transaction, backend reservation, regression/scope): blocker 없음

## 검증 메모

- 첫 browser 시도는 Regional 해상도 출력 연결을 확인하기 전에 1024×1536으로 queue되어 최종 증거에서 제외했습니다. history와 VRAM을 비운 뒤 두 UI 표면을 모두 512×512로 다시 실행한 결과만 위 증거로 사용했습니다.
- 일부 focused 명령의 최초 sandbox 실행은 테스트 본문 전에 Windows `CreateProcessAsUserW 1312`로 중단됐고, 동일 diff의 승인 실행은 통과했습니다.

## 범위

- 별도 Regional queue wrapper는 추가하지 않았습니다.
- Advanced subgraph 예약, native Wildcard top-level 계약, #105 retired-state lifecycle을 유지합니다.
- main merge, release, Registry publish는 포함하지 않습니다.

관련: #103
