### PR TITLE
fix: guard autocomplete adapter request epochs

### DIFF
--- a/docs/development/frontend-maintenance-execution-plan.md
+++ b/docs/development/frontend-maintenance-execution-plan.md
@@ -16,8 +16,8 @@ GitHub Issue ledgers, or live Git/GitHub/Codex/process read-back.
 - Before using this snapshot, fetch and reconcile the external state named in
   the relevant row.
 
-Snapshot: 2026-07-17 KST, immediately after PR #122/#55 canvas-lane cleanup and
-creation of the #56/#99 adapter-epoch integration branch.
+Snapshot: 2026-07-17 KST, immediately before the #56/#99 adapter-epoch PR after
+the final full and dual-canvas browser gates.
 
 ## Goal Boundary
 
@@ -62,7 +62,7 @@ Excluded without separate approval:
 | #55 LoRA Preset | open | #108 menu extraction, #115/#109 lifecycle hardening, #122 canvas-widget extraction | profile mutation, initialize/configure/serialize, save-sync/wheel/entry, final matrix |
 | #56 Autocomplete | open | #116 input/keyboard/composition controller | integrate the current #99 adapter epoch; then external input hook, listener installer/entry, #98/#100, final matrix |
 | #98 Autocomplete replacement syntax | open | none | deferred until the current adapter-epoch gate is integrated; preserve nested parentheses, weights, and artist prefix |
-| #99 Autocomplete request epochs | open | #116 controller generation and current adapter/result/source epoch working diff | finish focused/full/dual-canvas evidence, merge and ledger, then close if the full reported boundary is satisfied |
+| #99 Autocomplete request epochs | open | #116 controller generation plus the final adapter/result/source epoch working diff; focused, full, Legacy, and Node 2.0 gates passed | open the PR, squash merge/read back, write the final ledger, and close completed |
 | #100 Autocomplete result limit | open | none | deferred backend limit audit for configured values 51–100 |
 | #102 seed range | closed | production contract #112 and Korean/English user docs #121 | none; #111 remains a separate non-blocking Node 2.0 display mismatch |
 | #103 Regional seed | closed | PR #118 and final ledger | none |
@@ -98,7 +98,7 @@ in the roadmap and owning Issue ledgers.
 
 | Slice | Codex task | Branch / worktree | Base and status | Expected files |
 | --- | --- | --- | --- | --- |
-| #56/#99 adapter epoch | source task `019f6bc5-c33b-7960-b84e-0f2300525f2a`; integration owner `019f6a32-3b0f-7ed0-8ff6-03de8546f402` | clean source `codex/fix-autocomplete-adapter-epoch` / `f34bdaa`; active integration `codex/integrate-autocomplete-adapter-epoch` / `worktrees/ComfyUI-EasyUseAnima/codex/integrate-autocomplete-adapter-epoch` | source patch range-diff `=` as integration commit `b460f5e` on `3f8a6c0`; integration review fix supersedes hooked/active controller authority on setup and live setting invalidation | data adapter and smoke; input controller helper/smoke; autocomplete entry/static contract; this checkpoint |
+| #56/#99 adapter epoch | source task `019f6bc5-c33b-7960-b84e-0f2300525f2a`; integration owner `019f6a32-3b0f-7ed0-8ff6-03de8546f402` | clean source `codex/fix-autocomplete-adapter-epoch` / `f34bdaa`; active integration `codex/integrate-autocomplete-adapter-epoch` / `worktrees/ComfyUI-EasyUseAnima/codex/integrate-autocomplete-adapter-epoch` | source patch range-diff `=` as integration commit `b460f5e` plus review-fix/checkpoint HEAD `bc1d455` on `3f8a6c0`; focused, full, and dual-canvas gates passed | data adapter and smoke; input controller helper/smoke; autocomplete entry/static contract; this checkpoint |
 
 ## Integration Gates
 
@@ -106,7 +106,7 @@ Only one row may enter push/PR/merge at a time.
 
 | Order | Slice | Focused / audit | Full | Browser | Blocker / finding | Gate |
 | ---: | --- | --- | --- | --- | --- | --- |
-| 1 | #56/#99 adapter epoch | source range-diff; final four semantic smokes, related unittest 43/43, TS 6.0.3, diff check, and three no-P0-P3 audits passed | one full run | required once per final behavior diff on legacy and Node 2.0 | no known code blocker; full/browser pending | current |
+| 1 | #56/#99 adapter epoch | source range-diff; final four semantic smokes, related unittest 43/43, TS 6.0.3, diff check, and three no-P0-P3 audits passed | 398/398; 104 JavaScript files; TypeScript 6.0.3; diff check | Legacy and Node 2.0: Danbooru 20 -> e621 2 -> Danbooru 20, Escape/ArrowDown/Tab, save/reload, EasyUse errors 0 | no code blocker; the first stale-tab cache attempt was excluded and a fresh exact-diff tab passed | ready for PR |
 | 2 | 0.5.x release checkpoint | enter only after #99 has a merged/read-back safe checkpoint; then read back main/dev/tags/Releases/Registry before choosing the version | reuse identical final-diff evidence; rerun only if code/base changes | reuse valid merged evidence | blocked by current working diff | queued |
 | 3 | remaining #54/#55/#56 slices | create only after file ownership and priority audit | per PR-ready diff | per behavior diff; final Issue matrices required | sequence and overlap audit required | backlog |
 | 4 | final user-instance sync | all agreed Issues/bugs reconciled first | use merged `dev` evidence | one manual v0.27.0 confirmation | blocked by remaining Goal work and prerequisites | queued |
@@ -125,8 +125,12 @@ sandbox. Do not report the environment spawn error as a code failure.
   current. Source identities now make unchanged snapshots no-ops, while actual
   source, limit, mode, or query-shaping changes invalidate every hooked/active
   controller, preserve controller ownership while closing the popup, and
-  schedule a fresh update only for an enabled focused input. Final focused and
-  three independent audits passed; full/browser evidence is pending.
+  schedule a fresh update only for an enabled focused input. Final focused,
+  three independent audits, official full, and both canvas gates passed. The
+  initial Node 2.0 no-popup observation came from a tab retaining a stale
+  extension module; temporary test-instance diagnostics were excluded, the
+  exact branch file was restored and hash-checked, and a fresh exact-diff tab
+  passed the complete Node 2.0 matrix.
 - Non-blocking #111: ComfyUI frontend 1.45.20 Node 2.0 can display a newly
   entered unsafe seed while the widget and saved workflow retain max-safe.
   Prefer an upstream fix or stable public-API boundary over a private-DOM hook.

--- a/docs/development/frontend-maintenance-execution-plan.md
+++ b/docs/development/frontend-maintenance-execution-plan.md
@@ -16,8 +16,8 @@ GitHub Issue ledgers, or live Git/GitHub/Codex/process read-back.
 - Before using this snapshot, fetch and reconcile the external state named in
   the relevant row.
 
-Snapshot: 2026-07-17 KST, immediately after PR #121 and Issue #102 cleanup and
-creation of the #55 canvas-widget integration branch.
+Snapshot: 2026-07-17 KST, immediately after PR #122/#55 canvas-lane cleanup and
+creation of the #56/#99 adapter-epoch integration branch.
 
 ## Goal Boundary
 
@@ -32,10 +32,13 @@ Included:
 - Sequential integration audit, official full validation, required legacy and
   Node 2.0 browser smoke, `dev` PR, squash merge, Issue ledger, and cleanup.
 - #102 user documentation and this coordination plan/project Skill.
+- At a validated safe checkpoint, read back `origin/main`, `origin/dev`, tags,
+  GitHub Releases, and Registry state; then select a non-conflicting 0.5.x bugfix
+  version and complete the approved `dev` -> `main`, Release, and Registry flow.
 
 Excluded without separate approval:
 
-- `main` merge, release, tag, Registry publish, or security/permission changes.
+- Security or permission changes beyond the existing protected-branch flow.
 - Early or partial sync to the user instance.
 - Cleanup of unrelated worktrees whose ownership is not confirmed.
 
@@ -43,9 +46,9 @@ Excluded without separate approval:
 
 | Surface | Confirmed state |
 | --- | --- |
-| `origin/dev` | `e7a2cc4c95d40930a5076c25fd5f06a9bcc78c14` |
+| `origin/dev` | `3f8a6c0acd25fb0819818b39d3b6f29d70d39f51` |
 | local `dev` | same SHA, clean |
