### PR TITLE
fix: keep AiO preview wheel input local

### DIFF
--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -211,8 +211,12 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn(
             "installWheelForwarder: installGeneratorWheelForwarder,", source
         )
-        self.assertIn("owns the wheel even at either boundary", wheel_source)
-        self.assertIn("Canvas zoom is allowed only when neither intended scrollbar exists", wheel_source)
+        self.assertIn(
+            'const AIO_PREVIEW_SELECTOR = ".easyuse-anima-aio-node-preview";',
+            wheel_source,
+        )
+        self.assertIn("The preview surface always owns wheel input", wheel_source)
+        self.assertIn("unrelated panel space available", wheel_source)
 
     def test_generator_keeps_native_output_preview_suppressed_after_execution(self):
         source = AIO_JS.read_text(encoding="utf-8")

--- a/tests/test_aio_wheel.py
+++ b/tests/test_aio_wheel.py
@@ -12,7 +12,7 @@ WHEEL_JS = ROOT / "web" / "js" / "aio" / "wheel.js"
 
 
 class AIOWheelTests(unittest.TestCase):
-    def test_scroll_owners_consume_wheel_even_at_boundaries(self):
+    def test_preview_settings_and_canvas_wheel_ownership(self):
         node_bin = shutil.which("node")
         if not node_bin:
             self.skipTest("node executable is not available")
@@ -70,19 +70,22 @@ class AIOWheelTests(unittest.TestCase):
 
             const findPanel = globalThis.__aioWheelExports.aioPanelFromWheelEvent;
             const consumePanelWheel = globalThis.__aioWheelExports.consumeAioPanelWheel;
-            const makeEvent = (target, path, deltaY, deltaX = 0, deltaMode = 0) => ({
-              target,
-              deltaX,
-              deltaY,
-              deltaMode,
-              prevented: 0,
-              stopped: 0,
-              stoppedImmediately: 0,
-              composedPath: () => path,
-              preventDefault() { this.prevented += 1; },
-              stopPropagation() { this.stopped += 1; },
-              stopImmediatePropagation() { this.stoppedImmediately += 1; },
-            });
+            const makeEvent = (target, path, deltaY, deltaX = 0, deltaMode = 0) => {
+              const event = {
+                target,
+                deltaX,
+                deltaY,
+                deltaMode,
+                prevented: 0,
+                stopped: 0,
+                stoppedImmediately: 0,
+                preventDefault() { this.prevented += 1; },
+                stopPropagation() { this.stopped += 1; },
+                stopImmediatePropagation() { this.stoppedImmediately += 1; },
+              };
+              if (path !== null) event.composedPath = () => path;
+              return event;
+            };
 
             const panel = new HTMLElement(["easyuse-anima-aio-node-panel"]);
             const settings = new HTMLElement(
@@ -90,21 +93,70 @@ class AIOWheelTests(unittest.TestCase):
               { scrollHeight: 600, clientHeight: 200, scrollTop: 0 },
             );
             settings.parentElement = panel;
-            panel.queries.set(".easyuse-anima-aio-node-settings-scroll", settings);
+            const settingsTarget = new HTMLElement(["settings-target"]);
+            settingsTarget.parentElement = settings;
+            const previewCard = new HTMLElement(["easyuse-anima-aio-node-preview"]);
+            previewCard.parentElement = panel;
             const previewTarget = new HTMLElement(["preview-target"]);
-            previewTarget.parentElement = panel;
+            previewTarget.parentElement = previewCard;
 
-            let event = makeEvent(previewTarget, [previewTarget, panel], 120);
+            // The main preview consumes wheel input without moving settings or
+            // allowing the caller to forward the event to canvas zoom.
+            let event = makeEvent(previewTarget, [previewTarget, previewCard, panel], 120);
             assert.strictEqual(findPanel(event), panel);
             assert.strictEqual(consumePanelWheel(event, panel), true);
