### PR TITLE
docs: document wildcard seed range contract

### DIFF
--- a/docs/development/frontend-maintenance-execution-plan.md
+++ b/docs/development/frontend-maintenance-execution-plan.md
@@ -16,7 +16,8 @@ GitHub Issue ledgers, or live Git/GitHub/Codex/process read-back.
 - Before using this snapshot, fetch and reconcile the external state named in
   the relevant row.
 
-Snapshot: 2026-07-17 KST, immediately after PR #119 cleanup.
+Snapshot: 2026-07-17 KST, immediately after PR #120 cleanup and creation of the
+#102 documentation lane.
 
 ## Goal Boundary
 
@@ -42,9 +43,9 @@ Excluded without separate approval:
 
 | Surface | Confirmed state |
 | --- | --- |
-| `origin/dev` | `4119012881f4d1b35f61a29704fb18d23602a06d` |
+| `origin/dev` | `37c14f8cc10bd43fd33d3a1be76eeeeba435b920` |
 | local `dev` | same SHA, clean |
-| latest integration | PR #119, AiO sampler hydration ownership |
+| latest integration | PR #120, frontend maintenance execution ledger and project Skill |
 | Codex test server | stopped; port 8194 listener and related server/launcher count 0 |
 | test-instance canvas setting | `Comfy.VueNodes.Enabled=false` restored |
 | user v0.27.0 instance | not synced for this Goal |
@@ -57,7 +58,7 @@ Excluded without separate approval:
 | #54 AiO Generator | open | PR #107 lifecycle, #113 API queue/hook reentry and missing `prompt_id` no-commit regression, #119 sampler hydration owner and attached-subgraph refresh | direct concurrent API serialization/reservation, final broader matrix, #62/#66 triage, and optional #119 cycle/repeated-node/remove/root-replacement fixtures |
 | #55 LoRA Preset | open | #108 extraction, #115/#109 lifecycle hardening | integrate canvas-widget extraction; then profile mutation, initialize/configure/serialize, save-sync/wheel/entry, final matrix |
 | #56 Autocomplete | open | #116 input/keyboard/composition controller | integrate #99 adapter epoch; then external input hook, listener installer/entry, #98/#100, final matrix |
-| #102 seed range | open | production contract merged in #112 | approved Korean/English user docs; record #111 as non-blocking Node 2.0 display mismatch |
+| #102 seed range | open | production contract merged in #112 | integrate the current Korean/English user-doc lane, record #111 as a separate non-blocking Node 2.0 display mismatch, then reconcile the Issue ledger |
 | #103 Regional seed | closed | PR #118 and final ledger | none |
 | #104 subgraph Advanced seed | closed | PR #117 and final ledger | optional non-blocking settlement coverage only |
 | #105 seed lifecycle | closed | PR #110 and final ledger | do not reimplement |
@@ -83,6 +84,7 @@ in the roadmap and owning Issue ledgers.
 | #117 | `4b68cc4dfc1b402070939f51fd216c40e8b632a8` | Advanced node native-subgraph reservation | complete | status recorded in #104 | recorded |
 | #118 | `44eb91c1335f563e7ec05a9bf65fa74e1e219676` | Regional queue seed reservation | 395/395; 103 JS; TS 6.0.3 | Legacy and Node 2.0, 512×512 rapid queue 3/3 each | #103 final ledger |
 | #119 | `4119012881f4d1b35f61a29704fb18d23602a06d` | AiO sampler hydration single owner and attached-subgraph refresh | 396/396; 103 JS; TS 6.0.3 | Legacy and Node 2.0 512×512 queue/save-reload; attached native subgraph; EasyUse errors 0 | #54 ledger; Issue remains open |
+| #120 | `37c14f8cc10bd43fd33d3a1be76eeeeba435b920` | frontend maintenance execution ledger and repo-local coordination Skill | 396/396; 103 JS; TS 6.0.3 | not required: internal docs/procedure only | no owning feature Issue; merge/read-back and cleanup recorded here |
 
 ## Production Lane Ownership
 