-| latest integration | PR #121, wildcard seed range user documentation |
+| latest integration | PR #122, LoRA Preset canvas widget extraction |
 | Codex test server | stopped; port 8194 listener and related server/launcher count 0 |
 | test-instance canvas setting | `Comfy.VueNodes.Enabled=false` restored |
 | user v0.27.0 instance | not synced for this Goal |
@@ -56,8 +59,11 @@ Excluded without separate approval:
 | Issue | State | Completed boundary | Remaining or next action |
 | --- | --- | --- | --- |
 | #54 AiO Generator | open | PR #107 lifecycle, #113 API queue/hook reentry and missing `prompt_id` no-commit regression, #119 sampler hydration owner and attached-subgraph refresh | direct concurrent API serialization/reservation, final broader matrix, #62/#66 triage, and optional #119 cycle/repeated-node/remove/root-replacement fixtures |
-| #55 LoRA Preset | open | #108 extraction, #115/#109 lifecycle hardening | integrate the current canvas-widget extraction; then profile mutation, initialize/configure/serialize, save-sync/wheel/entry, final matrix |
-| #56 Autocomplete | open | #116 input/keyboard/composition controller | integrate #99 adapter epoch; then external input hook, listener installer/entry, #98/#100, final matrix |
+| #55 LoRA Preset | open | #108 menu extraction, #115/#109 lifecycle hardening, #122 canvas-widget extraction | profile mutation, initialize/configure/serialize, save-sync/wheel/entry, final matrix |
+| #56 Autocomplete | open | #116 input/keyboard/composition controller | integrate the current #99 adapter epoch; then external input hook, listener installer/entry, #98/#100, final matrix |
+| #98 Autocomplete replacement syntax | open | none | deferred until the current adapter-epoch gate is integrated; preserve nested parentheses, weights, and artist prefix |
+| #99 Autocomplete request epochs | open | #116 controller generation and current adapter/result/source epoch working diff | finish focused/full/dual-canvas evidence, merge and ledger, then close if the full reported boundary is satisfied |
+| #100 Autocomplete result limit | open | none | deferred backend limit audit for configured values 51–100 |
 | #102 seed range | closed | production contract #112 and Korean/English user docs #121 | none; #111 remains a separate non-blocking Node 2.0 display mismatch |
 | #103 Regional seed | closed | PR #118 and final ledger | none |
 | #104 subgraph Advanced seed | closed | PR #117 and final ledger | optional non-blocking settlement coverage only |
@@ -86,13 +92,13 @@ in the roadmap and owning Issue ledgers.
 | #119 | `4119012881f4d1b35f61a29704fb18d23602a06d` | AiO sampler hydration single owner and attached-subgraph refresh | 396/396; 103 JS; TS 6.0.3 | Legacy and Node 2.0 512×512 queue/save-reload; attached native subgraph; EasyUse errors 0 | #54 ledger; Issue remains open |
 | #120 | `37c14f8cc10bd43fd33d3a1be76eeeeba435b920` | frontend maintenance execution ledger and repo-local coordination Skill | 396/396; 103 JS; TS 6.0.3 | not required: internal docs/procedure only | no owning feature Issue; merge/read-back and cleanup recorded here |
 | #121 | `e7a2cc4c95d40930a5076c25fd5f06a9bcc78c14` | bilingual wildcard seed range and legacy workflow user documentation | 396/396; 103 JS; TS 6.0.3 | reused #112 identical production evidence; docs-only diff | #102 final ledger; Issue closed completed |
+| #122 | `3f8a6c0acd25fb0819818b39d3b6f29d70d39f51` | LoRA Preset canvas drawing/hit-testing/strength-drag/widget extraction | 398/398; 104 JS; TS 6.0.3 | not repeated: mechanically identical extraction; final #55 matrix remains | #55 ledger; Issue remains open |
 
 ## Production Lane Ownership
 
 | Slice | Codex task | Branch / worktree | Base and status | Expected files |
 | --- | --- | --- | --- | --- |
-| #55 canvas widgets | source task `019f6b77-702f-7863-8706-cc5db859b360`; integration owner `019f6a32-3b0f-7ed0-8ff6-03de8546f402` | clean source `codex/extract-lora-canvas-widgets` / `6d238677`; active integration `codex/integrate-lora-canvas-widgets` / `worktrees/ComfyUI-EasyUseAnima/codex/integrate-lora-canvas-widgets` | source patch range-diff `=` as integration commit `0cca9ea` on `e7a2cc4`; shared runner/checkpoint focused checks and final audits passed | canvas module, LoRA entry, dedicated smoke/unittest, runner registration, and this checkpoint |
-| #56/#99 adapter epoch | `019f6bc5-c33b-7960-b84e-0f2300525f2a` | `codex/fix-autocomplete-adapter-epoch`; `worktrees/ComfyUI-EasyUseAnima/codex/fix-autocomplete-adapter-epoch` | clean HEAD `f34bdaa224a34c2bd3097c24e77cd45258486079` on `4119012`; focused 43/43 and two audits passed | `web/js/autocomplete/data_adapter.js`, dedicated adapter smoke |
+| #56/#99 adapter epoch | source task `019f6bc5-c33b-7960-b84e-0f2300525f2a`; integration owner `019f6a32-3b0f-7ed0-8ff6-03de8546f402` | clean source `codex/fix-autocomplete-adapter-epoch` / `f34bdaa`; active integration `codex/integrate-autocomplete-adapter-epoch` / `worktrees/ComfyUI-EasyUseAnima/codex/integrate-autocomplete-adapter-epoch` | source patch range-diff `=` as integration commit `b460f5e` on `3f8a6c0`; integration review fix supersedes hooked/active controller authority on setup and live setting invalidation | data adapter and smoke; input controller helper/smoke; autocomplete entry/static contract; this checkpoint |
 
 ## Integration Gates
 
@@ -100,8 +106,8 @@ Only one row may enter push/PR/merge at a time.
 
 | Order | Slice | Focused / audit | Full | Browser | Blocker / finding | Gate |
 | ---: | --- | --- | --- | --- | --- | --- |
-| 1 | #55 canvas widgets | source and integration focused checks, range-diff, and final production/runner/plan audits passed | run once on final diff | omit for mechanical extraction; final #55 matrix remains required before Issue close | no known blocker | current |
-| 2 | #56/#99 adapter epoch | focused 43/43, range-diff, and two audits passed | one full run | required once per final behavior diff on legacy and Node 2.0 | rebase from `4119012` after #55 cleanup | queued |
+| 1 | #56/#99 adapter epoch | source range-diff; final four semantic smokes, related unittest 43/43, TS 6.0.3, diff check, and three no-P0-P3 audits passed | one full run | required once per final behavior diff on legacy and Node 2.0 | no known code blocker; full/browser pending | current |
+| 2 | 0.5.x release checkpoint | enter only after #99 has a merged/read-back safe checkpoint; then read back main/dev/tags/Releases/Registry before choosing the version | reuse identical final-diff evidence; rerun only if code/base changes | reuse valid merged evidence | blocked by current working diff | queued |
 | 3 | remaining #54/#55/#56 slices | create only after file ownership and priority audit | per PR-ready diff | per behavior diff; final Issue matrices required | sequence and overlap audit required | backlog |
 | 4 | final user-instance sync | all agreed Issues/bugs reconciled first | use merged `dev` evidence | one manual v0.27.0 confirmation | blocked by remaining Goal work and prerequisites | queued |
 
@@ -112,7 +118,15 @@ sandbox. Do not report the environment spawn error as a code failure.
 
 ## Current Blockers And Findings
 
-- Blocking the current #55 canvas-widget gate: none known.
+- Current #56/#99 review findings, fixed in the working diff: adapter-only epoch
+  clearing left pending input authority current; full settings snapshots also
+  made source-key presence over-invalidate unrelated changes; and saved/live
+  natural-sentence or completion-preview changes could leave an old token query
+  current. Source identities now make unchanged snapshots no-ops, while actual
+  source, limit, mode, or query-shaping changes invalidate every hooked/active
+  controller, preserve controller ownership while closing the popup, and
+  schedule a fresh update only for an enabled focused input. Final focused and
+  three independent audits passed; full/browser evidence is pending.
 - Non-blocking #111: ComfyUI frontend 1.45.20 Node 2.0 can display a newly
   entered unsafe seed while the widget and saved workflow retain max-safe.
   Prefer an upstream fix or stable public-API boundary over a private-DOM hook.
