### PR TITLE
refactor: LoRA Preset 노드 lifecycle 분리

### DIFF
--- a/tests/frontend_lora_preset_node_runtime_smoke.mjs
+++ b/tests/frontend_lora_preset_node_runtime_smoke.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const { createLoraPresetNodeRuntime } = await import(
+  dataModule("../web/js/lora_preset/node_runtime.js"),
+);
+
+const events = [];
+const animationFrames = [];
+const widgetIndex = {
+  profileCount: 2,
+  loraName: 3,
+  loras: 4,
+  profileData: 5,
+};
+const internalWidgetDefaults = {
+  profile_count: "4",
+  lora_name: "None",
+  loras: "[]",
+  profile_data: "{}",
+};
+
+function findWidget(node, name) {
+  return node.__easyuseAnimaHiddenWidgets?.[name]
+    || node.widgets?.find((widget) => widget.name === name);
+}
+
+function widgetValue(widget, fallback = "") {
+  return widget?.value ?? fallback;
+}
+
+function ensureWidgetValue(node, name) {
+  const widget = findWidget(node, name);
+  if (widget && (widget.value == null || widget.value === "")) {
+    widget.value = internalWidgetDefaults[name];
+  }
+}
+
+function resetInternalLoraSelector(node) {
+  const widget = findWidget(node, "lora_name");
+  if (widget) {
+    widget.value = internalWidgetDefaults.lora_name;
+  }
+}
+
+function profileCount(node) {
+  return Number.parseInt(widgetValue(findWidget(node, "profile_count"), "4"), 10) || 4;
+}
+
+function selectedProfileIndex(node) {
+  return Number.parseInt(widgetValue(findWidget(node, "profile_index"), 1), 10) || 1;
+}
+
+function activeProfileIndex(node) {
+  return node.__easyuseAnimaActiveProfileIndex || selectedProfileIndex(node);
+}
+
+function wrapProfileIndex(index, count) {
+  return ((Number(index) - 1) % count + count) % count + 1;
+}
+
+const canvasWidgets = {
+  ensureProfileBar(node) { events.push(`bar:${node.id}`); },
+  renderProfileBar(node) { events.push(`profile:${node.id}`); },
+  renderLoraWidgets(node) { events.push(`loras:${node.id}`); },
+};
+
+const runtime = createLoraPresetNodeRuntime({
+  nodeTypeName: "EasyUseAnimaLoraPreset",
+  internalWidgetDefaults,
+  widgetIndex,
+  findWidget,
+  findInputEl: () => null,
+  widgetValue,
+  ensureWidgetValue,
+  resetInternalLoraSelector,
+  normalizeSerializedWidgets(info) { events.push("normalize"); info.normalized = true; },
+  profileCount,
+  selectedProfileIndex,
+  activeProfileIndex,
+  wrapProfileIndex,
+  setProfileIndex(node, index) {
+    events.push(`set:${index}`);
+    findWidget(node, "profile_index").value = index;
+  },
+  lorasWidgetValue: () => [{ name: "styles/example.safetensors", on: true, strength: 1 }],
+  saveProfile(node, index) { events.push(`save:${node.id}:${index}`); },
+  saveCurrentProfile(node) { events.push(`save-current:${node.id}`); },
+  loadProfile(node, index, options) { events.push(`load:${node.id}:${index}:${Boolean(options?.initializeFromCurrent)}`); },
+  scrollProfileBarTo(node, index) { events.push(`scroll:${node.id}:${index}`); },
+  refreshLoraAvailability(node) { events.push(`availability:${node.id}`); },
+  canvasWidgets,
+  enforceNodeLayout(node) { events.push(`layout:${node.id}`); },
+  requestAnimationFrame(callback) { animationFrames.push(callback); },
+});
+
+function makeWidget(name, value) {
+  return { name, value };
+}
+
+function makeNode(id) {
+  return Object.assign(new NodeType(), {
+    id,
+    widgets: [
+      makeWidget("style_prompt", "style"),
+      makeWidget("profile_index", 1),
+      makeWidget("profile_count", "4"),
+      makeWidget("lora_name", "legacy"),
+      makeWidget("loras", "[]"),
+      makeWidget("profile_data", "{}"),
+    ],
+    inputs: [],
+    addInput(name, type) { this.inputs.push({ name, type }); },
+    setDirtyCanvas() { events.push(`dirty:${this.id}`); },
+  });
+}
+
+function NodeType() {}
+NodeType.prototype.configure = function (info) {
+  events.push(`configure:${this.id}:${info.normalized}:${this.widgets.map((widget) => widget.name).join(",")}`);
+  return "configured";
+};
+NodeType.prototype.onNodeCreated = function () {
+  events.push(`created:${this.id}`);
+  return "created-result";
+};
+NodeType.prototype.onConfigure = function () {
+  events.push(`node-configure:${this.id}`);
+};
+NodeType.prototype.onExecuted = function () {
+  events.push(`executed:${this.id}`);
+};
+NodeType.prototype.onSerialize = function () {
+  events.push(`serialized:${this.id}`);
+};
+
+runtime.beforeRegisterNodeDef(NodeType, { name: "OtherNode" });
+assert.equal(NodeType.prototype.configure.name, "");
+runtime.beforeRegisterNodeDef(NodeType, { name: "EasyUseAnimaLoraPreset" });
+
+const node = makeNode("node-a");
+assert.equal(node.onNodeCreated(), "created-result");
+assert.equal(node.onNodeCreated(), "created-result");
+assert.deepEqual(node.inputs, [{ name: "lora_stack", type: "LORA_STACK" }]);
+assert.equal(animationFrames.length, 1);
+assert.equal(node.serialize_widgets, true);
+assert.equal(node.widgets.filter((widget) => widget.__easyuseAnimaLoraWrapped).length, 4);
+
+animationFrames.shift()();
+assert.deepEqual(node.widgets.map((widget) => widget.name), [
+  "style_prompt", "profile_index", "profile_count", "lora_name", "loras", "profile_data",
+]);
+for (const index of [2, 3, 4, 5]) {
+  assert.equal(node.widgets[index].hidden, true);
+  assert.equal(node.widgets[index].serialize, true);
+  assert.equal(node.widgets[index].options.hidden, true);
+}
+
+const serialized = { widgets_values: Array(6).fill("") };
+node.onSerialize(serialized);
+assert.deepEqual(serialized.widgets_values, [
+  "",
+  "",
+  "4",
+  "None",
+  JSON.stringify([{ name: "styles/example.safetensors", on: true, strength: 1 }]),
+  "{}",
+]);
+assert.ok(events.indexOf("save-current:node-a") < events.indexOf("serialized:node-a"));
+
+node.widgets = [node.widgets[0], node.widgets[1]];
+const configureResult = node.configure({ widgets_values: [], normalized: false });
+assert.equal(configureResult, "configured");
+assert.deepEqual(node.widgets.map((widget) => widget.name), [
+  "style_prompt", "profile_index", "profile_count", "lora_name", "loras", "profile_data",
+]);
+assert.deepEqual(node.widgets.slice(2).map((widget) => widget.hidden), [true, true, true, true]);
+assert.ok(events.indexOf("normalize") < events.findIndex((event) => event.startsWith("configure:node-a:true:")));
+node.onConfigure();
+assert.equal(animationFrames.length, 1);
+assert.ok(events.includes("node-configure:node-a"));
+animationFrames.shift()();
+
+events.length = 0;
+node.onExecuted({ lora_preset_profile: [{ profile_index: 2 }] });
+assert.deepEqual(events.slice(0, 6), [
+  "executed:node-a",
+  "save:node-a:1",
+  "set:2",
+  "load:node-a:2:false",
+  "scroll:node-a:2",
+  "profile:node-a",
+]);
+assert.equal(node.__easyuseAnimaActiveProfileIndex, 2);
+assert.ok(events.includes("loras:node-a"));
+
+events.length = 0;
+node.onExecuted({ lora_preset_profile: [{ profile_index: 2 }] });
+assert.deepEqual(events, ["executed:node-a", "profile:node-a"]);

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -33,6 +33,12 @@ LORA_PRESET_MENU_LIFECYCLE = (
 LORA_PRESET_MENU_LIFECYCLE_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_menu_lifecycle_smoke.mjs"
 )