@@ -90,8 +92,7 @@ in the roadmap and owning Issue ledgers.
 | --- | --- | --- | --- | --- |
 | #55 canvas widgets | `019f6b77-702f-7863-8706-cc5db859b360` | `codex/extract-lora-canvas-widgets`; `worktrees/ComfyUI-EasyUseAnima/codex/extract-lora-canvas-widgets` | clean HEAD `6d2386777181d24472b6cfa4ce090ee630a12d71` on `4119012`; focused checks and two audits passed | `web/js/lora_preset/canvas_widgets.js`, LoRA entry, dedicated smoke and unittest |
 | #56/#99 adapter epoch | `019f6bc5-c33b-7960-b84e-0f2300525f2a` | `codex/fix-autocomplete-adapter-epoch`; `worktrees/ComfyUI-EasyUseAnima/codex/fix-autocomplete-adapter-epoch` | clean HEAD `f34bdaa224a34c2bd3097c24e77cd45258486079` on `4119012`; focused 43/43 and two audits passed | `web/js/autocomplete/data_adapter.js`, dedicated adapter smoke |
-| coordination plan/Skill | integration owner | `codex/docs-frontend-maintenance-plan`; `worktrees/ComfyUI-EasyUseAnima/codex/docs-frontend-maintenance-plan` | base `4119012`; active | this plan, repo-local Skill, development-doc links only |
-| #102 user docs | queued | branch/worktree/task not created | start from latest `origin/dev` after coordination PR cleanup | `docs/wildcards.ko.md`, `docs/wildcards.en.md`; optional canonical links only |
+| #102 user docs | `019f6a32-3b0f-7ed0-8ff6-03de8546f402` (integration owner) | `codex/docs-wildcard-seed-contract`; `worktrees/ComfyUI-EasyUseAnima/codex/docs-wildcard-seed-contract` | active on clean base `37c14f8`; focused contract check and final audits passed | `docs/wildcards.ko.md`, `docs/wildcards.en.md`, and this checkpoint only |
 
 ## Integration Gates
 
@@ -99,12 +100,11 @@ Only one row may enter push/PR/merge at a time.
 
 | Order | Slice | Focused / audit | Full | Browser | Blocker / finding | Gate |
 | ---: | --- | --- | --- | --- | --- | --- |
-| 1 | coordination plan/Skill | structure, link, YAML, and Skill validation plus two final audits passed after review-fix | run once on final diff | not required: internal docs/procedure only | no known blocker | current |
-| 2 | #102 user docs | production evidence already merged; docs review pending | run once on final diff | reuse #112 identical production evidence; docs do not change runtime | #111 is non-blocking and separately tracked | queued |
-| 3 | #55 canvas widgets | focused tests and two extraction audits passed | integration owner registers smoke, then one full run | omit for mechanical extraction; final #55 matrix remains required before Issue close | no known blocker | queued |
-| 4 | #56/#99 adapter epoch | focused 43/43, range-diff, and two audits passed | one full run | required once per final behavior diff on legacy and Node 2.0 | no known blocker | queued |
-| 5 | remaining #54/#55/#56 slices | create only after file ownership and priority audit | per PR-ready diff | per behavior diff; final Issue matrices required | sequence and overlap audit required | backlog |
-| 6 | final user-instance sync | all agreed Issues/bugs reconciled first | use merged `dev` evidence | one manual v0.27.0 confirmation | blocked by remaining Goal work and prerequisites | queued |
+| 1 | #102 user docs | focused contract check plus final contract, ledger, and readability audits passed | run once on final diff | reuse #112 identical production evidence; docs do not change runtime | #111 is non-blocking and separately tracked | current |
+| 2 | #55 canvas widgets | focused tests and two extraction audits passed | integration owner registers smoke, then one full run | omit for mechanical extraction; final #55 matrix remains required before Issue close | rebase from `4119012` after #102 cleanup | queued |
+| 3 | #56/#99 adapter epoch | focused 43/43, range-diff, and two audits passed | one full run | required once per final behavior diff on legacy and Node 2.0 | rebase from `4119012` after preceding integrations | queued |
+| 4 | remaining #54/#55/#56 slices | create only after file ownership and priority audit | per PR-ready diff | per behavior diff; final Issue matrices required | sequence and overlap audit required | backlog |
+| 5 | final user-instance sync | all agreed Issues/bugs reconciled first | use merged `dev` evidence | one manual v0.27.0 confirmation | blocked by remaining Goal work and prerequisites | queued |
 
 Known validation note: Windows sandbox may fail before command/test setup with
 `CreateProcessAsUserW 1312`. Record cwd, TEMP variables, runner, and failure