@@ -130,15 +144,18 @@ sandbox. Do not report the environment spawn error as a code failure.
   another approval during this Goal.
 - User documentation for #102 and the coordination plan/repo-local Skill are
   explicitly approved.
-- `main`, release, tag, Registry publish, and early user-instance changes are not
-  approved.
+- At a sufficiently validated safe checkpoint, `main` merge, a GitHub bugfix
+  Release, and Registry publish/registration are approved. Select the exact
+  0.5.x version only after live state read-back and do not pull an unfrozen lane
+  into the release.
+- Early user-instance changes remain unapproved.
 - GitHub mutation timeout/abort always requires state read-back before retry.
 
 ## Cleanup And Sync
 
-- The #103 Regional, #54 sampler-hydration, #120 coordination, and #121 user-doc
-  branches/worktrees were removed after merge-tree equality and clean-state
-  checks.
+- The #103 Regional, #54 sampler-hydration, #120 coordination, #121 user-doc,
+  and #122 LoRA canvas source/integration branches/worktrees were removed after
+  merge-tree equality and clean-state checks.
 - Existing unrelated `codex/*`, `fix/*`, and `feature/*` worktrees are untouched.
 - The Codex test server is stopped and port 8194 is free.
 - The user v0.27.0 instance remains untouched until all agreed maintenance and

--- a/tests/frontend_autocomplete_data_adapter_smoke.mjs
+++ b/tests/frontend_autocomplete_data_adapter_smoke.mjs
@@ -96,6 +96,7 @@ assert.deepEqual(Object.keys(adapter).sort(), [
   "clearWildcards",
   "search",
   "searchWildcards",
+  "syncSourceSettings",
 ]);
 assert.equal(fetchCalls.length, 0, "factory creation must not fetch data");
 assert.equal(normalizeCalls, 0, "factory creation must not normalize data");
@@ -195,6 +196,88 @@ limit = 1;
 const oneWildcard = await adapter.searchWildcards("folder");
 assert.deepEqual(oneWildcard, [folderResults[0]]);
 assert.equal(wildcardFetchCount, 2, "limit changes must not reload wildcard source items");