-            assert.strictEqual(settings.scrollTop, 120);
+            assert.strictEqual(settings.scrollTop, 0);
             assert.deepStrictEqual(
               [event.prevented, event.stopped, event.stoppedImmediately],
               [1, 1, 1],
             );
 
+            // A non-overflowing preview feed has the same ownership. Omitting
+            // composedPath exercises the target.closest() fallback.
+            const feed = new HTMLElement(
+              ["easyuse-anima-aio-node-preview-feed"],
+              { scrollWidth: 200, clientWidth: 200, scrollLeft: 0 },
+            );
+            feed.parentElement = previewCard;
+            const feedTarget = new HTMLElement(["feed-target"]);
+            feedTarget.parentElement = feed;
+            event = makeEvent(feedTarget, null, 100);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(feed.scrollLeft, 0);
+            assert.strictEqual(settings.scrollTop, 0);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [1, 1, 1],
+            );
+
+            // An overflowing feed translates the vertical wheel delta to X.
+            feed.scrollWidth = 500;
+            event = makeEvent(feedTarget, [feedTarget, feed, previewCard, panel], 100);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(feed.scrollLeft, 100);
+            assert.strictEqual(settings.scrollTop, 0);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [1, 1, 1],
+            );
+
+            feed.scrollLeft = 300;
+            event = makeEvent(feedTarget, [feedTarget, feed, previewCard, panel], 100);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(feed.scrollLeft, 300);
+            assert.deepStrictEqual(
+              [event.prevented, event.stopped, event.stoppedImmediately],
+              [1, 1, 1],
+            );
+
+            // Settings owns vertical wheel input only when the event target is
+            // inside the settings scroll surface.
+            event = makeEvent(settingsTarget, [settingsTarget, settings, panel], 120);
+            assert.strictEqual(consumePanelWheel(event, panel), true);
+            assert.strictEqual(settings.scrollTop, 120);
+
             settings.scrollTop = 400;
-            event = makeEvent(previewTarget, [previewTarget, panel], 120);
+            event = makeEvent(settingsTarget, [settingsTarget, settings, panel], 120);
             assert.strictEqual(consumePanelWheel(event, panel), true);
             assert.strictEqual(settings.scrollTop, 400);
             assert.deepStrictEqual(
@@ -113,41 +165,15 @@ class AIOWheelTests(unittest.TestCase):
             );
 
             settings.scrollTop = 0;
-            event = makeEvent(previewTarget, [previewTarget, panel], -120);
-            assert.strictEqual(consumePanelWheel(event, panel), true);
-            assert.strictEqual(settings.scrollTop, 0);
-            assert.deepStrictEqual(
-              [event.prevented, event.stopped, event.stoppedImmediately],
-              [1, 1, 1],
-            );
-
-            event = makeEvent(previewTarget, [previewTarget, panel], 2, 0, 1);
+            event = makeEvent(settingsTarget, [settingsTarget, settings, panel], 2, 0, 1);
             assert.strictEqual(consumePanelWheel(event, panel), true);
             assert.strictEqual(settings.scrollTop, 32);
 
-            const feed = new HTMLElement(
-              ["easyuse-anima-aio-node-preview-feed"],
-              { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 },
-            );
-            feed.parentElement = panel;
+            // Unrelated panel space remains unconsumed for canvas forwarding.
             settings.scrollTop = 0;
