### PR TITLE
refactor: extract LoRA preset canvas widgets

### DIFF
--- a/docs/development/frontend-maintenance-execution-plan.md
+++ b/docs/development/frontend-maintenance-execution-plan.md
@@ -16,8 +16,8 @@ GitHub Issue ledgers, or live Git/GitHub/Codex/process read-back.
 - Before using this snapshot, fetch and reconcile the external state named in
   the relevant row.
 
-Snapshot: 2026-07-17 KST, immediately after PR #120 cleanup and creation of the
-#102 documentation lane.
+Snapshot: 2026-07-17 KST, immediately after PR #121 and Issue #102 cleanup and
+creation of the #55 canvas-widget integration branch.
 
 ## Goal Boundary
 
@@ -43,9 +43,9 @@ Excluded without separate approval:
 
 | Surface | Confirmed state |
 | --- | --- |
-| `origin/dev` | `37c14f8cc10bd43fd33d3a1be76eeeeba435b920` |
+| `origin/dev` | `e7a2cc4c95d40930a5076c25fd5f06a9bcc78c14` |
 | local `dev` | same SHA, clean |
-| latest integration | PR #120, frontend maintenance execution ledger and project Skill |
+| latest integration | PR #121, wildcard seed range user documentation |
 | Codex test server | stopped; port 8194 listener and related server/launcher count 0 |
 | test-instance canvas setting | `Comfy.VueNodes.Enabled=false` restored |
 | user v0.27.0 instance | not synced for this Goal |
@@ -56,9 +56,9 @@ Excluded without separate approval:
 | Issue | State | Completed boundary | Remaining or next action |
 | --- | --- | --- | --- |
 | #54 AiO Generator | open | PR #107 lifecycle, #113 API queue/hook reentry and missing `prompt_id` no-commit regression, #119 sampler hydration owner and attached-subgraph refresh | direct concurrent API serialization/reservation, final broader matrix, #62/#66 triage, and optional #119 cycle/repeated-node/remove/root-replacement fixtures |
-| #55 LoRA Preset | open | #108 extraction, #115/#109 lifecycle hardening | integrate canvas-widget extraction; then profile mutation, initialize/configure/serialize, save-sync/wheel/entry, final matrix |
+| #55 LoRA Preset | open | #108 extraction, #115/#109 lifecycle hardening | integrate the current canvas-widget extraction; then profile mutation, initialize/configure/serialize, save-sync/wheel/entry, final matrix |
 | #56 Autocomplete | open | #116 input/keyboard/composition controller | integrate #99 adapter epoch; then external input hook, listener installer/entry, #98/#100, final matrix |
-| #102 seed range | open | production contract merged in #112 | integrate the current Korean/English user-doc lane, record #111 as a separate non-blocking Node 2.0 display mismatch, then reconcile the Issue ledger |
+| #102 seed range | closed | production contract #112 and Korean/English user docs #121 | none; #111 remains a separate non-blocking Node 2.0 display mismatch |
 | #103 Regional seed | closed | PR #118 and final ledger | none |
 | #104 subgraph Advanced seed | closed | PR #117 and final ledger | optional non-blocking settlement coverage only |
 | #105 seed lifecycle | closed | PR #110 and final ledger | do not reimplement |
@@ -85,14 +85,14 @@ in the roadmap and owning Issue ledgers.
 | #118 | `44eb91c1335f563e7ec05a9bf65fa74e1e219676` | Regional queue seed reservation | 395/395; 103 JS; TS 6.0.3 | Legacy and Node 2.0, 512×512 rapid queue 3/3 each | #103 final ledger |
 | #119 | `4119012881f4d1b35f61a29704fb18d23602a06d` | AiO sampler hydration single owner and attached-subgraph refresh | 396/396; 103 JS; TS 6.0.3 | Legacy and Node 2.0 512×512 queue/save-reload; attached native subgraph; EasyUse errors 0 | #54 ledger; Issue remains open |
 | #120 | `37c14f8cc10bd43fd33d3a1be76eeeeba435b920` | frontend maintenance execution ledger and repo-local coordination Skill | 396/396; 103 JS; TS 6.0.3 | not required: internal docs/procedure only | no owning feature Issue; merge/read-back and cleanup recorded here |
+| #121 | `e7a2cc4c95d40930a5076c25fd5f06a9bcc78c14` | bilingual wildcard seed range and legacy workflow user documentation | 396/396; 103 JS; TS 6.0.3 | reused #112 identical production evidence; docs-only diff | #102 final ledger; Issue closed completed |
 
 ## Production Lane Ownership
 
 | Slice | Codex task | Branch / worktree | Base and status | Expected files |
 | --- | --- | --- | --- | --- |
-| #55 canvas widgets | `019f6b77-702f-7863-8706-cc5db859b360` | `codex/extract-lora-canvas-widgets`; `worktrees/ComfyUI-EasyUseAnima/codex/extract-lora-canvas-widgets` | clean HEAD `6d2386777181d24472b6cfa4ce090ee630a12d71` on `4119012`; focused checks and two audits passed | `web/js/lora_preset/canvas_widgets.js`, LoRA entry, dedicated smoke and unittest |
+| #55 canvas widgets | source task `019f6b77-702f-7863-8706-cc5db859b360`; integration owner `019f6a32-3b0f-7ed0-8ff6-03de8546f402` | clean source `codex/extract-lora-canvas-widgets` / `6d238677`; active integration `codex/integrate-lora-canvas-widgets` / `worktrees/ComfyUI-EasyUseAnima/codex/integrate-lora-canvas-widgets` | source patch range-diff `=` as integration commit `0cca9ea` on `e7a2cc4`; shared runner/checkpoint focused checks and final audits passed | canvas module, LoRA entry, dedicated smoke/unittest, runner registration, and this checkpoint |
 | #56/#99 adapter epoch | `019f6bc5-c33b-7960-b84e-0f2300525f2a` | `codex/fix-autocomplete-adapter-epoch`; `worktrees/ComfyUI-EasyUseAnima/codex/fix-autocomplete-adapter-epoch` | clean HEAD `f34bdaa224a34c2bd3097c24e77cd45258486079` on `4119012`; focused 43/43 and two audits passed | `web/js/autocomplete/data_adapter.js`, dedicated adapter smoke |
-| #102 user docs | `019f6a32-3b0f-7ed0-8ff6-03de8546f402` (integration owner) | `codex/docs-wildcard-seed-contract`; `worktrees/ComfyUI-EasyUseAnima/codex/docs-wildcard-seed-contract` | active on clean base `37c14f8`; focused contract check and final audits passed | `docs/wildcards.ko.md`, `docs/wildcards.en.md`, and this checkpoint only |
 
 ## Integration Gates
 
@@ -100,11 +100,10 @@ Only one row may enter push/PR/merge at a time.
 
 | Order | Slice | Focused / audit | Full | Browser | Blocker / finding | Gate |
 | ---: | --- | --- | --- | --- | --- | --- |
-| 1 | #102 user docs | focused contract check plus final contract, ledger, and readability audits passed | run once on final diff | reuse #112 identical production evidence; docs do not change runtime | #111 is non-blocking and separately tracked | current |
-| 2 | #55 canvas widgets | focused tests and two extraction audits passed | integration owner registers smoke, then one full run | omit for mechanical extraction; final #55 matrix remains required before Issue close | rebase from `4119012` after #102 cleanup | queued |
-| 3 | #56/#99 adapter epoch | focused 43/43, range-diff, and two audits passed | one full run | required once per final behavior diff on legacy and Node 2.0 | rebase from `4119012` after preceding integrations | queued |
-| 4 | remaining #54/#55/#56 slices | create only after file ownership and priority audit | per PR-ready diff | per behavior diff; final Issue matrices required | sequence and overlap audit required | backlog |
-| 5 | final user-instance sync | all agreed Issues/bugs reconciled first | use merged `dev` evidence | one manual v0.27.0 confirmation | blocked by remaining Goal work and prerequisites | queued |
+| 1 | #55 canvas widgets | source and integration focused checks, range-diff, and final production/runner/plan audits passed | run once on final diff | omit for mechanical extraction; final #55 matrix remains required before Issue close | no known blocker | current |
+| 2 | #56/#99 adapter epoch | focused 43/43, range-diff, and two audits passed | one full run | required once per final behavior diff on legacy and Node 2.0 | rebase from `4119012` after #55 cleanup | queued |
+| 3 | remaining #54/#55/#56 slices | create only after file ownership and priority audit | per PR-ready diff | per behavior diff; final Issue matrices required | sequence and overlap audit required | backlog |
+| 4 | final user-instance sync | all agreed Issues/bugs reconciled first | use merged `dev` evidence | one manual v0.27.0 confirmation | blocked by remaining Goal work and prerequisites | queued |
 
 Known validation note: Windows sandbox may fail before command/test setup with
 `CreateProcessAsUserW 1312`. Record cwd, TEMP variables, runner, and failure
@@ -113,12 +112,15 @@ sandbox. Do not report the environment spawn error as a code failure.
 
 ## Current Blockers And Findings
 
-- Blocking the current #102 documentation gate: none known.
+- Blocking the current #55 canvas-widget gate: none known.
 - Non-blocking #111: ComfyUI frontend 1.45.20 Node 2.0 can display a newly
   entered unsafe seed while the widget and saved workflow retain max-safe.
   Prefer an upstream fix or stable public-API boundary over a private-DOM hook.
 - Non-blocking #119 coverage gap: explicit cycle, repeated generator object,
   hydration-before-remove, and root-replacement fixtures remain optional.
+- Non-blocking #55 coverage gap: the dedicated smoke is registered and runs in
+  the official frontend runner, but no Python static assertion locks that runner
+  line; exact canvas paint pixels and extreme scroll counts remain optional.
 - Environment: sandbox `CreateProcessAsUserW 1312` is a pre-test process-spawn
   failure, not a repository blocker, when the identical approved rerun passes.
 
@@ -134,7 +136,7 @@ sandbox. Do not report the environment spawn error as a code failure.
 
 ## Cleanup And Sync
 
-- The #103 Regional, #54 sampler-hydration, and #120 coordination
+- The #103 Regional, #54 sampler-hydration, #120 coordination, and #121 user-doc
   branches/worktrees were removed after merge-tree equality and clean-state
   checks.
 - Existing unrelated `codex/*`, `fix/*`, and `feature/*` worktrees are untouched.