+
+const settingsFetchCalls = [];
+const settingsAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: async (url) => {
+    settingsFetchCalls.push(url);
+    return url === "/easyuse_anima/wildcards"
+      ? { items: ["folder/setting"] }
+      : { results: [{ tag: `result-${settingsFetchCalls.length}` }] };
+  },
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 20,
+});
+const initialSettingsSnapshot = {
+  "autocomplete.source": "source-a",
+  "wildcard.extra_paths": "path-a",
+};
+assert.equal(
+  settingsAdapter.syncSourceSettings(initialSettingsSnapshot, { initialize: true }),
+  false,
+  "the initial full settings snapshot must establish identity without invalidating requests",
+);
+const settingsAutocompleteFirst = await settingsAdapter.search("snapshot");
+const settingsWildcardFirst = await settingsAdapter.searchWildcards("folder");
+assert.equal(settingsFetchCalls.length, 2);
+assert.equal(
+  settingsAdapter.syncSourceSettings({
+    ...initialSettingsSnapshot,
+    "autocomplete.commit_key": "enter",
+  }),
+  false,
+  "an unrelated full settings snapshot must not invalidate autocomplete data",
+);
+assert.equal(await settingsAdapter.search("snapshot"), settingsAutocompleteFirst);
+assert.equal(await settingsAdapter.searchWildcards("folder"), settingsWildcardFirst);
+assert.equal(settingsFetchCalls.length, 2, "unchanged source settings must remain cache hits");
+
+assert.equal(
+  settingsAdapter.syncSourceSettings({ "autocomplete.source": "source-b" }),
+  true,
+  "an autocomplete source change must invalidate result ownership",
+);
+const settingsAutocompleteSecond = await settingsAdapter.search("snapshot");
+assert.notEqual(settingsAutocompleteSecond, settingsAutocompleteFirst);
+assert.equal(settingsFetchCalls.length, 3);
+
+const settingsWildcardBeforePathChange = await settingsAdapter.searchWildcards("folder");
+assert.notEqual(settingsWildcardBeforePathChange, settingsWildcardFirst);
+assert.equal(
+  settingsAdapter.syncSourceSettings({ "wildcard.extra_paths": "path-b" }),
+  true,
+  "a wildcard path change must invalidate the wildcard source and derived results",
+);
+const settingsWildcardAfterPathChange = await settingsAdapter.searchWildcards("folder");
+assert.notEqual(settingsWildcardAfterPathChange, settingsWildcardBeforePathChange);
+assert.equal(settingsFetchCalls.length, 4);
+
+const firstEventAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: async () => ({ results: [] }),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 20,
+});
+assert.equal(
+  firstEventAdapter.syncSourceSettings({ "autocomplete.source": "source-first-event" }),
+  true,
+  "a live settings event without an initial snapshot must invalidate conservatively",
+);
+assert.equal(
+  firstEventAdapter.syncSourceSettings(
+    { "autocomplete.source": "source-late-setup" },
+    { initialize: true },
+  ),
+  true,
+  "a late setup snapshot must not overwrite a live-event identity without invalidation",
+);
+assert.equal(
+  firstEventAdapter.syncSourceSettings(
+    { "autocomplete.source": "source-late-setup" },
+    { initialize: true },
+  ),
+  false,
+  "a repeated setup snapshot with the current identity must remain a no-op",
+);
 
 const singleFlightRequests = [];
 const singleFlightAdapter = dataAdapterModule.createAutocompleteDataAdapter({

--- a/tests/frontend_autocomplete_data_adapter_smoke.mjs
+++ b/tests/frontend_autocomplete_data_adapter_smoke.mjs
@@ -9,6 +9,30 @@ function dataModule(relativePath) {
 const dataAdapterModule = await import(dataModule("../web/js/autocomplete/data_adapter.js"));
 const textModel = await import(dataModule("../web/js/autocomplete/text_model.js"));
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function controlledFetch(requests) {
+  return (url) => {
+    const request = { url, ...deferred() };
+    requests.push(request);
+    return request.promise;
+  };
+}
+
+async function flushMicrotasks(turns = 4) {
+  for (let index = 0; index < turns; index += 1) {
+    await Promise.resolve();
+  }
+}
+
 assert.deepEqual(Object.keys(dataAdapterModule), ["createAutocompleteDataAdapter"]);
 
 const fetchCalls = [];
@@ -171,5 +195,306 @@ limit = 1;
 const oneWildcard = await adapter.searchWildcards("folder");
 assert.deepEqual(oneWildcard, [folderResults[0]]);
 assert.equal(wildcardFetchCount, 2, "limit changes must not reload wildcard source items");
+
+const singleFlightRequests = [];
+const singleFlightAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: controlledFetch(singleFlightRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 12,
+});
+const sharedSearchFirst = singleFlightAdapter.search("Concurrent", "artist");
+const sharedSearchSecond = singleFlightAdapter.search("concurrent", "artist");
+await flushMicrotasks();
+assert.equal(singleFlightRequests.length, 1);
+singleFlightRequests[0].resolve({ results: [{ tag: "shared" }] });
+const [sharedSearchFirstResults, sharedSearchSecondResults] = await Promise.all([
+  sharedSearchFirst,
+  sharedSearchSecond,
+]);
+assert.equal(sharedSearchSecondResults, sharedSearchFirstResults);
+
+const defaultCategorySearch = singleFlightAdapter.search("category-partition");
+const explicitAllCategorySearch = singleFlightAdapter.search("category-partition", "all");
+await flushMicrotasks();
+assert.equal(singleFlightRequests.length, 3);
+singleFlightRequests[1].resolve({ results: [{ tag: "default-category" }] });
+singleFlightRequests[2].resolve({ results: [{ tag: "explicit-all-category" }] });
+const [defaultCategoryResults, explicitAllCategoryResults] = await Promise.all([
+  defaultCategorySearch,
+  explicitAllCategorySearch,
+]);
+assert.equal(
+  await singleFlightAdapter.search("category-partition"),
+  defaultCategoryResults,
+);
+assert.equal(
+  await singleFlightAdapter.search("category-partition", "all"),
+  explicitAllCategoryResults,
+);
+
+let searchLimitSnapshotCalls = 0;
+let searchLimitSnapshotUrl = "";
+const searchLimitSnapshotAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: async (url) => {
+    searchLimitSnapshotUrl = url;
+    return { results: [] };
+  },
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => {
+    searchLimitSnapshotCalls += 1;
+    return searchLimitSnapshotCalls === 1 ? 7 : 99;
+  },
+});
+await searchLimitSnapshotAdapter.search("snapshot", "artist");
+assert.equal(searchLimitSnapshotCalls, 1, "search must snapshot its limit once");
+assert.equal(
+  searchLimitSnapshotUrl,
+  "/easyuse_anima/autocomplete?q=snapshot&limit=7&category=artist",
+);
+
+let wildcardLimitSnapshotCalls = 0;
+const wildcardLimitSnapshotAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: async () => ({ items: ["alpha", "alpine", "alternate"] }),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => {
+    wildcardLimitSnapshotCalls += 1;
+    return wildcardLimitSnapshotCalls === 1 ? 2 : 1;
+  },
+});
+const wildcardLimitSnapshotResults = await wildcardLimitSnapshotAdapter.searchWildcards("al");
+assert.equal(
+  wildcardLimitSnapshotCalls,
+  1,
+  "wildcard search must snapshot its limit once",
+);
+assert.deepEqual(
+  wildcardLimitSnapshotResults.map((item) => item.tag),
+  ["alpha", "alpine"],
+);
+
+const staleResolveRequests = [];
+const staleResolveAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: controlledFetch(staleResolveRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 8,
+});
+const staleResolveOld = staleResolveAdapter.search("epoch", "general");
+await flushMicrotasks();
+staleResolveAdapter.clearResults();
+const staleResolveFresh = staleResolveAdapter.search("epoch", "general");
+await flushMicrotasks();
+assert.equal(staleResolveRequests.length, 2);
+const staleResolveOldPayload = [{ tag: "old-result" }];
+staleResolveRequests[0].resolve({ results: staleResolveOldPayload });
+assert.equal(await staleResolveOld, staleResolveOldPayload);
+const staleResolveSharedFresh = staleResolveAdapter.search("epoch", "general");
+await flushMicrotasks();
+assert.equal(staleResolveRequests.length, 2);
+const staleResolveFreshPayload = [{ tag: "fresh-result" }];
+staleResolveRequests[1].resolve({ results: staleResolveFreshPayload });
+const [staleResolveFreshResults, staleResolveSharedFreshResults] = await Promise.all([
+  staleResolveFresh,
+  staleResolveSharedFresh,
+]);
+assert.equal(staleResolveFreshResults, staleResolveFreshPayload);
+assert.equal(
+  staleResolveSharedFreshResults,
+  staleResolveFreshResults,
+  "a stale resolve must not close or replace the newer in-flight request",
+);
+assert.equal(
+  await staleResolveAdapter.search("epoch", "general"),
+  staleResolveFreshPayload,
+  "a stale resolve must not publish over the newer cache entry",
+);
+
+const staleRejectRequests = [];
+const staleRejectAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: controlledFetch(staleRejectRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 8,
+});
+const staleRejectOld = staleRejectAdapter.search("epoch-reject");
+await flushMicrotasks();
+staleRejectAdapter.clearResults();
+const staleRejectFresh = staleRejectAdapter.search("epoch-reject");
+await flushMicrotasks();
+const staleRejectAssertion = assert.rejects(staleRejectOld, /stale request failed/);
+staleRejectRequests[0].reject(new Error("stale request failed"));
+await staleRejectAssertion;
+const staleRejectSharedFresh = staleRejectAdapter.search("epoch-reject");
+await flushMicrotasks();
+assert.equal(staleRejectRequests.length, 2);
+staleRejectRequests[1].resolve({ results: [{ tag: "fresh-after-reject" }] });
+const [staleRejectFreshResults, staleRejectSharedFreshResults] = await Promise.all([
+  staleRejectFresh,
+  staleRejectSharedFresh,
+]);
+assert.equal(
+  staleRejectSharedFreshResults,
+  staleRejectFreshResults,
+  "a stale rejection must not delete the newer in-flight request",
+);
+assert.deepEqual(staleRejectFreshResults, [{ tag: "fresh-after-reject" }]);
+
+const preservedWildcardRequests = [];
+const preservedWildcardAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: controlledFetch(preservedWildcardRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 5,
+});
+const preservedWildcardOld = preservedWildcardAdapter.searchWildcards("folder");
+await flushMicrotasks();
+assert.equal(preservedWildcardRequests.length, 1);
+preservedWildcardAdapter.clearResults();
+const preservedWildcardFresh = preservedWildcardAdapter.searchWildcards("folder");
+await flushMicrotasks();
+assert.equal(
+  preservedWildcardRequests.length,
+  1,
+  "clearResults must preserve and share an in-flight wildcard source load",
+);
+preservedWildcardRequests[0].resolve({ items: ["folder/one", "folder/two"] });
+const [preservedWildcardOldResults, preservedWildcardFreshResults] = await Promise.all([
+  preservedWildcardOld,
+  preservedWildcardFresh,
+]);
+assert.notEqual(preservedWildcardOldResults, preservedWildcardFreshResults);
+assert.equal(
+  await preservedWildcardAdapter.searchWildcards("folder"),
+  preservedWildcardFreshResults,
+  "only the current result epoch may publish wildcard results",
+);
+assert.equal(preservedWildcardRequests.length, 1);
+
+const staleWildcardResolveRequests = [];
+const staleWildcardResolveAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: controlledFetch(staleWildcardResolveRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 5,
+});
+const staleWildcardResolveOld = staleWildcardResolveAdapter.searchWildcards("");
+await flushMicrotasks();
+staleWildcardResolveAdapter.clearWildcards();
+const staleWildcardResolveFresh = staleWildcardResolveAdapter.searchWildcards("");
+await flushMicrotasks();
+assert.equal(staleWildcardResolveRequests.length, 2);
+staleWildcardResolveRequests[0].resolve({ items: ["old/source"] });
+assert.deepEqual(await staleWildcardResolveOld, [
+  { tag: "old/source", category: "wildcard", count: 0, kind: "wildcard" },
+]);
+const staleWildcardDifferentQuery = staleWildcardResolveAdapter.searchWildcards("old");
+const staleWildcardResolveSharedFresh = staleWildcardResolveAdapter.searchWildcards("");
+await flushMicrotasks();
+assert.equal(staleWildcardResolveRequests.length, 2);
+staleWildcardResolveRequests[1].resolve({ items: ["new/source"] });
+const [staleWildcardResolveFreshResults, staleWildcardResolveSharedFreshResults] = (
+  await Promise.all([staleWildcardResolveFresh, staleWildcardResolveSharedFresh])
+);
+assert.equal(
+  staleWildcardResolveSharedFreshResults,
+  staleWildcardResolveFreshResults,
+  "a stale wildcard resolve must not close the newer result request",
+);
+assert.deepEqual(staleWildcardResolveFreshResults, [
+  { tag: "new/source", category: "wildcard", count: 0, kind: "wildcard" },
+]);
+assert.deepEqual(
+  await staleWildcardDifferentQuery,
+  [],
+  "a stale wildcard source must not publish into a later source epoch",
+);
+assert.equal(
+  await staleWildcardResolveAdapter.searchWildcards(""),
+  staleWildcardResolveFreshResults,
+);
+
+const staleWildcardRejectRequests = [];
+const staleWildcardRejectAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: controlledFetch(staleWildcardRejectRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 5,
+});
+const staleWildcardRejectOld = staleWildcardRejectAdapter.searchWildcards("reject");
+await flushMicrotasks();
+staleWildcardRejectAdapter.clearWildcards();
+const staleWildcardRejectFresh = staleWildcardRejectAdapter.searchWildcards("reject");
+await flushMicrotasks();
+const staleWildcardRejectAssertion = assert.rejects(
+  staleWildcardRejectOld,
+  /stale wildcard failed/,
+);
+staleWildcardRejectRequests[0].reject(new Error("stale wildcard failed"));
+await staleWildcardRejectAssertion;
+const staleWildcardRejectSharedFresh = staleWildcardRejectAdapter.searchWildcards("reject");
+await flushMicrotasks();
+assert.equal(staleWildcardRejectRequests.length, 2);
+staleWildcardRejectRequests[1].resolve({ items: ["reject/new"] });
+const [staleWildcardRejectFreshResults, staleWildcardRejectSharedFreshResults] = (
+  await Promise.all([staleWildcardRejectFresh, staleWildcardRejectSharedFresh])
+);
+assert.equal(
+  staleWildcardRejectSharedFreshResults,
+  staleWildcardRejectFreshResults,
+  "a stale wildcard rejection must not close the newer source or result request",
+);
+assert.deepEqual(staleWildcardRejectFreshResults.map((item) => item.tag), ["reject/new"]);
+
+const wildcardRetryRequests = [];
+const wildcardRetryAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: controlledFetch(wildcardRetryRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 5,
+});
+const wildcardRetryFirst = wildcardRetryAdapter.searchWildcards("folder");
+const wildcardRetrySame = wildcardRetryAdapter.searchWildcards("FOLDER");
+const wildcardRetryDifferent = wildcardRetryAdapter.searchWildcards("other");
+await flushMicrotasks();
+assert.equal(
+  wildcardRetryRequests.length,
+  1,
+  "different wildcard result queries must share one source load",
+);
+const wildcardRetryFirstAssertion = assert.rejects(
+  wildcardRetryFirst,
+  /wildcard source failed/,
+);
+const wildcardRetrySameAssertion = assert.rejects(
+  wildcardRetrySame,
+  /wildcard source failed/,
+);
+const wildcardRetryDifferentAssertion = assert.rejects(
+  wildcardRetryDifferent,
+  /wildcard source failed/,
+);
+wildcardRetryRequests[0].reject(new Error("wildcard source failed"));
+await Promise.all([
+  wildcardRetryFirstAssertion,
+  wildcardRetrySameAssertion,
+  wildcardRetryDifferentAssertion,
+]);
+const wildcardRetryFresh = wildcardRetryAdapter.searchWildcards("folder");
+const wildcardRetryFreshSame = wildcardRetryAdapter.searchWildcards("FOLDER");
+const wildcardRetryFreshDifferent = wildcardRetryAdapter.searchWildcards("other");
+await flushMicrotasks();
+assert.equal(wildcardRetryRequests.length, 2, "failed wildcard loads must be retryable");
+wildcardRetryRequests[1].resolve({ items: ["folder/retried", "other/retried"] });
+const [
+  wildcardRetryFreshResults,
+  wildcardRetryFreshSameResults,
+  wildcardRetryFreshDifferentResults,
+] = await Promise.all([
+  wildcardRetryFresh,
+  wildcardRetryFreshSame,
+  wildcardRetryFreshDifferent,
+]);
+assert.equal(
+  wildcardRetryFreshSameResults,
+  wildcardRetryFreshResults,
+  "same wildcard result key must be single-flight",
+);
+assert.notEqual(wildcardRetryFreshDifferentResults, wildcardRetryFreshResults);
+assert.deepEqual(wildcardRetryFreshResults.map((item) => item.tag), ["folder/retried"]);
+assert.deepEqual(wildcardRetryFreshDifferentResults.map((item) => item.tag), ["other/retried"]);
 
 console.log("Autocomplete data adapter smoke passed.");