@@ -113,7 +113,7 @@ sandbox. Do not report the environment spawn error as a code failure.
 
 ## Current Blockers And Findings
 
-- Blocking the current coordination gate: none known.
+- Blocking the current #102 documentation gate: none known.
 - Non-blocking #111: ComfyUI frontend 1.45.20 Node 2.0 can display a newly
   entered unsafe seed while the widget and saved workflow retain max-safe.
   Prefer an upstream fix or stable public-API boundary over a private-DOM hook.
@@ -134,8 +134,9 @@ sandbox. Do not report the environment spawn error as a code failure.
 
 ## Cleanup And Sync
 
-- The #103 Regional lane and #54 sampler-hydration lane branches/worktrees were
-  removed after merge-tree equality and clean-state checks.
+- The #103 Regional, #54 sampler-hydration, and #120 coordination
+  branches/worktrees were removed after merge-tree equality and clean-state
+  checks.
 - Existing unrelated `codex/*`, `fix/*`, and `feature/*` worktrees are untouched.
 - The Codex test server is stopped and port 8194 is free.
 - The user v0.27.0 instance remains untouched until all agreed maintenance and

--- a/docs/wildcards.en.md
+++ b/docs/wildcards.en.md
@@ -137,6 +137,38 @@ Seed controls:
 - `increment`
 - `decrement`
 
+## Seed Range and Legacy Workflows
+
+This range contract applies to wildcard seeds in `Anima Prompt Studio
+Advanced`, `Anima Prompt Studio Advanced v2`, `Anima Prompt Studio Regional`,
+and `Anima Wildcard`.
+
+- The public range for a current seed newly entered or edited in the browser,
+  and for a normal next seed, is `0..Number.MAX_SAFE_INTEGER`
+  (`0..9007199254740991`), inclusive.
+- `fixed` keeps the current seed unchanged.
+- `increment` wraps from the maximum to `0`, while `decrement` wraps from `0`
+  to the maximum.
+- `randomize` selects from the same inclusive public range, so both `0` and the
+  maximum are possible.
+- A new edit must contain only unsigned base-10 digits in that range. Inputs
+  with a `+` or `-` sign, a fraction, exponential notation, or an over-maximum
+  value are not published to the real widget or saved workflow; the previous
+  seed is kept.
+
+For compatibility with existing workflows, the Python backend continues to
+read the uint64 range `0..18446744073709551615`. EasyUse Anima does not
+intentionally clamp an existing seed above the public range, and values the
+browser can represent exactly are preserved across load/save. The backend uses
+that seed for the current generation and `fixed` keeps it unchanged. JavaScript
+cannot represent every large integer exactly, so exact browser display and
+save/reload round trips are best-effort. Advancing the state with `increment`,
+`decrement`, or `randomize` returns the next seed to the public range.
+
+Some Node 2.0 frontend versions can temporarily leave a rejected over-maximum
+string visible in the input. The real widget and saved workflow still keep the
+previous valid seed; reopening the workflow shows the stored value.
+
 ## Prompt Studio Advanced
 
 `Anima Prompt Studio Advanced` shows a `Wildcard Seed` button and a compact

--- a/docs/wildcards.ko.md
+++ b/docs/wildcards.ko.md
@@ -137,6 +137,37 @@ seed control:
 - `increment`
 - `decrement`
 