--- a/tests/frontend_lora_preset_canvas_widgets_smoke.mjs
+++ b/tests/frontend_lora_preset_canvas_widgets_smoke.mjs
@@ -1,0 +1,436 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+globalThis.Path2D = class Path2D {
+  constructor(path) {
+    this.path = path;
+  }
+};
+
+const canvasModule = await import(
+  dataModule("../web/js/lora_preset/canvas_widgets.js")
+);
+
+assert.deepEqual(Object.keys(canvasModule), ["createLoraPresetCanvasWidgets"]);
+
+const settings = {
+  strengthButtonStep: 0.05,
+  strengthDragStep: 0.05,
+  strengthDragPixels: 8,
+};
+const calls = [];
+const previewCalls = [];
+const promptCalls = [];
+let activeProfileWheelTarget = null;
+let chosenLoraCallback = null;
+
+const canvas = {
+  editor_alpha: 1,
+  prompt(message, value, callback, event) {
+    promptCalls.push({ message, value, callback, event });
+  },
+};
+const liteGraph = {
+  WIDGET_TEXT_COLOR: "#ddd",
+  WIDGET_BGCOLOR: "#222",
+  WIDGET_OUTLINE_COLOR: "#555",
+};
+
+function normalizeLoraEntry(value) {
+  return {
+    name: String(value?.name || ""),
+    on: value?.on !== false,
+    strength: Number(value?.strength ?? 1),
+    strengthTwo: value?.strengthTwo ?? null,
+  };
+}
+
+function updateLoraEntry(node, index, patch, options = {}) {
+  calls.push(["updateLoraEntry", index, { ...patch }, { ...options }]);
+  if (node.loras[index]) {
+    Object.assign(node.loras[index], patch);
+  }
+}
+
+function makeNode(options = {}) {
+  return {
+    size: [options.width ?? 520, 240],
+    pos: [100, 200],
+    profileCount: options.profileCount ?? 8,
+    activeProfileIndex: options.activeProfileIndex ?? 2,
+    pathProblem: options.pathProblem ?? true,
+    loraFixPending: options.loraFixPending ?? false,
+    profileFixPending: options.profileFixPending ?? false,
+    loras: options.loras ?? [
+      { name: "style/foo.safetensors", on: true, strength: 1, strengthTwo: null },
+      { name: "style/bar.safetensors", on: false, strength: 0.8, strengthTwo: null },
+    ],
+    widgets: options.widgets ?? [],
+    dirtyCalls: [],
+    setDirtyCanvas(...args) {
+      this.dirtyCalls.push(args);
+    },
+  };
+}
+
+const dependencies = {
+  getCanvas: () => canvas,
+  getLiteGraph: () => liteGraph,
+  getSettings: () => settings,
+  text: (key) => key,
+  formatText: (key, values = {}) => `${key}:${values.active}/${values.count}`,
+  normalizeLoraEntry,
+  lorasWidgetValue: (node) => node.loras,
+  mutateLoras(node, mutator, options = {}) {
+    calls.push(["mutateLoras", { ...options }]);
+    mutator(node.loras);
+  },
+  updateLoraEntry,
+  loraResolveState: (node) => ({ pathProblem: node.pathProblem }),
+  hasLoraPathProblem: (state) => state.pathProblem === true,
+  isAnyLoraFixPending: (node) => node.profileFixPending,
+  isLoraFixPending: (node) => node.loraFixPending,
+  loraDisplayName: (name) => String(name).split("/").pop(),
+  previewLifecycle: {
+    showPreview(name, event) {
+      previewCalls.push(["show", name, event]);
+    },
+    hidePreview() {
+      previewCalls.push(["hide"]);
+    },
+  },
+  openLoraMenu(node, event, pos, onChoose) {
+    calls.push(["openLoraMenu", node, event, pos]);
+    chosenLoraCallback = onChoose;
+  },
+  openLoraEntryMenu: (node, event, index) => calls.push(["openLoraEntryMenu", node, event, index]),
+  addLoraEntry: (node, entry) => calls.push(["addLoraEntry", node, entry]),
+  fixSingleLoraEntry: (node, index) => calls.push(["fixSingleLoraEntry", node, index]),
+  profileCount: (node) => node.profileCount,
+  activeProfileIndex: (node) => node.activeProfileIndex,
+  profileSaveStatus: (_node, index) => ({
+    state: index === 1 ? "saved" : "changed",
+    savedName: index === 1 ? "Demo" : "",
+    labelKey: index === 1 ? "profile.saved" : "profile.changed",
+  }),
+  addProfile: (node) => calls.push(["addProfile", node]),
+  deleteProfile: (node, index) => calls.push(["deleteProfile", node, index]),
+  saveProfileSet: (node) => calls.push(["saveProfileSet", node]),
+  openProfileLoadMenu: (node, event, pos) => calls.push(["openProfileLoadMenu", node, event, pos]),
+  fixProfileLoras: (node) => calls.push(["fixProfileLoras", node]),
+  switchProfile: (node, index) => calls.push(["switchProfile", node, index]),
+  nodePosToClient: (node, pos) => [node.pos[0] + pos[0], node.pos[1] + pos[1]],
+  getActiveProfileWheelTarget: () => activeProfileWheelTarget,
+  setActiveProfileWheelTarget(target) {
+    activeProfileWheelTarget = target;
+  },
+  enforceNodeLayout(node) {
+    calls.push(["enforceNodeLayout", node]);
+  },
+};
+
+const runtime = canvasModule.createLoraPresetCanvasWidgets(dependencies);
+assert.deepEqual(Object.keys(runtime).sort(), [
+  "AddLoraWidget",
+  "LoraHeaderWidget",
+  "LoraRowWidget",
+  "ProfileBarWidget",
+  "clearLoraStrengthDrag",
+  "ensureProfileBar",
+  "minNodeWidth",
+  "pointInArea",
+  "profileVisibleRows",
+  "renderLoraWidgets",
+  "renderProfileBar",
+]);
+assert.equal(runtime.minNodeWidth, 520);
+assert.equal(runtime.profileVisibleRows, 6);
+assert.equal(runtime.pointInArea([10, 20], [10, 20, 30, 40]), true);
+assert.equal(runtime.pointInArea([40, 60], [10, 20, 30, 40]), true);
+assert.equal(runtime.pointInArea([40.1, 60], [10, 20, 30, 40]), false);
+
+function fakeContext() {
+  const textCalls = [];
+  return {
+    textCalls,
+    save() {},
+    restore() {},
+    beginPath() {},
+    roundRect() {},
+    moveTo() {},
+    lineTo() {},
+    quadraticCurveTo() {},
+    rect() {},
+    clip() {},
+    arc() {},
+    fill() {},
+    stroke() {},
+    measureText(value) {
+      return { width: String(value).length * 6 };
+    },
+    fillText(value, x, y) {
+      textCalls.push({ value, x, y });
+    },
+  };
+}
+
+const profileWidget = new runtime.ProfileBarWidget();
+const headerWidget = new runtime.LoraHeaderWidget();
+const rowWidget = new runtime.LoraRowWidget(0);
+const addWidget = new runtime.AddLoraWidget();
+for (const widget of [profileWidget, headerWidget, rowWidget, addWidget]) {
+  assert.equal(widget.type, "custom");
+  assert.equal(widget.serialize, false);
+  assert.deepEqual(widget.options, { serialize: false });
+}
+assert.equal(profileWidget.name, "easyuse_anima_profile_bar");
+assert.equal(headerWidget.name, "easyuse_anima_lora_header");
+assert.equal(rowWidget.name, "easyuse_anima_lora_0");
+assert.equal(addWidget.name, "easyuse_anima_add_lora");
+assert.deepEqual(profileWidget.computeSize(undefined, makeNode({ profileCount: 1 })), [520, 60]);
+assert.deepEqual(profileWidget.computeSize(undefined, makeNode({ profileCount: 8 })), [520, 170]);
+assert.deepEqual(headerWidget.computeSize(), [520, 24]);
+assert.deepEqual(rowWidget.computeSize(), [520, 20]);
+assert.deepEqual(addWidget.computeSize(), [520, 36]);
+
+{
+  const node = makeNode({
+    widgets: [
+      { name: "style_prompt" },
+      { name: "stale_control", __easyuseAnimaControlWidget: true },
+      { name: "lora_name" },
+      { name: "loras" },
+      { name: "stale_lora", __easyuseAnimaLoraWidget: true },
+    ],
+  });
+  runtime.ensureProfileBar(node);
+  assert.deepEqual(node.widgets.map((widget) => widget.name), [
+    "style_prompt",
+    "easyuse_anima_profile_bar",
+    "lora_name",
+    "loras",
+    "easyuse_anima_lora_header",
+    "easyuse_anima_lora_0",
+    "easyuse_anima_lora_1",
+    "easyuse_anima_add_lora",
+  ]);
+  const firstBar = node.__easyuseAnimaProfileBar;
+  runtime.ensureProfileBar(node);
+  assert.equal(node.__easyuseAnimaProfileBar, firstBar);
+  assert.equal(node.widgets.filter((widget) => widget.name === "easyuse_anima_profile_bar").length, 1);
+  node.loras = [];
+  runtime.renderLoraWidgets(node);
+  assert.deepEqual(node.widgets.map((widget) => widget.name), [
+    "style_prompt",
+    "easyuse_anima_profile_bar",
+    "lora_name",
+    "loras",
+    "easyuse_anima_add_lora",
+  ]);
+}
+
+{
+  const node = makeNode({ profileCount: 8 });
+  const widget = new runtime.ProfileBarWidget();
+  const ctx = fakeContext();
+  widget.draw(ctx, node, 520, 0, 170);
+  assert.deepEqual(widget.hitAreas.slice(0, 5).map((area) => area[4]), [
+    "load",
+    "save",
+    "fix",
+    "delete",
+    "add",
+  ]);
+  assert.deepEqual(widget.listArea, [8, 34, 504, 132]);
+  assert.deepEqual(widget.listClientArea, [108, 234, 504, 132]);
+  assert.ok(widget.scrollTrackArea);
+  assert.ok(widget.scrollThumbArea);
+
+  const clickArea = (id) => {
+    const area = widget.hitAreas.find((candidate) => candidate[4] === id);
+    assert.ok(area, `missing hit area ${id}`);
+    const event = { type: "pointerdown", button: 0 };
+    const pos = [area[0] + area[2] / 2, area[1] + area[3] / 2];
+    assert.equal(widget.mouse(event, pos, node), true);
+  };
+  for (const id of ["add", "delete", "save", "load", "fix", "profile:3"]) {
+    clickArea(id);
+  }
+  assert.ok(calls.some((call) => call[0] === "addProfile"));
+  assert.ok(calls.some((call) => call[0] === "deleteProfile" && call[2] === 2));
+  assert.ok(calls.some((call) => call[0] === "saveProfileSet"));
+  assert.ok(calls.some((call) => call[0] === "openProfileLoadMenu"));
+  assert.ok(calls.some((call) => call[0] === "fixProfileLoras"));
+  assert.ok(calls.some((call) => call[0] === "switchProfile" && call[2] === 3));
+
+  assert.equal(widget.mouse({ type: "wheel", deltaY: 1 }, [20, 50], node), true);
+  assert.equal(widget.scrollOffset, 1);
+  assert.equal(widget.mouse({ type: "pointermove" }, [20, 50], node), false);
+  assert.equal(activeProfileWheelTarget.node, node);
+  assert.equal(activeProfileWheelTarget.widget, widget);
+  assert.equal(widget.mouse({ type: "pointerout" }, [700, 700], node), false);
+  assert.equal(activeProfileWheelTarget, null);
+
+  const thumb = widget.scrollThumbArea;
+  const thumbPos = [thumb[0] + 1, thumb[1] + 1];
+  assert.equal(widget.mouse({ type: "pointerdown", button: 0 }, thumbPos, node), true);
+  assert.equal(widget.scrollDragging, true);
+  assert.equal(widget.mouse({ type: "pointermove" }, [thumbPos[0], widget.scrollTrackArea[1] + widget.scrollTrackArea[3]], node), true);
+  assert.equal(widget.mouse({ type: "pointerup" }, thumbPos, node), true);
+  assert.equal(widget.scrollDragging, false);
+}
+
+{
+  const ctx = fakeContext();
+  const narrow = makeNode({ width: 229 });
+  const row = new runtime.LoraRowWidget(0);
+  row.draw(ctx, narrow, 520, 0, 20);
+  assert.equal(row.hitAreas.toggle[0], 6);
+  assert.equal(row.hitAreas.strengthAny, null);
+  assert.equal(row.hitAreas.menu, null);
+  assert.equal(row.hitAreas.info, null);
+  assert.equal(row.hitAreas.fix, null);
+
+  for (const [width, expected] of [
+    [230, { strength: true, menu: false, info: false, fix: false }],
+    [280, { strength: true, menu: true, info: false, fix: false }],
+    [310, { strength: true, menu: true, info: true, fix: false }],
+    [330, { strength: true, menu: true, info: true, fix: true }],
+  ]) {
+    const thresholdNode = makeNode({ width });
+    row.draw(fakeContext(), thresholdNode, 520, 0, 20);
+    assert.equal(!!row.hitAreas.strengthAny, expected.strength, `strength at ${width}`);
+    assert.equal(!!row.hitAreas.menu, expected.menu, `menu at ${width}`);
+    assert.equal(!!row.hitAreas.info, expected.info, `info at ${width}`);
+    assert.equal(!!row.hitAreas.fix, expected.fix, `fix at ${width}`);
+  }
+  const wide = makeNode({ width: 340 });
+  row.draw(fakeContext(), wide, 520, 0, 20);
+  assert.equal(row.hitAreas.toggle[0], 10);
+
+  const shortHeaderContext = fakeContext();
+  headerWidget.draw(shortHeaderContext, makeNode({ width: 319 }), 520, 0, 24);
+  assert.ok(shortHeaderContext.textCalls.some((call) => call.value === "lora.allShort"));
+  assert.ok(shortHeaderContext.textCalls.some((call) => call.value === "lora.strengthShort"));
+  const fullHeaderContext = fakeContext();
+  headerWidget.draw(fullHeaderContext, makeNode({ width: 320 }), 520, 0, 24);
+  assert.ok(fullHeaderContext.textCalls.some((call) => call.value === "lora.toggleAll"));
+  assert.ok(fullHeaderContext.textCalls.some((call) => call.value === "lora.strength"));
+}
+
+function rowWithHitAreas() {
+  const row = new runtime.LoraRowWidget(0);
+  row.hitAreas = {
+    toggle: [0, 0, 10, 20],
+    fix: [20, 0, 10, 20],
+    lora: [40, 0, 10, 20],
+    menu: [60, 0, 10, 20],
+    info: [80, 0, 10, 20],
+    dec: [100, 0, 9, 20],
+    value: [112, 0, 32, 20],
+    inc: [148, 0, 9, 20],
+    strengthAny: [100, 0, 57, 20],
+  };
+  return row;
+}
+
+{
+  const node = makeNode();
+  let row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [5, 10], node), true);
+  assert.equal(node.loras[0].on, false);
+  row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [25, 10], node), true);
+  assert.ok(calls.some((call) => call[0] === "fixSingleLoraEntry"));
+  row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [45, 10], node), true);
+  assert.ok(chosenLoraCallback);
+  chosenLoraCallback({ name: "replacement.safetensors" });
+  assert.equal(node.loras[0].name, "replacement.safetensors");
+  row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [65, 10], node), true);
+  assert.ok(calls.some((call) => call[0] === "openLoraEntryMenu"));
+  row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointermove" }, [85, 10], node), false);
+  assert.equal(previewCalls.at(-1)[0], "show");
+  assert.equal(row.mouse({ type: "pointermove" }, [15, 10], node), false);
+  assert.deepEqual(previewCalls.at(-1), ["hide"]);
+  assert.equal(row.mouse({ type: "pointerout" }, [15, 10], node), false);
+  assert.deepEqual(previewCalls.at(-1), ["hide"]);
+  assert.equal(row.mouse({ type: "pointercancel" }, [15, 10], node), false);
+  assert.deepEqual(previewCalls.at(-1), ["hide"]);
+  row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 2 }, [300, 10], node), true);
+
+  node.loras[0].strength = 1;
+  row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [104, 10], node), true);
+  assert.equal(node.loras[0].strength, 0.95);
+  row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [152, 10], node), true);
+  assert.equal(node.loras[0].strength, 1);
+}
+
+{
+  const node = makeNode({ loras: [{ name: "drag.safetensors", on: true, strength: 1 }] });
+  const row = rowWithHitAreas();
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [120, 10], node), true);
+  assert.deepEqual(node.__easyuseAnimaStrengthDrag, {
+    index: 0,
+    startX: 120,
+    startStrength: 1,
+    lastSteps: 0,
+    moved: false,
+    promptOnClick: true,
+  });
+  const previewCountBeforeDragOut = previewCalls.length;
+  assert.equal(addWidget.mouse({ type: "pointerout" }, [127, 10], node), true);
+  assert.equal(previewCalls.length, previewCountBeforeDragOut);
+  assert.equal(headerWidget.mouse({ type: "pointermove" }, [127, 10], node), true);
+  assert.equal(node.loras[0].strength, 1);
+  assert.equal(headerWidget.mouse({ type: "pointermove" }, [128, 10], node), true);
+  assert.equal(node.loras[0].strength, 1.05);
+  assert.equal(headerWidget.mouse({ type: "pointermove" }, [136, 10], node), true);
+  assert.equal(node.loras[0].strength, 1.1);
+  assert.equal(headerWidget.mouse({ type: "pointermove" }, [120, 10], node), true);
+  assert.equal(node.loras[0].strength, 1);
+  assert.equal(headerWidget.mouse({ type: "pointerup" }, [120, 10], node), true);
+  assert.equal(node.__easyuseAnimaStrengthDrag, null);
+  assert.equal(promptCalls.length, 0);
+
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [120, 10], node), true);
+  const pointerUpEvent = { type: "pointerup" };
+  assert.equal(addWidget.mouse(pointerUpEvent, [120, 10], node), true);
+  assert.equal(promptCalls.length, 1);
+  assert.equal(promptCalls[0].message, "lora.strengthPrompt");
+  assert.equal(promptCalls[0].value, 1);
+  assert.equal(promptCalls[0].event, pointerUpEvent);
+  promptCalls[0].callback("1.2345");
+  assert.equal(node.loras[0].strength, 1.235);
+
+  assert.equal(row.mouse({ type: "pointerdown", button: 0 }, [120, 10], node), true);
+  assert.equal(profileWidget.mouse({ type: "pointercancel" }, [120, 10], node), true);
+  assert.equal(node.__easyuseAnimaStrengthDrag, null);
+  assert.equal(promptCalls.length, 1);
+}
+
+{
+  const node = makeNode();
+  const header = new runtime.LoraHeaderWidget();
+  header.toggleArea = [0, 0, 20, 20];
+  assert.equal(header.mouse({ type: "pointerdown", button: 0 }, [5, 5], node), true);
+  assert.ok(node.loras.every((lora) => lora.on === true));
+
+  const add = new runtime.AddLoraWidget();
+  add.hitArea = [0, 0, 100, 20];
+  assert.equal(add.mouse({ type: "pointerdown", button: 0 }, [5, 5], node), true);
+  chosenLoraCallback({ name: "added.safetensors" });
+  assert.ok(calls.some((call) => call[0] === "addLoraEntry" && call[2].name === "added.safetensors"));
+}
+
+console.log("LoRA preset canvas widgets smoke passed.");

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -15,6 +15,12 @@ LORA_PRESET_API_CLIENT = ROOT / "web" / "js" / "lora_preset" / "api_client.js"
 LORA_PRESET_API_CLIENT_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_api_client_smoke.mjs"
 )
+LORA_PRESET_CANVAS_WIDGETS = (
+    ROOT / "web" / "js" / "lora_preset" / "canvas_widgets.js"
+)
+LORA_PRESET_CANVAS_WIDGETS_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_canvas_widgets_smoke.mjs"
+)
 LORA_PRESET_PREVIEW_LIFECYCLE = (
     ROOT / "web" / "js" / "lora_preset" / "preview_lifecycle.js"
 )
@@ -156,9 +162,187 @@ class LoraPresetFrontendTests(unittest.TestCase):
         if completed.returncode != 0:
             self.fail((completed.stdout + completed.stderr).strip())
 