--- a/tests/frontend_autocomplete_input_controller_smoke.mjs
+++ b/tests/frontend_autocomplete_input_controller_smoke.mjs
@@ -66,9 +66,66 @@ function createScheduler() {
 const controllerModule = await import(
   dataModule("../web/js/autocomplete/input_controller.js")
 );
-assert.deepEqual(Object.keys(controllerModule), ["createAutocompleteInputController"]);
+assert.deepEqual(Object.keys(controllerModule), [
+  "createAutocompleteInputController",
+  "invalidateAutocompleteControllerStates",
+]);
 
-const { createAutocompleteInputController } = controllerModule;
+const {
+  createAutocompleteInputController,
+  invalidateAutocompleteControllerStates,
+} = controllerModule;
+
+{
+  let sharedInvalidations = 0;
+  let activeInvalidations = 0;
+  let detachedActiveInvalidations = 0;
+  const sharedController = {
+    invalidate() {
+      sharedInvalidations += 1;
+    },
+  };
+  const activeController = {
+    invalidate() {
+      activeInvalidations += 1;
+    },
+  };
+  const detachedActiveController = {
+    invalidate() {
+      detachedActiveInvalidations += 1;
+    },
+  };
+
+  invalidateAutocompleteControllerStates(
+    [
+      { controller: sharedController },
+      { controller: sharedController },
+      { controller: activeController },
+      {},
+      null,
+    ],
+    { controller: activeController },
+  );
+  assert.equal(
+    sharedInvalidations,
+    1,
+    "duplicate state references must invalidate a shared controller once",
+  );
+  assert.equal(
+    activeInvalidations,
+    1,
+    "the active popup clone must not invalidate its controller twice",
+  );
+
+  invalidateAutocompleteControllerStates([], {
+    controller: detachedActiveController,
+  });
+  assert.equal(
+    detachedActiveInvalidations,
+    1,
+    "an active popup controller must be invalidated even after input-set cleanup",
+  );
+}
 
 {
   const scheduler = createScheduler();

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -50,7 +50,10 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
                 module_source,
                 re.MULTILINE,
             ),
-            ["createAutocompleteInputController"],
+            [
+                "invalidateAutocompleteControllerStates",
+                "createAutocompleteInputController",
+            ],
         )
         self.assertNotRegex(
             module_source,
@@ -64,10 +67,26 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
                 r"HTMLElement|HTMLInputElement|HTMLTextAreaElement)\b"
             ),
         )
