### PR TITLE
fix: centralize AiO sampler hydration refresh

### DIFF
--- a/tests/frontend_aio_extension_runtime_smoke.mjs
+++ b/tests/frontend_aio_extension_runtime_smoke.mjs
@@ -75,7 +75,7 @@ function createFixture(options = {}) {
           samplerSetupFailures -= 1;
           throw options.samplerSetupError;
         }
-        return Promise.resolve();
+        return options.samplerOptionsPromise ?? Promise.resolve();
       },
       loadUserProfiles() {
         trace.push("loadUserProfiles");
@@ -85,7 +85,7 @@ function createFixture(options = {}) {
         }
         return options.profileError
           ? Promise.reject(options.profileError)
-          : Promise.resolve();
+          : options.userProfilesPromise ?? Promise.resolve();
       },
       warnUserProfiles(error) {
         trace.push(`warnUserProfiles:${error.message}`);
@@ -283,6 +283,42 @@ function createNodeType(trace, options = {}) {
     "repeated setup must not reload data or reinstall global listeners",
   );
   assert.deepEqual(fixture.eventRegistrations, firstSetupRegistrations);
+}
+
+{
+  let resolveSamplerOptions;
+  const samplerOptionsPromise = new Promise((resolve) => {
+    resolveSamplerOptions = resolve;
+  });
+  const fixture = createFixture({
+    samplerOptionsPromise,
+    userProfilesPromise: new Promise(() => {}),
+  });
+  await fixture.runtime.setup();
+  const { NodeType } = createNodeType(fixture.trace);
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  new NodeType().onNodeCreated("cold-a");
+  new NodeType().onConfigure("cold-b");
+
+  assert.equal(
+    fixture.trace.filter((item) => item === "hookGeneratorNode").length,
+    2,
+    "generator creation/configure must keep their normal per-node hook path while hydration is pending",
+  );
+  assert.equal(
+    fixture.trace.filter((item) => item === "refreshPanels").length,
+    0,
+    "sampler hydration must not refresh panels before its shared load resolves",
+  );
+
+  resolveSamplerOptions();
+  await samplerOptionsPromise;
+  await Promise.resolve();
+  assert.equal(
+    fixture.trace.filter((item) => item === "refreshPanels").length,
+    1,
+    "sampler hydration must have one extension-owned global panel refresh regardless of node hook count",
+  );
 }
 
 {

--- a/tests/frontend_aio_extension_runtime_smoke.mjs
+++ b/tests/frontend_aio_extension_runtime_smoke.mjs
@@ -9,8 +9,8 @@ function dataModule(relativePath) {
 const extensionModule = await import(dataModule("../web/js/aio/extension_runtime.js"));
 assert.deepEqual(
   Object.keys(extensionModule),
-  ["aioCreateExtensionRuntime"],
-  "AiO extension runtime must expose only its factory contract",
+  ["aioCreateExtensionRuntime", "aioListAttachedGeneratorNodes"],
+  "AiO extension runtime must expose only its factory and attached-node traversal contracts",
 );
 
 const INPUT_NODE_TYPE = "EasyUseAnimaInput";
@@ -25,6 +25,22 @@ function createFixture(options = {}) {
   const callbacks = {
     refreshPanels() {
       trace.push("refreshPanels");
+      if (options.getGraph || options.rootGraph) {
+        const rootGraph = options.getGraph?.() ?? options.rootGraph;
+        const isGeneratorNode = options.isGeneratorNode
+          || ((node) => (
+            node?.type === GENERATOR_NODE_TYPE
+            || node?.comfyClass === GENERATOR_NODE_TYPE
+          ));
+        for (
+          const node of extensionModule.aioListAttachedGeneratorNodes(
+            rootGraph,
+            isGeneratorNode,
+          )
+        ) {
+          options.renderGeneratorPanel?.(node);
+        }
+      }
     },
     handlePreviewEvent() {},
     handleProgressEvent() {},
@@ -290,19 +306,46 @@ function createNodeType(trace, options = {}) {
   const samplerOptionsPromise = new Promise((resolve) => {
     resolveSamplerOptions = resolve;
   });
+  const rootGraph = { _nodes: [] };
+  const refreshedPanels = [];
   const fixture = createFixture({
     samplerOptionsPromise,
     userProfilesPromise: new Promise(() => {}),
+    getGraph: () => rootGraph,
+    renderGeneratorPanel(node) {
+      refreshedPanels.push(node);
+    },
   });
   await fixture.runtime.setup();
   const { NodeType } = createNodeType(fixture.trace);
   await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
-  new NodeType().onNodeCreated("cold-a");
-  new NodeType().onConfigure("cold-b");
+  const topGenerator = Object.assign(new NodeType(), {
+    id: 1,
+    type: GENERATOR_NODE_TYPE,
+    graph: rootGraph,
+  });
+  const subgraph = { nodes: [] };
+  const subgraphGenerator = Object.assign(new NodeType(), {
+    id: 7,
+    type: GENERATOR_NODE_TYPE,
+    graph: subgraph,
+  });
+  const detachedGenerator = Object.assign(new NodeType(), {
+    id: 99,
+    type: GENERATOR_NODE_TYPE,
+  });
+  const firstSubgraphNode = { id: 5, type: "Subgraph", graph: rootGraph, subgraph };
+  const secondSubgraphNode = { id: 6, type: "Subgraph", graph: rootGraph, subgraph };
+
+  topGenerator.onNodeCreated("cold-top");
+  subgraphGenerator.onConfigure("cold-subgraph");
+  detachedGenerator.onNodeCreated("cold-detached");
+  subgraph.nodes.push(subgraphGenerator);
+  rootGraph._nodes.push(topGenerator, firstSubgraphNode, secondSubgraphNode);
 
   assert.equal(
     fixture.trace.filter((item) => item === "hookGeneratorNode").length,
-    2,
+    3,
     "generator creation/configure must keep their normal per-node hook path while hydration is pending",
   );
   assert.equal(
@@ -310,6 +353,7 @@ function createNodeType(trace, options = {}) {
     0,
     "sampler hydration must not refresh panels before its shared load resolves",
   );
+  assert.deepEqual(refreshedPanels, []);
 
   resolveSamplerOptions();
   await samplerOptionsPromise;
@@ -319,6 +363,69 @@ function createNodeType(trace, options = {}) {
     1,
     "sampler hydration must have one extension-owned global panel refresh regardless of node hook count",
   );
+  assert.deepEqual(
+    refreshedPanels,
+    [topGenerator, subgraphGenerator],
+    "the shared hydration refresh must render each attached top-level/subgraph panel once and skip detached nodes",
+  );
+}
+
+{
+  let rootGraph;
+  const refreshedPanels = [];
+  const fixture = createFixture({
+    getGraph: () => rootGraph,
+    userProfilesPromise: new Promise(() => {}),
+    renderGeneratorPanel(node) {
+      refreshedPanels.push(node);
+    },
+  });
+  await fixture.runtime.setup();
+  await Promise.resolve();
+  assert.equal(
+    fixture.trace.filter((item) => item === "refreshPanels").length,
+    1,
+    "sampler hydration before lazy graph initialization must complete as one safe no-op refresh",
+  );
+  assert.deepEqual(refreshedPanels, []);
+
+  rootGraph = { nodes: [] };
+  const { NodeType } = createNodeType(fixture.trace);
+  await fixture.runtime.beforeRegisterNodeDef(NodeType, { name: GENERATOR_NODE_TYPE });
+  const warmTopGenerator = Object.assign(new NodeType(), {
+    id: 11,
+    type: GENERATOR_NODE_TYPE,
+    graph: rootGraph,
+  });
+  const warmSubgraph = { _nodes: [] };
+  const warmSubgraphGenerator = Object.assign(new NodeType(), {
+    id: 17,
+    type: GENERATOR_NODE_TYPE,
+    graph: warmSubgraph,
+  });
+  const warmSubgraphNode = {
+    id: 15,
+    type: "Subgraph",
+    graph: rootGraph,
+    subgraph: warmSubgraph,
+  };
+  rootGraph.nodes.push(warmTopGenerator, warmSubgraphNode);
+  warmSubgraph._nodes.push(warmSubgraphGenerator);
+  warmTopGenerator.onNodeCreated("warm-top");
+  warmSubgraphGenerator.onConfigure("warm-subgraph");
+  await Promise.resolve();
+
+  assert.equal(
+    fixture.trace.filter((item) => item === "hookGeneratorNode").length,
+    2,
+    "warm top-level/subgraph nodes must keep their per-node initial hook path",
+  );
+  assert.equal(
+    fixture.trace.filter((item) => item === "refreshPanels").length,
+    1,
+    "warm node hooks must not restore a per-node sampler hydration refresh owner",
+  );
+  assert.deepEqual(refreshedPanels, []);
 }
 
 {

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -530,6 +530,41 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("clearGeneratorDenoisePreview(node, false);", dispose_body)
         self.assertNotIn("URL.revokeObjectURL", panel_source)
 
+    def test_generator_sampler_hydration_refresh_has_single_owner(self):
+        source = AIO_JS.read_text(encoding="utf-8")
+        extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
+        panel_source = AIO_GENERATOR_PANEL_RUNTIME_JS.read_text(encoding="utf-8")
+
+        hook_start = source.index("function hookGeneratorNode(node)")
+        hook_end = source.index(
+            "\nfunction addGeneratorPreviewImagesToNode", hook_start
+        )
+        hook_body = source[hook_start:hook_end]
+        self.assertEqual(hook_body.count("ensureGeneratorPanel(node);"), 1)
+        self.assertNotIn("loadGeneratorSamplerOptions(", hook_body)
+        self.assertNotIn("renderGeneratorPanel(", hook_body)
+
+        ensure_start = panel_source.index("  function ensureGeneratorPanel(node)")
+        ensure_end = panel_source.index("\n\n  return {", ensure_start)
+        ensure_body = panel_source[ensure_start:ensure_end]
+        self.assertEqual(
+            ensure_body.count("renderGeneratorPanel(node, lifecycleState);"),
+            1,
+        )
+
+        setup_start = extension_source.index("    async setup() {")
+        setup_end = extension_source.index(
+            "\n    async beforeRegisterNodeDef", setup_start
+        )
+        setup_body = extension_source[setup_start:setup_end]
+        self.assertEqual(
+            setup_body.count("loadSamplerOptions().then(refreshPanels);"),
+            1,
+        )
+        self.assertIn(
+            "loadSamplerOptions: loadGeneratorSamplerOptions,", source
+        )
+
     def test_generator_panel_lifecycle_keeps_entry_behavior_boundaries(self):
         source = AIO_JS.read_text(encoding="utf-8")
         extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -561,6 +561,22 @@ class AIOFrontendSourceTests(unittest.TestCase):
             setup_body.count("loadSamplerOptions().then(refreshPanels);"),
             1,
         )
+        refresh_start = source.index("function refreshGeneratorPanels()")
+        refresh_end = source.index("\nfunction findWidget", refresh_start)
+        refresh_body = source[refresh_start:refresh_end]
+        self.assertIn(
+            "aioListAttachedGeneratorNodes(app.graph, isGeneratorGraphNode)",
+            refresh_body,
+        )
+        self.assertNotIn("generatorGraphNodes()", refresh_body)
+        self.assertIn(
+            "export function aioListAttachedGeneratorNodes(",
+            extension_source,
+        )
+        self.assertIn("Array.isArray(graph?.nodes)", extension_source)
+        self.assertIn("node.subgraph", extension_source)
+        self.assertIn("visitedGraphs", extension_source)
+        self.assertIn("visitedNodes", extension_source)
         self.assertIn(
             "loadSamplerOptions: loadGeneratorSamplerOptions,", source
         )

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -365,7 +365,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             re.findall(
                 r"^export function ([A-Za-z0-9_]+)\(", source, re.MULTILINE
             ),
-            ["aioCreateExtensionRuntime"],
+            ["aioListAttachedGeneratorNodes", "aioCreateExtensionRuntime"],
         )
         self.assertIn(
             'const EXTENSION_SETUP_HOST_MARKER = '
@@ -380,7 +380,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("Object.defineProperty(nodeType.prototype, prototypeHookMarker", source)
         self.assertIn("throw error;", source)
         self.assertIn(
-            'import { aioCreateExtensionRuntime } from "./aio/extension_runtime.js";',
+            "import {\n"
+            "  aioCreateExtensionRuntime,\n"
+            "  aioListAttachedGeneratorNodes,\n"
+            '} from "./aio/extension_runtime.js";',
             entry_source,
         )
         factory_match = re.search(

--- a/web/js/aio/extension_runtime.js
+++ b/web/js/aio/extension_runtime.js
@@ -4,6 +4,49 @@ const INPUT_PROTOTYPE_HOOK_MARKER = "__easyuseAnimaAioInputHooksInstalled";
 const GENERATOR_PROTOTYPE_HOOK_MARKER = "__easyuseAnimaAioGeneratorHooksInstalled";
 const EXTENSION_SETUP_HOST_MARKER = "__easyuseAnimaAioExtensionSetupInstalled";
 
+function graphNodes(graph) {
+  if (Array.isArray(graph?.nodes)) {
+    return graph.nodes;
+  }
+  if (Array.isArray(graph?._nodes)) {
+    return graph._nodes;
+  }
+  return Object.values(graph?._nodes_by_id || {});
+}
+
+/**
+ * List generator nodes reachable from the current root graph through attached
+ * ComfyUI SubgraphNode.subgraph definitions. Shared or cyclic graph references
+ * and repeated node objects are visited once per refresh.
+ */
+export function aioListAttachedGeneratorNodes(rootGraph, isGeneratorNode) {
+  const result = [];
+  const pendingGraphs = [rootGraph];
+  const visitedGraphs = new Set();
+  const visitedNodes = new Set();
+  for (let index = 0; index < pendingGraphs.length; index += 1) {
+    const graph = pendingGraphs[index];
+    if (!graph || visitedGraphs.has(graph)) {
+      continue;
+    }
+    visitedGraphs.add(graph);
+    for (const node of graphNodes(graph)) {
+      if (!node) {
+        continue;
+      }
+      if (node.subgraph && !visitedGraphs.has(node.subgraph)) {
+        pendingGraphs.push(node.subgraph);
+      }
+      if (visitedNodes.has(node) || !isGeneratorNode(node)) {
+        continue;
+      }
+      visitedNodes.add(node);
+      result.push(node);
+    }
+  }
+  return result;
+}
+
 function extensionSetupState(api) {
   const existing = api[EXTENSION_SETUP_HOST_MARKER];
   if (

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -29,7 +29,10 @@ import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js
 import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";
 import { aioCreateAdvancedSettingsDialog } from "./aio/advanced_settings_dialog.js";
 import { aioCreateNativePreviewRuntime } from "./aio/native_preview_runtime.js";
-import { aioCreateExtensionRuntime } from "./aio/extension_runtime.js";
+import {
+  aioCreateExtensionRuntime,
+  aioListAttachedGeneratorNodes,
+} from "./aio/extension_runtime.js";
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
@@ -2096,7 +2099,7 @@ function schedulerNameOptions(current) {
 }
 
 function refreshGeneratorPanels() {
-  for (const node of generatorGraphNodes()) {
+  for (const node of aioListAttachedGeneratorNodes(app.graph, isGeneratorGraphNode)) {
     renderGeneratorPanel(node);
   }
 }

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -4073,7 +4073,7 @@ function hookInputNode(node) {
 }
 
 function hookGeneratorNode(node) {
-  const panelLifecycle = activateGeneratorPanel(node);
+  activateGeneratorPanel(node);
   activateGeneratorNativePreviewLifecycle(node);
   node.serialize_widgets = true;
   suppressGeneratorDefaultPreview(node, { markDirty: false });
@@ -4081,9 +4081,6 @@ function hookGeneratorNode(node) {
   ensureGeneratorPanel(node);
   syncGeneratorStateFromDom(node);
   scheduleGeneratorDefaultPreviewSuppression(node);
-  loadGeneratorSamplerOptions().then(() => {
-    renderGeneratorPanel(node, panelLifecycle);
-  });
 }
 
 function addGeneratorPreviewImagesToNode(node, nextImages, runId = "", options = {}) {


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 sampler/scheduler 초기 hydration 소유권을 extension 수준의 단일 refresh로 통합합니다.
- 노드별 sampler load promise 뒤의 중복 전체 render를 제거합니다.
- 현재 root graph에서 실제로 연결된 native subgraph만 순회해 그 안의 AiO Generator도 cold hydration 후 정확히 한 번 갱신합니다.
- shared/cyclic subgraph와 동일 노드 중복은 identity set으로 한 번만 처리하고, lazy graph와 분리된 stale subgraph는 안전하게 제외합니다.

Refs #54

## 주요 파일

- `web/js/aio/extension_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_extension_runtime_smoke.mjs`
- `tests/test_aio_frontend.py`
- `tests/test_frontend_modules.py`

## 검증

### Focused

- 변경 JS와 관련 panel/queue runtime 및 smoke `node --check`: 통과
- `frontend_aio_extension_runtime_smoke.mjs`: 통과
- `frontend_aio_generator_panel_runtime_smoke.mjs`: 통과
- `frontend_aio_generator_queue_runtime_smoke.mjs`: 통과
- `python -m unittest tests.test_aio_frontend`: 34/34 통과
- 관련 구조/ownership unittest 3개: 3/3 통과
- `git diff --check`: 통과

### Official full

```powershell
powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <PR worktree> -Profile full
```

- Python unittest: 396/396
- Frontend smoke/syntax: JavaScript 103개
- TypeScript: 6.0.3
- git diff check: 통과

### Live browser

ComfyUI v0.27.0 / frontend 1.45.20 Codex test instance:

- Legacy canvas: 512×512, batch 1, step 1 queue 성공; sampler/scheduler hydration, seed increment, preview, save/reload 단일 패널 복원 확인
- Node 2.0: 512×512, batch 1, step 1 queue 성공; sampler/scheduler hydration, seed increment, preview, save/reload 단일 패널 복원 확인
- 실제 attached native subgraph 진입: AiO 패널 1개, sampler 44개 중 `er_sde`, scheduler 9개 중 `kl_optimal`, 저장 seed 복원 확인
- EasyUse Anima 관련 browser error: 0

## 유지되는 동작

- 최초 panel 생성/render와 singleton/focus/scroll lifecycle
- 사용자 profile refresh wiring
- #113 queue idempotence 및 no-commit 계약
- top-level AiO Generator의 기존 queue/save/preview 동작

## 남은 위험

- explicit cyclic graph, 동일 generator object 재참조, hydration 직전 remove, root graph 교체를 각각 단독 fixture로 고정한 테스트는 아직 없습니다. 구현은 current-root traversal과 graph/node identity set으로 해당 경계를 처리하며 기존 통합 smoke는 통과했습니다.
- #54의 direct concurrent API contract와 #62/#66 등 나머지 경계는 이 PR 범위가 아니므로 Issue #54는 병합 후에도 열어 둡니다.