+    def test_canvas_widgets_module_boundary(self):
+        module_source = LORA_PRESET_CANVAS_WIDGETS.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createLoraPresetCanvasWidgets"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|registerExtension|"
+                r"MutationObserver)\b"
+            ),
+        )
+        self.assertIn(
+            'import { createLoraPresetCanvasWidgets } from '
+            '"./lora_preset/canvas_widgets.js";',
+            entry_source,
+        )
+
+        factory_match = re.search(
+            r"const\s+loraCanvasWidgets\s*=\s*"
+            r"createLoraPresetCanvasWidgets"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().rstrip(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "getCanvas: () => app.canvas",
+                "getLiteGraph: () => LiteGraph",
+                "getSettings: () => LORA_PRESET_SETTINGS",
+                "text: lpText",
+                "formatText: lpFormat",
+                "normalizeLoraEntry",
+                "lorasWidgetValue",
+                "mutateLoras",
+                "updateLoraEntry",
+                "loraResolveState",
+                "hasLoraPathProblem",
+                "isAnyLoraFixPending",
+                "isLoraFixPending",
+                "loraDisplayName",
+                "previewLifecycle: loraPreviewLifecycle",
+                "openLoraMenu",
+                "openLoraEntryMenu",
+                "addLoraEntry",
+                "fixSingleLoraEntry",
+                "profileCount",
+                "activeProfileIndex",
+                "profileSaveStatus",
+                "addProfile",
+                "deleteProfile",
+                "saveProfileSet",
+                "openProfileLoadMenu",
+                "fixProfileLoras",
+                "switchProfile",
+                "nodePosToClient",
+                "getActiveProfileWheelTarget",
+                "setActiveProfileWheelTarget",
+                "enforceNodeLayout",
+            },
+        )
+
+        moved_declarations = {
+            "MIN_NODE_WIDTH",
+            "PROFILE_CONTROLS_HEIGHT",
+            "PROFILE_ROW_HEIGHT",
+            "PROFILE_LIST_PADDING",
+            "PROFILE_VISIBLE_ROWS",
+            "LORA_HEADER_HEIGHT",
+            "LORA_ROW_HEIGHT",
+            "LORA_ADD_HEIGHT",
+            "roundStrength",
+            "clearLoraStrengthDrag",
+            "beginLoraStrengthDrag",
+            "handleLoraStrengthDrag",
+            "fitCanvasText",
+            "roundedRect",
+            "pointInArea",
+            "drawToggle",
+            "drawNumberPart",
+            "nodeWidgetWidth",
+            "ProfileBarWidget",
+            "LoraHeaderWidget",
+            "LoraRowWidget",
+            "AddLoraWidget",
+            "renderProfileBar",
+            "renderLoraWidgets",
+            "ensureProfileBar",
+        }
+        for name in moved_declarations:
+            with self.subTest(moved_declaration=name):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\b(?:const|let|var|function|class)\s+{re.escape(name)}\b",
+                )
+
+        for class_name in (
+            "ProfileBarWidget",
+            "LoraHeaderWidget",
+            "LoraRowWidget",
+            "AddLoraWidget",
+        ):
+            with self.subTest(canvas_widget_class=class_name):
+                self.assertIn(f"class {class_name}", module_source)
+        self.assertEqual(module_source.count("this.serialize = false;"), 4)
+        self.assertEqual(
+            module_source.count('this.options = { serialize: false };'),
+            4,
+        )
+        self.assertIn("let activeProfileWheelTarget = null;", entry_source)
+        self.assertIn(
+            'document.addEventListener("wheel", scrollProfileListFromWheel, '
+            '{ capture: true, passive: false });',
+            entry_source,
+        )
+        self.assertIn("function scrollProfileListFromWheel(event)", entry_source)
+        self.assertIn("loraMenuLifecycle.install()", entry_source)
+        self.assertNotIn("loraMenuLifecycle.install()", module_source)
+        for entry_owned_token in (
+            "function addProfile(",
+            "function deleteProfile(",
+            "function saveCurrentProfile(",
+            "function mutateLoras(",
+            "function installLoraPresetSaveSync(",
+            "function scrollProfileListFromWheel(",
+            "function installProfileWheelListener(",
+            "function initializeNode(",
+            "node.onSerialize = function",
+            "node.onConfigure = function",
+            "app.registerExtension({",
+        ):
+            with self.subTest(entry_owned_token=entry_owned_token):
+                self.assertIn(entry_owned_token, entry_source)
+                self.assertNotIn(entry_owned_token, module_source)
+        self.assertGreater(entry_source.count("loraCanvasWidgets.renderProfileBar("), 0)
+        self.assertGreater(entry_source.count("loraCanvasWidgets.renderLoraWidgets("), 0)
+        self.assertTrue(LORA_PRESET_CANVAS_WIDGETS_SMOKE.is_file())
+        self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+
+    def test_canvas_widgets_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_CANVAS_WIDGETS_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_preview_lifecycle_module_boundary(self):
         module_source = LORA_PRESET_PREVIEW_LIFECYCLE.read_text(encoding="utf-8")
         entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        canvas_widgets_source = LORA_PRESET_CANVAS_WIDGETS.read_text(
+            encoding="utf-8"
+        )
         config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
@@ -223,8 +407,10 @@ class LoraPresetFrontendTests(unittest.TestCase):
                     entry_source,
                     rf"\b(?:const|let|var|function|class)\s+{moved_name}\b",
                 )