+## Seed 범위와 기존 workflow 호환성
+
+이 범위 계약은 `Anima Prompt Studio Advanced`,
+`Anima Prompt Studio Advanced v2`, `Anima Prompt Studio Regional`,
+`Anima Wildcard`의 와일드카드 seed에 공통으로 적용됩니다.
+
+- 브라우저에서 새로 입력하거나 편집하는 현재 seed와 일반적인 다음 seed의 공개
+  범위는 `0..Number.MAX_SAFE_INTEGER` (`0..9007199254740991`)이며 양 끝값을
+  포함합니다.
+- `fixed`는 현재 seed를 그대로 유지합니다.
+- `increment`는 최댓값 다음에 `0`으로 돌아가고, `decrement`는 `0` 다음에
+  최댓값으로 돌아갑니다.
+- `randomize`도 같은 공개 범위 전체에서 seed를 선택하며 `0`과 최댓값을 모두
+  포함할 수 있습니다.
+- 새 편집값은 이 범위 안의 부호 없는 10진 숫자만 사용할 수 있습니다. `+`나
+  `-` 부호, 소수, 지수 표기와 최댓값 초과 입력은 실제 widget이나 저장
+  workflow에 반영하지 않고 이전 seed를 유지합니다.
+
+Python backend는 기존 workflow 호환을 위해 uint64 범위
+`0..18446744073709551615`를 계속 읽습니다. EasyUse Anima는 이미 저장된 공개
+범위 초과 seed를 의도적으로 공개 범위로 clamp하지 않으며, 브라우저가 정확히
+표현할 수 있는 값은 load/save에서 그대로 보존합니다. backend는 현재 generation에
+그 seed를 사용하고 `fixed`는 값을 유지합니다. 다만 JavaScript는 모든 큰 정수의
+정밀도를 보장하지 못하므로 정확한 화면 표시와 save/reload round-trip은
+best-effort입니다. `increment`, `decrement`, `randomize`로 상태를 진행하면 다음
+seed는 다시 공개 범위로 들어옵니다.
+
+일부 Node 2.0 frontend에서는 거부된 최댓값 초과 문자열이 입력칸에 일시적으로
+남을 수 있습니다. 이 경우에도 실제 widget과 저장 workflow는 이전 유효 seed를
+유지하며, workflow를 다시 열면 저장된 값이 표시됩니다.
+
 ## Prompt Studio Advanced
 
 `Anima Prompt Studio Advanced`에는 `와일드카드 시드` 버튼과 현재 설정 요약이


### PR DESCRIPTION
## 변경 요약

- Wildcard seed의 공개 편집/일반 next 범위를 `0..Number.MAX_SAFE_INTEGER` (`0..9007199254740991`)로 한국어·영어 사용자 가이드에 명시합니다.
- `fixed`, `increment`, `decrement`, `randomize`의 유지·wrap·random 범위를 설명합니다.
- Python uint64 legacy workflow 호환, 표현 가능한 loaded unsafe seed 보존, 새 unsafe 편집 거부, JavaScript 정밀도에 따른 best-effort round-trip을 구분합니다.
- Advanced, Advanced v2, Regional, native Anima Wildcard에 같은 계약이 적용됨을 명시하고, Node 2.0의 #111 표시 caveat를 기록합니다.
- PR #120 cleanup 이후의 frontend maintenance 실행 ledger checkpoint를 갱신합니다.

## 주요 파일

- `docs/wildcards.ko.md`
- `docs/wildcards.en.md`
- `docs/development/frontend-maintenance-execution-plan.md`

## 검증

- 문서 필수 계약 및 exact changed-file focused 검사: 통과
- 한국어 계약 감사: 통과
- 영어 계약 감사: 통과
- production 계약 대조 감사: 초기 legacy round-trip 표현 보정 후 통과
- final contract / ledger / readability 독립 감사: P0-P3 finding 없음
- 공식 full runner: Python unittest 396/396, frontend 103 JavaScript files, TypeScript 6.0.3, git diff check 통과
- `git diff --check`: 통과

## 테스트 표면

- production runtime 코드는 변경하지 않았습니다.
- PR #112의 동일 production diff에서 Legacy canvas와 Node 2.0 각각 512×512 max-safe wrap, save/reload, loaded legacy unsafe seed 보존을 검증했습니다.
- 이 문서 전용 PR에서는 browser smoke를 반복하지 않았습니다.

## 남은 위험

- ComfyUI frontend 1.45.20 Node 2.0의 rejected raw 문자열 표시 불일치는 #111에서 별도로 추적합니다. 실제 widget 및 저장 workflow는 이전 유효값을 유지합니다.
- `main` merge, release, tag, Registry publish와 사용자 인스턴스 반영은 이 PR 범위가 아닙니다.
- 저장소에 `type: docs`, `area: docs` 라벨이 없어 기존 `documentation`, `type: chore`, `area: frontend` 라벨을 사용합니다.

관련: #102, #111
