### PR TITLE
fix: autocomplete input binding lifecycle 정리

### DIFF
--- a/tests/frontend_autocomplete_input_binding_smoke.mjs
+++ b/tests/frontend_autocomplete_input_binding_smoke.mjs
@@ -1,0 +1,570 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function captureOf(options) {
+  return options === true || !!options?.capture;
+}
+
+function createEvent(values = {}) {
+  return {
+    type: "",
+    key: "",
+    button: 0,
+    shiftKey: false,
+    defaultPrevented: false,
+    propagationStopped: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    stopPropagation() {
+      this.propagationStopped = true;
+    },
+    ...values,
+  };
+}
+
+class FakeInput {
+  constructor() {
+    this.listeners = new Map();
+    this.isConnected = true;
+  }
+
+  addEventListener(type, listener, options = false) {
+    const records = this.listeners.get(type) || [];
+    records.push({ listener, capture: captureOf(options) });
+    this.listeners.set(type, records);
+  }
+
+  removeEventListener(type, listener, options = false) {
+    const capture = captureOf(options);
+    const records = this.listeners.get(type) || [];
+    this.listeners.set(
+      type,
+      records.filter((record) => record.listener !== listener || record.capture !== capture),
+    );
+  }
+
+  listenerCount(type = null) {
+    if (type) {
+      return (this.listeners.get(type) || []).length;
+    }
+    return [...this.listeners.values()].reduce((total, records) => total + records.length, 0);
+  }
+
+  listenerLedger() {
+    return [...this.listeners.entries()].map(([type, records]) => [
+      type,
+      records.map((record) => record.capture),
+    ]);
+  }
+
+  emit(type, values = {}) {
+    const event = createEvent({ type, ...values });
+    for (const { listener } of [...(this.listeners.get(type) || [])]) {
+      listener.call(this, event);
+    }
+    return event;
+  }
+}
+
+const entrySource = readFileSync(
+  new URL("../web/js/easyuse_anima_autocomplete.js", import.meta.url),
+  "utf8",
+);
+
+function createDisconnectedInputPruner(registry, disposeInput) {
+  const functionStart = entrySource.indexOf("function pruneDisconnectedAutocompleteInputs");
+  const functionEnd = entrySource.indexOf("\nfunction syncAutocompleteInputFlags", functionStart);
+  assert.ok(functionStart >= 0 && functionEnd > functionStart);
+  return new Function(
+    "hookedAutocompleteInputs",
+    "disposeAutocompleteInput",
+    `"use strict";\n${entrySource.slice(functionStart, functionEnd)}\nreturn pruneDisconnectedAutocompleteInputs;`,
+  )(registry, disposeInput);
+}
+
+function createAutocompleteInputDisposer(registry) {
+  const functionStart = entrySource.indexOf("function disposeAutocompleteInput");
+  const functionEnd = entrySource.indexOf("\nfunction pruneDisconnectedAutocompleteInputs", functionStart);
+  assert.ok(functionStart >= 0 && functionEnd > functionStart);
+  return new Function(
+    "hookedAutocompleteInputs",
+    "activeState",
+    "hidePopup",
+    "clearAutocompletePreview",
+    `"use strict";\n${entrySource.slice(functionStart, functionEnd)}\nreturn disposeAutocompleteInput;`,
+  )(registry, null, () => {}, () => {});
+}
+
+const bindingModule = await import(
+  dataModule("../web/js/autocomplete/input_binding.js")
+);
+assert.deepEqual(Object.keys(bindingModule), ["createAutocompleteInputBinding"]);
+
+const { createAutocompleteInputBinding } = bindingModule;
+
+{
+  const input = new FakeInput();
+  const state = { input };
+  const owner = {};
+  const registry = new Set();
+  let activeState = { input, index: 0, results: ["first", "second"] };
+  let compositionEndPending = true;
+  const calls = {
+    beginComposition: 0,
+    cancelMiddlePan: 0,
+    caret: 0,
+    commit: [],
+    dispose: 0,
+    endComposition: 0,
+    hide: [],
+    invalidate: 0,
+    schedule: 0,
+    setActive: [],
+    update: 0,
+  };
+  const timers = new Map();
+  let nextTimer = 1;
+  const controller = {
+    beginComposition() {
+      calls.beginComposition += 1;
+    },
+    dispose() {
+      calls.dispose += 1;
+    },
+    endComposition() {
+      calls.endComposition += 1;
+    },
+    invalidate() {
+      calls.invalidate += 1;
+    },
+    isComposing(event) {
+      return !!event?.composing;
+    },
+    isCompositionEndUpdatePending() {
+      return compositionEndPending;
+    },
+    scheduleCaretUpdate() {
+      calls.caret += 1;
+    },
+    scheduleUpdate() {
+      calls.schedule += 1;
+    },
+    updateNow() {
+      calls.update += 1;
+    },
+  };
+
+  const binding = createAutocompleteInputBinding({
+    input,
+    state,
+    owner,
+    registry,
+    controller,
+    getActiveState: () => activeState,
+    hidePopup: (options = {}) => calls.hide.push(options),
+    isTextEditingShortcut: (event) => !!event.shortcut,
+    handleBracketPreviewKeydown: (_state, event) => !!event.bracket,
+    forwardMiddlePan: (event) => {
+      if (!event.middle) {
+        return null;
+      }
+      return () => {
+        calls.cancelMiddlePan += 1;
+      };
+    },
+    setActive: (index) => calls.setActive.push(index),
+    commitSuggestion: (active, entry, options) => {
+      calls.commit.push({ active, entry, options });
+    },
+    getCommitKey: () => "enter",
+    setTimer(callback, delay) {
+      const handle = nextTimer++;
+      timers.set(handle, { callback, delay });
+      return handle;
+    },
+    clearTimer(handle) {
+      timers.delete(handle);
+    },
+  });
+
+  assert.equal(input.listenerCount(), 18, "one binding must own one exact listener set");
+  assert.deepEqual(input.listenerLedger(), [
+    ["compositionstart", [false]],
+    ["compositionupdate", [false]],
+    ["compositionend", [false]],
+    ["input", [false]],
+    ["focus", [false]],
+    ["click", [false]],
+    ["mousedown", [false, true]],
+    ["mouseup", [false]],
+    ["pointerup", [false]],
+    ["pointerdown", [true]],
+    ["auxclick", [true]],
+    ["keyup", [false]],
+    ["select", [false]],
+    ["blur", [false]],
+    ["keydown", [false, false, false]],
+  ], "the listener type and capture ledger must remain exact");
+  assert.equal(input.__easyuseAnimaAutocompleteState, state);
+  assert.equal(input.__easyuseAnimaAutocompleteDispose, state.dispose);
+  assert.equal(registry.has(input), true);
+  assert.equal(input.listenerCount("mousedown"), 2);
+  assert.equal(input.listenerCount("keydown"), 3);
+
+  input.emit("compositionstart");
+  input.emit("compositionupdate");
+  input.emit("compositionend");
+  assert.equal(calls.beginComposition, 1);
+  assert.equal(calls.schedule, 1);
+  assert.equal(calls.endComposition, 1);
+
+  input.emit("input");
+  assert.deepEqual(calls.hide.at(-1), { preserveController: true });
+  assert.equal(calls.schedule, 2);
+  compositionEndPending = false;
+
+  input.emit("focus");
+  input.emit("click");
+  input.emit("mousedown");
+  input.emit("mouseup");
+  input.emit("pointerup");
+  input.emit("keyup", { key: "ArrowLeft" });
+  input.emit("select");
+  assert.equal(calls.update, 1);
+  assert.equal(calls.caret, 6);
+
+  input.emit("keydown", { bracket: true });
+  assert.equal(calls.caret, 7, "bracket preview must retain its caret refresh");
+
+  const shortcut = input.emit("keydown", { key: "a", shortcut: true });
+  assert.equal(shortcut.propagationStopped, true);
+
+  const down = input.emit("keydown", { key: "ArrowDown" });
+  const up = input.emit("keydown", { key: "ArrowUp" });
+  assert.equal(down.defaultPrevented, true);
+  assert.equal(up.defaultPrevented, true);
+  assert.deepEqual(calls.setActive, [1, -1]);
+
+  const tab = input.emit("keydown", { key: "Tab" });
+  const enter = input.emit("keydown", { key: "Enter" });
+  assert.equal(tab.defaultPrevented, true);
+  assert.equal(enter.defaultPrevented, true);
+  assert.equal(calls.commit.length, 2);
+  assert.equal(calls.commit[0].entry, "first");
+  assert.deepEqual(calls.commit[0].options, { suppressPopup: true });
+
+  const composingEnter = input.emit("keydown", { key: "Enter", composing: true });
+  assert.equal(composingEnter.defaultPrevented, false);
+  assert.equal(calls.commit.length, 2);
+
+  const escape = input.emit("keydown", { key: "Escape" });
+  assert.equal(escape.defaultPrevented, true);
+  assert.equal(calls.invalidate, 1);
+
+  const middle = input.emit("pointerdown", { button: 1, middle: true });
+  assert.equal(middle.defaultPrevented, false, "the forwarding dependency owns event cancellation");
+
+  const aux = input.emit("auxclick", { button: 1 });
+  assert.equal(aux.defaultPrevented, true);
+  assert.equal(aux.propagationStopped, true);
+
+  input.emit("blur");
+  assert.equal(calls.invalidate, 2);
+  assert.deepEqual([...timers.values()].map((entry) => entry.delay), [120]);
+  const firstBlurHandle = [...timers.keys()][0];
+  input.emit("blur");
+  assert.equal(calls.invalidate, 3);
+  assert.equal(timers.has(firstBlurHandle), false, "a repeated blur must replace its timer");
+  assert.deepEqual([...timers.values()].map((entry) => entry.delay), [120]);
+  const staleBlur = [...timers.values()][0].callback;
+
+  const pruneDisconnected = createDisconnectedInputPruner(
+    registry,
+    createAutocompleteInputDisposer(registry),
+  );
+  pruneDisconnected();
+  assert.equal(registry.has(input), true, "a connected input must remain registered");
+  input.isConnected = false;
+  pruneDisconnected(input);
+  assert.equal(registry.has(input), true, "the candidate input must survive its own hook pass");
+  pruneDisconnected();
+  binding.dispose();
+  assert.equal(input.listenerCount(), 0, "dispose must remove capture and bubble listeners");
+  assert.equal(timers.size, 0, "dispose must cancel the pending blur timer");
+  assert.equal(calls.dispose, 1, "controller disposal must be idempotent");
+  assert.equal(calls.cancelMiddlePan, 1, "the binding must cancel only its forwarded pan");
+  assert.equal(registry.has(input), false);
+  assert.equal(input.__easyuseAnimaAutocompleteState, undefined);
+  assert.equal(input.__easyuseAnimaAutocompleteHooked, undefined);
+
+  const hideCount = calls.hide.length;
+  staleBlur();
+  input.emit("input");
+  assert.equal(calls.hide.length, hideCount, "disposed timer/listeners must not mutate popup state");
+
+  activeState = null;
+}
+
+{
+  const connected = new FakeInput();
+  const disconnected = new FakeInput();
+  const stateless = new FakeInput();
+  connected.__easyuseAnimaAutocompleteState = { input: connected };
+  disconnected.__easyuseAnimaAutocompleteState = { input: disconnected };
+  disconnected.isConnected = false;
+  const registry = new Set([connected, disconnected, stateless]);
+  const pruneDisconnected = createDisconnectedInputPruner(
+    registry,
+    createAutocompleteInputDisposer(registry),
+  );
+
+  pruneDisconnected(disconnected);
+  assert.equal(registry.has(stateless), false, "a stateless marker must be pruned");
+  assert.equal(stateless.__easyuseAnimaAutocomplete, false);
+  assert.equal(registry.has(connected), true);
+  assert.equal(registry.has(disconnected), true, "exceptInput must be preserved while hooking it");
+
+  pruneDisconnected();
+  assert.equal(registry.has(connected), true, "connected inputs must remain registered");
+  assert.equal(registry.has(disconnected), false, "disconnected inputs must be disposed");
+  assert.equal(disconnected.__easyuseAnimaAutocompleteState, undefined);
+  assert.equal(disconnected.__easyuseAnimaAutocomplete, false);
+}
+
+{
+  const functionStart = entrySource.indexOf("function forwardMiddlePanFromAutocompleteInput");
+  const functionEnd = entrySource.indexOf("\nfunction commitSuggestion", functionStart);
+  assert.ok(functionStart >= 0 && functionEnd > functionStart);
+
+  const documentTarget = new FakeInput();
+  let blurCalls = 0;
+  documentTarget.activeElement = { blur: () => { blurCalls += 1; } };
+  const app = { canvas: { canvas: {} } };
+  const dispatches = [];
+  const forwardMiddlePan = new Function(
+    "app",
+    "document",
+    "dispatchAutocompleteCanvasPointerEvent",
+    "dispatchAutocompleteCanvasMouseEvent",
+    `"use strict";\nlet middlePanForwardCleanup = null;\n${entrySource.slice(functionStart, functionEnd)}\nreturn forwardMiddlePanFromAutocompleteInput;`,
+  )(
+    app,
+    documentTarget,
+    (type, event, overrides) => dispatches.push(["pointer", type, event, overrides]),
+    (type, event, overrides) => dispatches.push(["mouse", type, event, overrides]),
+  );
+
+  const firstDown = createEvent({ button: 1 });
+  const firstCleanup = forwardMiddlePan(firstDown);
+  assert.equal(typeof firstCleanup, "function");
+  assert.equal(firstDown.defaultPrevented, true);
+  assert.equal(firstDown.propagationStopped, true);
+  assert.equal(blurCalls, 1);
+  assert.deepEqual(dispatches.map((entry) => entry.slice(0, 2)), [
+    ["pointer", "pointerdown"],
+    ["mouse", "mousedown"],
+  ]);
+  assert.deepEqual(documentTarget.listenerLedger(), [
+    ["pointermove", [true]],
+    ["pointerup", [true]],
+    ["pointercancel", [true]],
+    ["mousemove", [true]],
+    ["mouseup", [true]],
+  ]);
+
+  const repeatedDown = createEvent({ button: 1 });
+  assert.equal(forwardMiddlePan(repeatedDown), firstCleanup);
+  assert.equal(repeatedDown.defaultPrevented, true);
+  assert.equal(dispatches.length, 2, "an active pan must not dispatch a second down pair");
+  assert.equal(documentTarget.listenerCount(), 5, "an active pan must retain one document listener set");
+
+  documentTarget.emit("pointermove", { button: 1 });
+  assert.deepEqual(dispatches.slice(-2).map((entry) => entry.slice(0, 2)), [
+    ["pointer", "pointermove"],
+    ["mouse", "mousemove"],
+  ]);
+  documentTarget.emit("pointerup", { button: 1 });
+  assert.deepEqual(dispatches.slice(-2).map((entry) => entry.slice(0, 2)), [
+    ["pointer", "pointerup"],
+    ["mouse", "mouseup"],
+  ]);
+  assert.equal(documentTarget.listenerCount(), 0, "a natural release must remove every document listener");
+  const dispatchCountAfterRelease = dispatches.length;
+  firstCleanup();
+  assert.equal(dispatches.length, dispatchCountAfterRelease, "cleanup must be idempotent after release");
+
+  const secondDown = createEvent({ button: 1 });
+  const secondCleanup = forwardMiddlePan(secondDown);
+  const dispatchCountBeforeSyntheticRelease = dispatches.length;
+  secondCleanup();
+  secondCleanup();
+  assert.equal(
+    dispatches.length,
+    dispatchCountBeforeSyntheticRelease + 2,
+    "disposal cleanup must synthesize exactly one release pair",
+  );
+  assert.equal(documentTarget.listenerCount(), 0, "disposal cleanup must remove every document listener");
+  assert.deepEqual(dispatches.slice(-2).map((entry) => entry.slice(0, 2)), [
+    ["pointer", "pointerup"],
+    ["mouse", "mouseup"],
+  ]);
+
+  const forwarded = createEvent({ button: 1, __easyuseAnimaForwarded: true });
+  assert.equal(forwardMiddlePan(forwarded), null);
+  app.canvas.canvas = null;
+  const noCanvas = createEvent({ button: 1 });
+  assert.equal(forwardMiddlePan(noCanvas), null);
+  assert.equal(noCanvas.defaultPrevented, false);
+}
+
+function noOpController(disposeCall) {
+  return {
+    beginComposition() {},
+    dispose: disposeCall,
+    endComposition() {},
+    invalidate() {},
+    isComposing() { return false; },
+    isCompositionEndUpdatePending() { return false; },
+    scheduleCaretUpdate() {},
+    scheduleUpdate() {},
+    updateNow() {},
+  };
+}
+
+function replacementBinding(input, state, owner, registry, controller) {
+  return createAutocompleteInputBinding({
+    input,
+    state,
+    owner,
+    registry,
+    controller,
+    getActiveState: () => null,
+    hidePopup() {},
+    isTextEditingShortcut: () => false,
+    handleBracketPreviewKeydown: () => false,
+    forwardMiddlePan: () => null,
+    setActive() {},
+    commitSuggestion() {},
+    getCommitKey: () => "enter",
+    setTimer: () => 1,
+    clearTimer() {},
+  });
+}
+
+{
+  const input = new FakeInput();
+  const ownerA = {};
+  const ownerB = {};
+  const registryA = new Set();
+  const registryB = new Set();
+  let disposeA = 0;
+  let disposeB = 0;
+  const stateA = { input };
+  const stateB = { input };
+  const bindingA = replacementBinding(
+    input,
+    stateA,
+    ownerA,
+    registryA,
+    noOpController(() => { disposeA += 1; }),
+  );
+  const staleDispose = stateA.dispose;
+
+  assert.equal(input.listenerCount(), 18);
+  assert.equal(registryA.has(input), true);
+
+  const bindingB = replacementBinding(
+    input,
+    stateB,
+    ownerB,
+    registryB,
+    noOpController(() => { disposeB += 1; }),
+  );
+  assert.equal(disposeA, 1, "a new owner must dispose the previous binding");
+  assert.equal(registryA.has(input), false);
+  assert.equal(registryB.has(input), true);
+  assert.equal(input.__easyuseAnimaAutocompleteState, stateB);
+  assert.equal(input.listenerCount(), 18, "owner replacement must leave one listener set");
+
+  staleDispose();
+  assert.equal(input.__easyuseAnimaAutocompleteState, stateB);
+  assert.equal(input.listenerCount(), 18, "an old disposer must not clear the new owner");
+
+  bindingA.dispose();
+  bindingB.dispose();
+  assert.equal(disposeA, 1);
+  assert.equal(disposeB, 1);
+  assert.equal(input.listenerCount(), 0);
+  assert.equal(registryB.has(input), false);
+
+  input.__easyuseAnimaAutocompleteHooked = true;
+  const registryC = new Set();
+  let disposeC = 0;
+  const stateC = { input };
+  const bindingC = replacementBinding(
+    input,
+    stateC,
+    {},
+    registryC,
+    noOpController(() => { disposeC += 1; }),
+  );
+  assert.equal(input.__easyuseAnimaAutocompleteState, stateC);
+  assert.equal(input.listenerCount(), 18, "a state-less stale marker must not block re-hook");
+
+  delete input.__easyuseAnimaAutocompleteState;
+  const pruneMissingState = createDisconnectedInputPruner(
+    registryC,
+    createAutocompleteInputDisposer(registryC),
+  );
+  pruneMissingState();
+  assert.equal(disposeC, 1, "prune must invoke the saved disposer for a missing state expando");
+  assert.equal(registryC.has(input), false);
+  assert.equal(input.listenerCount(), 0, "missing-state prune must remove the live listener set");
+
+  const registryD = new Set();
+  let disposeD = 0;
+  const stateD = { input };
+  const bindingD = replacementBinding(
+    input,
+    stateD,
+    {},
+    registryD,
+    noOpController(() => { disposeD += 1; }),
+  );
+  assert.equal(registryD.has(input), true);
+  assert.equal(input.__easyuseAnimaAutocompleteState, stateD);
+  assert.equal(input.listenerCount(), 18);
+
+  delete input.__easyuseAnimaAutocompleteState;
+  const registryE = new Set();
+  let disposeE = 0;
+  const stateE = { input };
+  const bindingE = replacementBinding(
+    input,
+    stateE,
+    {},
+    registryE,
+    noOpController(() => { disposeE += 1; }),
+  );
+  assert.equal(disposeD, 1, "direct re-hook must invoke the saved disposer for a missing state expando");
+  assert.equal(registryD.has(input), false);
+  assert.equal(registryE.has(input), true);
+  assert.equal(input.__easyuseAnimaAutocompleteState, stateE);
+  assert.equal(input.listenerCount(), 18, "state repair must not leave duplicate listeners");
+
+  bindingC.dispose();
+  bindingD.dispose();
+  bindingE.dispose();
+  assert.equal(disposeC, 1);
+  assert.equal(disposeD, 1);
+  assert.equal(disposeE, 1);
+  assert.equal(input.listenerCount(), 0);
+}
+
+console.log("Autocomplete input binding smoke passed.");