-        self.assertEqual(entry_source.count("loraPreviewLifecycle.showPreview"), 2)
-        self.assertEqual(entry_source.count("loraPreviewLifecycle.hidePreview"), 4)
+        self.assertEqual(entry_source.count("loraPreviewLifecycle.showPreview"), 0)
+        self.assertEqual(entry_source.count("loraPreviewLifecycle.hidePreview"), 1)
+        self.assertEqual(canvas_widgets_source.count("previewLifecycle.showPreview"), 2)
+        self.assertEqual(canvas_widgets_source.count("previewLifecycle.hidePreview"), 3)
         self.assertEqual(
             entry_source.count("loraPreviewLifecycle.forgetMissingPreview"),
             1,
@@ -578,6 +764,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const apiClientPath = process.argv[4];
             const previewLifecyclePath = process.argv[5];
             const menuLifecyclePath = process.argv[6];
+            const canvasWidgetsPath = process.argv[7];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -603,10 +790,15 @@ class LoraPresetFrontendTests(unittest.TestCase):
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let canvasWidgetsSource = fs.readFileSync(canvasWidgetsPath, "utf8");
+            canvasWidgetsSource = canvasWidgetsSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${source}`;
-            source += "\nglobalThis.__loraPresetTest = { LoraRowWidget, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${source}`;
+            source += "\nglobalThis.__loraPresetTest = { loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
             class StubMutationObserver {
@@ -704,7 +896,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             vm.runInContext(source, context, { filename: sourcePath });
 
             const {
-              LoraRowWidget,
+              loraCanvasWidgets,
               LORA_PRESET_SETTINGS,
               applyLoraPresetSettings,
               loraPresetApi,
@@ -712,6 +904,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
               loraMenuLifecycle,
               saveProfileSet,
             } = context.__loraPresetTest;
+            const { LoraRowWidget } = loraCanvasWidgets;
 
             function widget(name, value) {
               return { name, value };
@@ -935,6 +1128,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_API_CLIENT),
                 str(LORA_PRESET_PREVIEW_LIFECYCLE),
                 str(LORA_PRESET_MENU_LIFECYCLE),
+                str(LORA_PRESET_CANVAS_WIDGETS),
             ],
             cwd=ROOT,
             text=True,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -179,6 +179,11 @@ try {
         throw "Frontend LoRA preset menu lifecycle smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_canvas_widgets_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset canvas widgets smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_data_adapter_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -3,6 +3,7 @@ import { api } from "../../../scripts/api.js";
 import { easyuseAnimaEncodeRFC3986URIComponent as encodeRFC3986URIComponent, easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
 import { createLoraPresetApiClient } from "./lora_preset/api_client.js";
+import { createLoraPresetCanvasWidgets } from "./lora_preset/canvas_widgets.js";
 import { createLoraPresetMenuLifecycle } from "./lora_preset/menu_lifecycle.js";
 import { createLoraPresetPreviewLifecycle } from "./lora_preset/preview_lifecycle.js";
 import {
@@ -33,14 +34,6 @@ import {
 } from "./lora_preset/lora_state.js";
 
 const NODE_TYPE = "EasyUseAnimaLoraPreset";
-const MIN_NODE_WIDTH = 520;
-const PROFILE_CONTROLS_HEIGHT = 30;
-const PROFILE_ROW_HEIGHT = 22;
-const PROFILE_LIST_PADDING = 4;
-const PROFILE_VISIBLE_ROWS = 6;
-const LORA_HEADER_HEIGHT = 24;
-const LORA_ROW_HEIGHT = 20;
-const LORA_ADD_HEIGHT = 36;
 const DEFAULT_STRENGTH_BUTTON_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_PIXELS = 8;
@@ -54,6 +47,15 @@ const LORA_PRESET_SETTINGS = {
   strengthDragStep: DEFAULT_STRENGTH_DRAG_STEP,
   strengthDragPixels: DEFAULT_STRENGTH_DRAG_PIXELS,
 };
+
+function getActiveProfileWheelTarget() {
+  return activeProfileWheelTarget;
+}
+
+function setActiveProfileWheelTarget(target) {
+  activeProfileWheelTarget = target;
+}
+
 const LORA_PRESET_TEXT = {
   en: {
     "profile.deleteConfirm": "Delete profile {index}?",
@@ -316,6 +318,40 @@ const loraMenuLifecycle = createLoraPresetMenuLifecycle({
   nodeType: NODE_TYPE,
   previewSize: PREVIEW_SIZE,
 });
+const loraCanvasWidgets = createLoraPresetCanvasWidgets({
+  getCanvas: () => app.canvas,
+  getLiteGraph: () => LiteGraph,
+  getSettings: () => LORA_PRESET_SETTINGS,
+  text: lpText,
+  formatText: lpFormat,
+  normalizeLoraEntry,
+  lorasWidgetValue,
+  mutateLoras,
+  updateLoraEntry,
+  loraResolveState,
+  hasLoraPathProblem,
+  isAnyLoraFixPending,
+  isLoraFixPending,
+  loraDisplayName,
+  previewLifecycle: loraPreviewLifecycle,
+  openLoraMenu,
+  openLoraEntryMenu,
+  addLoraEntry,
+  fixSingleLoraEntry,
+  profileCount,
+  activeProfileIndex,
+  profileSaveStatus,
+  addProfile,
+  deleteProfile,
+  saveProfileSet,
+  openProfileLoadMenu,
+  fixProfileLoras,
+  switchProfile,
+  nodePosToClient,
+  getActiveProfileWheelTarget,
+  setActiveProfileWheelTarget,
+  enforceNodeLayout,
+});
 
 function firstValue(value, fallback = null) {
   if (Array.isArray(value)) {
@@ -429,12 +465,12 @@ function scrollProfileBarTo(node, index) {
     return;
   }
   const count = profileCount(node);
-  const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
+  const maxOffset = Math.max(0, count - loraCanvasWidgets.profileVisibleRows);
   const target = wrapProfileIndex(index, count);
   if (target <= (bar.scrollOffset || 0)) {
     bar.scrollOffset = Math.max(0, target - 1);
-  } else if (target > (bar.scrollOffset || 0) + PROFILE_VISIBLE_ROWS) {
-    bar.scrollOffset = Math.max(0, Math.min(maxOffset, target - PROFILE_VISIBLE_ROWS));
+  } else if (target > (bar.scrollOffset || 0) + loraCanvasWidgets.profileVisibleRows) {
+    bar.scrollOffset = Math.max(0, Math.min(maxOffset, target - loraCanvasWidgets.profileVisibleRows));
   }
 }
 
@@ -464,7 +500,7 @@ function setLorasWidgetValue(node, loras, options = {}) {
     : [];
   setWidgetValue(widget, JSON.stringify(value));
   if (options.render !== false) {
-    renderLoraWidgets(node);
+    loraCanvasWidgets.renderLoraWidgets(node);
   } else {
     node.setDirtyCanvas?.(true, true);
   }
@@ -520,7 +556,7 @@ function switchProfile(node, index) {
   const nextIndex = wrapProfileIndex(index, profileCount(node));
   const currentIndex = activeProfileIndex(node);
   if (nextIndex === currentIndex) {
-    renderProfileBar(node);
+    loraCanvasWidgets.renderProfileBar(node);
     return;
   }
   saveProfile(node, currentIndex);
@@ -528,7 +564,7 @@ function switchProfile(node, index) {
   node.__easyuseAnimaActiveProfileIndex = nextIndex;
   loadProfile(node, nextIndex);
   scrollProfileBarTo(node, nextIndex);
-  renderProfileBar(node);
+  loraCanvasWidgets.renderProfileBar(node);
   node.setDirtyCanvas?.(true, true);
 }
 
@@ -572,7 +608,7 @@ function deleteProfile(node, index) {
   setProfileIndex(node, nextActive);
   loadProfile(node, nextActive);
   scrollProfileBarTo(node, nextActive);
-  renderProfileBar(node);
+  loraCanvasWidgets.renderProfileBar(node);
   node.setDirtyCanvas?.(true, true);
 }
 
@@ -675,8 +711,8 @@ function appendProfilePayload(node, payload) {
   node.__easyuseAnimaActiveProfileIndex = nextIndex;
   loadProfile(node, nextIndex);
   scrollProfileBarTo(node, nextIndex);
-  renderProfileBar(node);
-  renderLoraWidgets(node);
+  loraCanvasWidgets.renderProfileBar(node);
+  loraCanvasWidgets.renderLoraWidgets(node);
   node.setDirtyCanvas?.(true, true);
 }
 
@@ -696,7 +732,7 @@ async function saveProfileSet(node) {
       selectedProfilePayload(node),
     );
     markSelectedProfileSaved(node, data?.profile?.name || trimmedName);
-    renderProfileBar(node);
+    loraCanvasWidgets.renderProfileBar(node);
     node.setDirtyCanvas?.(true, true);
   } catch (error) {
     window.alert(lpFormat("profile.saveFailed", { message: errorMessage(error) }));
@@ -793,8 +829,8 @@ function applyFixedProfilePayload(node, payload) {
   node.__easyuseAnimaActiveProfileIndex = nextIndex;
   loadProfile(node, nextIndex);
   scrollProfileBarTo(node, nextIndex);
-  renderProfileBar(node);
-  renderLoraWidgets(node);
+  loraCanvasWidgets.renderProfileBar(node);
+  loraCanvasWidgets.renderLoraWidgets(node);
   refreshLoraAvailability(node);
   node.setDirtyCanvas?.(true, true);
 }
@@ -804,8 +840,8 @@ async function fixProfileLoras(node) {
     return;
   }
   node.__easyuseAnimaProfileFixPending = true;
-  renderProfileBar(node);
-  renderLoraWidgets(node);
+  loraCanvasWidgets.renderProfileBar(node);
+  loraCanvasWidgets.renderLoraWidgets(node);
   try {
     await refreshLoraLookupForFix(node);
     saveCurrentProfile(node);
@@ -824,8 +860,8 @@ async function fixProfileLoras(node) {
     window.alert(lpFormat("profile.fixFailed", { message: errorMessage(error) }));
   } finally {
     node.__easyuseAnimaProfileFixPending = false;
-    renderProfileBar(node);
-    renderLoraWidgets(node);
+    loraCanvasWidgets.renderProfileBar(node);
+    loraCanvasWidgets.renderLoraWidgets(node);
   }
 }
 
@@ -834,13 +870,13 @@ async function fixSingleLoraEntry(node, index) {
     return;
   }
   loraFixPendingSet(node).add(index);
-  renderLoraWidgets(node);
+  loraCanvasWidgets.renderLoraWidgets(node);
   saveCurrentProfile(node);
   const loras = lorasWidgetValue(node).map(normalizeLoraEntry);
   const lora = loras[index];
   if (!lora?.name) {
     loraFixPendingSet(node).delete(index);
-    renderLoraWidgets(node);
+    loraCanvasWidgets.renderLoraWidgets(node);
     return;
   }
   try {
@@ -879,7 +915,7 @@ async function fixSingleLoraEntry(node, index) {
     window.alert(lpFormat("lora.fixFailed", { message: errorMessage(error) }));
   } finally {
     loraFixPendingSet(node).delete(index);
-    renderLoraWidgets(node);
+    loraCanvasWidgets.renderLoraWidgets(node);
   }
 }
 
@@ -907,7 +943,7 @@ function setLoraLookup(node, values) {
     return;
   }
   node.__easyuseAnimaLoraLookup = buildLoraLookup(values);
-  renderLoraWidgets(node);
+  loraCanvasWidgets.renderLoraWidgets(node);
 }
 
 async function fetchLoraNameValues(node) {
@@ -931,73 +967,6 @@ function refreshLoraAvailability(node) {
   fetchLoraNameValues(node).catch((error) => {
     console.warn("[EasyUse Anima] failed to refresh LoRA availability", error);
   });
-}
-
-function roundStrength(value) {
-  return Math.round(Number(value || 0) * 1000) / 1000;
-}
-
-function clearLoraStrengthDrag(node) {
-  if (node?.__easyuseAnimaStrengthDrag) {
-    node.__easyuseAnimaStrengthDrag = null;
-  }
-}
-
-function beginLoraStrengthDrag(node, index, pos, lora) {
-  node.__easyuseAnimaStrengthDrag = {
-    index,
-    startX: Number(pos?.[0]) || 0,
-    startStrength: Number(lora?.strength ?? 1) || 0,
-    lastSteps: 0,
-    moved: false,
-    promptOnClick: true,
-  };
-}
-
-function handleLoraStrengthDrag(node, event, pos) {
-  const drag = node?.__easyuseAnimaStrengthDrag;
-  if (!drag) {
-    return false;
-  }
-  if (event.type === "pointerleave" || event.type === "pointerout") {
-    return true;
-  }
-  if (event.type === "pointercancel") {
-    clearLoraStrengthDrag(node);
-    return true;
-  }
-  if (event.type === "pointermove") {
-    const currentX = Number(pos?.[0]);
-    const distance = Number.isFinite(currentX) ? currentX - drag.startX : Number(event.deltaX || 0);
-    const pixels = Math.max(1, LORA_PRESET_SETTINGS.strengthDragPixels);
-    const steps = Math.trunc(distance / pixels);
-    if (steps !== drag.lastSteps) {
-      drag.lastSteps = steps;
-      drag.moved = true;
-      updateLoraEntry(
-        node,
-        drag.index,
-        { strength: roundStrength(drag.startStrength + steps * LORA_PRESET_SETTINGS.strengthDragStep) },
-        { render: false },
-      );
-    }
-    return true;
-  }
-  if (event.type === "pointerup") {
-    const shouldPrompt = drag.promptOnClick && !drag.moved;
-    const lora = normalizeLoraEntry(lorasWidgetValue(node)[drag.index]);
-    clearLoraStrengthDrag(node);
-    if (shouldPrompt && lora.name) {
-      app.canvas.prompt(lpText("lora.strengthPrompt"), lora.strength ?? 1, (value) => {
-        const next = Number(value);
-        if (Number.isFinite(next)) {
-          updateLoraEntry(node, drag.index, { strength: roundStrength(next) });
-        }
-      }, event);
-    }
-    return true;
-  }
-  return false;
 }
 
 function loraEntryFromName(name, base = {}) {
@@ -1105,86 +1074,6 @@ function openLoraEntryMenu(node, event, index) {
   });
 }
 
-function fitCanvasText(ctx, text, maxWidth) {
-  const value = String(text || "");
-  if (ctx.measureText(value).width <= maxWidth) {
-    return value;
-  }
-  const ellipsis = "...";
-  let result = value;
-  while (result.length > 1 && ctx.measureText(`${result}${ellipsis}`).width > maxWidth) {
-    result = result.slice(0, -1);
-  }
-  return `${result}${ellipsis}`;
-}
-
-function roundedRect(ctx, x, y, width, height, radius) {
-  if (typeof ctx.roundRect === "function") {
-    ctx.roundRect(x, y, width, height, radius);
-    return;
-  }
-  const r = Math.min(radius, width / 2, height / 2);
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + width - r, y);
-  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
-  ctx.lineTo(x + width, y + height - r);
-  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-  ctx.lineTo(x + r, y + height);
-  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
-}
-
-function pointInArea(pos, area) {
-  return !!area
-    && pos[0] >= area[0]
-    && pos[0] <= area[0] + area[2]
-    && pos[1] >= area[1]
-    && pos[1] <= area[1] + area[3];
-}
-
-function drawToggle(ctx, x, y, height, value) {
-  const width = height * 1.5;
-  ctx.save();
-  ctx.globalAlpha = app.canvas.editor_alpha * 0.25;
-  ctx.fillStyle = "rgba(255,255,255,0.45)";
-  ctx.beginPath();
-  roundedRect(ctx, x + 4, y + 4, width - 8, height - 8, height / 2);
-  ctx.fill();
-  ctx.globalAlpha = app.canvas.editor_alpha;
-  ctx.fillStyle = value ? "#89B" : "#888";
-  ctx.beginPath();
-  ctx.arc(value ? x + height : x + height * 0.5, y + height * 0.5, height * 0.36, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.restore();
-  return [x, y, width, height];
-}
-
-function drawNumberPart(ctx, x, y, height, value) {
-  const arrowWidth = 9;
-  const arrowHeight = 10;
-  const inner = 3;
-  const numberWidth = 32;
-  const total = arrowWidth + inner + numberWidth + inner + arrowWidth;
-  const startX = x - total;
-  const midY = y + height / 2;
-  ctx.save();
-  ctx.fill(new Path2D(`M ${startX} ${midY} l ${arrowWidth} ${arrowHeight / 2} l 0 -${arrowHeight} L ${startX} ${midY} z`));
-  const textX = startX + arrowWidth + inner;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
-  ctx.fillText(Number(value ?? 1).toFixed(2), textX + numberWidth / 2, midY);
-  const rightX = textX + numberWidth + inner;
-  ctx.fill(new Path2D(`M ${rightX} ${midY - arrowHeight / 2} l ${arrowWidth} ${arrowHeight / 2} l -${arrowWidth} ${arrowHeight / 2} v -${arrowHeight} z`));
-  ctx.restore();
-  return {
-    dec: [startX, y, arrowWidth, height],
-    value: [textX, y, numberWidth, height],
-    inc: [rightX, y, arrowWidth, height],
-    any: [startX, y, total, height],
-  };
-}
-
 function hideInternalWidget(node, name) {
   const widget = findWidget(node, name);
   if (!widget) {
@@ -1254,16 +1143,12 @@ function enforceNodeLayout(node) {
   const currentWidth = Number(node.size[0]) || 0;
   const currentHeight = Number(node.size[1]) || 0;
   const computed = typeof node.computeSize === "function" ? node.computeSize() : null;
-  const nextWidth = currentWidth || MIN_NODE_WIDTH;
+  const nextWidth = currentWidth || loraCanvasWidgets.minNodeWidth;
   const nextHeight = Math.max(120, Number(computed?.[1]) || currentHeight);
   if (nextWidth !== currentWidth || nextHeight !== currentHeight) {
     node.setSize([nextWidth, nextHeight]);
   }
   node.setDirtyCanvas?.(true, true);
-}
-
-function nodeWidgetWidth(node, fallbackWidth) {
-  return Math.max(1, Number(node?.size?.[0]) || Number(fallbackWidth) || MIN_NODE_WIDTH);
 }
 
 function ensureLoraStackInput(node) {
@@ -1389,625 +1274,6 @@ async function openLoraMenu(node, event, pos, onChoose) {
   });
 }
 
-class ProfileBarWidget {
-  constructor() {
-    this.name = "easyuse_anima_profile_bar";
-    this.type = "custom";
-    this.options = { serialize: false };
-    this.serialize = false;
-    this.__easyuseAnimaControlWidget = true;
-    this.hitAreas = [];
-    this.scrollOffset = 0;
-    this.listArea = null;
-    this.listClientArea = null;
-    this.scrollTrackArea = null;
-    this.scrollThumbArea = null;
-    this.scrollDragging = false;
-    this.scrollDragDelta = 0;
-  }
-
-  computeSize(_width, node) {
-    const count = node || this.node ? profileCount(node || this.node) : 1;
-    const visibleRows = Math.max(1, Math.min(PROFILE_VISIBLE_ROWS, count));
-    return [
-      MIN_NODE_WIDTH,
-      PROFILE_CONTROLS_HEIGHT + PROFILE_LIST_PADDING * 2 + visibleRows * PROFILE_ROW_HEIGHT,
-    ];
-  }
-
-  draw(ctx, node, width, y, height) {
-    const drawWidth = nodeWidgetWidth(node, width);
-    this.hitAreas = [];
-    this.listArea = null;
-    this.listClientArea = null;
-    this.scrollTrackArea = null;
-    this.scrollThumbArea = null;
-    const active = activeProfileIndex(node);
-    const count = profileCount(node);
-    const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
-    this.scrollOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset || 0));
-
-    const buttonY = y + 4;
-    const buttonH = 22;
-    const gap = 4;
-
-    ctx.save();
-    ctx.font = "13px sans-serif";
-    ctx.textBaseline = "middle";
-    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-    ctx.globalAlpha = app.canvas.editor_alpha * 0.75;
-    ctx.textAlign = "left";
-    ctx.fillText(lpFormat("profile.header", { active, count }), 10, buttonY + buttonH / 2);
-    ctx.globalAlpha = 1;
-
-    let x = Math.max(120, drawWidth - 8);
-
-    const drawButton = (id, label, buttonW, selected = false, disabled = false) => {
-      x -= buttonW;
-      if (x < 8) {
-        return;
-      }
-      this.hitAreas.push([x, buttonY, buttonW, buttonH, id, disabled]);
-      ctx.globalAlpha = disabled ? 0.45 : 1;
-      ctx.fillStyle = selected ? "#3f79d8" : LiteGraph.WIDGET_BGCOLOR;
-      ctx.strokeStyle = selected ? "#6fa2ff" : LiteGraph.WIDGET_OUTLINE_COLOR;
-      ctx.beginPath();
-      roundedRect(ctx, x, buttonY, buttonW, buttonH, 4);
-      ctx.fill();
-      ctx.stroke();
-      ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-      ctx.textAlign = "center";
-      let fontSize = 13;
-      ctx.font = `${fontSize}px sans-serif`;
-      while (fontSize > 10 && ctx.measureText(label).width > buttonW - 8) {
-        fontSize -= 1;
-        ctx.font = `${fontSize}px sans-serif`;
-      }
-      ctx.fillText(fitCanvasText(ctx, label, buttonW - 8), x + buttonW / 2, buttonY + buttonH / 2);
-      ctx.font = "13px sans-serif";
-      x -= gap;
-      ctx.globalAlpha = 1;
-    };
-
-    drawButton("load", lpText("profile.load"), 66);
-    drawButton("save", lpText("profile.save"), 46);
-    drawButton("fix", lpText("profile.fix"), 40, false, isAnyLoraFixPending(node));
-    drawButton("delete", "X", 28, false, count <= 1);
-    drawButton("add", "+", 28);
-
-    const listX = 8;
-    const listY = y + PROFILE_CONTROLS_HEIGHT + PROFILE_LIST_PADDING;
-    const listW = Math.max(0, drawWidth - 16);
-    const visibleRows = Math.max(1, Math.min(PROFILE_VISIBLE_ROWS, count));
-    const listH = visibleRows * PROFILE_ROW_HEIGHT;
-    const hasScrollbar = count > visibleRows;
-    const scrollbarW = hasScrollbar ? 10 : 0;
-    const rowW = Math.max(0, listW - scrollbarW - (hasScrollbar ? 4 : 0));
-    this.listArea = [listX, listY, listW, listH];
-    const listClientStart = nodePosToClient(node, [listX, listY]);
-    const listClientEnd = nodePosToClient(node, [listX + listW, listY + listH]);
-    if (listClientStart && listClientEnd) {
-      this.listClientArea = [
-        Math.min(listClientStart[0], listClientEnd[0]),
-        Math.min(listClientStart[1], listClientEnd[1]),
-        Math.abs(listClientEnd[0] - listClientStart[0]),
-        Math.abs(listClientEnd[1] - listClientStart[1]),
-      ];
-    }
-
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(listX, listY, listW, listH);
-    ctx.clip();
-    for (let row = 0; row < visibleRows; row += 1) {
-      const index = this.scrollOffset + row + 1;
-      if (index > count) {
-        break;
-      }
-      const rowY = listY + row * PROFILE_ROW_HEIGHT;
-      const selected = index === active;
-      const status = profileSaveStatus(node, index);
-      const rowArea = [listX, rowY + 1, rowW, PROFILE_ROW_HEIGHT - 2];
-      this.hitAreas.push([...rowArea, `profile:${index}`, false]);
-      ctx.fillStyle = selected ? "#3f79d8" : "rgba(255,255,255,0.045)";
-      ctx.strokeStyle = selected ? "#6fa2ff" : "rgba(255,255,255,0.12)";
-      ctx.beginPath();
-      roundedRect(ctx, ...rowArea, 4);
-      ctx.fill();
-      ctx.stroke();
-
-      const stateColor = {
-        saved: "#8ecf8e",
-        changed: "#e3ba66",
-        unsaved: "#b8b8b8",
-      }[status.state] || "#b8b8b8";
-      const leftText = `${index}. ${status.savedName || lpText("profile.unsaved")}`;
-      const rightText = lpText(status.labelKey || `profile.${status.state}`);
-      ctx.font = "12px sans-serif";
-      const rightWidth = Math.min(82, Math.max(58, ctx.measureText(rightText).width + 16));
-      ctx.textAlign = "left";
-      ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-      ctx.fillText(fitCanvasText(ctx, leftText, Math.max(20, rowW - rightWidth - 18)), listX + 8, rowY + PROFILE_ROW_HEIGHT / 2);
-      ctx.textAlign = "right";
-      ctx.fillStyle = stateColor;
-      ctx.fillText(rightText, listX + rowW - 8, rowY + PROFILE_ROW_HEIGHT / 2);
-    }
-    ctx.restore();
-
-    if (hasScrollbar) {
-      const trackW = 8;
-      const trackX = listX + listW - trackW - 1;
-      this.scrollTrackArea = [trackX - 2, listY, trackW + 4, listH];
-      ctx.fillStyle = "rgba(255,255,255,0.08)";
-      ctx.beginPath();
-      roundedRect(ctx, trackX, listY, trackW, listH, 4);
-      ctx.fill();
-
-      const barH = Math.max(14, listH * (visibleRows / count));
-      const barY = listY + (listH - barH) * (this.scrollOffset / Math.max(1, maxOffset));
-      this.scrollThumbArea = [trackX - 2, barY, trackW + 4, barH];
-      ctx.fillStyle = "rgba(255,255,255,0.42)";
-      ctx.beginPath();
-      roundedRect(ctx, trackX, barY, trackW, barH, 4);
-      ctx.fill();
-    }
-    ctx.restore();
-  }
-
-  scrollToPointer(pos, node) {
-    const count = profileCount(node);
-    const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
-    if (maxOffset <= 0 || !this.scrollTrackArea || !this.scrollThumbArea) {
-      return false;
-    }
-    const trackY = this.scrollTrackArea[1];
-    const trackH = this.scrollTrackArea[3];
-    const thumbH = this.scrollThumbArea[3];
-    const range = Math.max(1, trackH - thumbH);
-    const y = Math.max(0, Math.min(range, pos[1] - trackY - this.scrollDragDelta));
-    const nextOffset = Math.round((y / range) * maxOffset);
-    if (nextOffset !== this.scrollOffset) {
-      this.scrollOffset = nextOffset;
-      node.setDirtyCanvas?.(true, true);
-    }
-    return true;
-  }
-
-  scrollByWheel(deltaY, node) {
-    const count = profileCount(node);
-    const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
-    if (maxOffset <= 0) {
-      return false;
-    }
-    const direction = Number(deltaY || 0) > 0 ? 1 : -1;
-    const nextOffset = Math.max(0, Math.min(maxOffset, (this.scrollOffset || 0) + direction));
-    if (nextOffset !== this.scrollOffset) {
-      this.scrollOffset = nextOffset;
-      node.setDirtyCanvas?.(true, true);
-    }
-    return true;
-  }
-
-  updateWheelTarget(pos, node) {
-    if (pointInArea(pos, this.listArea)) {
-      activeProfileWheelTarget = {
-        node,
-        widget: this,
-        time: performance.now(),
-      };
-    } else if (activeProfileWheelTarget?.widget === this) {
-      activeProfileWheelTarget = null;
-    }
-  }
-
-  mouse(event, pos, node) {
-    if (node?.__easyuseAnimaStrengthDrag) {
-      return handleLoraStrengthDrag(node, event, pos);
-    }
-    if (event.type === "wheel" && pointInArea(pos, this.listArea)) {
-      return this.scrollByWheel(event.deltaY, node);
-    }
-    if (event.type === "pointermove" && this.scrollDragging) {
-      return this.scrollToPointer(pos, node);
-    }
-    if ((event.type === "pointerup" || event.type === "pointercancel" || event.type === "pointerleave") && this.scrollDragging) {
-      this.scrollDragging = false;
-      this.scrollDragDelta = 0;
-      return true;
-    }
-    if (event.type === "pointermove") {
-      this.updateWheelTarget(pos, node);
-      return false;
-    }
-    if (event.type === "pointerout" || event.type === "pointerleave" || event.type === "pointercancel") {
-      if (activeProfileWheelTarget?.widget === this) {
-        activeProfileWheelTarget = null;
-      }
-      return false;
-    }
-    if (event.type !== "pointerdown" || event.button !== 0) {
-      return false;
-    }
-    this.updateWheelTarget(pos, node);
-    if (pointInArea(pos, this.scrollThumbArea)) {
-      this.scrollDragging = true;
-      this.scrollDragDelta = pos[1] - this.scrollThumbArea[1];
-      return true;
-    }
-    if (pointInArea(pos, this.scrollTrackArea)) {
-      this.scrollDragging = true;
-      this.scrollDragDelta = this.scrollThumbArea ? this.scrollThumbArea[3] / 2 : 0;
-      return this.scrollToPointer(pos, node);
-    }
-    for (const [x, y, width, height, id, disabled] of this.hitAreas) {
-      if (disabled || !pointInArea(pos, [x, y, width, height])) {
-        continue;
-      }
-      if (id === "add") {
-        addProfile(node);
-      } else if (id === "delete") {
-        deleteProfile(node, activeProfileIndex(node));
-      } else if (id === "save") {
-        saveProfileSet(node);
-      } else if (id === "load") {
-        openProfileLoadMenu(node, event, pos);
-      } else if (id === "fix") {
-        fixProfileLoras(node);
-      } else if (String(id).startsWith("profile:")) {
-        switchProfile(node, Number.parseInt(String(id).slice(8), 10));
-      }
-      return true;
-    }
-    return false;
-  }
-}
-
-class LoraHeaderWidget {
-  constructor() {
-    this.name = "easyuse_anima_lora_header";
-    this.type = "custom";
-    this.options = { serialize: false };
-    this.serialize = false;
-    this.__easyuseAnimaLoraWidget = true;
-    this.toggleArea = null;
-  }
-
-  computeSize() {
-    return [MIN_NODE_WIDTH, LORA_HEADER_HEIGHT];
-  }
-
-  draw(ctx, node, width, y, height) {
-    const drawWidth = nodeWidgetWidth(node, width);
-    const loras = lorasWidgetValue(node);
-    if (!loras.length) {
-      return;
-    }
-    const allOn = loras.every((lora) => normalizeLoraEntry(lora).on !== false);
-    const margin = 10;
-    const midY = y + height / 2 + 1;
-    ctx.save();
-    this.toggleArea = drawToggle(ctx, margin, y + 2, height, allOn);
-    ctx.globalAlpha = app.canvas.editor_alpha * 0.55;
-    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-    ctx.textAlign = "left";
-    ctx.textBaseline = "middle";
-    ctx.fillText(drawWidth < 320 ? lpText("lora.allShort") : lpText("lora.toggleAll"), margin + this.toggleArea[2] + 4, midY);
-    ctx.textAlign = "center";
-    ctx.fillText(drawWidth < 320 ? lpText("lora.strengthShort") : lpText("lora.strength"), Math.max(margin + 90, drawWidth - margin - 28), midY);
-    ctx.restore();
-  }
-
-  mouse(event, pos, node) {
-    if (node?.__easyuseAnimaStrengthDrag) {
-      return handleLoraStrengthDrag(node, event, pos);
-    }
-    if (event.type !== "pointerdown" || event.button !== 0 || !pointInArea(pos, this.toggleArea)) {
-      return false;
-    }
-    const nextOn = !lorasWidgetValue(node).every((lora) => normalizeLoraEntry(lora).on !== false);
-    mutateLoras(node, (loras) => {
-      for (const lora of loras) {
-        lora.on = nextOn;
-      }
-    });
-    return true;
-  }
-}
-
-class LoraRowWidget {
-  constructor(index) {
-    this.name = `easyuse_anima_lora_${index}`;
-    this.type = "custom";
-    this.options = { serialize: false };
-    this.serialize = false;
-    this.__easyuseAnimaLoraWidget = true;
-    this.index = index;
-    this.hitAreas = {};
-  }
-
-  computeSize() {
-    return [MIN_NODE_WIDTH, LORA_ROW_HEIGHT];
-  }
-
-  draw(ctx, node, width, y, height) {
-    const drawWidth = nodeWidgetWidth(node, width);
-    this.hitAreas = {};
-    const lora = normalizeLoraEntry(lorasWidgetValue(node)[this.index]);
-    if (!lora.name) {
-      return;
-    }
-    const margin = drawWidth < 340 ? 6 : 10;
-    const inner = drawWidth < 340 ? 2 : 4;
-    const rowX = margin;
-    const rowW = Math.max(0, drawWidth - margin * 2);
-    const rowH = Math.max(16, height - 2);
-    const rowY = y + 1;
-    const midY = y + height / 2;
-    const right = rowX + rowW;
-    const resolveState = loraResolveState(node, lora);
-    const pathProblem = hasLoraPathProblem(resolveState);
-    const fixPending = isLoraFixPending(node, this.index);
-
-    ctx.save();
-    ctx.fillStyle = pathProblem ? "rgba(95, 34, 34, 0.72)" : LiteGraph.WIDGET_BGCOLOR;
-    ctx.strokeStyle = pathProblem ? "#ff5f5f" : LiteGraph.WIDGET_OUTLINE_COLOR;
-    ctx.beginPath();
-    roundedRect(ctx, rowX, rowY, rowW, rowH, rowH / 2);
-    ctx.fill();
-    ctx.stroke();
-
-    this.hitAreas.toggle = drawToggle(ctx, rowX, rowY, rowH, lora.on !== false);
-    let posX = rowX + this.hitAreas.toggle[2] + inner;
-
-    if (lora.on === false) {
-      ctx.globalAlpha = app.canvas.editor_alpha * 0.4;
-    }
-    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-
-    const showStrength = drawWidth >= 230;
-    const showInfo = drawWidth >= 310;
-    const showMenu = drawWidth >= 280;
-    let nameRight = right - inner;
-    if (showStrength) {
-      const number = drawNumberPart(ctx, right - inner, rowY, rowH, lora.strength);
-      this.hitAreas.dec = number.dec;
-      this.hitAreas.value = number.value;
-      this.hitAreas.inc = number.inc;
-      this.hitAreas.strengthAny = number.any;
-      nameRight = number.dec[0] - inner;
-
-      if (showInfo) {
-        const infoSize = 16;
-        const infoX = number.dec[0] - infoSize - inner * 2;
-        this.hitAreas.info = [infoX, rowY + 2, infoSize, Math.max(12, rowH - 4)];
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText("i", infoX + infoSize / 2, midY);
-        nameRight = infoX - inner;
-      } else {
-        this.hitAreas.info = null;
-      }
-    } else {
-      this.hitAreas.dec = null;
-      this.hitAreas.value = null;
-      this.hitAreas.inc = null;
-      this.hitAreas.strengthAny = null;
-      this.hitAreas.info = null;
-    }
-
-    const showFix = pathProblem && drawWidth >= 330;
-    if (showFix) {
-      const fixW = 28;
-      const fixX = nameRight - fixW - inner;
-      this.hitAreas.fix = [fixX, rowY + 2, fixW, Math.max(12, rowH - 4)];
-      ctx.fillStyle = fixPending ? "rgba(110, 80, 80, 0.7)" : "rgba(190, 58, 58, 0.8)";
-      ctx.strokeStyle = "#ff8989";
-      ctx.beginPath();
-      roundedRect(ctx, ...this.hitAreas.fix, 4);
-      ctx.fill();
-      ctx.stroke();
-      ctx.font = "10px sans-serif";
-      ctx.fillStyle = "#fff2f2";
-      ctx.textAlign = "center";
-      ctx.textBaseline = "middle";
-      ctx.fillText(lpText("lora.fix"), fixX + fixW / 2, midY);
-      ctx.font = "13px sans-serif";
-      nameRight = fixX - inner;
-    } else {
-      this.hitAreas.fix = null;
-    }
-
-    if (showMenu) {
-      const menuSize = 14;
-      const menuX = nameRight - menuSize - inner;
-      this.hitAreas.menu = [menuX, rowY + 2, menuSize, Math.max(12, rowH - 4)];
-      ctx.textAlign = "center";
-      ctx.textBaseline = "middle";
-      ctx.fillStyle = pathProblem ? "#ff9a9a" : LiteGraph.WIDGET_TEXT_COLOR;
-      ctx.fillText("⋮", menuX + menuSize / 2, midY);
-      nameRight = menuX - inner;
-    } else {
-      this.hitAreas.menu = null;
-    }
-
-    const nameW = Math.max(0, nameRight - posX - inner);
-    this.hitAreas.lora = [posX, y, nameW, height];
-    ctx.textAlign = "left";
-    ctx.textBaseline = "middle";
-    ctx.fillStyle = pathProblem ? "#ffd8d8" : LiteGraph.WIDGET_TEXT_COLOR;
-    if (nameW > 4) {
-      ctx.fillText(fitCanvasText(ctx, loraDisplayName(lora.name), nameW), posX, midY);
-    }
-    ctx.restore();
-  }
-
-  mouse(event, pos, node) {
-    if (node?.__easyuseAnimaStrengthDrag) {
-      return handleLoraStrengthDrag(node, event, pos);
-    }
-    const lora = normalizeLoraEntry(lorasWidgetValue(node)[this.index]);
-    if (!lora.name) {
-      return false;
-    }
-    if (event.type === "pointerout" || event.type === "pointerleave") {
-      loraPreviewLifecycle.hidePreview();
-      return false;
-    }
-    if (event.type === "pointercancel") {
-      loraPreviewLifecycle.hidePreview();
-      clearLoraStrengthDrag(node);
-      return false;
-    }
-    if (event.type === "pointermove") {
-      if (pointInArea(pos, this.hitAreas.info)) {
-        loraPreviewLifecycle.showPreview(lora.name, event);
-      } else {
-        loraPreviewLifecycle.hidePreview();
-      }
-    }
-    if (event.type !== "pointerdown") {
-      return false;
-    }
-    if (event.button === 2 && pointInArea(pos, [0, this.hitAreas.lora?.[1] ?? 0, node.size[0], LORA_ROW_HEIGHT])) {
-      openLoraEntryMenu(node, event, this.index);
-      return true;
-    }
-    if (event.button !== 0) {
-      return false;
-    }
-    if (pointInArea(pos, this.hitAreas.toggle)) {
-      updateLoraEntry(node, this.index, { on: lora.on === false });
-      return true;
-    }
-    const fixPending = isLoraFixPending(node, this.index);
-    if (!fixPending && pointInArea(pos, this.hitAreas.fix)) {
-      fixSingleLoraEntry(node, this.index);
-      return true;
-    }
-    if (pointInArea(pos, this.hitAreas.lora)) {
-      openLoraMenu(node, event, pos, (entry) => updateLoraEntry(node, this.index, entry));
-      return true;
-    }
-    if (pointInArea(pos, this.hitAreas.menu)) {
-      openLoraEntryMenu(node, event, this.index);
-      return true;
-    }
-    if (pointInArea(pos, this.hitAreas.info)) {
-      loraPreviewLifecycle.showPreview(lora.name, event);
-      return true;
-    }
-    if (pointInArea(pos, this.hitAreas.dec)) {
-      updateLoraEntry(node, this.index, { strength: roundStrength((lora.strength ?? 1) - LORA_PRESET_SETTINGS.strengthButtonStep) });
-      return true;
-    }
-    if (pointInArea(pos, this.hitAreas.inc)) {
-      updateLoraEntry(node, this.index, { strength: roundStrength((lora.strength ?? 1) + LORA_PRESET_SETTINGS.strengthButtonStep) });
-      return true;
-    }
-    if (pointInArea(pos, this.hitAreas.strengthAny)) {
-      beginLoraStrengthDrag(node, this.index, pos, lora);
-      return true;
-    }
-    return false;
-  }
-
-  promptStrength(event, node, lora) {
-    app.canvas.prompt(lpText("lora.strengthPrompt"), lora.strength ?? 1, (value) => {
-      const next = Number(value);
-      if (Number.isFinite(next)) {
-        updateLoraEntry(node, this.index, { strength: roundStrength(next) });
-      }
-    }, event);
-  }
-}
-
-class AddLoraWidget {
-  constructor() {
-    this.name = "easyuse_anima_add_lora";
-    this.type = "custom";
-    this.options = { serialize: false };
-    this.serialize = false;
-    this.__easyuseAnimaLoraWidget = true;
-    this.hitArea = null;
-  }
-
-  computeSize() {
-    return [MIN_NODE_WIDTH, LORA_ADD_HEIGHT];
-  }
-
-  draw(ctx, node, width, y, height) {
-    const drawWidth = nodeWidgetWidth(node, width);
-    const margin = 15;
-    const buttonY = y + 5;
-    const buttonH = height - 10;
-    this.hitArea = [margin, buttonY, Math.max(0, drawWidth - margin * 2), buttonH];
-    ctx.save();
-    ctx.fillStyle = LiteGraph.WIDGET_BGCOLOR;
-    ctx.strokeStyle = LiteGraph.WIDGET_OUTLINE_COLOR;
-    ctx.beginPath();
-    roundedRect(ctx, ...this.hitArea, 5);
-    ctx.fill();
-    ctx.stroke();
-    ctx.fillStyle = LiteGraph.WIDGET_TEXT_COLOR;
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.fillText(lpText("lora.add"), drawWidth / 2, buttonY + buttonH / 2);
-    ctx.restore();
-  }
-
-  mouse(event, pos, node) {
-    if (node?.__easyuseAnimaStrengthDrag) {
-      return handleLoraStrengthDrag(node, event, pos);
-    }
-    if (event.type !== "pointerdown" || event.button !== 0 || !pointInArea(pos, this.hitArea)) {
-      return false;
-    }
-    openLoraMenu(node, event, pos, (entry) => addLoraEntry(node, entry));
-    return true;
-  }
-}
-
-function renderProfileBar(node) {
-  if (node.__easyuseAnimaProfileBar) {
-    node.__easyuseAnimaProfileBar.node = node;
-  }
-  enforceNodeLayout(node);
-}
-
-function renderLoraWidgets(node) {
-  if (!node.widgets) {
-    return;
-  }
-  node.widgets = node.widgets.filter((widget) => !widget.__easyuseAnimaLoraWidget);
-  const loras = lorasWidgetValue(node);
-  if (loras.length) {
-    node.widgets.push(new LoraHeaderWidget());
-  }
-  for (let index = 0; index < loras.length; index += 1) {
-    node.widgets.push(new LoraRowWidget(index));
-  }
-  node.widgets.push(new AddLoraWidget());
-  enforceNodeLayout(node);
-}
-
-function ensureProfileBar(node) {
-  if (node.__easyuseAnimaProfileBar || !node.widgets) {
-    return;
-  }
-  const profileBar = new ProfileBarWidget();
-  profileBar.node = node;
-  node.__easyuseAnimaProfileBar = profileBar;
-  node.widgets = node.widgets.filter((widget) => !widget.__easyuseAnimaControlWidget);
-  const insertBeforeIndex = node.widgets.findIndex((widget) => widget.name === "lora_name" || widget.name === "loras");
-  if (insertBeforeIndex >= 0) {
-    node.widgets.splice(insertBeforeIndex, 0, profileBar);
-  } else {
-    node.widgets.push(profileBar);
-  }
-  renderProfileBar(node);
-  renderLoraWidgets(node);
-}
-
 function wrapWidgetCallback(node, name, callback) {
   const widget = findWidget(node, name);
   if (!widget || widget.__easyuseAnimaLoraWrapped) {
@@ -2027,7 +1293,7 @@ function syncAfterWidgetChange(node) {
     return;
   }
   saveCurrentProfile(node);
-  renderProfileBar(node);
+  loraCanvasWidgets.renderProfileBar(node);
 }
 
 function syncLoraPresetNode(node) {
@@ -2073,7 +1339,7 @@ function applyExecutedProfile(node, message) {
   const nextIndex = wrapProfileIndex(index, profileCount(node));
   const currentIndex = activeProfileIndex(node);
   if (nextIndex === currentIndex) {
-    renderProfileBar(node);
+    loraCanvasWidgets.renderProfileBar(node);
     return;
   }
   saveProfile(node, currentIndex);
@@ -2081,8 +1347,8 @@ function applyExecutedProfile(node, message) {
   node.__easyuseAnimaActiveProfileIndex = nextIndex;
   loadProfile(node, nextIndex);
   scrollProfileBarTo(node, nextIndex);
-  renderProfileBar(node);
-  renderLoraWidgets(node);
+  loraCanvasWidgets.renderProfileBar(node);
+  loraCanvasWidgets.renderLoraWidgets(node);
   node.setDirtyCanvas?.(true, true);
 }
 
@@ -2092,8 +1358,8 @@ function refreshLoraPresetNodes() {
     if (node?.comfyClass !== NODE_TYPE) {
       continue;
     }
-    renderLoraWidgets(node);
-    renderProfileBar(node);
+    loraCanvasWidgets.renderLoraWidgets(node);
+    loraCanvasWidgets.renderProfileBar(node);
     node.setDirtyCanvas?.(true, true);
   }
 }
@@ -2106,7 +1372,7 @@ function scrollProfileListFromWheel(event) {
     && (performance.now() - activeProfileWheelTarget.time) < 30000
     && (app.graph?._nodes || []).includes(activeProfileWheelTarget.node)
   ) {
-    if (!pointInArea(clientPos, activeProfileWheelTarget.widget.listClientArea)) {
+    if (!loraCanvasWidgets.pointInArea(clientPos, activeProfileWheelTarget.widget.listClientArea)) {
       activeProfileWheelTarget = null;
     } else {
       activeProfileWheelTarget.time = performance.now();
@@ -2122,7 +1388,7 @@ function scrollProfileListFromWheel(event) {
   const nodesByZ = [...(app.graph?._nodes || [])].reverse();
   for (const node of nodesByZ) {
     const bar = node?.comfyClass === NODE_TYPE ? node.__easyuseAnimaProfileBar : null;
-    if (!bar || !pointInArea(clientPos, bar.listClientArea)) {
+    if (!bar || !loraCanvasWidgets.pointInArea(clientPos, bar.listClientArea)) {
       continue;
     }
     const handled = bar.scrollByWheel(event.deltaY, node);
@@ -2160,11 +1426,11 @@ function scrollProfileListFromWheel(event) {
       Number(graphPoint[1] || 0) - Number(node.pos[1] || 0),
     ];
     const bar = node.__easyuseAnimaProfileBar;
-    if (!pointInArea(localPos, bar.listArea)) {
+    if (!loraCanvasWidgets.pointInArea(localPos, bar.listArea)) {
       continue;
     }
     const count = profileCount(node);
-    const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
+    const maxOffset = Math.max(0, count - loraCanvasWidgets.profileVisibleRows);
     if (maxOffset <= 0) {
       return false;
     }
@@ -2206,7 +1472,7 @@ function initializeNode(node) {
   wrapWidgetCallback(node, "profile_count", () => {
     if (!node.__easyuseAnimaSuppressProfileCountCallback) {
       saveCurrentProfile(node);
-      renderProfileBar(node);
+      loraCanvasWidgets.renderProfileBar(node);
     }
   });
   wrapWidgetCallback(node, "profile_index", () => {
@@ -2221,7 +1487,7 @@ function initializeNode(node) {
     node.__easyuseAnimaActiveProfileIndex = index;
     loadProfile(node, index);
     scrollProfileBarTo(node, index);
-    renderProfileBar(node);
+    loraCanvasWidgets.renderProfileBar(node);
   });
 
   const originalOnSerialize = node.onSerialize;
@@ -2242,11 +1508,11 @@ function initializeNode(node) {
     originalOnConfigure?.apply(this, args);
     window.requestAnimationFrame(() => {
       finalizeInternalWidgets(this);
-      ensureProfileBar(this);
+      loraCanvasWidgets.ensureProfileBar(this);
       this.__easyuseAnimaActiveProfileIndex = selectedProfileIndex(this);
       loadProfile(this, selectedProfileIndex(this), { initializeFromCurrent: true });
       scrollProfileBarTo(this, selectedProfileIndex(this));
-      renderProfileBar(this);
+      loraCanvasWidgets.renderProfileBar(this);
       refreshLoraAvailability(this);
       enforceNodeLayout(this);
     });
@@ -2254,11 +1520,11 @@ function initializeNode(node) {
 
   window.requestAnimationFrame(() => {
     finalizeInternalWidgets(node);
-    ensureProfileBar(node);
+    loraCanvasWidgets.ensureProfileBar(node);
     node.__easyuseAnimaActiveProfileIndex = selectedProfileIndex(node);
     loadProfile(node, selectedProfileIndex(node), { initializeFromCurrent: true });
     scrollProfileBarTo(node, selectedProfileIndex(node));
-    renderProfileBar(node);
+    loraCanvasWidgets.renderProfileBar(node);
     refreshLoraAvailability(node);
     enforceNodeLayout(node);
   });

--- a/web/js/lora_preset/canvas_widgets.js
+++ b/web/js/lora_preset/canvas_widgets.js
@@ -1,0 +1,881 @@
+// @ts-check
+
+const MIN_NODE_WIDTH = 520;
+const PROFILE_CONTROLS_HEIGHT = 30;
+const PROFILE_ROW_HEIGHT = 22;
+const PROFILE_LIST_PADDING = 4;
+const PROFILE_VISIBLE_ROWS = 6;
+const LORA_HEADER_HEIGHT = 24;
+const LORA_ROW_HEIGHT = 20;
+const LORA_ADD_HEIGHT = 36;
+
+/**
+ * @typedef {object} LoraPresetCanvasWidgetDependencies
+ * @property {() => any} getCanvas
+ * @property {() => any} getLiteGraph
+ * @property {() => {strengthButtonStep: number, strengthDragStep: number, strengthDragPixels: number}} getSettings
+ * @property {(key: string) => string} text
+ * @property {(key: string, values?: Record<string, unknown>) => string} formatText
+ * @property {(value: unknown) => any} normalizeLoraEntry
+ * @property {(node: any) => any[]} lorasWidgetValue
+ * @property {(node: any, mutator: (loras: any[]) => void, options?: Record<string, unknown>) => void} mutateLoras
+ * @property {(node: any, index: number, patch: Record<string, unknown>, options?: Record<string, unknown>) => void} updateLoraEntry
+ * @property {(node: any, lora: any) => any} loraResolveState
+ * @property {(state: any) => boolean} hasLoraPathProblem
+ * @property {(node: any) => boolean} isAnyLoraFixPending
+ * @property {(node: any, index: number) => boolean} isLoraFixPending
+ * @property {(name: unknown) => string} loraDisplayName
+ * @property {{showPreview: (name: string, event?: any) => void, hidePreview: () => void}} previewLifecycle
+ * @property {(node: any, event: any, pos: number[], onChoose: (entry: any) => void) => void} openLoraMenu
+ * @property {(node: any, event: any, index: number) => void} openLoraEntryMenu
+ * @property {(node: any, entry: any) => void} addLoraEntry
+ * @property {(node: any, index: number) => void} fixSingleLoraEntry
+ * @property {(node: any) => number} profileCount
+ * @property {(node: any) => number} activeProfileIndex
+ * @property {(node: any, index: number) => {state?: string, savedName?: string, labelKey?: string}} profileSaveStatus
+ * @property {(node: any) => void} addProfile
+ * @property {(node: any, index: number) => void} deleteProfile
+ * @property {(node: any) => void} saveProfileSet
+ * @property {(node: any, event: any, pos: number[]) => void} openProfileLoadMenu
+ * @property {(node: any) => void} fixProfileLoras
+ * @property {(node: any, index: number) => void} switchProfile
+ * @property {(node: any, pos: number[]) => number[] | null} nodePosToClient
+ * @property {() => any} getActiveProfileWheelTarget
+ * @property {(target: any) => void} setActiveProfileWheelTarget
+ * @property {(node: any) => void} enforceNodeLayout
+ */
+
+/**
+ * Own the LoRA Preset canvas drawing, hit testing, strength drag session, and
+ * custom widget creation while the entry module keeps profile/runtime state.
+ *
+ * @param {LoraPresetCanvasWidgetDependencies} dependencies
+ */
+export function createLoraPresetCanvasWidgets(dependencies) {
+  const {
+    getCanvas,
+    getLiteGraph,
+    getSettings,
+    text,
+    formatText,
+    normalizeLoraEntry,
+    lorasWidgetValue,
+    mutateLoras,
+    updateLoraEntry,
+    loraResolveState,
+    hasLoraPathProblem,
+    isAnyLoraFixPending,
+    isLoraFixPending,
+    loraDisplayName,
+    previewLifecycle,
+    openLoraMenu,
+    openLoraEntryMenu,
+    addLoraEntry,
+    fixSingleLoraEntry,
+    profileCount,
+    activeProfileIndex,
+    profileSaveStatus,
+    addProfile,
+    deleteProfile,
+    saveProfileSet,
+    openProfileLoadMenu,
+    fixProfileLoras,
+    switchProfile,
+    nodePosToClient,
+    getActiveProfileWheelTarget,
+    setActiveProfileWheelTarget,
+    enforceNodeLayout,
+  } = dependencies;
+
+  function roundStrength(value) {
+    return Math.round(Number(value || 0) * 1000) / 1000;
+  }
+
+  function clearLoraStrengthDrag(node) {
+    if (node?.__easyuseAnimaStrengthDrag) {
+      node.__easyuseAnimaStrengthDrag = null;
+    }
+  }
+
+  function beginLoraStrengthDrag(node, index, pos, lora) {
+    node.__easyuseAnimaStrengthDrag = {
+      index,
+      startX: Number(pos?.[0]) || 0,
+      startStrength: Number(lora?.strength ?? 1) || 0,
+      lastSteps: 0,
+      moved: false,
+      promptOnClick: true,
+    };
+  }
+
+  function handleLoraStrengthDrag(node, event, pos) {
+    const drag = node?.__easyuseAnimaStrengthDrag;
+    if (!drag) {
+      return false;
+    }
+    if (event.type === "pointerleave" || event.type === "pointerout") {
+      return true;
+    }
+    if (event.type === "pointercancel") {
+      clearLoraStrengthDrag(node);
+      return true;
+    }
+    if (event.type === "pointermove") {
+      const currentX = Number(pos?.[0]);
+      const distance = Number.isFinite(currentX) ? currentX - drag.startX : Number(event.deltaX || 0);
+      const settings = getSettings();
+      const pixels = Math.max(1, settings.strengthDragPixels);
+      const steps = Math.trunc(distance / pixels);
+      if (steps !== drag.lastSteps) {
+        drag.lastSteps = steps;
+        drag.moved = true;
+        updateLoraEntry(
+          node,
+          drag.index,
+          { strength: roundStrength(drag.startStrength + steps * settings.strengthDragStep) },
+          { render: false },
+        );
+      }
+      return true;
+    }
+    if (event.type === "pointerup") {
+      const shouldPrompt = drag.promptOnClick && !drag.moved;
+      const lora = normalizeLoraEntry(lorasWidgetValue(node)[drag.index]);
+      clearLoraStrengthDrag(node);
+      if (shouldPrompt && lora.name) {
+        getCanvas().prompt(text("lora.strengthPrompt"), lora.strength ?? 1, (value) => {
+          const next = Number(value);
+          if (Number.isFinite(next)) {
+            updateLoraEntry(node, drag.index, { strength: roundStrength(next) });
+          }
+        }, event);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function fitCanvasText(ctx, value, maxWidth) {
+    const textValue = String(value || "");
+    if (ctx.measureText(textValue).width <= maxWidth) {
+      return textValue;
+    }
+    const ellipsis = "...";
+    let result = textValue;
+    while (result.length > 1 && ctx.measureText(`${result}${ellipsis}`).width > maxWidth) {
+      result = result.slice(0, -1);
+    }
+    return `${result}${ellipsis}`;
+  }
+
+  function roundedRect(ctx, x, y, width, height, radius) {
+    if (typeof ctx.roundRect === "function") {
+      ctx.roundRect(x, y, width, height, radius);
+      return;
+    }
+    const r = Math.min(radius, width / 2, height / 2);
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + width - r, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+    ctx.lineTo(x + width, y + height - r);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+    ctx.lineTo(x + r, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+  }
+
+  function pointInArea(pos, area) {
+    return !!area
+      && pos[0] >= area[0]
+      && pos[0] <= area[0] + area[2]
+      && pos[1] >= area[1]
+      && pos[1] <= area[1] + area[3];
+  }
+
+  function drawToggle(ctx, x, y, height, value) {
+    const width = height * 1.5;
+    ctx.save();
+    ctx.globalAlpha = getCanvas().editor_alpha * 0.25;
+    ctx.fillStyle = "rgba(255,255,255,0.45)";
+    ctx.beginPath();
+    roundedRect(ctx, x + 4, y + 4, width - 8, height - 8, height / 2);
+    ctx.fill();
+    ctx.globalAlpha = getCanvas().editor_alpha;
+    ctx.fillStyle = value ? "#89B" : "#888";
+    ctx.beginPath();
+    ctx.arc(value ? x + height : x + height * 0.5, y + height * 0.5, height * 0.36, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+    return [x, y, width, height];
+  }
+
+  function drawNumberPart(ctx, x, y, height, value) {
+    const arrowWidth = 9;
+    const arrowHeight = 10;
+    const inner = 3;
+    const numberWidth = 32;
+    const total = arrowWidth + inner + numberWidth + inner + arrowWidth;
+    const startX = x - total;
+    const midY = y + height / 2;
+    ctx.save();
+    ctx.fill(new Path2D(`M ${startX} ${midY} l ${arrowWidth} ${arrowHeight / 2} l 0 -${arrowHeight} L ${startX} ${midY} z`));
+    const textX = startX + arrowWidth + inner;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(Number(value ?? 1).toFixed(2), textX + numberWidth / 2, midY);
+    const rightX = textX + numberWidth + inner;
+    ctx.fill(new Path2D(`M ${rightX} ${midY - arrowHeight / 2} l ${arrowWidth} ${arrowHeight / 2} l -${arrowWidth} ${arrowHeight / 2} v -${arrowHeight} z`));
+    ctx.restore();
+    return {
+      dec: [startX, y, arrowWidth, height],
+      value: [textX, y, numberWidth, height],
+      inc: [rightX, y, arrowWidth, height],
+      any: [startX, y, total, height],
+    };
+  }
+
+  function nodeWidgetWidth(node, fallbackWidth) {
+    return Math.max(1, Number(node?.size?.[0]) || Number(fallbackWidth) || MIN_NODE_WIDTH);
+  }
+
+  class ProfileBarWidget {
+    constructor() {
+      this.name = "easyuse_anima_profile_bar";
+      this.type = "custom";
+      this.options = { serialize: false };
+      this.serialize = false;
+      this.__easyuseAnimaControlWidget = true;
+      this.hitAreas = [];
+      this.scrollOffset = 0;
+      this.listArea = null;
+      this.listClientArea = null;
+      this.scrollTrackArea = null;
+      this.scrollThumbArea = null;
+      this.scrollDragging = false;
+      this.scrollDragDelta = 0;
+    }
+
+    computeSize(_width, node) {
+      const widgetNode = /** @type {any} */ (this).node;
+      const count = node || widgetNode ? profileCount(node || widgetNode) : 1;
+      const visibleRows = Math.max(1, Math.min(PROFILE_VISIBLE_ROWS, count));
+      return [
+        MIN_NODE_WIDTH,
+        PROFILE_CONTROLS_HEIGHT + PROFILE_LIST_PADDING * 2 + visibleRows * PROFILE_ROW_HEIGHT,
+      ];
+    }
+
+    draw(ctx, node, width, y, _height) {
+      const drawWidth = nodeWidgetWidth(node, width);
+      const canvas = getCanvas();
+      const liteGraph = getLiteGraph();
+      this.hitAreas = [];
+      this.listArea = null;
+      this.listClientArea = null;
+      this.scrollTrackArea = null;
+      this.scrollThumbArea = null;
+      const active = activeProfileIndex(node);
+      const count = profileCount(node);
+      const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
+      this.scrollOffset = Math.max(0, Math.min(maxOffset, this.scrollOffset || 0));
+
+      const buttonY = y + 4;
+      const buttonH = 22;
+      const gap = 4;
+
+      ctx.save();
+      ctx.font = "13px sans-serif";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = liteGraph.WIDGET_TEXT_COLOR;
+      ctx.globalAlpha = canvas.editor_alpha * 0.75;
+      ctx.textAlign = "left";
+      ctx.fillText(formatText("profile.header", { active, count }), 10, buttonY + buttonH / 2);
+      ctx.globalAlpha = 1;
+
+      let x = Math.max(120, drawWidth - 8);
+
+      const drawButton = (id, label, buttonW, selected = false, disabled = false) => {
+        x -= buttonW;
+        if (x < 8) {
+          return;
+        }
+        this.hitAreas.push([x, buttonY, buttonW, buttonH, id, disabled]);
+        ctx.globalAlpha = disabled ? 0.45 : 1;
+        ctx.fillStyle = selected ? "#3f79d8" : liteGraph.WIDGET_BGCOLOR;
+        ctx.strokeStyle = selected ? "#6fa2ff" : liteGraph.WIDGET_OUTLINE_COLOR;
+        ctx.beginPath();
+        roundedRect(ctx, x, buttonY, buttonW, buttonH, 4);
+        ctx.fill();
+        ctx.stroke();
+        ctx.fillStyle = liteGraph.WIDGET_TEXT_COLOR;
+        ctx.textAlign = "center";
+        let fontSize = 13;
+        ctx.font = `${fontSize}px sans-serif`;
+        while (fontSize > 10 && ctx.measureText(label).width > buttonW - 8) {
+          fontSize -= 1;
+          ctx.font = `${fontSize}px sans-serif`;
+        }
+        ctx.fillText(fitCanvasText(ctx, label, buttonW - 8), x + buttonW / 2, buttonY + buttonH / 2);
+        ctx.font = "13px sans-serif";
+        x -= gap;
+        ctx.globalAlpha = 1;
+      };
+
+      drawButton("load", text("profile.load"), 66);
+      drawButton("save", text("profile.save"), 46);
+      drawButton("fix", text("profile.fix"), 40, false, isAnyLoraFixPending(node));
+      drawButton("delete", "X", 28, false, count <= 1);
+      drawButton("add", "+", 28);
+
+      const listX = 8;
+      const listY = y + PROFILE_CONTROLS_HEIGHT + PROFILE_LIST_PADDING;
+      const listW = Math.max(0, drawWidth - 16);
+      const visibleRows = Math.max(1, Math.min(PROFILE_VISIBLE_ROWS, count));
+      const listH = visibleRows * PROFILE_ROW_HEIGHT;
+      const hasScrollbar = count > visibleRows;
+      const scrollbarW = hasScrollbar ? 10 : 0;
+      const rowW = Math.max(0, listW - scrollbarW - (hasScrollbar ? 4 : 0));
+      this.listArea = [listX, listY, listW, listH];
+      const listClientStart = nodePosToClient(node, [listX, listY]);
+      const listClientEnd = nodePosToClient(node, [listX + listW, listY + listH]);
+      if (listClientStart && listClientEnd) {
+        this.listClientArea = [
+          Math.min(listClientStart[0], listClientEnd[0]),
+          Math.min(listClientStart[1], listClientEnd[1]),
+          Math.abs(listClientEnd[0] - listClientStart[0]),
+          Math.abs(listClientEnd[1] - listClientStart[1]),
+        ];
+      }
+
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(listX, listY, listW, listH);
+      ctx.clip();
+      for (let row = 0; row < visibleRows; row += 1) {
+        const index = this.scrollOffset + row + 1;
+        if (index > count) {
+          break;
+        }
+        const rowY = listY + row * PROFILE_ROW_HEIGHT;
+        const selected = index === active;
+        const status = profileSaveStatus(node, index);
+        const rowArea = [listX, rowY + 1, rowW, PROFILE_ROW_HEIGHT - 2];
+        this.hitAreas.push([...rowArea, `profile:${index}`, false]);
+        ctx.fillStyle = selected ? "#3f79d8" : "rgba(255,255,255,0.045)";
+        ctx.strokeStyle = selected ? "#6fa2ff" : "rgba(255,255,255,0.12)";
+        ctx.beginPath();
+        roundedRect(ctx, ...rowArea, 4);
+        ctx.fill();
+        ctx.stroke();
+
+        const stateColor = {
+          saved: "#8ecf8e",
+          changed: "#e3ba66",
+          unsaved: "#b8b8b8",
+        }[status.state] || "#b8b8b8";
+        const leftText = `${index}. ${status.savedName || text("profile.unsaved")}`;
+        const rightText = text(status.labelKey || `profile.${status.state}`);
+        ctx.font = "12px sans-serif";
+        const rightWidth = Math.min(82, Math.max(58, ctx.measureText(rightText).width + 16));
+        ctx.textAlign = "left";
+        ctx.fillStyle = liteGraph.WIDGET_TEXT_COLOR;
+        ctx.fillText(fitCanvasText(ctx, leftText, Math.max(20, rowW - rightWidth - 18)), listX + 8, rowY + PROFILE_ROW_HEIGHT / 2);
+        ctx.textAlign = "right";
+        ctx.fillStyle = stateColor;
+        ctx.fillText(rightText, listX + rowW - 8, rowY + PROFILE_ROW_HEIGHT / 2);
+      }
+      ctx.restore();
+
+      if (hasScrollbar) {
+        const trackW = 8;
+        const trackX = listX + listW - trackW - 1;
+        this.scrollTrackArea = [trackX - 2, listY, trackW + 4, listH];
+        ctx.fillStyle = "rgba(255,255,255,0.08)";
+        ctx.beginPath();
+        roundedRect(ctx, trackX, listY, trackW, listH, 4);
+        ctx.fill();
+
+        const barH = Math.max(14, listH * (visibleRows / count));
+        const barY = listY + (listH - barH) * (this.scrollOffset / Math.max(1, maxOffset));
+        this.scrollThumbArea = [trackX - 2, barY, trackW + 4, barH];
+        ctx.fillStyle = "rgba(255,255,255,0.42)";
+        ctx.beginPath();
+        roundedRect(ctx, trackX, barY, trackW, barH, 4);
+        ctx.fill();
+      }
+      ctx.restore();
+    }
+
+    scrollToPointer(pos, node) {
+      const count = profileCount(node);
+      const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
+      if (maxOffset <= 0 || !this.scrollTrackArea || !this.scrollThumbArea) {
+        return false;
+      }
+      const trackY = this.scrollTrackArea[1];
+      const trackH = this.scrollTrackArea[3];
+      const thumbH = this.scrollThumbArea[3];
+      const range = Math.max(1, trackH - thumbH);
+      const y = Math.max(0, Math.min(range, pos[1] - trackY - this.scrollDragDelta));
+      const nextOffset = Math.round((y / range) * maxOffset);
+      if (nextOffset !== this.scrollOffset) {
+        this.scrollOffset = nextOffset;
+        node.setDirtyCanvas?.(true, true);
+      }
+      return true;
+    }
+
+    scrollByWheel(deltaY, node) {
+      const count = profileCount(node);
+      const maxOffset = Math.max(0, count - PROFILE_VISIBLE_ROWS);
+      if (maxOffset <= 0) {
+        return false;
+      }
+      const direction = Number(deltaY || 0) > 0 ? 1 : -1;
+      const nextOffset = Math.max(0, Math.min(maxOffset, (this.scrollOffset || 0) + direction));
+      if (nextOffset !== this.scrollOffset) {
+        this.scrollOffset = nextOffset;
+        node.setDirtyCanvas?.(true, true);
+      }
+      return true;
+    }
+
+    updateWheelTarget(pos, node) {
+      if (pointInArea(pos, this.listArea)) {
+        setActiveProfileWheelTarget({
+          node,
+          widget: this,
+          time: performance.now(),
+        });
+      } else if (getActiveProfileWheelTarget()?.widget === this) {
+        setActiveProfileWheelTarget(null);
+      }
+    }
+
+    mouse(event, pos, node) {
+      if (node?.__easyuseAnimaStrengthDrag) {
+        return handleLoraStrengthDrag(node, event, pos);
+      }
+      if (event.type === "wheel" && pointInArea(pos, this.listArea)) {
+        return this.scrollByWheel(event.deltaY, node);
+      }
+      if (event.type === "pointermove" && this.scrollDragging) {
+        return this.scrollToPointer(pos, node);
+      }
+      if ((event.type === "pointerup" || event.type === "pointercancel" || event.type === "pointerleave") && this.scrollDragging) {
+        this.scrollDragging = false;
+        this.scrollDragDelta = 0;
+        return true;
+      }
+      if (event.type === "pointermove") {
+        this.updateWheelTarget(pos, node);
+        return false;
+      }
+      if (event.type === "pointerout" || event.type === "pointerleave" || event.type === "pointercancel") {
+        if (getActiveProfileWheelTarget()?.widget === this) {
+          setActiveProfileWheelTarget(null);
+        }
+        return false;
+      }
+      if (event.type !== "pointerdown" || event.button !== 0) {
+        return false;
+      }
+      this.updateWheelTarget(pos, node);
+      if (pointInArea(pos, this.scrollThumbArea)) {
+        this.scrollDragging = true;
+        this.scrollDragDelta = pos[1] - this.scrollThumbArea[1];
+        return true;
+      }
+      if (pointInArea(pos, this.scrollTrackArea)) {
+        this.scrollDragging = true;
+        this.scrollDragDelta = this.scrollThumbArea ? this.scrollThumbArea[3] / 2 : 0;
+        return this.scrollToPointer(pos, node);
+      }
+      for (const [x, y, width, height, id, disabled] of this.hitAreas) {
+        if (disabled || !pointInArea(pos, [x, y, width, height])) {
+          continue;
+        }
+        if (id === "add") {
+          addProfile(node);
+        } else if (id === "delete") {
+          deleteProfile(node, activeProfileIndex(node));
+        } else if (id === "save") {
+          saveProfileSet(node);
+        } else if (id === "load") {
+          openProfileLoadMenu(node, event, pos);
+        } else if (id === "fix") {
+          fixProfileLoras(node);
+        } else if (String(id).startsWith("profile:")) {
+          switchProfile(node, Number.parseInt(String(id).slice(8), 10));
+        }
+        return true;
+      }
+      return false;
+    }
+  }
+
+  class LoraHeaderWidget {
+    constructor() {
+      this.name = "easyuse_anima_lora_header";
+      this.type = "custom";
+      this.options = { serialize: false };
+      this.serialize = false;
+      this.__easyuseAnimaLoraWidget = true;
+      this.toggleArea = null;
+    }
+
+    computeSize() {
+      return [MIN_NODE_WIDTH, LORA_HEADER_HEIGHT];
+    }
+
+    draw(ctx, node, width, y, height) {
+      const drawWidth = nodeWidgetWidth(node, width);
+      const canvas = getCanvas();
+      const liteGraph = getLiteGraph();
+      const loras = lorasWidgetValue(node);
+      if (!loras.length) {
+        return;
+      }
+      const allOn = loras.every((lora) => normalizeLoraEntry(lora).on !== false);
+      const margin = 10;
+      const midY = y + height / 2 + 1;
+      ctx.save();
+      this.toggleArea = drawToggle(ctx, margin, y + 2, height, allOn);
+      ctx.globalAlpha = canvas.editor_alpha * 0.55;
+      ctx.fillStyle = liteGraph.WIDGET_TEXT_COLOR;
+      ctx.textAlign = "left";
+      ctx.textBaseline = "middle";
+      ctx.fillText(drawWidth < 320 ? text("lora.allShort") : text("lora.toggleAll"), margin + this.toggleArea[2] + 4, midY);
+      ctx.textAlign = "center";
+      ctx.fillText(drawWidth < 320 ? text("lora.strengthShort") : text("lora.strength"), Math.max(margin + 90, drawWidth - margin - 28), midY);
+      ctx.restore();
+    }
+
+    mouse(event, pos, node) {
+      if (node?.__easyuseAnimaStrengthDrag) {
+        return handleLoraStrengthDrag(node, event, pos);
+      }
+      if (event.type !== "pointerdown" || event.button !== 0 || !pointInArea(pos, this.toggleArea)) {
+        return false;
+      }
+      const nextOn = !lorasWidgetValue(node).every((lora) => normalizeLoraEntry(lora).on !== false);
+      mutateLoras(node, (loras) => {
+        for (const lora of loras) {
+          lora.on = nextOn;
+        }
+      });
+      return true;
+    }
+  }
+
+  class LoraRowWidget {
+    constructor(index) {
+      this.name = `easyuse_anima_lora_${index}`;
+      this.type = "custom";
+      this.options = { serialize: false };
+      this.serialize = false;
+      this.__easyuseAnimaLoraWidget = true;
+      this.index = index;
+      this.hitAreas = {};
+    }
+
+    computeSize() {
+      return [MIN_NODE_WIDTH, LORA_ROW_HEIGHT];
+    }
+
+    draw(ctx, node, width, y, height) {
+      const drawWidth = nodeWidgetWidth(node, width);
+      const liteGraph = getLiteGraph();
+      this.hitAreas = {};
+      const lora = normalizeLoraEntry(lorasWidgetValue(node)[this.index]);
+      if (!lora.name) {
+        return;
+      }
+      const margin = drawWidth < 340 ? 6 : 10;
+      const inner = drawWidth < 340 ? 2 : 4;
+      const rowX = margin;
+      const rowW = Math.max(0, drawWidth - margin * 2);
+      const rowH = Math.max(16, height - 2);
+      const rowY = y + 1;
+      const midY = y + height / 2;
+      const right = rowX + rowW;
+      const resolveState = loraResolveState(node, lora);
+      const pathProblem = hasLoraPathProblem(resolveState);
+      const fixPending = isLoraFixPending(node, this.index);
+
+      ctx.save();
+      ctx.fillStyle = pathProblem ? "rgba(95, 34, 34, 0.72)" : liteGraph.WIDGET_BGCOLOR;
+      ctx.strokeStyle = pathProblem ? "#ff5f5f" : liteGraph.WIDGET_OUTLINE_COLOR;
+      ctx.beginPath();
+      roundedRect(ctx, rowX, rowY, rowW, rowH, rowH / 2);
+      ctx.fill();
+      ctx.stroke();
+
+      this.hitAreas.toggle = drawToggle(ctx, rowX, rowY, rowH, lora.on !== false);
+      let posX = rowX + this.hitAreas.toggle[2] + inner;
+
+      if (lora.on === false) {
+        ctx.globalAlpha = getCanvas().editor_alpha * 0.4;
+      }
+      ctx.fillStyle = liteGraph.WIDGET_TEXT_COLOR;
+
+      const showStrength = drawWidth >= 230;
+      const showInfo = drawWidth >= 310;
+      const showMenu = drawWidth >= 280;
+      let nameRight = right - inner;
+      if (showStrength) {
+        const number = drawNumberPart(ctx, right - inner, rowY, rowH, lora.strength);
+        this.hitAreas.dec = number.dec;
+        this.hitAreas.value = number.value;
+        this.hitAreas.inc = number.inc;
+        this.hitAreas.strengthAny = number.any;
+        nameRight = number.dec[0] - inner;
+
+        if (showInfo) {
+          const infoSize = 16;
+          const infoX = number.dec[0] - infoSize - inner * 2;
+          this.hitAreas.info = [infoX, rowY + 2, infoSize, Math.max(12, rowH - 4)];
+          ctx.textAlign = "center";
+          ctx.textBaseline = "middle";
+          ctx.fillText("i", infoX + infoSize / 2, midY);
+          nameRight = infoX - inner;
+        } else {
+          this.hitAreas.info = null;
+        }
+      } else {
+        this.hitAreas.dec = null;
+        this.hitAreas.value = null;
+        this.hitAreas.inc = null;
+        this.hitAreas.strengthAny = null;
+        this.hitAreas.info = null;
+      }
+
+      const showFix = pathProblem && drawWidth >= 330;
+      if (showFix) {
+        const fixW = 28;
+        const fixX = nameRight - fixW - inner;
+        this.hitAreas.fix = [fixX, rowY + 2, fixW, Math.max(12, rowH - 4)];
+        ctx.fillStyle = fixPending ? "rgba(110, 80, 80, 0.7)" : "rgba(190, 58, 58, 0.8)";
+        ctx.strokeStyle = "#ff8989";
+        ctx.beginPath();
+        roundedRect(ctx, ...this.hitAreas.fix, 4);
+        ctx.fill();
+        ctx.stroke();
+        ctx.font = "10px sans-serif";
+        ctx.fillStyle = "#fff2f2";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(text("lora.fix"), fixX + fixW / 2, midY);
+        ctx.font = "13px sans-serif";
+        nameRight = fixX - inner;
+      } else {
+        this.hitAreas.fix = null;
+      }
+
+      if (showMenu) {
+        const menuSize = 14;
+        const menuX = nameRight - menuSize - inner;
+        this.hitAreas.menu = [menuX, rowY + 2, menuSize, Math.max(12, rowH - 4)];
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillStyle = pathProblem ? "#ff9a9a" : liteGraph.WIDGET_TEXT_COLOR;
+        ctx.fillText("⋮", menuX + menuSize / 2, midY);
+        nameRight = menuX - inner;
+      } else {
+        this.hitAreas.menu = null;
+      }
+
+      const nameW = Math.max(0, nameRight - posX - inner);
+      this.hitAreas.lora = [posX, y, nameW, height];
+      ctx.textAlign = "left";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = pathProblem ? "#ffd8d8" : liteGraph.WIDGET_TEXT_COLOR;
+      if (nameW > 4) {
+        ctx.fillText(fitCanvasText(ctx, loraDisplayName(lora.name), nameW), posX, midY);
+      }
+      ctx.restore();
+    }
+
+    mouse(event, pos, node) {
+      if (node?.__easyuseAnimaStrengthDrag) {
+        return handleLoraStrengthDrag(node, event, pos);
+      }
+      const lora = normalizeLoraEntry(lorasWidgetValue(node)[this.index]);
+      if (!lora.name) {
+        return false;
+      }
+      if (event.type === "pointerout" || event.type === "pointerleave") {
+        previewLifecycle.hidePreview();
+        return false;
+      }
+      if (event.type === "pointercancel") {
+        previewLifecycle.hidePreview();
+        clearLoraStrengthDrag(node);
+        return false;
+      }
+      if (event.type === "pointermove") {
+        if (pointInArea(pos, this.hitAreas.info)) {
+          previewLifecycle.showPreview(lora.name, event);
+        } else {
+          previewLifecycle.hidePreview();
+        }
+      }
+      if (event.type !== "pointerdown") {
+        return false;
+      }
+      if (event.button === 2 && pointInArea(pos, [0, this.hitAreas.lora?.[1] ?? 0, node.size[0], LORA_ROW_HEIGHT])) {
+        openLoraEntryMenu(node, event, this.index);
+        return true;
+      }
+      if (event.button !== 0) {
+        return false;
+      }
+      if (pointInArea(pos, this.hitAreas.toggle)) {
+        updateLoraEntry(node, this.index, { on: lora.on === false });
+        return true;
+      }
+      const fixPending = isLoraFixPending(node, this.index);
+      if (!fixPending && pointInArea(pos, this.hitAreas.fix)) {
+        fixSingleLoraEntry(node, this.index);
+        return true;
+      }
+      if (pointInArea(pos, this.hitAreas.lora)) {
+        openLoraMenu(node, event, pos, (entry) => updateLoraEntry(node, this.index, entry));
+        return true;
+      }
+      if (pointInArea(pos, this.hitAreas.menu)) {
+        openLoraEntryMenu(node, event, this.index);
+        return true;
+      }
+      if (pointInArea(pos, this.hitAreas.info)) {
+        previewLifecycle.showPreview(lora.name, event);
+        return true;
+      }
+      if (pointInArea(pos, this.hitAreas.dec)) {
+        updateLoraEntry(node, this.index, { strength: roundStrength((lora.strength ?? 1) - getSettings().strengthButtonStep) });
+        return true;
+      }
+      if (pointInArea(pos, this.hitAreas.inc)) {
+        updateLoraEntry(node, this.index, { strength: roundStrength((lora.strength ?? 1) + getSettings().strengthButtonStep) });
+        return true;
+      }
+      if (pointInArea(pos, this.hitAreas.strengthAny)) {
+        beginLoraStrengthDrag(node, this.index, pos, lora);
+        return true;
+      }
+      return false;
+    }
+
+    promptStrength(event, node, lora) {
+      getCanvas().prompt(text("lora.strengthPrompt"), lora.strength ?? 1, (value) => {
+        const next = Number(value);
+        if (Number.isFinite(next)) {
+          updateLoraEntry(node, this.index, { strength: roundStrength(next) });
+        }
+      }, event);
+    }
+  }
+
+  class AddLoraWidget {
+    constructor() {
+      this.name = "easyuse_anima_add_lora";
+      this.type = "custom";
+      this.options = { serialize: false };
+      this.serialize = false;
+      this.__easyuseAnimaLoraWidget = true;
+      this.hitArea = null;
+    }
+
+    computeSize() {
+      return [MIN_NODE_WIDTH, LORA_ADD_HEIGHT];
+    }
+
+    draw(ctx, node, width, y, height) {
+      const drawWidth = nodeWidgetWidth(node, width);
+      const liteGraph = getLiteGraph();
+      const margin = 15;
+      const buttonY = y + 5;
+      const buttonH = height - 10;
+      this.hitArea = [margin, buttonY, Math.max(0, drawWidth - margin * 2), buttonH];
+      ctx.save();
+      ctx.fillStyle = liteGraph.WIDGET_BGCOLOR;
+      ctx.strokeStyle = liteGraph.WIDGET_OUTLINE_COLOR;
+      ctx.beginPath();
+      roundedRect(ctx, ...this.hitArea, 5);
+      ctx.fill();
+      ctx.stroke();
+      ctx.fillStyle = liteGraph.WIDGET_TEXT_COLOR;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(text("lora.add"), drawWidth / 2, buttonY + buttonH / 2);
+      ctx.restore();
+    }
+
+    mouse(event, pos, node) {
+      if (node?.__easyuseAnimaStrengthDrag) {
+        return handleLoraStrengthDrag(node, event, pos);
+      }
+      if (event.type !== "pointerdown" || event.button !== 0 || !pointInArea(pos, this.hitArea)) {
+        return false;
+      }
+      openLoraMenu(node, event, pos, (entry) => addLoraEntry(node, entry));
+      return true;
+    }
+  }
+
+  function renderProfileBar(node) {
+    if (node.__easyuseAnimaProfileBar) {
+      node.__easyuseAnimaProfileBar.node = node;
+    }
+    enforceNodeLayout(node);
+  }
+
+  function renderLoraWidgets(node) {
+    if (!node.widgets) {
+      return;
+    }
+    node.widgets = node.widgets.filter((widget) => !widget.__easyuseAnimaLoraWidget);
+    const loras = lorasWidgetValue(node);
+    if (loras.length) {
+      node.widgets.push(new LoraHeaderWidget());
+    }
+    for (let index = 0; index < loras.length; index += 1) {
+      node.widgets.push(new LoraRowWidget(index));
+    }
+    node.widgets.push(new AddLoraWidget());
+    enforceNodeLayout(node);
+  }
+
+  function ensureProfileBar(node) {
+    if (node.__easyuseAnimaProfileBar || !node.widgets) {
+      return;
+    }
+    const profileBar = new ProfileBarWidget();
+    /** @type {any} */ (profileBar).node = node;
+    node.__easyuseAnimaProfileBar = profileBar;
+    node.widgets = node.widgets.filter((widget) => !widget.__easyuseAnimaControlWidget);
+    const insertBeforeIndex = node.widgets.findIndex((widget) => widget.name === "lora_name" || widget.name === "loras");
+    if (insertBeforeIndex >= 0) {
+      node.widgets.splice(insertBeforeIndex, 0, profileBar);
+    } else {
+      node.widgets.push(profileBar);
+    }
+    renderProfileBar(node);
+    renderLoraWidgets(node);
+  }
+
+  return {
+    AddLoraWidget,
+    LoraHeaderWidget,
+    LoraRowWidget,
+    ProfileBarWidget,
+    clearLoraStrengthDrag,
+    ensureProfileBar,
+    minNodeWidth: MIN_NODE_WIDTH,
+    pointInArea,
+    profileVisibleRows: PROFILE_VISIBLE_ROWS,
+    renderLoraWidgets,
+    renderProfileBar,
+  };
+}


### PR DESCRIPTION
## 변경 요약

- LoRA Preset의 canvas drawing, hit testing, strength drag session과 네 canvas widget class를 `createLoraPresetCanvasWidgets` factory 경계로 분리합니다.
- 기존 entry는 profile/menu/preview/save/wheel/initialize/configure/serialize lifecycle 소유권을 유지하고, active wheel target은 getter/setter callback으로만 주입합니다.
- 신규 canvas-widget semantic smoke를 official frontend runner에 등록합니다.
- PR #121/#102 cleanup과 현재 #55 integration 상태를 frontend maintenance 실행 ledger에 반영합니다.

## 주요 파일

- `web/js/lora_preset/canvas_widgets.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_canvas_widgets_smoke.mjs`
- `tests/test_frontend_lora_preset.py`
- `tools/check_frontend.ps1`
- `docs/development/frontend-maintenance-execution-plan.md`

## 유지한 동작

- widget 이름·순서, `serialize=false`, 높이/크기와 반응형 width threshold
- profile/add/delete/save/load/FIX/scroll 및 LoRA toggle/menu/FIX/info/strength dispatch
- strength drag 시작값·pixel threshold·역방향·pointercancel·click prompt
- pointerout/preview cleanup과 #109 menu/preview/install-dispose lifecycle 경계
- document wheel listener, save sync, profile mutation, node initialize/configure/serialize와 extension entry 소유권

## 검증

- source `6d238677` → integration `0cca9ea` range-diff: `=`
- Node syntax check: canvas module, entry, dedicated smoke 통과
- 신규 canvas-widget smoke와 기존 API/profile-data/LoRA-state/preview/menu smokes 6개 통과
- `python -m unittest -v tests.test_frontend_lora_preset`: 13/13 통과
- TypeScript 6.0.3 통과
- production / runner-test / plan-scope 독립 final audit: P0-P3 finding 없음
- official full runner: Python unittest 398/398, frontend 104 JavaScript files, TypeScript 6.0.3, git diff check 통과
- `git diff --check`: 통과

## 테스트 표면

- 관찰 가능한 동작 변경이 없는 기계적 extraction이며 source patch와 integration patch가 동일합니다.
- 이 PR에서는 Legacy/Node 2.0 browser smoke를 반복하지 않았습니다.
- Issue #55 종료 전 남은 runtime/entry slice까지 통합한 뒤 load/edit/FIX/queue/save-reload dual-canvas matrix를 수행합니다.

## 남은 위험

- profile mutation 및 node initialize/configure/serialize runtime, save sync/wheel/extension entry extraction은 후속 #55 slice입니다.
- runner 등록 자체의 Python static assertion, exact paint pixel과 극단 scroll-count coverage는 비차단 gap으로 남겼습니다.
- 사용자 v0.27.0 인스턴스, `main`, release, Registry는 변경하지 않았습니다.

관련: #55