+LORA_PRESET_NODE_RUNTIME = (
+    ROOT / "web" / "js" / "lora_preset" / "node_runtime.js"
+)
+LORA_PRESET_NODE_RUNTIME_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_node_runtime_smoke.mjs"
+)
 LORA_PRESET_PROFILE_DATA = ROOT / "web" / "js" / "lora_preset" / "profile_data.js"
 LORA_PRESET_PROFILE_DATA_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_profile_data_smoke.mjs"
@@ -46,6 +52,118 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class LoraPresetFrontendTests(unittest.TestCase):
+    def test_node_runtime_module_boundary(self):
+        module_source = LORA_PRESET_NODE_RUNTIME.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createLoraPresetNodeRuntime"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|LiteGraph|registerExtension|"
+                r"MutationObserver)\b"
+            ),
+        )
+        self.assertIn(
+            'import { createLoraPresetNodeRuntime } from '
+            '"./lora_preset/node_runtime.js";',
+            entry_source,
+        )
+        factory_match = re.search(
+            r"const\s+loraPresetNodeRuntime\s*=\s*"
+            r"createLoraPresetNodeRuntime"
+            r"\(\{(?P<dependencies>.*?)\}\);",
+            entry_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(factory_match)
+        dependency_entries = {
+            line.strip().rstrip(",")
+            for line in factory_match.group("dependencies").splitlines()
+            if line.strip()
+        }
+        self.assertEqual(
+            dependency_entries,
+            {
+                "nodeTypeName: NODE_TYPE",
+                "internalWidgetDefaults: INTERNAL_WIDGET_DEFAULTS",
+                "widgetIndex: WIDGET_INDEX",
+                "findWidget",
+                "findInputEl",
+                "widgetValue",
+                "ensureWidgetValue",
+                "resetInternalLoraSelector",
+                "normalizeSerializedWidgets",
+                "profileCount",
+                "selectedProfileIndex",
+                "activeProfileIndex",
+                "wrapProfileIndex",
+                "setProfileIndex",
+                "lorasWidgetValue",
+                "saveProfile",
+                "saveCurrentProfile",
+                "loadProfile",
+                "scrollProfileBarTo",
+                "refreshLoraAvailability",
+                "canvasWidgets: loraCanvasWidgets",
+                "enforceNodeLayout",
+                "requestAnimationFrame: (callback) => window.requestAnimationFrame(callback)",
+            },
+        )
+        for moved_declaration in (
+            "hideInternalWidget",
+            "restoreInternalWidgetsForConfigure",
+            "finalizeInternalWidgets",
+            "ensureLoraStackInput",
+            "wrapWidgetCallback",
+            "applyExecutedProfile",
+            "initializeNode",
+        ):
+            with self.subTest(moved_declaration=moved_declaration):
+                self.assertNotRegex(
+                    entry_source,
+                    rf"\bfunction\s+{re.escape(moved_declaration)}\b",
+                )
+                self.assertRegex(
+                    module_source,
+                    rf"\bfunction\s+{re.escape(moved_declaration)}\b",
+                )
+        self.assertIn(
+            "loraPresetNodeRuntime.beforeRegisterNodeDef(nodeType, nodeData);",
+            entry_source,
+        )
+        self.assertTrue(LORA_PRESET_NODE_RUNTIME_SMOKE.is_file())
+        self.assertIn("web/js/lora_preset/**/*.js", config["include"])
+
+    def test_node_runtime_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_NODE_RUNTIME_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_api_client_module_boundary(self):
         module_source = LORA_PRESET_API_CLIENT.read_text(encoding="utf-8")
         entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
@@ -308,9 +426,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
             "function installLoraPresetSaveSync(",
             "function scrollProfileListFromWheel(",
             "function installProfileWheelListener(",
-            "function initializeNode(",
-            "node.onSerialize = function",
-            "node.onConfigure = function",
             "app.registerExtension({",
         ):
             with self.subTest(entry_owned_token=entry_owned_token):