-            event = makeEvent(feed, [feed, panel], 100);
-            assert.strictEqual(consumePanelWheel(event, panel), true);
-            assert.strictEqual(feed.scrollLeft, 100);
-            assert.strictEqual(settings.scrollTop, 0);
-
-            feed.scrollLeft = 300;
-            event = makeEvent(feed, [feed, panel], 100);
-            assert.strictEqual(consumePanelWheel(event, panel), true);
-            assert.strictEqual(feed.scrollLeft, 300);
-            assert.deepStrictEqual(
-              [event.prevented, event.stopped, event.stoppedImmediately],
-              [1, 1, 1],
-            );
-
-            settings.scrollHeight = 200;
-            settings.clientHeight = 200;
-            event = makeEvent(previewTarget, [previewTarget, panel], 120);
+            const panelTarget = new HTMLElement(["panel-target"]);
+            panelTarget.parentElement = panel;
+            event = makeEvent(panelTarget, [panelTarget, panel], 120);
             assert.strictEqual(consumePanelWheel(event, panel), false);
             assert.strictEqual(settings.scrollTop, 0);
             assert.deepStrictEqual(

--- a/web/js/aio/wheel.js
+++ b/web/js/aio/wheel.js
@@ -2,6 +2,7 @@
 
 const AIO_PANEL_SELECTOR = ".easyuse-anima-aio-node-panel";
 const AIO_SETTINGS_SCROLL_SELECTOR = ".easyuse-anima-aio-node-settings-scroll";
+const AIO_PREVIEW_SELECTOR = ".easyuse-anima-aio-node-preview";
 const AIO_PREVIEW_FEED_SELECTOR = ".easyuse-anima-aio-node-preview-feed";
 
 function wheelPathElement(event, selector) {
@@ -21,6 +22,16 @@ function aioPanelFromWheelEvent(event) {
 function aioPreviewFeedFromWheelEvent(event, panel) {
   const feed = wheelPathElement(event, AIO_PREVIEW_FEED_SELECTOR);
   return feed && panel?.contains?.(feed) ? feed : null;
+}
+
+function aioPreviewSurfaceFromWheelEvent(event, panel) {
+  const preview = wheelPathElement(event, AIO_PREVIEW_SELECTOR);
+  return preview && panel?.contains?.(preview) ? preview : null;
+}
+
+function aioSettingsScrollFromWheelEvent(event, panel) {
+  const settingsScroll = wheelPathElement(event, AIO_SETTINGS_SCROLL_SELECTOR);
+  return settingsScroll && panel?.contains?.(settingsScroll) ? settingsScroll : null;
 }
 
 function aioScrollMaximum(element, axis) {
@@ -47,6 +58,13 @@ function aioWheelDeltaPixels(event, element, axis) {
   return delta;
 }
 
+function consumeAioWheelEvent(event) {
+  event.preventDefault?.();
+  event.stopPropagation?.();
+  event.stopImmediatePropagation?.();
+  return true;
+}
+
 function consumeAioScrollAreaWheel(event, element, axis) {
   const maximum = aioScrollMaximum(element, axis);
   if (maximum <= 1) {
@@ -55,9 +73,7 @@ function consumeAioScrollAreaWheel(event, element, axis) {
 
   // A visible scrollbar owns the wheel even at either boundary. Do not let a
   // no-op boundary wheel fall through to ComfyUI canvas zoom.
-  event.preventDefault?.();
-  event.stopPropagation?.();
-  event.stopImmediatePropagation?.();
+  consumeAioWheelEvent(event);
   const property = axis === "x" ? "scrollLeft" : "scrollTop";
   const current = Number(element[property]) || 0;
   element[property] = Math.max(
@@ -68,28 +84,35 @@ function consumeAioScrollAreaWheel(event, element, axis) {
 }
 
 /**
- * AiO uses one vertical scroll owner: the left settings column. Its scrollbar
- * owns wheel input from anywhere in the panel. The preview feed remains a more
- * local horizontal owner only while the pointer is over that overflowing feed.
- * Canvas zoom is allowed only when neither intended scrollbar exists.
+ * The preview surface always owns wheel input so it cannot scroll settings or
+ * zoom the canvas. An overflowing preview feed maps that input to horizontal
+ * scrolling. Settings owns vertical input only under its own surface, leaving
+ * unrelated panel space available for the existing canvas forwarding path.
  */
 function consumeAioPanelWheel(event, panel) {
   const previewFeed = aioPreviewFeedFromWheelEvent(event, panel);
   if (previewFeed && consumeAioScrollAreaWheel(event, previewFeed, "x")) {
     return true;
   }
-  const settingsScroll = panel?.querySelector?.(AIO_SETTINGS_SCROLL_SELECTOR);
+  if (aioPreviewSurfaceFromWheelEvent(event, panel)) {
+    return consumeAioWheelEvent(event);
+  }
+  const settingsScroll = aioSettingsScrollFromWheelEvent(event, panel);
   return consumeAioScrollAreaWheel(event, settingsScroll, "y");
 }
 
 export {
   AIO_PANEL_SELECTOR,
+  AIO_PREVIEW_SELECTOR,
   AIO_PREVIEW_FEED_SELECTOR,
   AIO_SETTINGS_SCROLL_SELECTOR,
   aioPanelFromWheelEvent,
   aioPreviewFeedFromWheelEvent,
+  aioPreviewSurfaceFromWheelEvent,
   aioScrollMaximum,
+  aioSettingsScrollFromWheelEvent,
   aioWheelDeltaPixels,
   consumeAioPanelWheel,
   consumeAioScrollAreaWheel,
+  consumeAioWheelEvent,
 };


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 main preview와 비오버플로 preview feed가 wheel 입력을 자체 소비하도록 소유권을 명확히 했습니다.
- overflow preview feed는 기존처럼 세로 wheel delta를 X축 스크롤로 변환하고, settings 영역 내부에서만 Y축 스크롤을 소유합니다.
- 그 외 패널 공간은 기존 ComfyUI canvas wheel forwarding을 유지합니다.
- `composedPath()` 우선 판정과 `closest()` fallback을 모두 유지합니다.

## 주요 파일

- `web/js/aio/wheel.js`
- `tests/test_aio_wheel.py`
- `tests/test_aio_frontend.py`

## 검증

### Focused

- `node --check web\js\aio\wheel.js` — PASS
- `test_aio_wheel.py` — 1/1 PASS
- `test_aio_frontend.py` — 34/34 PASS
- `git diff --check origin/dev...HEAD` — PASS
- rebase patch 무결성: range-diff `=`, stable patch-id 동일

### Official full runner

`powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <absolute-target-worktree> -Profile full`

- Python unittest: 404/404 PASS
- frontend smoke: 105 JavaScript files PASS
- TypeScript: 6.0.3 PASS
- git diff check: PASS

### Live ComfyUI browser smoke

ComfyUI Codex test instance / frontend 1.45.20:

- Legacy canvas
  - 512×512, batch 1, step 1 queue 성공
  - main preview wheel: canvas zoom 및 settings/feed offset 불변
  - non-overflow feed wheel: canvas zoom 및 settings/feed offset 불변
  - unrelated panel space wheel: canvas zoom 28% → 25%로 기존 forwarding 유지
  - 저장 후 reload: AiO panel과 disabled stage 상태 복원
- Nodes 2.0
  - 512×512, batch 1, step 1 queue 성공
  - main preview 및 non-overflow feed wheel: canvas zoom/offset 불변
  - unrelated panel space wheel: canvas zoom 23% → 21%로 기존 forwarding 유지
  - 저장 후 reload: Vue node surface와 disabled stage 상태 복원
- EasyUse Anima 관련 browser warning/error: 없음

## 남은 위험 및 메모

- 실제 overflow feed의 X축 이동은 deterministic focused regression으로 검증했습니다. 현재 live workflow의 preview feed는 overflow가 발생하지 않아 브라우저에서는 non-overflow 소유권을 직접 검증했습니다.
- 각 전체 reload에서 ComfyUI core asset이 `ComfyApp graph accessed before initialization`을 1회 기록했지만, EasyUse Anima 경로를 가리키지 않았고 이번 diff는 wheel router 세 파일에 한정됩니다.
- Issue #62의 Detailer threshold 경계는 이 PR 범위가 아니므로 issue는 계속 open으로 유지합니다.
