### PR TITLE
fix: Registry 패키지에 autocomplete 런타임 포함

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -44,7 +44,7 @@ workflow/
 workflows/
 wildcards/
 styles/
-autocomplete/
+/autocomplete/
 web_beta/
 web_version/dev/
 node.tar.gz

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import subprocess
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+AUTOCOMPLETE_RUNTIME_PATHS = {
+    "web/js/easyuse_anima_autocomplete.js",
+    "web/js/autocomplete/data_adapter.js",
+    "web/js/autocomplete/input_controller.js",
+    "web/js/autocomplete/popup_geometry.js",
+    "web/js/autocomplete/text_model.js",
+}
 
 
 class RegistryScannerSafetyTests(unittest.TestCase):
@@ -71,7 +79,7 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "workflows/",
             "wildcards/",
             "styles/",
-            "autocomplete/",
+            "/autocomplete/",
             "web_beta/",
             "web_version/dev/",
             "*.cache",
@@ -91,6 +99,38 @@ class RegistryScannerSafetyTests(unittest.TestCase):
         for required_readme in ("README.md", "README.en.md", "README.ko.md", "*.md"):
             with self.subTest(required_readme=required_readme):
                 self.assertNotIn(required_readme, ignored_lines)
+        self.assertNotIn("autocomplete/", ignored_lines)
+
+    def test_autocomplete_runtime_imports_are_in_registry_package_surface(self):
+        entry = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
+        source = entry.read_text(encoding="utf-8")
+        for runtime_path in sorted(AUTOCOMPLETE_RUNTIME_PATHS - {entry.relative_to(ROOT).as_posix()}):
+            module = Path(runtime_path)
+            self.assertTrue((ROOT / module).is_file())
+            specifier = f"./{module.relative_to('web/js').as_posix()}"
+            with self.subTest(specifier=specifier):
+                self.assertIn(f'from "{specifier}"', source)
+
+        result = subprocess.run(
+            [
+                "git",
+                "ls-files",
+                "--cached",
+                "--ignored",
+                "--exclude-from=.comfyignore",
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        ignored = {line for line in result.stdout.splitlines() if line}
+        self.assertFalse(
+            AUTOCOMPLETE_RUNTIME_PATHS & ignored,
+            f"autocomplete runtime imports are excluded from the Registry package: "
+            f"{sorted(AUTOCOMPLETE_RUNTIME_PATHS & ignored)}",
+        )
 
     def test_registry_safety_doc_is_linked_from_development_entry(self):
         entry = (ROOT / "docs" / "development" / "README.md").read_text(encoding="utf-8")

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -1,18 +1,91 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-AUTOCOMPLETE_RUNTIME_PATHS = {
-    "web/js/easyuse_anima_autocomplete.js",
+AUTOCOMPLETE_ENTRY = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
+EXPECTED_AUTOCOMPLETE_MODULES = {
     "web/js/autocomplete/data_adapter.js",
     "web/js/autocomplete/input_controller.js",
     "web/js/autocomplete/popup_geometry.js",
     "web/js/autocomplete/text_model.js",
 }
+STATIC_IMPORT_FROM_RE = re.compile(
+    r"""
+    ^[ \t]*(?:import|export)[ \t\r\n]+
+    (?:(?!;).)*?\bfrom[ \t\r\n]*
+    (?P<quote>["'])
+    (?P<specifier>\.{1,2}/[^"']+)
+    (?P=quote)[ \t\r\n]*;
+    """,
+    re.MULTILINE | re.DOTALL | re.VERBOSE,
+)
+STATIC_SIDE_EFFECT_IMPORT_RE = re.compile(
+    r"""
+    ^[ \t]*import[ \t\r\n]+
+    (?P<quote>["'])
+    (?P<specifier>\.{1,2}/[^"']+)
+    (?P=quote)[ \t\r\n]*;
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+
+def _static_relative_imports(source: str) -> set[str]:
+    imports = set()
+    for pattern in (STATIC_IMPORT_FROM_RE, STATIC_SIDE_EFFECT_IMPORT_RE):
+        imports.update(match.group("specifier") for match in pattern.finditer(source))
+    return imports
+
+
+def _repository_static_import_closure(entry: Path) -> set[str]:
+    root = ROOT.resolve()
+    pending = [entry.resolve()]
+    visited: set[Path] = set()
+
+    while pending:
+        source_path = pending.pop()
+        if source_path in visited:
+            continue
+        try:
+            source_path.relative_to(root)
+        except ValueError:
+            continue
+        if not source_path.is_file():
+            raise AssertionError(f"missing static import source: {source_path}")
+        visited.add(source_path)
+
+        source = source_path.read_text(encoding="utf-8")
+        for specifier in _static_relative_imports(source):
+            imported_path = (source_path.parent / specifier).resolve()
+            try:
+                imported_path.relative_to(root)
+            except ValueError:
+                continue
+            if not imported_path.is_file():
+                raise AssertionError(
+                    f"missing repository static import: {source_path} -> {specifier}"
+                )
+            pending.append(imported_path)
+
+    return {path.relative_to(root).as_posix() for path in visited}
+
+
+def _git_paths(*args: str) -> set[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+    )
+    return {line for line in result.stdout.splitlines() if line}
 
 
 class RegistryScannerSafetyTests(unittest.TestCase):
@@ -101,35 +174,54 @@ class RegistryScannerSafetyTests(unittest.TestCase):
                 self.assertNotIn(required_readme, ignored_lines)
         self.assertNotIn("autocomplete/", ignored_lines)
 
-    def test_autocomplete_runtime_imports_are_in_registry_package_surface(self):
-        entry = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
-        source = entry.read_text(encoding="utf-8")
-        for runtime_path in sorted(AUTOCOMPLETE_RUNTIME_PATHS - {entry.relative_to(ROOT).as_posix()}):
-            module = Path(runtime_path)
-            self.assertTrue((ROOT / module).is_file())
-            specifier = f"./{module.relative_to('web/js').as_posix()}"
-            with self.subTest(specifier=specifier):
-                self.assertIn(f'from "{specifier}"', source)
-
-        result = subprocess.run(
-            [
-                "git",
-                "ls-files",
-                "--cached",
-                "--ignored",
-                "--exclude-from=.comfyignore",
-            ],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
+    def test_static_relative_import_parser_covers_supported_forms(self):
+        source = """
+            import defaultExport from "./default.js";
+            import {
+              namedExport,
+            } from '../named.js';
+            export { forwarded } from "./forwarded.js";
+            export * from "../export_all.js";
+            import "./side_effect.js";
+            import external from "external-package";
+            import "/absolute.js";
+            const dynamic = import("./dynamic.js");
+        """
+        self.assertEqual(
+            _static_relative_imports(source),
+            {
+                "./default.js",
+                "../named.js",
+                "./forwarded.js",
+                "../export_all.js",
+                "./side_effect.js",
+            },
         )
-        ignored = {line for line in result.stdout.splitlines() if line}
+
+    def test_autocomplete_static_import_closure_is_in_registry_package_surface(self):
+        closure = _repository_static_import_closure(AUTOCOMPLETE_ENTRY)
         self.assertFalse(
-            AUTOCOMPLETE_RUNTIME_PATHS & ignored,
-            f"autocomplete runtime imports are excluded from the Registry package: "
-            f"{sorted(AUTOCOMPLETE_RUNTIME_PATHS & ignored)}",
+            EXPECTED_AUTOCOMPLETE_MODULES - closure,
+            f"expected autocomplete modules missing from static import closure: "
+            f"{sorted(EXPECTED_AUTOCOMPLETE_MODULES - closure)}",
+        )
+
+        tracked = _git_paths("ls-files", "--cached")
+        self.assertFalse(
+            closure - tracked,
+            f"autocomplete static import closure is not tracked: {sorted(closure - tracked)}",
+        )
+
+        ignored = _git_paths(
+            "ls-files",
+            "--cached",
+            "--ignored",
+            "--exclude-from=.comfyignore",
+        )
+        self.assertFalse(
+            closure & ignored,
+            f"autocomplete static import closure is excluded from the Registry package: "
+            f"{sorted(closure & ignored)}",
         )
 
     def test_registry_safety_doc_is_linked_from_development_entry(self):


### PR DESCRIPTION
## 변경 요약

- `.comfyignore`의 광범위한 `autocomplete/` 패턴을 루트 전용 `/autocomplete/`로 제한했습니다.
- 이로써 사용자 데이터용 루트 폴더 제외는 유지하면서 `web/js/autocomplete/`의 production 모듈이 Registry 패키지에 포함됩니다.
- autocomplete entry부터 재귀 계산한 repository-local static import closure 전체가 파일로 존재하고, Git에 추적되며, `.comfyignore`에서 제외되지 않는지 회귀 테스트로 고정했습니다.
- 현재 누락 회귀의 핵심 네 모듈은 expected subset으로 별도 고정했습니다.

Issue #56의 v0.5.0 package-surface runtime blocker를 해결합니다. #98, #99, #100의 동작 경계와는 별도입니다.

## 주요 파일

- `.comfyignore`
- `tests/test_registry_scanner_safety.py`

Production JavaScript 동작은 변경하지 않습니다.

## 검증

- Focused unittest: 6/6 통과
- Official full runner:
  - Python unittest: 400/400
  - Frontend: 104 JavaScript files
  - TypeScript 6.0.3
  - git diff check 통과
- `comfy-cli 1.11.1 node validate`: 통과
- publish와 동일한 `comfy node pack`:
  - `node.zip` 138 entries
  - autocomplete entry와 전체 local import closure 8개 포함
  - ZIP SHA256: `17B6D50FCF0A24BF0FD19023EC92812C763336E4A41AE7069F83D7D6F0F5DA1E`
- ComfyUI v0.27.0 package-installed browser smoke:
  - Legacy canvas: 제안 20개 표시, active row 이동, Enter 선택, Escape 닫기, save/reload 유지
  - Node 2.0: 동일 matrix 통과
  - 패키지 모듈 HTTP 200 및 archive payload와 SHA256 일치
  - EasyUse Anima module 404/import/console error 없음

## 남은 작업

- 잘못 게시된 v0.5.0은 Registry에서 삭제된 상태이며, 이 PR이 dev에 병합된 뒤 별도 0.5.1 release checkpoint에서 main/GitHub Release/Registry payload를 다시 검증합니다.
- Issue #56의 나머지 external input hook/listener/extension lifecycle 및 최종 close checkpoint는 maintenance Goal에서 계속 추적합니다.