@@ -765,6 +880,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const previewLifecyclePath = process.argv[5];
             const menuLifecyclePath = process.argv[6];
             const canvasWidgetsPath = process.argv[7];
+            const nodeRuntimePath = process.argv[8];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -795,9 +911,14 @@ class LoraPresetFrontendTests(unittest.TestCase):
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let nodeRuntimeSource = fs.readFileSync(nodeRuntimePath, "utf8");
+            nodeRuntimeSource = nodeRuntimeSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${source}`;
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${source}`;
             source += "\nglobalThis.__loraPresetTest = { loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
@@ -1129,6 +1250,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_PREVIEW_LIFECYCLE),
                 str(LORA_PRESET_MENU_LIFECYCLE),
                 str(LORA_PRESET_CANVAS_WIDGETS),
+                str(LORA_PRESET_NODE_RUNTIME),
             ],
             cwd=ROOT,
             text=True,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -184,6 +184,11 @@ try {
         throw "Frontend LoRA preset canvas widgets smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_node_runtime_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset node runtime smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_data_adapter_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -5,6 +5,7 @@ import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.
 import { createLoraPresetApiClient } from "./lora_preset/api_client.js";
 import { createLoraPresetCanvasWidgets } from "./lora_preset/canvas_widgets.js";
 import { createLoraPresetMenuLifecycle } from "./lora_preset/menu_lifecycle.js";
+import { createLoraPresetNodeRuntime } from "./lora_preset/node_runtime.js";
 import { createLoraPresetPreviewLifecycle } from "./lora_preset/preview_lifecycle.js";
 import {
   INTERNAL_WIDGET_DEFAULTS,
@@ -352,13 +353,31 @@ const loraCanvasWidgets = createLoraPresetCanvasWidgets({
   setActiveProfileWheelTarget,
   enforceNodeLayout,
 });
-
-function firstValue(value, fallback = null) {
-  if (Array.isArray(value)) {
-    return value.length ? value[0] : fallback;
-  }
-  return value ?? fallback;
-}
+const loraPresetNodeRuntime = createLoraPresetNodeRuntime({
+  nodeTypeName: NODE_TYPE,
+  internalWidgetDefaults: INTERNAL_WIDGET_DEFAULTS,
+  widgetIndex: WIDGET_INDEX,
+  findWidget,
+  findInputEl,
+  widgetValue,
+  ensureWidgetValue,
+  resetInternalLoraSelector,
+  normalizeSerializedWidgets,
+  profileCount,
+  selectedProfileIndex,
+  activeProfileIndex,
+  wrapProfileIndex,
+  setProfileIndex,
+  lorasWidgetValue,
+  saveProfile,
+  saveCurrentProfile,
+  loadProfile,
+  scrollProfileBarTo,
+  refreshLoraAvailability,
+  canvasWidgets: loraCanvasWidgets,
+  enforceNodeLayout,
+  requestAnimationFrame: (callback) => window.requestAnimationFrame(callback),
+});
 
 function findWidget(node, name) {
   return node.__easyuseAnimaHiddenWidgets?.[name]
@@ -1074,68 +1093,6 @@ function openLoraEntryMenu(node, event, index) {
   });
 }
 
-function hideInternalWidget(node, name) {
-  const widget = findWidget(node, name);
-  if (!widget) {
-    return;
-  }
-  ensureWidgetValue(node, name);
-  if (name === "lora_name") {
-    resetInternalLoraSelector(node);
-  }
-  widget.__easyuseAnimaHidden = true;
-  widget.hidden = true;
-  widget.serialize = true;
-  widget.options ||= {};
-  widget.options.hidden = true;
-  widget.computeSize = () => [0, 0];
-  widget.draw = () => {};
-  const input = findInputEl(widget);
-  if (input) {
-    input.style.display = "none";
-    input.style.pointerEvents = "none";
-    input.tabIndex = -1;
-  }
-  node.__easyuseAnimaHiddenWidgets ||= {};
-  node.__easyuseAnimaHiddenWidgets[name] = widget;
-  node.setDirtyCanvas?.(true, true);
-}
-
-function restoreInternalWidgetsForConfigure(node) {
-  const hidden = node.__easyuseAnimaHiddenWidgets;
-  if (!hidden || !Array.isArray(node.widgets)) {
-    return;
-  }
-  const entries = [
-    ["profile_count", WIDGET_INDEX.profileCount],
-    ["lora_name", WIDGET_INDEX.loraName],
-    ["loras", WIDGET_INDEX.loras],
-    ["profile_data", WIDGET_INDEX.profileData],
-  ];
-  for (const [name, index] of entries) {
-    const widget = hidden[name];
-    if (!widget || node.widgets.includes(widget)) {
-      continue;
-    }
-    widget.__easyuseAnimaHidden = true;
-    widget.hidden = true;
-    widget.serialize = true;
-    widget.options ||= {};
-    widget.options.hidden = true;
-    widget.computeSize = () => [0, 0];
-    widget.draw = () => {};
-    node.widgets.splice(Math.min(index, node.widgets.length), 0, widget);
-  }
-}
-
-function finalizeInternalWidgets(node) {
-  resetInternalLoraSelector(node);
-  hideInternalWidget(node, "profile_data");
-  hideInternalWidget(node, "profile_count");
-  hideInternalWidget(node, "lora_name");
-  hideInternalWidget(node, "loras");
-}
-
 function enforceNodeLayout(node) {
   if (!node?.size || typeof node.setSize !== "function") {
     return;
@@ -1149,12 +1106,6 @@ function enforceNodeLayout(node) {
     node.setSize([nextWidth, nextHeight]);
   }
   node.setDirtyCanvas?.(true, true);
-}
-
-function ensureLoraStackInput(node) {
-  if (!node.inputs?.some((input) => input.name === "lora_stack")) {
-    node.addInput?.("lora_stack", "LORA_STACK");
-  }
 }
 
 function canvasPointToClient(point) {
@@ -1274,28 +1225,6 @@ async function openLoraMenu(node, event, pos, onChoose) {
   });
 }
 
-function wrapWidgetCallback(node, name, callback) {
-  const widget = findWidget(node, name);
-  if (!widget || widget.__easyuseAnimaLoraWrapped) {
-    return;
-  }
-  widget.__easyuseAnimaLoraWrapped = true;
-  const previous = widget.callback;
-  widget.callback = function (...args) {
-    const result = previous?.apply(this, args);
-    callback?.();
-    return result;
-  };
-}
-
-function syncAfterWidgetChange(node) {
-  if (node.__easyuseAnimaLoadingProfile) {
-    return;
-  }
-  saveCurrentProfile(node);
-  loraCanvasWidgets.renderProfileBar(node);
-}
-
 function syncLoraPresetNode(node) {
   if (!node || node.comfyClass !== NODE_TYPE) {
     return;
@@ -1328,28 +1257,6 @@ function installLoraPresetSaveSync() {
     };
     app.queuePrompt.__easyuseAnimaLoraPresetWrapped = true;
   }
-}
-
-function applyExecutedProfile(node, message) {
-  const payload = firstValue(message?.lora_preset_profile, null);
-  const index = Number.parseInt(payload?.profile_index, 10);
-  if (!Number.isFinite(index)) {
-    return;
-  }
-  const nextIndex = wrapProfileIndex(index, profileCount(node));
-  const currentIndex = activeProfileIndex(node);
-  if (nextIndex === currentIndex) {
-    loraCanvasWidgets.renderProfileBar(node);
-    return;
-  }
-  saveProfile(node, currentIndex);
-  setProfileIndex(node, nextIndex);
-  node.__easyuseAnimaActiveProfileIndex = nextIndex;
-  loadProfile(node, nextIndex);
-  scrollProfileBarTo(node, nextIndex);
-  loraCanvasWidgets.renderProfileBar(node);
-  loraCanvasWidgets.renderLoraWidgets(node);
-  node.setDirtyCanvas?.(true, true);
 }
 
 function refreshLoraPresetNodes() {
@@ -1455,81 +1362,6 @@ function installProfileWheelListener() {
   document.addEventListener("wheel", scrollProfileListFromWheel, { capture: true, passive: false });
 }
 
-function initializeNode(node) {
-  if (node.__easyuseAnimaLoraPresetInitialized) {
-    return;
-  }
-  node.__easyuseAnimaLoraPresetInitialized = true;
-  node.serialize_widgets = true;
-  ensureLoraStackInput(node);
-  for (const name of Object.keys(INTERNAL_WIDGET_DEFAULTS)) {
-    ensureWidgetValue(node, name);
-  }
-  resetInternalLoraSelector(node);
-
-  wrapWidgetCallback(node, "style_prompt", () => syncAfterWidgetChange(node));
-  wrapWidgetCallback(node, "loras", () => syncAfterWidgetChange(node));
-  wrapWidgetCallback(node, "profile_count", () => {
-    if (!node.__easyuseAnimaSuppressProfileCountCallback) {
-      saveCurrentProfile(node);
-      loraCanvasWidgets.renderProfileBar(node);
-    }
-  });
-  wrapWidgetCallback(node, "profile_index", () => {
-    if (node.__easyuseAnimaSuppressProfileIndexCallback) {
-      return;
-    }
-    const index = selectedProfileIndex(node);
-    const current = activeProfileIndex(node);
-    if (index !== current) {
-      saveProfile(node, current);
-    }
-    node.__easyuseAnimaActiveProfileIndex = index;
-    loadProfile(node, index);
-    scrollProfileBarTo(node, index);
-    loraCanvasWidgets.renderProfileBar(node);
-  });
-
-  const originalOnSerialize = node.onSerialize;
-  node.onSerialize = function (workflowNode) {
-    saveCurrentProfile(this);
-    originalOnSerialize?.apply(this, arguments);
-    const dataWidget = findWidget(this, "profile_data");
-    if (workflowNode?.widgets_values && dataWidget) {
-      workflowNode.widgets_values[WIDGET_INDEX.profileCount] = String(widgetValue(findWidget(this, "profile_count"), profileCount(this)) || "4");
-      workflowNode.widgets_values[WIDGET_INDEX.loraName] = INTERNAL_WIDGET_DEFAULTS.lora_name;
-      workflowNode.widgets_values[WIDGET_INDEX.loras] = JSON.stringify(lorasWidgetValue(this));
-      workflowNode.widgets_values[WIDGET_INDEX.profileData] = widgetValue(dataWidget, "{}");
-    }
-  };
-
-  const originalOnConfigure = node.onConfigure;
-  node.onConfigure = function (...args) {
-    originalOnConfigure?.apply(this, args);
-    window.requestAnimationFrame(() => {
-      finalizeInternalWidgets(this);
-      loraCanvasWidgets.ensureProfileBar(this);
-      this.__easyuseAnimaActiveProfileIndex = selectedProfileIndex(this);
-      loadProfile(this, selectedProfileIndex(this), { initializeFromCurrent: true });
-      scrollProfileBarTo(this, selectedProfileIndex(this));
-      loraCanvasWidgets.renderProfileBar(this);
-      refreshLoraAvailability(this);
-      enforceNodeLayout(this);
-    });
-  };
-
-  window.requestAnimationFrame(() => {
-    finalizeInternalWidgets(node);
-    loraCanvasWidgets.ensureProfileBar(node);
-    node.__easyuseAnimaActiveProfileIndex = selectedProfileIndex(node);
-    loadProfile(node, selectedProfileIndex(node), { initializeFromCurrent: true });
-    scrollProfileBarTo(node, selectedProfileIndex(node));
-    loraCanvasWidgets.renderProfileBar(node);
-    refreshLoraAvailability(node);
-    enforceNodeLayout(node);
-  });
-}
-
 app.registerExtension({
   name: "EasyUseAnima.LoraPreset",
   init() {
@@ -1548,25 +1380,6 @@ app.registerExtension({
     installLoraPresetSaveSync();
   },
   async beforeRegisterNodeDef(nodeType, nodeData) {
-    if (nodeData.name !== NODE_TYPE) {
-      return;
-    }
-    const originalConfigure = nodeType.prototype.configure;
-    nodeType.prototype.configure = function (info) {
-      restoreInternalWidgetsForConfigure(this);
-      normalizeSerializedWidgets(info);
-      return originalConfigure?.apply(this, arguments);
-    };
-    const originalOnNodeCreated = nodeType.prototype.onNodeCreated;
-    nodeType.prototype.onNodeCreated = function (...args) {
-      const result = originalOnNodeCreated?.apply(this, args);
-      initializeNode(this);
-      return result;
-    };
-    const originalOnExecuted = nodeType.prototype.onExecuted;
-    nodeType.prototype.onExecuted = function (message) {
-      originalOnExecuted?.apply(this, arguments);
-      applyExecutedProfile(this, message);
-    };
+    loraPresetNodeRuntime.beforeRegisterNodeDef(nodeType, nodeData);
   },
 });

--- a/web/js/lora_preset/node_runtime.js
+++ b/web/js/lora_preset/node_runtime.js
@@ -1,0 +1,245 @@
+// @ts-check
+
+/**
+ * Installs the per-node lifecycle for the LoRA Preset node.
+ *
+ * All host and profile behavior is injected so this module remains usable in
+ * frontend semantic tests without reaching through to the application shell.
+ */
+export function createLoraPresetNodeRuntime({
+  nodeTypeName,
+  internalWidgetDefaults,
+  widgetIndex,
+  findWidget,
+  findInputEl,
+  widgetValue,
+  ensureWidgetValue,
+  resetInternalLoraSelector,
+  normalizeSerializedWidgets,
+  profileCount,
+  selectedProfileIndex,
+  activeProfileIndex,
+  wrapProfileIndex,
+  setProfileIndex,
+  lorasWidgetValue,
+  saveProfile,
+  saveCurrentProfile,
+  loadProfile,
+  scrollProfileBarTo,
+  refreshLoraAvailability,
+  canvasWidgets,
+  enforceNodeLayout,
+  requestAnimationFrame,
+}) {
+  function hideInternalWidget(node, name) {
+    const widget = findWidget(node, name);
+    if (!widget) {
+      return;
+    }
+    ensureWidgetValue(node, name);
+    if (name === "lora_name") {
+      resetInternalLoraSelector(node);
+    }
+    widget.__easyuseAnimaHidden = true;
+    widget.hidden = true;
+    widget.serialize = true;
+    widget.options ||= {};
+    widget.options.hidden = true;
+    widget.computeSize = () => [0, 0];
+    widget.draw = () => {};
+    const input = findInputEl(widget);
+    if (input) {
+      input.style.display = "none";
+      input.style.pointerEvents = "none";
+      input.tabIndex = -1;
+    }
+    node.__easyuseAnimaHiddenWidgets ||= {};
+    node.__easyuseAnimaHiddenWidgets[name] = widget;
+    node.setDirtyCanvas?.(true, true);
+  }
+
+  function restoreInternalWidgetsForConfigure(node) {
+    const hidden = node.__easyuseAnimaHiddenWidgets;
+    if (!hidden || !Array.isArray(node.widgets)) {
+      return;
+    }
+    const entries = [
+      ["profile_count", widgetIndex.profileCount],
+      ["lora_name", widgetIndex.loraName],
+      ["loras", widgetIndex.loras],
+      ["profile_data", widgetIndex.profileData],
+    ];
+    for (const [name, index] of entries) {
+      const widget = hidden[name];
+      if (!widget || node.widgets.includes(widget)) {
+        continue;
+      }
+      widget.__easyuseAnimaHidden = true;
+      widget.hidden = true;
+      widget.serialize = true;
+      widget.options ||= {};
+      widget.options.hidden = true;
+      widget.computeSize = () => [0, 0];
+      widget.draw = () => {};
+      node.widgets.splice(Math.min(index, node.widgets.length), 0, widget);
+    }
+  }
+
+  function finalizeInternalWidgets(node) {
+    resetInternalLoraSelector(node);
+    hideInternalWidget(node, "profile_data");
+    hideInternalWidget(node, "profile_count");
+    hideInternalWidget(node, "lora_name");
+    hideInternalWidget(node, "loras");
+  }
+
+  function ensureLoraStackInput(node) {
+    if (!node.inputs?.some((input) => input.name === "lora_stack")) {
+      node.addInput?.("lora_stack", "LORA_STACK");
+    }
+  }
+
+  function wrapWidgetCallback(node, name, callback) {
+    const widget = findWidget(node, name);
+    if (!widget || widget.__easyuseAnimaLoraWrapped) {
+      return;
+    }
+    widget.__easyuseAnimaLoraWrapped = true;
+    const previous = widget.callback;
+    widget.callback = function (...args) {
+      const result = previous?.apply(this, args);
+      callback?.();
+      return result;
+    };
+  }
+
+  function rehydrateNode(node) {
+    finalizeInternalWidgets(node);
+    canvasWidgets.ensureProfileBar(node);
+    node.__easyuseAnimaActiveProfileIndex = selectedProfileIndex(node);
+    loadProfile(node, selectedProfileIndex(node), { initializeFromCurrent: true });
+    scrollProfileBarTo(node, selectedProfileIndex(node));
+    canvasWidgets.renderProfileBar(node);
+    refreshLoraAvailability(node);
+    enforceNodeLayout(node);
+  }
+
+  function initializeNode(node) {
+    if (node.__easyuseAnimaLoraPresetInitialized) {
+      return;
+    }
+    node.__easyuseAnimaLoraPresetInitialized = true;
+    node.serialize_widgets = true;
+    ensureLoraStackInput(node);
+    for (const name of Object.keys(internalWidgetDefaults)) {
+      ensureWidgetValue(node, name);
+    }
+    resetInternalLoraSelector(node);
+
+    wrapWidgetCallback(node, "style_prompt", () => {
+      if (!node.__easyuseAnimaLoadingProfile) {
+        saveCurrentProfile(node);
+        canvasWidgets.renderProfileBar(node);
+      }
+    });
+    wrapWidgetCallback(node, "loras", () => {
+      if (!node.__easyuseAnimaLoadingProfile) {
+        saveCurrentProfile(node);
+        canvasWidgets.renderProfileBar(node);
+      }
+    });
+    wrapWidgetCallback(node, "profile_count", () => {
+      if (!node.__easyuseAnimaSuppressProfileCountCallback) {
+        saveCurrentProfile(node);
+        canvasWidgets.renderProfileBar(node);
+      }
+    });
+    wrapWidgetCallback(node, "profile_index", () => {
+      if (node.__easyuseAnimaSuppressProfileIndexCallback) {
+        return;
+      }
+      const index = selectedProfileIndex(node);
+      const current = activeProfileIndex(node);
+      if (index !== current) {
+        saveProfile(node, current);
+      }
+      node.__easyuseAnimaActiveProfileIndex = index;
+      loadProfile(node, index);
+      scrollProfileBarTo(node, index);
+      canvasWidgets.renderProfileBar(node);
+    });
+
+    const originalOnSerialize = node.onSerialize;
+    node.onSerialize = function (workflowNode) {
+      saveCurrentProfile(this);
+      originalOnSerialize?.apply(this, arguments);
+      const dataWidget = findWidget(this, "profile_data");
+      if (workflowNode?.widgets_values && dataWidget) {
+        workflowNode.widgets_values[widgetIndex.profileCount] = String(widgetValue(findWidget(this, "profile_count"), profileCount(this)) || "4");
+        workflowNode.widgets_values[widgetIndex.loraName] = internalWidgetDefaults.lora_name;
+        workflowNode.widgets_values[widgetIndex.loras] = JSON.stringify(lorasWidgetValue(this));
+        workflowNode.widgets_values[widgetIndex.profileData] = widgetValue(dataWidget, "{}");
+      }
+    };
+
+    const originalOnConfigure = node.onConfigure;
+    node.onConfigure = function (...args) {
+      originalOnConfigure?.apply(this, args);
+      requestAnimationFrame(() => rehydrateNode(this));
+    };
+
+    requestAnimationFrame(() => rehydrateNode(node));
+  }
+
+  function applyExecutedProfile(node, message) {
+    const payload = Array.isArray(message?.lora_preset_profile)
+      ? message.lora_preset_profile[0]
+      : message?.lora_preset_profile;
+    const index = Number.parseInt(payload?.profile_index, 10);
+    if (!Number.isFinite(index)) {
+      return;
+    }
+    const nextIndex = wrapProfileIndex(index, profileCount(node));
+    const currentIndex = activeProfileIndex(node);
+    if (nextIndex === currentIndex) {
+      canvasWidgets.renderProfileBar(node);
+      return;
+    }
+    saveProfile(node, currentIndex);
+    setProfileIndex(node, nextIndex);
+    node.__easyuseAnimaActiveProfileIndex = nextIndex;
+    loadProfile(node, nextIndex);
+    scrollProfileBarTo(node, nextIndex);
+    canvasWidgets.renderProfileBar(node);
+    canvasWidgets.renderLoraWidgets(node);
+    node.setDirtyCanvas?.(true, true);
+  }
+
+  function beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== nodeTypeName) {
+      return;
+    }
+    const originalConfigure = nodeType.prototype.configure;
+    nodeType.prototype.configure = function (info) {
+      restoreInternalWidgetsForConfigure(this);
+      normalizeSerializedWidgets(info);
+      return originalConfigure?.apply(this, arguments);
+    };
+    const originalOnNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function (...args) {
+      const result = originalOnNodeCreated?.apply(this, args);
+      initializeNode(this);
+      return result;
+    };
+    const originalOnExecuted = nodeType.prototype.onExecuted;
+    nodeType.prototype.onExecuted = function (message) {
+      originalOnExecuted?.apply(this, arguments);
+      applyExecutedProfile(this, message);
+    };
+  }
+
+  return {
+    beforeRegisterNodeDef,
+    initializeNode,
+  };
+}


### PR DESCRIPTION
## 변경 요약

- LoRA Preset의 노드별 initialize/configure/serialize/executed lifecycle을 `createLoraPresetNodeRuntime(...)` 경계로 분리했습니다.
- entry는 의존성 주입과 extension 등록을 유지하고, profile mutation/API/FIX, save sync, wheel, menu/preview/canvas 소유권은 기존 위치에 남겼습니다.
- 공식 frontend runner에 새 node-runtime smoke를 등록했습니다.

## 주요 파일

- `web/js/lora_preset/node_runtime.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_node_runtime_smoke.mjs`
- `tests/test_frontend_lora_preset.py`
- `tools/check_frontend.ps1`

## 보존한 계약

- hidden widget identity/order와 `WIDGET_INDEX` 직렬화 위치
- hidden restore → serialized normalize → original configure 순서
- original node hook 우선 실행
- callback/init sentinel과 중복 initialize no-op
- rAF rehydration 및 accepted executed-profile transition

## 검증

- focused node runtime + 기존 LoRA smoke: PASS
- Python focused unittest: 15/15
- TypeScript 6.0.3: PASS
- 독립 behavior/test 감사 2개: GO
- rebase range-diff 및 stable patch-id: 동일
- official full runner: PASS
  - Python unittest 404/404
  - frontend 105 JavaScript files
  - TypeScript 6.0.3
  - git diff check

## 테스트 표면

- ComfyUI Codex test environment: official full/static/runtime smoke
- Live ComfyUI browser smoke: 동작 보존형 extraction이므로 이 PR에서는 미실행

## 남은 범위

- #55의 profile mutation/save sync/wheel/extension entry 후속 경계와 최종 Legacy/Node 2.0 load/edit/FIX/queue/save-reload matrix는 계속 남습니다.

Refs #55