--- a/tests/frontend_autocomplete_input_controller_smoke.mjs
+++ b/tests/frontend_autocomplete_input_controller_smoke.mjs
@@ -269,3 +269,5 @@ const {
 }
 
 console.log("Autocomplete input controller smoke passed.");
+
+await import("./frontend_autocomplete_input_binding_smoke.mjs");

--- a/tests/frontend_autocomplete_input_controller_smoke.mjs
+++ b/tests/frontend_autocomplete_input_controller_smoke.mjs
@@ -269,5 +269,3 @@ const {
 }
 
 console.log("Autocomplete input controller smoke passed.");
-
-await import("./frontend_autocomplete_input_binding_smoke.mjs");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -50,6 +50,9 @@ AUTOCOMPLETE_DATA_ADAPTER_JS = (
 AUTOCOMPLETE_INPUT_CONTROLLER_JS = (
     ROOT / "web" / "js" / "autocomplete" / "input_controller.js"
 )
+AUTOCOMPLETE_INPUT_BINDING_JS = (
+    ROOT / "web" / "js" / "autocomplete" / "input_binding.js"
+)
 AUTOCOMPLETE_TEXT_MODEL_JS = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -852,24 +855,23 @@ class AIOFrontendSourceTests(unittest.TestCase):
         controller_source = AUTOCOMPLETE_INPUT_CONTROLLER_JS.read_text(
             encoding="utf-8"
         )
+        binding_source = AUTOCOMPLETE_INPUT_BINDING_JS.read_text(encoding="utf-8")
         hook_start = source.index("function hookInput")
         hook_end = source.index("\nfunction hookWidget", hook_start)
         hook_body = source[hook_start:hook_end]
 
         self.assertIn("document.activeElement !== input", hook_body)
         self.assertIn(
-            'input.addEventListener("compositionstart", '
-            "controller.beginComposition);",
-            hook_body,
+            'listen("compositionstart", controller.beginComposition);',
+            binding_source,
         )
         self.assertIn(
-            'input.addEventListener("compositionupdate", '
-            "controller.scheduleUpdate);",
-            hook_body,
+            'listen("compositionupdate", controller.scheduleUpdate);',
+            binding_source,
         )
         self.assertIn(
-            'input.addEventListener("compositionend", controller.endComposition);',
-            hook_body,
+            'listen("compositionend", controller.endComposition);',
+            binding_source,
         )
         self.assertIn("function beginComposition()", controller_source)
         self.assertIn("function endComposition()", controller_source)
@@ -878,22 +880,22 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn(
             "if (!controller.isComposing(event) "
             "&& handleBracketPreviewKeydown(state, event))",
-            hook_body,
+            binding_source,
         )
 
-        autocomplete_done = source.index("  input.__easyuseAnimaAutocompleteHooked = true;")
-        keydown_start = source.rindex('  input.addEventListener("keydown", (event) => {', 0, autocomplete_done)
-        keydown_end = source.index("  });", keydown_start)
-        keydown_body = source[keydown_start:keydown_end]
+        keydown_start = binding_source.index("function handleNavigation")
+        keydown_end = binding_source.index("\n\n  listen(", keydown_start)
+        keydown_body = binding_source[keydown_start:keydown_end]
 
         self.assertIn("controller.isComposing(event)", keydown_body)
         self.assertLess(
             keydown_body.index("controller.isComposing(event)"),
-            keydown_body.index("!activeState"),
+            keydown_body.index("const active = activeForInput();"),
         )
 
     def test_autocomplete_public_flag_tracks_enabled_state(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        binding_source = AUTOCOMPLETE_INPUT_BINDING_JS.read_text(encoding="utf-8")
 
         self.assertIn("const hookedAutocompleteInputs = new Set();", source)
         self.assertIn("input.__easyuseAnimaAutocompleteHooked", source)
@@ -916,10 +918,22 @@ class AIOFrontendSourceTests(unittest.TestCase):
         end = source.index("\nfunction hookWidget", start)
         hook_body = source[start:end]
 
-        self.assertIn("if (input.__easyuseAnimaAutocompleteHooked) {", hook_body)
+        self.assertIn(
+            'existing?.owner === autocompleteInputOwner && typeof existing.dispose === "function"',
+            hook_body,
+        )
         self.assertIn("syncAutocompleteInputFlag(input, existing);", hook_body)
-        self.assertIn("hookedAutocompleteInputs.add(input);", hook_body)
+        self.assertIn(
+            "input.__easyuseAnimaAutocompleteDispose = existing.dispose;",
+            hook_body,
+        )
+        self.assertIn("state.binding = createAutocompleteInputBinding({", hook_body)
+        self.assertIn("owner: autocompleteInputOwner,", hook_body)
+        self.assertIn("registry: hookedAutocompleteInputs,", hook_body)
+        self.assertIn("registry.add(input);", binding_source)
         self.assertIn("syncAutocompleteInputFlag(input, state);", hook_body)
+        self.assertIn("return existing.dispose;", hook_body)
+        self.assertIn("return state.dispose;", hook_body)
 
     def test_autocomplete_arrow_navigation_keeps_adjacent_items_visible(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -247,16 +247,13 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
     def test_input_controller_module_semantics(self):
         self.assertTrue(AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE.is_file())
         self.assertTrue(AUTOCOMPLETE_INPUT_BINDING_SMOKE.is_file())
-        controller_smoke_source = AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE.read_text(
-            encoding="utf-8"
-        )
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
         self.assertIn(
-            'await import("./frontend_autocomplete_input_binding_smoke.mjs");',
-            controller_smoke_source,
+            r'node "tests\frontend_autocomplete_input_controller_smoke.mjs"',
+            frontend_check_source,
         )
         self.assertIn(
-            r'node "tests\frontend_autocomplete_input_controller_smoke.mjs"',
+            r'node "tests\frontend_autocomplete_input_binding_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -22,6 +22,12 @@ AUTOCOMPLETE_INPUT_CONTROLLER = (
 AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE = (
     ROOT / "tests" / "frontend_autocomplete_input_controller_smoke.mjs"
 )
+AUTOCOMPLETE_INPUT_BINDING = (
+    ROOT / "web" / "js" / "autocomplete" / "input_binding.js"
+)
+AUTOCOMPLETE_INPUT_BINDING_SMOKE = (
+    ROOT / "tests" / "frontend_autocomplete_input_binding_smoke.mjs"
+)
 AUTOCOMPLETE_TEXT_MODEL = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -101,22 +107,9 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
         self.assertNotIn("requestAnimationFrame(updateNow)", hook_body)
         self.assertNotIn("setTimeout(updateNow, 0)", hook_body)
         self.assertIn("const controller = createAutocompleteInputController({", hook_body)
-        self.assertIn(
-            'input.addEventListener("compositionstart", controller.beginComposition);',
-            hook_body,
-        )
-        self.assertIn(
-            'input.addEventListener("compositionupdate", controller.scheduleUpdate);',
-            hook_body,
-        )
-        self.assertIn(
-            'input.addEventListener("compositionend", controller.endComposition);',
-            hook_body,
-        )
+        self.assertIn("state.binding = createAutocompleteInputBinding({", hook_body)
         self.assertIn("const results = await request(", hook_body)
         self.assertIn("isCurrent()", hook_body)
-        self.assertIn("controller.invalidate();", hook_body)
-        self.assertIn("controller.isComposing(event)", hook_body)
         self.assertIn("state?.controller?.invalidate();", entry_source)
 
         invalidate_start = entry_source.index(
@@ -251,17 +244,21 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
         )
         self.assertNotIn("hidePopup();", settings_body)
 
-        keydown_start = hook_body.rindex(
-            'input.addEventListener("keydown", (event) => {'
-        )
-        keydown_body = hook_body[keydown_start:]
-        self.assertLess(
-            keydown_body.index('event.key === "Escape"'),
-            keydown_body.index("!activeState"),
-        )
-
     def test_input_controller_module_semantics(self):
         self.assertTrue(AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE.is_file())
+        self.assertTrue(AUTOCOMPLETE_INPUT_BINDING_SMOKE.is_file())
+        controller_smoke_source = AUTOCOMPLETE_INPUT_CONTROLLER_SMOKE.read_text(
+            encoding="utf-8"
+        )
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn(
+            'await import("./frontend_autocomplete_input_binding_smoke.mjs");',
+            controller_smoke_source,
+        )
+        self.assertIn(
+            r'node "tests\frontend_autocomplete_input_controller_smoke.mjs"',
+            frontend_check_source,
+        )
 
         node_bin = shutil.which("node")
         if not node_bin:
@@ -277,6 +274,75 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
 
         if completed.returncode != 0:
             self.fail((completed.stdout + completed.stderr).strip())
+
+    def test_input_binding_has_exact_listener_lifecycle_boundary(self):
+        module_source = AUTOCOMPLETE_INPUT_BINDING.read_text(encoding="utf-8")
+        entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createAutocompleteInputBinding"],
+        )
+        self.assertNotRegex(
+            module_source,
+            re.compile(r"^\s*import\b", re.MULTILINE),
+        )
+        self.assertNotRegex(
+            module_source,
+            (
+                r"\b(?:document|window|app|api|fetch|registerExtension|"
+                r"MutationObserver|HTMLElement|HTMLInputElement|"
+                r"HTMLTextAreaElement)\b"
+            ),
+        )
+        self.assertIn(
+            'import { createAutocompleteInputBinding } from '
+            '"./autocomplete/input_binding.js";',
+            entry_source,
+        )
+        self.assertEqual(entry_source.count("createAutocompleteInputBinding({"), 1)
+
+        hook_start = entry_source.index("function hookInput")
+        hook_end = entry_source.index("\nfunction hookWidget", hook_start)
+        hook_body = entry_source[hook_start:hook_end]
+        self.assertIn("state.binding = createAutocompleteInputBinding({", hook_body)
+        self.assertIn("return existing.dispose;", hook_body)
+        self.assertIn("return state.dispose;", hook_body)
+        self.assertNotIn("input.addEventListener(", hook_body)
+
+        self.assertIn('listen("compositionstart", controller.beginComposition);', module_source)
+        self.assertIn('listen("compositionupdate", controller.scheduleUpdate);', module_source)
+        self.assertIn('listen("compositionend", controller.endComposition);', module_source)
+        self.assertEqual(module_source.count('listen("keydown"'), 3)
+        self.assertIn("input.removeEventListener(type, listener, options);", module_source)
+        self.assertIn("controller.dispose();", module_source)
+        self.assertIn("clearTimer(blurTimer);", module_source)
+        self.assertIn("middlePanCleanup?.();", module_source)
+        self.assertIn(
+            "const staleDispose = input.__easyuseAnimaAutocompleteDispose;",
+            module_source,
+        )
+        self.assertIn('typeof staleDispose === "function"', module_source)
+        self.assertIn("staleDispose();", module_source)
+
+        dispose_start = entry_source.index("function disposeAutocompleteInput")
+        dispose_end = entry_source.index("\nfunction syncAutocompleteInputFlags", dispose_start)
+        dispose_body = entry_source[dispose_start:dispose_end]
+        self.assertIn(
+            "const staleDispose = input.__easyuseAnimaAutocompleteDispose;",
+            dispose_body,
+        )
+        self.assertIn("staleDispose();", dispose_body)
+        self.assertIn("expectedState.binding?.dispose();", dispose_body)
+        self.assertIn("expectedState.controller?.dispose?.();", dispose_body)
+        self.assertIn("input.__easyuseAnimaAutocompleteState === expectedState", dispose_body)
+        self.assertIn("input?.isConnected === false", dispose_body)
+        self.assertIn("pruneDisconnectedAutocompleteInputs(input);", hook_body)
 
     def test_popup_geometry_has_exact_dom_free_boundary(self):
         module_source = AUTOCOMPLETE_POPUP_GEOMETRY.read_text(encoding="utf-8")

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 AUTOCOMPLETE_ENTRY = ROOT / "web" / "js" / "easyuse_anima_autocomplete.js"
 EXPECTED_AUTOCOMPLETE_MODULES = {
     "web/js/autocomplete/data_adapter.js",
+    "web/js/autocomplete/input_binding.js",
     "web/js/autocomplete/input_controller.js",
     "web/js/autocomplete/popup_geometry.js",
     "web/js/autocomplete/text_model.js",

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -199,6 +199,11 @@ try {
         throw "Frontend autocomplete input controller smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_autocomplete_input_binding_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend autocomplete input binding smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_popup_geometry_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete popup geometry smoke failed with exit code $LASTEXITCODE."

--- a/web/js/autocomplete/input_binding.js
+++ b/web/js/autocomplete/input_binding.js
@@ -1,0 +1,239 @@
+// @ts-check
+
+/**
+ * Owns every DOM listener and delayed blur action for one autocomplete input.
+ * Search authority and popup behavior remain injected so replacing or removing
+ * an input can dispose this boundary without reaching through to host globals.
+ *
+ * @param {{
+ *   input: any,
+ *   state: any,
+ *   owner: object,
+ *   registry: Set<any>,
+ *   controller: any,
+ *   onBeforeDispose?: (input: any, state: any, ownsCurrentState: boolean) => void,
+ *   getActiveState: () => any,
+ *   hidePopup: (options?: { preserveController?: boolean }) => void,
+ *   isTextEditingShortcut: (event: any) => boolean,
+ *   handleBracketPreviewKeydown: (state: any, event: any) => boolean,
+ *   forwardMiddlePan: (event: any) => null | false | true | (() => void),
+ *   setActive: (index: number) => void,
+ *   commitSuggestion: (state: any, entry: any, options?: any) => void,
+ *   getCommitKey: () => string,
+ *   setTimer: (callback: () => unknown, delay: number) => any,
+ *   clearTimer: (handle: any) => void,
+ * }} dependencies
+ */
+export function createAutocompleteInputBinding(dependencies) {
+  const {
+    input,
+    state,
+    owner,
+    registry,
+    controller,
+    onBeforeDispose = () => {},
+    getActiveState,
+    hidePopup,
+    isTextEditingShortcut,
+    handleBracketPreviewKeydown,
+    forwardMiddlePan,
+    setActive,
+    commitSuggestion,
+    getCommitKey,
+    setTimer,
+    clearTimer,
+  } = dependencies;
+  let disposed = false;
+  let blurTimer = null;
+  let middlePanCleanup = null;
+  const listeners = [];
+
+  function listen(type, listener, options = false) {
+    input.addEventListener(type, listener, options);
+    listeners.push([type, listener, options]);
+  }
+
+  function activeForInput() {
+    const active = getActiveState();
+    return active?.input === input ? active : null;
+  }
+
+  function scheduleInputUpdate() {
+    const preserveController = controller.isCompositionEndUpdatePending();
+    if (activeForInput()) {
+      hidePopup({ preserveController });
+    }
+    controller.scheduleUpdate();
+  }
+
+  function handleMiddlePanStart(event) {
+    const cleanup = forwardMiddlePan(event);
+    if (!cleanup) {
+      return;
+    }
+    if (typeof cleanup === "function") {
+      middlePanCleanup = cleanup;
+    }
+    hidePopup();
+  }
+
+  function handleMiddleAuxClick(event) {
+    if (event.button !== 1) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  function handleCaretKeyup(event) {
+    if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"].includes(event.key)) {
+      controller.scheduleCaretUpdate();
+    }
+  }
+
+  function handleBlur() {
+    controller.invalidate();
+    if (blurTimer != null) {
+      clearTimer(blurTimer);
+    }
+    blurTimer = setTimer(() => {
+      blurTimer = null;
+      if (!disposed && activeForInput()) {
+        hidePopup();
+      }
+    }, 120);
+  }
+
+  function handleTextEditingShortcut(event) {
+    if (isTextEditingShortcut(event)) {
+      event.stopPropagation();
+    }
+  }
+
+  function handleBracketPreview(event) {
+    if (!controller.isComposing(event) && handleBracketPreviewKeydown(state, event)) {
+      controller.scheduleCaretUpdate();
+    }
+  }
+
+  function handleNavigation(event) {
+    if (controller.isComposing(event)) {
+      return;
+    }
+    if (event.key === "Escape") {
+      controller.invalidate();
+      if (activeForInput()) {
+        event.preventDefault();
+        hidePopup();
+      }
+      return;
+    }
+    const active = activeForInput();
+    if (!active) {
+      return;
+    }
+    if (event.key === "Enter" && event.shiftKey) {
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActive(active.index + 1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActive(active.index - 1);
+    } else if (
+      (event.key === "Tab" && !event.shiftKey)
+      || (event.key === "Enter" && getCommitKey() === "enter")
+    ) {
+      event.preventDefault();
+      commitSuggestion(active, active.results[active.index], {
+        suppressPopup: true,
+      });
+    }
+  }
+
+  const previousState = input.__easyuseAnimaAutocompleteState;
+  if (previousState && previousState !== state) {
+    if (typeof previousState.dispose === "function") {
+      previousState.dispose();
+    } else {
+      previousState.binding?.dispose?.();
+      previousState.controller?.dispose?.();
+      if (input.__easyuseAnimaAutocompleteState === previousState) {
+        delete input.__easyuseAnimaAutocompleteState;
+        delete input.__easyuseAnimaAutocompleteHooked;
+        delete input.__easyuseAnimaAutocompleteDispose;
+        input.__easyuseAnimaAutocomplete = false;
+      }
+    }
+  } else if (!previousState && input.__easyuseAnimaAutocompleteHooked) {
+    const staleDispose = input.__easyuseAnimaAutocompleteDispose;
+    if (typeof staleDispose === "function") {
+      staleDispose();
+    }
+    if (!input.__easyuseAnimaAutocompleteState) {
+      delete input.__easyuseAnimaAutocompleteHooked;
+      delete input.__easyuseAnimaAutocompleteDispose;
+      input.__easyuseAnimaAutocomplete = false;
+    }
+  }
+
+  listen("compositionstart", controller.beginComposition);
+  listen("compositionupdate", controller.scheduleUpdate);
+  listen("compositionend", controller.endComposition);
+  listen("input", scheduleInputUpdate);
+  listen("focus", controller.updateNow);
+  listen("click", controller.scheduleCaretUpdate);
+  listen("mousedown", controller.scheduleCaretUpdate);
+  listen("mouseup", controller.scheduleCaretUpdate);
+  listen("pointerup", controller.scheduleCaretUpdate);
+  listen("pointerdown", handleMiddlePanStart, true);
+  listen("mousedown", handleMiddlePanStart, true);
+  listen("auxclick", handleMiddleAuxClick, true);
+  listen("keyup", handleCaretKeyup);
+  listen("select", controller.scheduleCaretUpdate);
+  listen("blur", handleBlur);
+  listen("keydown", handleTextEditingShortcut);
+  listen("keydown", handleBracketPreview);
+  listen("keydown", handleNavigation);
+
+  function dispose() {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    const ownsCurrentState = input.__easyuseAnimaAutocompleteState === state;
+    onBeforeDispose(input, state, ownsCurrentState);
+    if (blurTimer != null) {
+      clearTimer(blurTimer);
+      blurTimer = null;
+    }
+    middlePanCleanup?.();
+    middlePanCleanup = null;
+    for (const [type, listener, options] of listeners) {
+      input.removeEventListener(type, listener, options);
+    }
+    listeners.length = 0;
+    controller.dispose();
+    registry.delete(input);
+    state.binding = null;
+    if (ownsCurrentState) {
+      if (input.__easyuseAnimaAutocompleteDispose === dispose) {
+        delete input.__easyuseAnimaAutocompleteDispose;
+      }
+      delete input.__easyuseAnimaAutocompleteState;
+      delete input.__easyuseAnimaAutocompleteHooked;
+      input.__easyuseAnimaAutocomplete = false;
+    }
+  }
+
+  const binding = { dispose };
+  state.owner = owner;
+  state.binding = binding;
+  state.dispose = dispose;
+  input.__easyuseAnimaAutocompleteHooked = true;
+  input.__easyuseAnimaAutocompleteState = state;
+  input.__easyuseAnimaAutocompleteDispose = dispose;
+  registry.add(input);
+  return binding;
+}

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -10,6 +10,7 @@ import {
   createAutocompleteInputController,
   invalidateAutocompleteControllerStates,
 } from "./autocomplete/input_controller.js";
+import { createAutocompleteInputBinding } from "./autocomplete/input_binding.js";
 import {
   calculateAutocompletePopupGeometry,
   calculateCaretMirrorGeometry,
@@ -184,7 +185,8 @@ let autocompletePreviewCompletion = false;
 let popup = null;
 let activeState = null;
 let activeRefreshFrame = null;
-let middlePanForwardActive = false;
+let middlePanForwardCleanup = null;
+const autocompleteInputOwner = {};
 const hookedAutocompleteInputs = new Set();
 window.__easyuseAnimaPendingAutocompleteInputs ||= [];
 
@@ -340,7 +342,62 @@ function syncAutocompleteInputFlag(input, state = input?.__easyuseAnimaAutocompl
   }
 }
 
+function disposeAutocompleteInput(input, expectedState = input?.__easyuseAnimaAutocompleteState) {
+  if (!input) {
+    return;
+  }
+  if (!expectedState) {
+    const staleDispose = input.__easyuseAnimaAutocompleteDispose;
+    if (typeof staleDispose === "function") {
+      staleDispose();
+    }
+    if (!input.__easyuseAnimaAutocompleteState) {
+      hookedAutocompleteInputs.delete(input);
+      delete input.__easyuseAnimaAutocompleteHooked;
+      delete input.__easyuseAnimaAutocompleteDispose;
+      input.__easyuseAnimaAutocomplete = false;
+    }
+    return;
+  }
+  if (typeof expectedState.dispose === "function") {
+    expectedState.dispose();
+    return;
+  }
+  const ownsCurrentState = input.__easyuseAnimaAutocompleteState === expectedState;
+  if (activeState?.input === input && activeState.controller === expectedState.controller) {
+    hidePopup();
+  } else if (ownsCurrentState) {
+    clearAutocompletePreview(input);
+  }
+  expectedState.binding?.dispose();
+  expectedState.controller?.dispose?.();
+  expectedState.binding = null;
+  if (!ownsCurrentState) {
+    return;
+  }
+  hookedAutocompleteInputs.delete(input);
+  if (input.__easyuseAnimaAutocompleteDispose === expectedState.dispose) {
+    delete input.__easyuseAnimaAutocompleteDispose;
+  }
+  delete input.__easyuseAnimaAutocompleteState;
+  delete input.__easyuseAnimaAutocompleteHooked;
+  input.__easyuseAnimaAutocomplete = false;
+}
+
+function pruneDisconnectedAutocompleteInputs(exceptInput = null) {
+  for (const input of [...hookedAutocompleteInputs]) {
+    if (input === exceptInput) {
+      continue;
+    }
+    const state = input?.__easyuseAnimaAutocompleteState;
+    if (!state || input?.isConnected === false) {
+      disposeAutocompleteInput(input, state);
+    }
+  }
+}
+
 function syncAutocompleteInputFlags() {
+  pruneDisconnectedAutocompleteInputs();
   for (const input of [...hookedAutocompleteInputs]) {
     const state = input?.__easyuseAnimaAutocompleteState;
     if (!state) {
@@ -489,6 +546,7 @@ function hideTrainedTagTooltips() {
 }
 
 function invalidateAutocompleteDataRequests() {
+  pruneDisconnectedAutocompleteInputs();
   const states = [];
   let focusedState = null;
   for (const input of [...hookedAutocompleteInputs]) {
@@ -510,6 +568,7 @@ function invalidateAutocompleteDataRequests() {
 }
 
 function refreshActiveAutocomplete() {
+  pruneDisconnectedAutocompleteInputs();
   if (!activeState?.input || document.activeElement !== activeState.input || !autocompleteEnabledForState(activeState)) {
     hidePopup();
     return;
@@ -993,14 +1052,13 @@ function dispatchAutocompleteCanvasMouseEvent(type, sourceEvent, overrides = {})
 
 function forwardMiddlePanFromAutocompleteInput(event) {
   if (event.__easyuseAnimaForwarded || event.button !== 1 || !app.canvas?.canvas) {
-    return false;
+    return null;
   }
   event.preventDefault();
   event.stopPropagation();
-  if (middlePanForwardActive) {
-    return true;
+  if (middlePanForwardCleanup) {
+    return middlePanForwardCleanup;
   }
-  middlePanForwardActive = true;
   document.activeElement?.blur?.();
   dispatchAutocompleteCanvasPointerEvent("pointerdown", event, { button: 1, buttons: 4 });
   dispatchAutocompleteCanvasMouseEvent("mousedown", event, { button: 1, buttons: 4 });
@@ -1014,27 +1072,34 @@ function forwardMiddlePanFromAutocompleteInput(event) {
     dispatchAutocompleteCanvasPointerEvent("pointermove", moveEvent, { button: 1, buttons: 4 });
     dispatchAutocompleteCanvasMouseEvent("mousemove", moveEvent, { button: 1, buttons: 4 });
   };
-  const stop = (upEvent) => {
-    if (upEvent.__easyuseAnimaForwarded) {
+  const cleanup = (upEvent = null) => {
+    if (middlePanForwardCleanup !== cleanup) {
       return;
     }
-    upEvent.preventDefault();
-    upEvent.stopPropagation();
-    dispatchAutocompleteCanvasPointerEvent("pointerup", upEvent, { button: 1, buttons: 0 });
-    dispatchAutocompleteCanvasMouseEvent("mouseup", upEvent, { button: 1, buttons: 0 });
-    middlePanForwardActive = false;
+    const releaseEvent = upEvent || event;
+    upEvent?.preventDefault?.();
+    upEvent?.stopPropagation?.();
+    dispatchAutocompleteCanvasPointerEvent("pointerup", releaseEvent, { button: 1, buttons: 0 });
+    dispatchAutocompleteCanvasMouseEvent("mouseup", releaseEvent, { button: 1, buttons: 0 });
+    middlePanForwardCleanup = null;
     document.removeEventListener("pointermove", move, true);
     document.removeEventListener("pointerup", stop, true);
     document.removeEventListener("pointercancel", stop, true);
     document.removeEventListener("mousemove", move, true);
     document.removeEventListener("mouseup", stop, true);
   };
+  const stop = (upEvent) => {
+    if (!upEvent.__easyuseAnimaForwarded) {
+      cleanup(upEvent);
+    }
+  };
+  middlePanForwardCleanup = cleanup;
   document.addEventListener("pointermove", move, true);
   document.addEventListener("pointerup", stop, true);
   document.addEventListener("pointercancel", stop, true);
   document.addEventListener("mousemove", move, true);
   document.addEventListener("mouseup", stop, true);
-  return true;
+  return cleanup;
 }
 
 function commitSuggestion(state, entry, options = {}) {
@@ -1371,22 +1436,24 @@ function isTextEditingShortcut(event) {
 
 function hookInput(input, options = {}) {
   if (!input) {
-    return;
+    return null;
   }
-  if (input.__easyuseAnimaAutocompleteHooked) {
-    const existing = input.__easyuseAnimaAutocompleteState;
-    if (existing) {
-      existing.node = options.node || existing.node || null;
-      existing.widget = options.widget || existing.widget || null;
-      existing.scope = autocompleteScope(options);
-      existing.forceArtistOnly = !!options.forceArtistOnly;
-      existing.onCommit = typeof options.onCommit === "function" ? options.onCommit : existing.onCommit;
-      syncAutocompleteInputFlag(input, existing);
-    }
-    return;
+  pruneDisconnectedAutocompleteInputs(input);
+  const existing = input.__easyuseAnimaAutocompleteState;
+  if (existing?.owner === autocompleteInputOwner && typeof existing.dispose === "function") {
+    input.__easyuseAnimaAutocompleteHooked = true;
+    input.__easyuseAnimaAutocompleteDispose = existing.dispose;
+    existing.node = options.node || existing.node || null;
+    existing.widget = options.widget || existing.widget || null;
+    existing.scope = autocompleteScope(options);
+    existing.forceArtistOnly = !!options.forceArtistOnly;
+    existing.onCommit = typeof options.onCommit === "function" ? options.onCommit : existing.onCommit;
+    syncAutocompleteInputFlag(input, existing);
+    return existing.dispose;
   }
 
   const state = {
+    owner: autocompleteInputOwner,
     node: options.node || null,
     widget: options.widget || null,
     input,
@@ -1394,6 +1461,8 @@ function hookInput(input, options = {}) {
     forceArtistOnly: !!options.forceArtistOnly,
     onCommit: typeof options.onCommit === "function" ? options.onCommit : null,
     lastAutocompleteSignature: undefined,
+    binding: null,
+    dispose: null,
   };
 
   const markAutocompleteInactive = () => {
@@ -1479,102 +1548,34 @@ function hookInput(input, options = {}) {
   state.controller = controller;
   state.refresh = controller.updateNow;
   state.reposition = () => positionPopup(input);
-  const scheduleInputUpdate = () => {
-    const preserveController = controller.isCompositionEndUpdatePending();
-    if (activeState?.input === input) {
-      hidePopup({ preserveController });
-    }
-    controller.scheduleUpdate();
-  };
-
-  input.addEventListener("compositionstart", controller.beginComposition);
-  input.addEventListener("compositionupdate", controller.scheduleUpdate);
-  input.addEventListener("compositionend", controller.endComposition);
-  input.addEventListener("input", scheduleInputUpdate);
-  input.addEventListener("focus", controller.updateNow);
-  input.addEventListener("click", controller.scheduleCaretUpdate);
-  input.addEventListener("mousedown", controller.scheduleCaretUpdate);
-  input.addEventListener("mouseup", controller.scheduleCaretUpdate);
-  input.addEventListener("pointerup", controller.scheduleCaretUpdate);
-  input.addEventListener("pointerdown", (event) => {
-    if (forwardMiddlePanFromAutocompleteInput(event)) {
-      hidePopup();
-    }
-  }, true);
-  input.addEventListener("mousedown", (event) => {
-    if (forwardMiddlePanFromAutocompleteInput(event)) {
-      hidePopup();
-    }
-  }, true);
-  input.addEventListener("auxclick", (event) => {
-    if (event.button === 1) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  }, true);
-  input.addEventListener("keyup", (event) => {
-    if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"].includes(event.key)) {
-      controller.scheduleCaretUpdate();
-    }
-  });
-  input.addEventListener("select", controller.scheduleCaretUpdate);
-  input.addEventListener("blur", () => {
-    controller.invalidate();
-    setTimeout(() => {
-      if (activeState?.input === input) {
-        hidePopup();
+  state.binding = createAutocompleteInputBinding({
+    input,
+    state,
+    owner: autocompleteInputOwner,
+    registry: hookedAutocompleteInputs,
+    controller,
+    onBeforeDispose: (ownedInput, ownedState, ownsCurrentState) => {
+      if (activeState?.input === ownedInput && activeState.controller === ownedState.controller) {
+        hidePopup({ preserveController: true });
+        return;
       }
-    }, 120);
-  });
-  input.addEventListener("keydown", (event) => {
-    if (isTextEditingShortcut(event)) {
-      event.stopPropagation();
-    }
-  });
-  input.addEventListener("keydown", (event) => {
-    if (!controller.isComposing(event) && handleBracketPreviewKeydown(state, event)) {
-      controller.scheduleCaretUpdate();
-    }
-  });
-  input.addEventListener("keydown", (event) => {
-    if (controller.isComposing(event)) {
-      return;
-    }
-    if (event.key === "Escape") {
-      controller.invalidate();
-      if (activeState?.input === input) {
-        event.preventDefault();
-        hidePopup();
+      if (ownsCurrentState) {
+        clearAutocompletePreview(ownedInput);
       }
-      return;
-    }
-    if (!activeState || activeState.input !== input) {
-      return;
-    }
-    if (event.key === "Enter" && event.shiftKey) {
-      return;
-    }
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setActive(activeState.index + 1);
-    } else if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setActive(activeState.index - 1);
-    } else if (
-      (event.key === "Tab" && !event.shiftKey)
-      || (event.key === "Enter" && autocompleteCommitKey === "enter")
-    ) {
-      event.preventDefault();
-      commitSuggestion(activeState, activeState.results[activeState.index], {
-        suppressPopup: true,
-      });
-    }
+    },
+    getActiveState: () => activeState,
+    hidePopup,
+    isTextEditingShortcut,
+    handleBracketPreviewKeydown,
+    forwardMiddlePan: forwardMiddlePanFromAutocompleteInput,
+    setActive,
+    commitSuggestion,
+    getCommitKey: () => autocompleteCommitKey,
+    setTimer: (callback, delay) => setTimeout(callback, delay),
+    clearTimer: (handle) => clearTimeout(handle),
   });
-
-  input.__easyuseAnimaAutocompleteHooked = true;
-  input.__easyuseAnimaAutocompleteState = state;
-  hookedAutocompleteInputs.add(input);
   syncAutocompleteInputFlag(input, state);
+  return state.dispose;
 }
 
 function hookWidget(node, widget, scope = "compatible") {
@@ -1664,7 +1665,7 @@ function hookFocusedDomInput(input) {
 
 function installExternalInputHook() {
   window.easyuseAnimaHookAutocompleteInput = (input, options = {}) => {
-    hookInput(input, options);
+    return hookInput(input, options);
   };
   window.easyuseAnimaAutocompleteEntryTooltip = (entry) => autocompleteEntryTooltip(entry);
   const pending = window.__easyuseAnimaPendingAutocompleteInputs || [];


### PR DESCRIPTION
## 변경 요약

Issue #56의 Autocomplete input binding lifecycle을 별도 모듈로 분리했습니다.

- input별 18개 DOM listener의 등록 순서와 capture/bubble 계약을 보존
- blur timer, input controller, middle-button canvas pan 임시 listener를 disposer가 일괄 정리
- detached input을 registry에서 prune하고 stale state/marker 재바인딩 시 기존 listener와 controller를 복구 정리
- external input hook이 disposer를 반환하도록 해 후속 installer/global lifecycle 경계에서 teardown할 기반 마련
- 새 runtime 모듈을 Registry 정적 import closure 검증과 공식 frontend runner에 등록

v0.5.0의 suggestion popup 미표시는 PR #127에서 package-surface 누락으로 해결됐습니다. 이번 PR은 그 증상을 lifecycle 원인으로 재분류하지 않고, 현재 source의 per-input listener/disposal 유지보수 경계를 완료합니다.

Refs #56

## 주요 변경 파일

- `web/js/autocomplete/input_binding.js`: listener, timer, controller, middle-pan cleanup의 단일 소유권과 idempotent disposer
- `web/js/easyuse_anima_autocomplete.js`: input binding 조립, disconnected-input prune, stale-state 복구, disposer 반환
- `tests/frontend_autocomplete_input_binding_smoke.mjs`: listener ledger, keyboard/composition, blur timer, middle-pan, owner 교체, stale-state 회귀
- `tests/test_autocomplete_frontend.py`, `tests/test_aio_frontend.py`: 새 모듈 경계와 기존 public contract 검증
- `tests/test_registry_scanner_safety.py`: 새 module을 Registry import closure에 포함
- `tools/check_frontend.ps1`: input binding smoke를 공식 frontend runner에 직접 등록

## 유지한 동작과 변경한 동작

기존 input/keyboard/composition 이벤트 순서, popup navigation/commit, request authority, middle-button canvas pan forwarding, widget option 동기화, save/reload 및 queue 계약은 유지합니다.

input binding에는 명시적인 disposer를 추가했습니다. detached/stale input과 owner 교체 시 이전 listener, timer, controller, registry 참조를 먼저 정리해 중복 등록을 방지합니다.

## 검증

### Focused

- `node tests/frontend_autocomplete_input_binding_smoke.mjs`: 통과
- `python -m unittest tests.test_autocomplete_frontend tests.test_aio_frontend tests.test_registry_scanner_safety`: 50/50
- `git diff --check origin/dev...HEAD`: 통과
- 독립 scope/code-health 감사: blocking finding 없음

### Official full

- `tools/check_custom_node.ps1 -Project <branch-worktree> -Profile full`
  - Python unittest 405/405
  - frontend JavaScript 106파일
  - TypeScript 6.0.3
  - diff checks 통과

### Browser

ComfyUI v0.27.0 Codex test surface:

- Legacy canvas: 20개 suggestion, 키보드 이동/Tab 적용, Escape, blur, 재진입 단일 popup, save/reload 통과
- Node 2.0: 동일 popup lifecycle 및 save/reload 통과
- 두 surface 모두 512×512, batch 1, step 1 queue 성공 및 history `success/completed`
- Autocomplete fixture는 출력 노드가 없어 queue는 기존 output-capable AiO fixture로 분리 검증
- EasyUse Anima/Autocomplete 관련 신규 browser error 없음

## 남은 위험 및 후속 범위

- 이번 disposer는 per-input 경계만 소유합니다.
- `focusin`, `scroll`, `wheel`, outside pointer, `selectionchange`, `resize`, settings listener와 extension setup/prototype wrapper의 설치·재진입·정리는 Issue #56의 다음 installer/global lifecycle slice로 남습니다.
- Prompt Studio 외부 DOM owner가 반환 disposer를 node/editor teardown에 즉시 연결하는 작업도 다음 slice 범위입니다.
- Issue #98의 중첩 괄호, 가중치, artist 접두사 보존 parser/text replacement는 별도 경계입니다.
- 실제 Registry archive/package read-back은 release gate에서 전체 import closure와 함께 다시 확인합니다.