-        self.assertIn(
-            'import { createAutocompleteInputController } from '
-            '"./autocomplete/input_controller.js";',
+        import_match = re.search(
+            (
+                r'^import\s*\{(?P<names>[^}]*)\}\s*from\s*'
+                r'"\./autocomplete/input_controller\.js";'
+            ),
             entry_source,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(import_match)
+        imported_names = {
+            name.strip().rstrip(",")
+            for name in import_match.group("names").splitlines()
+            if name.strip()
+        }
+        self.assertEqual(
+            imported_names,
+            {
+                "createAutocompleteInputController",
+                "invalidateAutocompleteControllerStates",
+            },
         )
         self.assertEqual(
             entry_source.count("createAutocompleteInputController({"),
@@ -99,6 +118,138 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
         self.assertIn("controller.invalidate();", hook_body)
         self.assertIn("controller.isComposing(event)", hook_body)
         self.assertIn("state?.controller?.invalidate();", entry_source)
+
+        invalidate_start = entry_source.index(
+            "function invalidateAutocompleteDataRequests"
+        )
+        invalidate_end = entry_source.index(
+            "\nfunction refreshActiveAutocomplete", invalidate_start
+        )
+        invalidate_body = entry_source[invalidate_start:invalidate_end]
+        self.assertIn(
+            "invalidateAutocompleteControllerStates(states, activeState);",
+            invalidate_body,
+        )
+        self.assertIn("for (const input of [...hookedAutocompleteInputs])", invalidate_body)
+        self.assertIn("states.push(state);", invalidate_body)
+        self.assertIn("if (document.activeElement === input) {", invalidate_body)
+        self.assertIn("hidePopup({ preserveController: true });", invalidate_body)
+        self.assertIn("focusedState.controller.scheduleUpdate();", invalidate_body)
+        self.assertIn("autocompleteEnabledForState(focusedState)", invalidate_body)
+        self.assertLess(
+            invalidate_body.index(
+                "invalidateAutocompleteControllerStates(states, activeState);"
+            ),
+            invalidate_body.index("hidePopup({ preserveController: true });"),
+        )
+        self.assertLess(
+            invalidate_body.index("hidePopup({ preserveController: true });"),
+            invalidate_body.index("focusedState.controller.scheduleUpdate();"),
+        )
+
+        refresh_start = entry_source.index(
+            "async function refreshAutocompleteSettings"
+        )
+        refresh_end = entry_source.index("\nfunction ensureStyle", refresh_start)
+        refresh_body = entry_source[refresh_start:refresh_end]
+        self.assertIn(
+            "let dataRequestsInvalidated = autocompleteData.syncSourceSettings(",
+            refresh_body,
+        )
+        self.assertIn(
+            "const previousMode = autocompleteMode;",
+            refresh_body,
+        )
+        self.assertRegex(
+            refresh_body,
+            re.compile(
+                r"autocompleteData\.syncSourceSettings\(\s*"
+                r"settings,\s*\{ initialize: true \},\s*\)",
+                re.DOTALL,
+            ),
+        )
+        self.assertIn(
+            "const previousDetectNaturalSentences = "
+            "autocompleteDetectNaturalSentences;",
+            refresh_body,
+        )
+        self.assertIn(
+            "const previousPreviewCompletion = autocompletePreviewCompletion;",
+            refresh_body,
+        )
+        self.assertIn(
+            "if (autocompleteDetectNaturalSentences !== "
+            "previousDetectNaturalSentences) {",
+            refresh_body,
+        )
+        self.assertIn(
+            "if (autocompletePreviewCompletion !== previousPreviewCompletion) {",
+            refresh_body,
+        )
+        self.assertIn(
+            "invalidateAutocompleteDataRequests();",
+            refresh_body,
+        )
+        self.assertIn(
+            "if (dataRequestsInvalidated) {\n"
+            "      invalidateAutocompleteDataRequests();\n"
+            "    }",
+            refresh_body,
+        )
+
+        settings_start = entry_source.index(
+            'window.addEventListener("easyuse-anima-settings-updated"'
+        )
+        settings_end = entry_source.index(
+            "\n\napp.registerExtension({", settings_start
+        )
+        settings_body = entry_source[settings_start:settings_end]
+        self.assertIn("let dataRequestsInvalidated = false;", settings_body)
+        self.assertIn("dataRequestsInvalidated = true;", settings_body)
+        self.assertIn(
+            'const nextMaxResults = clampMaxResults(detail["autocomplete.limit"]);',
+            settings_body,
+        )
+        self.assertIn("if (nextMaxResults !== maxResults) {", settings_body)
+        self.assertIn(
+            "if (autocompleteMode !== previousMode) {\n"
+            "      dataRequestsInvalidated = true;\n"
+            "    }",
+            settings_body,
+        )
+        self.assertIn(
+            "if (autocompleteData.syncSourceSettings(detail)) {\n"
+            "    dataRequestsInvalidated = true;\n"
+            "  }",
+            settings_body,
+        )
+        self.assertIn(
+            "const previousDetectNaturalSentences = "
+            "autocompleteDetectNaturalSentences;",
+            settings_body,
+        )
+        self.assertIn(
+            "const previousPreviewCompletion = autocompletePreviewCompletion;",
+            settings_body,
+        )
+        self.assertIn(
+            "if (autocompleteDetectNaturalSentences !== "
+            "previousDetectNaturalSentences) {",
+            settings_body,
+        )
+        self.assertIn(
+            "if (autocompletePreviewCompletion !== previousPreviewCompletion) {",
+            settings_body,
+        )
+        self.assertIn(
+            "invalidateAutocompleteDataRequests();",
+            settings_body,
+        )
+        self.assertIn(
+            "} else {\n    scheduleActiveRefresh();\n  }",
+            settings_body,
+        )
+        self.assertNotIn("hidePopup();", settings_body)
 
         keydown_start = hook_body.rindex(
             'input.addEventListener("keydown", (event) => {'
@@ -310,11 +461,15 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
         )
         self.assertEqual(
             entry_source.count("autocompleteData.clearResults()"),
-            4,
+            3,
         )
         self.assertEqual(
             entry_source.count("autocompleteData.clearWildcards()"),
-            1,
+            0,
+        )
+        self.assertEqual(
+            entry_source.count("autocompleteData.syncSourceSettings("),
+            2,
         )
         self.assertIn("app.registerExtension({", entry_source)
         self.assertIn('document.addEventListener("pointerdown"', entry_source)

--- a/web/js/autocomplete/data_adapter.js
+++ b/web/js/autocomplete/data_adapter.js
@@ -8,6 +8,18 @@
  */
 
 /**
+ * @typedef {object} ResultRequestOwner
+ * @property {number} epoch
+ * @property {Promise<any[]>} promise
+ */
+
+/**
+ * @typedef {object} WildcardSourceRequestOwner
+ * @property {number} epoch
+ * @property {Promise<string[]>} promise
+ */
+
+/**
  * Own autocomplete result caching and wildcard source loading without taking
  * ownership of settings, DOM, popup, or extension lifecycle.
  *
@@ -19,61 +31,187 @@ export function createAutocompleteDataAdapter(dependencies) {
     normalizeWildcardSearchText,
     getLimit,
   } = dependencies;
+  /** @type {Map<string, any[]>} */
   const cache = new Map();
+  /** @type {Map<string, ResultRequestOwner>} */
+  const pendingResults = new Map();
+  let resultsEpoch = 0;
+  let wildcardSourceEpoch = 0;
+  /** @type {string[] | null} */
   let wildcardItemsCache = null;
+  /** @type {WildcardSourceRequestOwner | null} */
+  let wildcardLoadOwner = null;
+
+  /**
+   * @param {string} key
+   * @param {() => Promise<any[]>} load
+  * @returns {Promise<any[]>}
+  */
+  function requestResults(key, load) {
+    const cachedResults = cache.get(key);
+    if (cachedResults) {
+      return Promise.resolve(cachedResults);
+    }
+
+    const epoch = resultsEpoch;
+    const existingOwner = pendingResults.get(key);
+    if (existingOwner?.epoch === epoch) {
+      return existingOwner.promise;
+    }
+
+    /** @type {(value: any[]) => void} */
+    let resolveRequest = () => {};
+    /** @type {(reason?: any) => void} */
+    let rejectRequest = () => {};
+    /** @type {Promise<any[]>} */
+    const promise = new Promise((resolve, reject) => {
+      resolveRequest = resolve;
+      rejectRequest = reject;
+    });
+    const owner = { epoch, promise };
+    pendingResults.set(key, owner);
+
+    /** @type {Promise<any[]>} */
+    let loadPromise;
+    try {
+      loadPromise = load();
+    } catch (error) {
+      if (pendingResults.get(key) === owner) {
+        pendingResults.delete(key);
+      }
+      rejectRequest(error);
+      return promise;
+    }
+
+    Promise.resolve(loadPromise).then(
+      (results) => {
+        if (resultsEpoch === epoch && pendingResults.get(key) === owner) {
+          cache.set(key, results);
+        }
+        if (pendingResults.get(key) === owner) {
+          pendingResults.delete(key);
+        }
+        resolveRequest(results);
+      },
+      (error) => {
+        if (pendingResults.get(key) === owner) {
+          pendingResults.delete(key);
+        }
+        rejectRequest(error);
+      },
+    );
+
+    return promise;
+  }
 
   function clearResults() {
+    resultsEpoch += 1;
     cache.clear();
+    pendingResults.clear();
   }
 
   function clearWildcards() {
+    wildcardSourceEpoch += 1;
     wildcardItemsCache = null;
-    cache.clear();
+    wildcardLoadOwner = null;
+    clearResults();
   }
 
   async function search(query, category = "") {
-    const key = `${category || "all"}:${getLimit()}:${query.toLocaleLowerCase()}`;
-    if (cache.has(key)) {
-      return cache.get(key);
-    }
-    const categoryParam = category ? `&category=${encodeURIComponent(category)}` : "";
-    const data = await fetchJson(
-      `/easyuse_anima/autocomplete?q=${encodeURIComponent(query)}&limit=${getLimit()}${categoryParam}`,
-    );
-    const results = Array.isArray(data.results) ? data.results : [];
-    cache.set(key, results);
-    return results;
+    const limit = getLimit();
+    const normalizedCategory = category || "";
+    const key = JSON.stringify([
+      "autocomplete",
+      normalizedCategory,
+      limit,
+      query.toLocaleLowerCase(),
+    ]);
+    const categoryParam = normalizedCategory
+      ? `&category=${encodeURIComponent(normalizedCategory)}`
+      : "";
+    const url = "/easyuse_anima/autocomplete"
+      + `?q=${encodeURIComponent(query)}`
+      + `&limit=${limit}${categoryParam}`;
+    return requestResults(key, async () => {
+      const data = await fetchJson(url);
+      return Array.isArray(data.results) ? data.results : [];
+    });
   }
 
-  async function loadWildcardItems() {
+  function loadWildcardItems() {
     if (Array.isArray(wildcardItemsCache)) {
-      return wildcardItemsCache;
+      return Promise.resolve(wildcardItemsCache);
     }
-    const data = await fetchJson("/easyuse_anima/wildcards");
-    wildcardItemsCache = Array.isArray(data.items)
-      ? data.items.map((item) => String(item || "")).filter(Boolean)
-      : [];
-    return wildcardItemsCache;
+
+    const epoch = wildcardSourceEpoch;
+    if (wildcardLoadOwner?.epoch === epoch) {
+      return wildcardLoadOwner.promise;
+    }
+
+    /** @type {(value: string[]) => void} */
+    let resolveRequest = () => {};
+    /** @type {(reason?: any) => void} */
+    let rejectRequest = () => {};
+    /** @type {Promise<string[]>} */
+    const promise = new Promise((resolve, reject) => {
+      resolveRequest = resolve;
+      rejectRequest = reject;
+    });
+    const owner = { epoch, promise };
+    wildcardLoadOwner = owner;
+
+    /** @type {Promise<any>} */
+    let loadPromise;
+    try {
+      loadPromise = fetchJson("/easyuse_anima/wildcards");
+    } catch (error) {
+      if (wildcardLoadOwner === owner) {
+        wildcardLoadOwner = null;
+      }
+      rejectRequest(error);
+      return promise;
+    }
+
+    Promise.resolve(loadPromise).then(
+      (data) => {
+        const items = Array.isArray(data.items)
+          ? data.items.map((item) => String(item || "")).filter(Boolean)
+          : [];
+        if (wildcardSourceEpoch === epoch && wildcardLoadOwner === owner) {
+          wildcardItemsCache = items;
+        }
+        if (wildcardLoadOwner === owner) {
+          wildcardLoadOwner = null;
+        }
+        resolveRequest(items);
+      },
+      (error) => {
+        if (wildcardLoadOwner === owner) {
+          wildcardLoadOwner = null;
+        }
+        rejectRequest(error);
+      },
+    );
+
+    return promise;
   }
 
   async function searchWildcards(query) {
     const normalized = normalizeWildcardSearchText(query);
-    const key = `wildcard:${getLimit()}:${normalized}`;
-    if (cache.has(key)) {
-      return cache.get(key);
-    }
-    const items = await loadWildcardItems();
-    const results = items
-      .filter((item) => !normalized || normalizeWildcardSearchText(item).includes(normalized))
-      .slice(0, getLimit())
-      .map((item) => ({
-        tag: item,
-        category: "wildcard",
-        count: 0,
-        kind: "wildcard",
-      }));
-    cache.set(key, results);
-    return results;
+    const limit = getLimit();
+    const key = JSON.stringify(["wildcard", limit, normalized]);
+    return requestResults(key, async () => {
+      const items = await loadWildcardItems();
+      return items
+        .filter((item) => !normalized || normalizeWildcardSearchText(item).includes(normalized))
+        .slice(0, limit)
+        .map((item) => ({
+          tag: item,
+          category: "wildcard",
+          count: 0,
+          kind: "wildcard",
+        }));
+    });
   }
 
   return {

--- a/web/js/autocomplete/data_adapter.js
+++ b/web/js/autocomplete/data_adapter.js
@@ -20,8 +20,8 @@
  */
 
 /**
- * Own autocomplete result caching and wildcard source loading without taking
- * ownership of settings, DOM, popup, or extension lifecycle.
+ * Own autocomplete result caching, wildcard source loading, and source-setting
+ * identity without taking ownership of DOM, popup, or extension lifecycle.
  *
  * @param {AutocompleteDataAdapterDependencies} dependencies
  */
@@ -41,12 +41,24 @@ export function createAutocompleteDataAdapter(dependencies) {
   let wildcardItemsCache = null;
   /** @type {WildcardSourceRequestOwner | null} */
   let wildcardLoadOwner = null;
+  let autocompleteSourceSeen = false;
+  let autocompleteSourceSignature = "";
+  let wildcardExtraPathsSeen = false;
+  let wildcardExtraPathsSignature = "";
+
+  function dataSettingSignature(value) {
+    try {
+      return JSON.stringify([value]);
+    } catch {
+      return String(value);
+    }
+  }
 
   /**
    * @param {string} key
    * @param {() => Promise<any[]>} load
-  * @returns {Promise<any[]>}
-  */
+   * @returns {Promise<any[]>}
+   */
   function requestResults(key, load) {
     const cachedResults = cache.get(key);
     if (cachedResults) {
@@ -115,6 +127,56 @@ export function createAutocompleteDataAdapter(dependencies) {
     wildcardItemsCache = null;
     wildcardLoadOwner = null;
     clearResults();
+  }
+
+  /**
+   * Track the backend settings that select autocomplete and wildcard sources.
+   * Settings events carry a full snapshot, so key presence alone cannot own
+   * invalidation without turning unrelated setting updates into fresh fetches.
+   *
+   * @param {Record<string, any> | null | undefined} settings
+   * @param {{initialize?: boolean}} [options]
+   * @returns {boolean}
+   */
+  function syncSourceSettings(settings, options = {}) {
+    const initialize = !!options.initialize;
+    let resultsChanged = false;
+    let wildcardSourceChanged = false;
+
+    if (
+      settings
+      && Object.prototype.hasOwnProperty.call(settings, "autocomplete.source")
+    ) {
+      const nextSignature = dataSettingSignature(settings["autocomplete.source"]);
+      const changed = !autocompleteSourceSeen
+        || nextSignature !== autocompleteSourceSignature;
+      if (changed && (!initialize || autocompleteSourceSeen)) {
+        resultsChanged = true;
+      }
+      autocompleteSourceSeen = true;
+      autocompleteSourceSignature = nextSignature;
+    }
+
+    if (
+      settings
+      && Object.prototype.hasOwnProperty.call(settings, "wildcard.extra_paths")
+    ) {
+      const nextSignature = dataSettingSignature(settings["wildcard.extra_paths"]);
+      const changed = !wildcardExtraPathsSeen
+        || nextSignature !== wildcardExtraPathsSignature;
+      if (changed && (!initialize || wildcardExtraPathsSeen)) {
+        wildcardSourceChanged = true;
+      }
+      wildcardExtraPathsSeen = true;
+      wildcardExtraPathsSignature = nextSignature;
+    }
+
+    if (wildcardSourceChanged) {
+      clearWildcards();
+    } else if (resultsChanged) {
+      clearResults();
+    }
+    return resultsChanged || wildcardSourceChanged;
   }
 
   async function search(query, category = "") {
@@ -219,5 +281,6 @@ export function createAutocompleteDataAdapter(dependencies) {
     searchWildcards,
     clearResults,
     clearWildcards,
+    syncSourceSettings,
   };
 }

--- a/web/js/autocomplete/input_controller.js
+++ b/web/js/autocomplete/input_controller.js
@@ -18,6 +18,39 @@
  */
 
 /**
+ * @typedef {object} AutocompleteInputControllerHandle
+ * @property {() => void} invalidate
+ */
+
+/**
+ * @typedef {object} AutocompleteControllerState
+ * @property {AutocompleteInputControllerHandle | null | undefined} [controller]
+ */
+
+/**
+ * Invalidate every distinct input controller that can still publish results.
+ * The active popup state may be a shallow clone of its hooked input state, so
+ * controller identity owns de-duplication rather than state identity.
+ *
+ * @param {Iterable<AutocompleteControllerState | null | undefined>} states
+ * @param {AutocompleteControllerState | null | undefined} [activeState]
+ */
+export function invalidateAutocompleteControllerStates(states, activeState = null) {
+  const controllers = new Set();
+  for (const state of states) {
+    if (state?.controller) {
+      controllers.add(state.controller);
+    }
+  }
+  if (activeState?.controller) {
+    controllers.add(activeState.controller);
+  }
+  for (const controller of controllers) {
+    controller.invalidate();
+  }
+}
+
+/**
  * Own one autocomplete input's scheduled updates, composition state, and
  * asynchronous request authority. DOM listeners and popup rendering stay in
  * the entry module; this controller only decides which update is current.

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -6,7 +6,10 @@ import {
 import { easyuseAnimaFetchJson, easyuseAnimaGetSettings } from "./easyuse_anima_api.js";
 import { easyuseAnimaText } from "./easyuse_anima_i18n.js";
 import { createAutocompleteDataAdapter } from "./autocomplete/data_adapter.js";
-import { createAutocompleteInputController } from "./autocomplete/input_controller.js";
+import {
+  createAutocompleteInputController,
+  invalidateAutocompleteControllerStates,
+} from "./autocomplete/input_controller.js";
 import {
   calculateAutocompletePopupGeometry,
   calculateCaretMirrorGeometry,
@@ -354,18 +357,38 @@ async function refreshAutocompleteSettings() {
     if (!settings) {
       return;
     }
+    let dataRequestsInvalidated = autocompleteData.syncSourceSettings(
+      settings,
+      { initialize: true },
+    );
     const nextMaxResults = clampMaxResults(settings["autocomplete.limit"]);
     if (nextMaxResults !== maxResults) {
       maxResults = nextMaxResults;
       autocompleteData.clearResults();
+      dataRequestsInvalidated = true;
     }
+    const previousMode = autocompleteMode;
     setAutocompleteMode(settings["autocomplete.mode"]);
+    if (autocompleteMode !== previousMode) {
+      dataRequestsInvalidated = true;
+    }
     setAutocompleteCommitKey(settings["autocomplete.commit_key"]);
     setAutocompleteAppendSeparator(settings["autocomplete.append_separator"]);
     setAutocompleteNoCommaAfterPeriod(settings["autocomplete.no_comma_after_period"]);
+    const previousDetectNaturalSentences = autocompleteDetectNaturalSentences;
     setAutocompleteDetectNaturalSentences(settings["autocomplete.detect_natural_sentences"]);
+    if (autocompleteDetectNaturalSentences !== previousDetectNaturalSentences) {
+      dataRequestsInvalidated = true;
+    }
     setAutocompletePreviewClosingBrackets(settings["autocomplete.preview_closing_brackets"]);
+    const previousPreviewCompletion = autocompletePreviewCompletion;
     setAutocompletePreviewCompletion(settings["autocomplete.preview_completion"]);
+    if (autocompletePreviewCompletion !== previousPreviewCompletion) {
+      dataRequestsInvalidated = true;
+    }
+    if (dataRequestsInvalidated) {
+      invalidateAutocompleteDataRequests();
+    }
   } catch {
     // Keep the built-in default if settings cannot be read.
   }
@@ -462,6 +485,27 @@ function markAutocompleteInputInactive(input) {
 function hideTrainedTagTooltips() {
   for (const tooltip of document.querySelectorAll(".easyuse-anima-trained-tag-tooltip")) {
     tooltip.classList.add("hidden");
+  }
+}
+
+function invalidateAutocompleteDataRequests() {
+  const states = [];
+  let focusedState = null;
+  for (const input of [...hookedAutocompleteInputs]) {
+    const state = input?.__easyuseAnimaAutocompleteState;
+    if (!state) {
+      hookedAutocompleteInputs.delete(input);
+      continue;
+    }
+    states.push(state);
+    if (document.activeElement === input) {
+      focusedState = state;
+    }
+  }
+  invalidateAutocompleteControllerStates(states, activeState);
+  hidePopup({ preserveController: true });
+  if (autocompleteEnabledForState(focusedState)) {
+    focusedState.controller.scheduleUpdate();
   }
 }
 
@@ -1685,8 +1729,13 @@ document.addEventListener("selectionchange", scheduleActiveRefresh);
 window.addEventListener("resize", scheduleActiveRefresh);
 window.addEventListener("easyuse-anima-settings-updated", (event) => {
   const detail = event?.detail || {};
+  let dataRequestsInvalidated = false;
   if ("autocomplete.mode" in detail) {
+    const previousMode = autocompleteMode;
     setAutocompleteMode(detail["autocomplete.mode"]);
+    if (autocompleteMode !== previousMode) {
+      dataRequestsInvalidated = true;
+    }
   }
   if ("autocomplete.commit_key" in detail) {
     setAutocompleteCommitKey(detail["autocomplete.commit_key"]);
@@ -1698,27 +1747,38 @@ window.addEventListener("easyuse-anima-settings-updated", (event) => {
     setAutocompleteNoCommaAfterPeriod(detail["autocomplete.no_comma_after_period"]);
   }
   if ("autocomplete.detect_natural_sentences" in detail) {
+    const previousDetectNaturalSentences = autocompleteDetectNaturalSentences;
     setAutocompleteDetectNaturalSentences(detail["autocomplete.detect_natural_sentences"]);
+    if (autocompleteDetectNaturalSentences !== previousDetectNaturalSentences) {
+      dataRequestsInvalidated = true;
+    }
   }
   if ("autocomplete.preview_closing_brackets" in detail) {
     setAutocompletePreviewClosingBrackets(detail["autocomplete.preview_closing_brackets"]);
   }
   if ("autocomplete.preview_completion" in detail) {
+    const previousPreviewCompletion = autocompletePreviewCompletion;
     setAutocompletePreviewCompletion(detail["autocomplete.preview_completion"]);
+    if (autocompletePreviewCompletion !== previousPreviewCompletion) {
+      dataRequestsInvalidated = true;
+    }
   }
   if ("autocomplete.limit" in detail) {
-    maxResults = clampMaxResults(detail["autocomplete.limit"]);
-    autocompleteData.clearResults();
+    const nextMaxResults = clampMaxResults(detail["autocomplete.limit"]);
+    if (nextMaxResults !== maxResults) {
+      maxResults = nextMaxResults;
+      autocompleteData.clearResults();
+      dataRequestsInvalidated = true;
+    }
   }
-  if ("autocomplete.source" in detail) {
-    autocompleteData.clearResults();
-    hidePopup();
+  if (autocompleteData.syncSourceSettings(detail)) {
+    dataRequestsInvalidated = true;
   }
-  if ("wildcard.extra_paths" in detail) {
-    autocompleteData.clearWildcards();
-    hidePopup();
+  if (dataRequestsInvalidated) {
+    invalidateAutocompleteDataRequests();
+  } else {
+    scheduleActiveRefresh();
   }
-  scheduleActiveRefresh();
 });
 
 app.registerExtension({


### PR DESCRIPTION
## 변경 요약

- autocomplete data adapter에 result/source epoch와 동일 요청 single-flight 소유권을 추가해 stale resolve/reject가 최신 결과를 덮거나 popup을 닫지 못하게 했습니다.
- CSV source와 wildcard path identity를 추적해 실제 source 변경만 cache/request authority를 무효화하고, 동일한 전체 settings snapshot과 무관한 설정 변경은 no-op으로 유지합니다.
- setup 및 live settings 변경 시 hooked input과 detached active input을 포함한 controller 집합을 중복 없이 무효화합니다.
- popup을 닫아도 controller 소유권은 보존하고, 활성화된 focused input만 최신 query를 다시 예약합니다.
- #98 텍스트 치환 문법과 #100 backend limit은 변경하지 않았습니다.

## 주요 파일

- `web/js/autocomplete/data_adapter.js`
- `web/js/autocomplete/input_controller.js`
- `web/js/easyuse_anima_autocomplete.js`
- `tests/frontend_autocomplete_data_adapter_smoke.mjs`
- `tests/frontend_autocomplete_input_controller_smoke.mjs`
- `tests/test_autocomplete_frontend.py`
- `docs/development/frontend-maintenance-execution-plan.md`

## 검증

Focused:

- 변경 production/test JavaScript `node --check`: 통과
- data adapter, input controller, text model, popup geometry semantic smoke: 통과
- `python -m unittest tests.test_autocomplete_frontend tests.test_aio_frontend`: 43/43 통과
- TypeScript 6.0.3: 통과
- `git diff --check`: 통과
- source/integration `range-diff`: 동일
- 3개 독립 감사: P0-P3 finding 없음

Official full runner:

- `powershell -ExecutionPolicy Bypass -File tools/check_custom_node.ps1 -Project <PR worktree> -Profile full`
- Python unittest: 398/398
- frontend smoke: 104 JavaScript files
- TypeScript: 6.0.3
- git diff check: 통과

Browser, ComfyUI Codex test instance / frontend 1.45.20:

- Legacy: Danbooru 20개 → e621 2개 → Danbooru 20개 live source 전환
- Node 2.0: 동일 source 전환
- 두 캔버스 모두 Escape 닫기, ArrowDown 재열기, Tab commit, `hatsune miku` save/reload 통과
- EasyUse Anima/autocomplete browser error 0
- 최초 Node 2.0 시도는 기존 탭의 stale extension module cache가 확인되어 증거에서 제외했고, 정확한 branch module을 새 탭에서 검증한 결과만 사용했습니다.

Focused semantic 명령은 Windows sandbox의 `CreateProcessAsUserW 1312`로 일부 시작 전 실패했으며, 동일 명령을 비샌드박스에서 다시 실행해 모두 통과했습니다. 테스트 본문 실패는 아니었습니다.

## 남은 경계

- Issue #56의 external DOM input hook, listener installer/extension entry lifecycle은 후속 PR입니다.
- Issue #98 replacement syntax와 Issue #100 configured limit 51-100 backend 경계는 변경하지 않았습니다.
- 사용자 v0.27.0 인스턴스에는 아직 반영하지 않았습니다.

Closes #99
