### PR TITLE
fix: autocomplete 결과 제한을 100개까지 일치

### DIFF
--- a/autocomplete_dataset.py
+++ b/autocomplete_dataset.py
@@ -626,6 +626,7 @@ def search_autocomplete(
     category: str | None = None,
 ) -> dict:
     started = time.perf_counter()
+    effective_limit = max(1, min(limit, 100))
     normalized_query = _normalize(query)
     category = str(category or "").strip()
     categories = {item.strip() for item in category.split(",") if item.strip()}
@@ -653,11 +654,11 @@ def search_autocomplete(
         else:
             continue
         results.append((score, entry))
-        if len(results) >= max(limit * 8, limit):
+        if len(results) >= max(effective_limit * 8, effective_limit):
             break
 
     results.sort(key=lambda item: (item[0], -item[1].count, item[1].tag))
-    limited = results[: max(1, min(limit, 50))]
+    limited = results[:effective_limit]
     return {
         "query": query,
         "category": category,

--- a/tests/frontend_autocomplete_data_adapter_smoke.mjs
+++ b/tests/frontend_autocomplete_data_adapter_smoke.mjs
@@ -133,6 +133,17 @@ const limitedUrl = "/easyuse_anima/autocomplete"
   + `&category=${encodeURIComponent(firstCategory)}`;
 await adapter.search(firstQuery, firstCategory);
 assert.equal(autocompleteFetchCounts.get(limitedUrl), 1, "limit must partition the cache");
+limit = 100;
+const maximumLimitUrl = "/easyuse_anima/autocomplete"
+  + `?q=${encodeURIComponent(firstQuery)}`
+  + "&limit=100"
+  + `&category=${encodeURIComponent(firstCategory)}`;
+await adapter.search(firstQuery, firstCategory);
+assert.equal(
+  autocompleteFetchCounts.get(maximumLimitUrl),
+  1,
+  "the configured maximum limit must be forwarded in the request URL",
+);
 limit = 20;
 assert.equal(await adapter.search(firstQuery, firstCategory), firstResults);
 

--- a/tests/test_lora_profiles.py
+++ b/tests/test_lora_profiles.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import sys
 import tempfile
@@ -231,6 +232,65 @@ class LoraProfileStorageTests(unittest.TestCase):
         self.assertEqual(fixed["fixed"], [])
         self.assertEqual(fixed["unresolved"], [])
         self.assertEqual(fixed["missing"], 0)
+
+
+class AutocompleteApiRouteTests(unittest.TestCase):
+    def test_autocomplete_route_forwards_valid_limits_and_uses_resolver_fallback(self):
+        class RouteRegistry:
+            def __init__(self):
+                self.get_handlers = {}
+
+            def get(self, path):
+                def register(handler):
+                    self.get_handlers[path] = handler
+                    return handler
+
+                return register
+
+            def post(self, path):
+                return self.get(path)
+
+        routes = RouteRegistry()
+        fake_server = types.ModuleType("server")
+        fake_server.PromptServer = type(
+            "PromptServer",
+            (),
+            {"instance": types.SimpleNamespace(routes=routes)},
+        )
+        fake_aiohttp = types.ModuleType("aiohttp")
+        fake_aiohttp.web = types.SimpleNamespace(
+            json_response=lambda payload, status=200: {"payload": payload, "status": status},
+        )
+
+        with patch.dict(sys.modules, {"server": fake_server, "aiohttp": fake_aiohttp}):
+            api = load_api_module()
+
+        calls = []
+
+        def search(query, *, limit, path, category):
+            calls.append({"query": query, "limit": limit, "path": path, "category": category})
+            return {"results": [{"tag": f"match {index}"} for index in range(limit)]}
+
+        handler = routes.get_handlers["/easyuse_anima/autocomplete"]
+        with (
+            patch.object(api, "resolve_autocomplete_limit", return_value=51),
+            patch.object(api, "resolve_autocomplete_source", return_value="test_source"),
+            patch.object(
+                api,
+                "resolve_autocomplete_source_path",
+                return_value=("test_source", Path("tags.csv")),
+            ),
+            patch.object(api, "search_autocomplete", side_effect=search),
+        ):
+            for raw_limit, expected_limit in (("51", 51), ("100", 100), ("bad", 51)):
+                with self.subTest(raw_limit=raw_limit):
+                    response = asyncio.run(
+                        handler(types.SimpleNamespace(query={"q": "match", "limit": raw_limit}))
+                    )
+                    self.assertEqual(response["status"], 200)
+                    self.assertEqual(len(response["payload"]["results"]), expected_limit)
+
+        self.assertEqual([call["limit"] for call in calls], [51, 100, 51])
 
 
 if __name__ == "__main__":

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import autocomplete_dataset
 import settings as easyuse_settings
 from nodes import (
     ADVANCED_FIELDS_WORKFLOW_PROPERTY,
@@ -3078,6 +3079,48 @@ class DetailerHookTests(unittest.TestCase):
 
 
 class AutocompleteDatasetTests(unittest.TestCase):
+    def test_search_autocomplete_normalizes_result_limit_and_bounds_scanning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tags.csv"
+            path.write_text(
+                "\n".join(
+                    f'limit match {index:03d},0,{1000 - index},"[일반] 제한 테스트"'
+                    for index in range(120)
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            for requested_limit in (1, 50, 51, 100):
+                with self.subTest(requested_limit=requested_limit):
+                    result = search_autocomplete("limit match", limit=requested_limit, path=path)
+                    self.assertEqual(len(result["results"]), requested_limit)
+
+            self.assertEqual(len(search_autocomplete("limit match", limit=0, path=path)["results"]), 1)
+            self.assertEqual(len(search_autocomplete("limit match", limit=-1, path=path)["results"]), 1)
+            self.assertEqual(len(search_autocomplete("limit match", limit=10_000, path=path)["results"]), 100)
+
+        scanned = 0
+
+        def entries():
+            nonlocal scanned
+            for index in range(801):
+                scanned += 1
+                yield autocomplete_dataset.AutocompleteEntry(
+                    tag=f"scan match {index:03d}",
+                    tag_key=f"scan match {index:03d}",
+                    category="general",
+                    count=1000 - index,
+                    description="[일반] 스캔 제한 테스트",
+                    search=f"scan match {index:03d}",
+                )
+
+        with patch.object(autocomplete_dataset, "_entries", return_value=entries()):
+            result = search_autocomplete("scan match", limit=10_000, path=Path("missing.csv"))
+
+        self.assertEqual(len(result["results"]), 100)
+        self.assertEqual(scanned, 800)
+
     def test_searches_english_tags_and_korean_descriptions(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tags.csv"


### PR DESCRIPTION
## 변경 요약

- Autocomplete backend의 결과 제한을 단일 `1..100` 계약으로 정규화했습니다.
- 정규화된 제한을 후보 스캔 상한과 최종 결과 슬라이스에 동일하게 사용합니다.
- Issue #100의 51~100개 결과 요청과 과대·음수 입력 회귀를 고정합니다.

## 주요 파일

- `autocomplete_dataset.py`
- `tests/test_prompt_corrector.py`
- `tests/test_lora_profiles.py`
- `tests/frontend_autocomplete_data_adapter_smoke.mjs`

## 검증

- focused backend/API/frontend tests: PASS
  - Autocomplete dataset 및 settings 28 tests
  - 실제 등록 API route의 limit 51/100 및 malformed fallback
  - frontend adapter `&limit=100` 전달
- official full runner: PASS
  - Python unittest 402/402
  - frontend checks 104 JavaScript files
  - TypeScript 6.0.3
  - git diff check
- 독립 correctness/regression 감사: GO

## 테스트 표면

- ComfyUI Codex test environment: official full/static/runtime smoke
- Live ComfyUI browser smoke: backend-only slice라 미실행

## 남은 범위

- #56의 external DOM input/listener lifecycle, #98 replacement syntax, 최종 Legacy/Node 2.0 input/select/close/save-reload matrix는 후속입니다.

Closes #100