### PR TITLE
fix: stabilize autocomplete entry lifecycle ownership

### DIFF
--- a/tests/frontend_autocomplete_entry_lifecycle_smoke.mjs
+++ b/tests/frontend_autocomplete_entry_lifecycle_smoke.mjs
@@ -68,6 +68,16 @@ const entrySource = readFileSync(
   "utf8",
 );
 assert.match(entrySource, /createAutocompleteEntryLifecycle\(\{/);
+assert.match(
+  entrySource,
+  /async init\(\)\s*{\s*autocompleteEntryLifecycle\.install\(\);\s*}/,
+  "entry lifecycle must install during init before beforeRegisterNodeDef and initial graph configuration",
+);
+assert.match(
+  entrySource,
+  /async setup\(\)\s*{\s*autocompleteEntryLifecycle\.install\(\);\s*if \(!autocompleteEntryLifecycle\.isActive\(\)\)\s*{\s*return;\s*}/,
+  "a stale setup must not refresh settings after losing entry ownership",
+);
 assert.match(entrySource, /autocompleteEntryLifecycle\.install\(\)/);
 assert.match(entrySource, /autocompleteEntryLifecycle\.installNodeTypeHooks\(nodeType, nodeData\)/);
 assert.doesNotMatch(entrySource, /document\.addEventListener\("(?:focusin|scroll|wheel|pointerdown|mousedown|selectionchange)"/);
@@ -149,6 +159,32 @@ function createRuntime(hostWindow, hostDocument, name) {
     },
   });
   return { calls, runtime, timers };
+}
+
+{
+  const hostWindow = new FakeTarget();
+  const hostDocument = new FakeTarget();
+  hostDocument.activeElement = null;
+  const stale = createRuntime(hostWindow, hostDocument, "stale");
+  const latest = createRuntime(hostWindow, hostDocument, "latest");
+  class NodeType {}
+  const nodeData = { name: "Prompt" };
+
+  assert.equal(stale.runtime.install(), false, "a stale init must not claim entry ownership");
+  assert.equal(latest.runtime.install(), true, "the newest init must claim entry ownership");
+  assert.equal(stale.runtime.installNodeTypeHooks(NodeType, nodeData), false);
+  assert.equal(latest.runtime.installNodeTypeHooks(NodeType, nodeData), true);
+  const latestWrapper = NodeType.prototype.onNodeCreated;
+
+  assert.equal(stale.runtime.install(), false, "a stale setup must not reclaim entry ownership");
+  assert.equal(latest.runtime.install(), false, "the active setup re-entry must be idempotent");
+  assert.equal(
+    NodeType.prototype.onNodeCreated,
+    latestWrapper,
+    "stale setup must not dispose the newest prototype wrapper",
+  );
+  latest.runtime.dispose();
+  assert.equal(stale.runtime.install(), false, "disposing the newest owner must not resurrect a stale owner");
 }
 
 {

--- a/tests/frontend_autocomplete_entry_lifecycle_smoke.mjs
+++ b/tests/frontend_autocomplete_entry_lifecycle_smoke.mjs
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
+}
+
+function captureOf(options) {
+  return options === true || !!options?.capture;
+}
+
+class FakeTarget {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener, options = false) {
+    const records = this.listeners.get(type) || [];
+    records.push({ listener, capture: captureOf(options) });
+    this.listeners.set(type, records);
+  }
+
+  removeEventListener(type, listener, options = false) {
+    const capture = captureOf(options);
+    const records = this.listeners.get(type) || [];
+    this.listeners.set(
+      type,
+      records.filter((record) => record.listener !== listener || record.capture !== capture),
+    );
+  }
+
+  listenerCount(type = null) {
+    if (type) {
+      return (this.listeners.get(type) || []).length;
+    }
+    return [...this.listeners.values()].reduce((total, records) => total + records.length, 0);
+  }
+
+  emit(type, values = {}) {
+    const event = { type, target: this, ...values };
+    for (const { listener } of [...(this.listeners.get(type) || [])]) {
+      listener.call(this, event);
+    }
+    return event;
+  }
+}
+
+const lifecycleModule = await import(
+  dataModule("../web/js/autocomplete/entry_lifecycle.js")
+);
+assert.deepEqual(Object.keys(lifecycleModule).sort(), [
+  "createAutocompleteEntryLifecycle",
+  "disposeExternalAutocompleteInput",
+  "disposeExternalAutocompleteInputs",
+  "registerExternalAutocompleteInput",
+]);
+
+const {
+  createAutocompleteEntryLifecycle,
+  disposeExternalAutocompleteInput,
+  disposeExternalAutocompleteInputs,
+  registerExternalAutocompleteInput,
+} = lifecycleModule;
+
+const entrySource = readFileSync(
+  new URL("../web/js/easyuse_anima_autocomplete.js", import.meta.url),
+  "utf8",
+);
+assert.match(entrySource, /createAutocompleteEntryLifecycle\(\{/);
+assert.match(entrySource, /autocompleteEntryLifecycle\.install\(\)/);
+assert.match(entrySource, /autocompleteEntryLifecycle\.installNodeTypeHooks\(nodeType, nodeData\)/);
+assert.doesNotMatch(entrySource, /document\.addEventListener\("(?:focusin|scroll|wheel|pointerdown|mousedown|selectionchange)"/);
+assert.doesNotMatch(entrySource, /window\.addEventListener\("(?:resize|easyuse-anima-settings-updated)"/);
+
+for (const relativePath of [
+  "../web/js/prompt_studio/advanced_node_ui.js",
+  "../web/js/prompt_studio/regional/field_editor.js",
+  "../web/js/prompt_studio/regional/extension.js",
+]) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  assert.match(source, /disposeExternalAutocompleteInputs\(/, `${relativePath} must dispose external inputs`);
+}
+const promptStudioNodeHooksSource = readFileSync(
+  new URL("../web/js/prompt_studio/node_hooks.js", import.meta.url),
+  "utf8",
+);
+const promptStudioRuntimeSource = readFileSync(
+  new URL("../web/js/prompt_studio/extension_runtime.js", import.meta.url),
+  "utf8",
+);
+assert.match(promptStudioNodeHooksSource, /hooks\.disposeAdvancedAutocompleteInputs\?\.\(this\)/);
+assert.match(promptStudioRuntimeSource, /disposeAdvancedAutocompleteInputs,/);
+
+function createRuntime(hostWindow, hostDocument, name) {
+  const calls = {
+    disposedInputs: 0,
+    disposedUi: 0,
+    focused: [],
+    hookedInputs: [],
+    hookedNodes: [],
+    settings: 0,
+  };
+  const timers = new Map();
+  let nextTimer = 1;
+  const runtime = createAutocompleteEntryLifecycle({
+    hostWindow,
+    hostDocument,
+    hookInput(input, options) {
+      calls.hookedInputs.push({ input, options });
+      let disposed = false;
+      return () => {
+        if (!disposed) {
+          disposed = true;
+          input.disposedBy = name;
+        }
+      };
+    },
+    hookFocusedInput(input) {
+      calls.focused.push(input);
+    },
+    entryTooltip(entry) {
+      return `${name}:${entry.tag}`;
+    },
+    handleScroll() {},
+    handleWheel() {},
+    handleOutsidePointer() {},
+    handleSelectionChange() {},
+    handleResize() {},
+    handleSettingsUpdated() {
+      calls.settings += 1;
+    },
+    hookNode(node, nodeData) {
+      calls.hookedNodes.push({ node, nodeData });
+    },
+    disposeInputs() {
+      calls.disposedInputs += 1;
+    },
+    disposeUi() {
+      calls.disposedUi += 1;
+    },
+    setTimer(callback, delay) {
+      const handle = nextTimer++;
+      timers.set(handle, { callback, delay });
+      return handle;
+    },
+    clearTimer(handle) {
+      timers.delete(handle);
+    },
+  });
+  return { calls, runtime, timers };
+}
+
+{
+  const hostWindow = new FakeTarget();
+  const hostDocument = new FakeTarget();
+  const focusedInput = { id: "focused" };
+  const pendingInput = { id: "pending" };
+  hostDocument.activeElement = focusedInput;
+  let pendingDispose = null;
+  hostWindow.__easyuseAnimaPendingAutocompleteInputs = [{
+    input: pendingInput,
+    options: { scope: "easyuse" },
+    onBound(dispose) {
+      pendingDispose = dispose;
+    },
+  }];
+
+  const first = createRuntime(hostWindow, hostDocument, "first");
+  assert.equal(first.runtime.install(), true);
+  assert.equal(hostDocument.listenerCount(), 6, "one owner must install one document listener set");
+  assert.equal(hostWindow.listenerCount(), 2, "one owner must install resize and settings listeners");
+  assert.equal(first.calls.hookedInputs.length, 1, "pending inputs must bind during install");
+  assert.equal(typeof pendingDispose, "function");
+  assert.deepEqual(first.calls.focused, [focusedInput]);
+  assert.equal(first.runtime.install(), false, "same-owner re-entry must be idempotent");
+  assert.equal(hostDocument.listenerCount(), 6);
+  assert.equal(hostWindow.listenerCount(), 2);
+
+  const externalInput = { id: "external" };
+  const externalDispose = hostWindow.easyuseAnimaHookAutocompleteInput(externalInput, { scope: "compatible" });
+  assert.equal(typeof externalDispose, "function");
+  assert.equal(hostWindow.easyuseAnimaAutocompleteEntryTooltip({ tag: "tag" }), "first:tag");
+
+  const originalCalls = [];
+  class NodeType {}
+  NodeType.prototype.onNodeCreated = function (value) {
+    originalCalls.push(["created", this, value]);
+    return `created:${value}`;
+  };
+  NodeType.prototype.onConfigure = function (value) {
+    originalCalls.push(["configured", this, value]);
+    return `configured:${value}`;
+  };
+  const originalCreated = NodeType.prototype.onNodeCreated;
+  const originalConfigure = NodeType.prototype.onConfigure;
+  const nodeData = { name: "Prompt" };
+  assert.equal(first.runtime.installNodeTypeHooks(NodeType, nodeData), true);
+  assert.equal(first.runtime.installNodeTypeHooks(NodeType, nodeData), false);
+  const node = new NodeType();
+  assert.equal(node.onNodeCreated("a"), "created:a");
+  assert.equal(node.onConfigure("b"), "configured:b");
+  assert.deepEqual(originalCalls.map((call) => [call[0], call[2]]), [
+    ["created", "a"],
+    ["configured", "b"],
+  ]);
+  assert.equal(originalCalls.every((call) => call[1] === node), true, "wrappers must preserve this");
+  assert.equal(first.calls.hookedNodes.length, 2);
+
+  class BaseNode {}
+  BaseNode.prototype.onNodeCreated = function () { return "base"; };
+  class InheritedNode extends BaseNode {}
+  assert.equal(Object.hasOwn(InheritedNode.prototype, "onNodeCreated"), false);
+  assert.equal(first.runtime.installNodeTypeHooks(InheritedNode, nodeData), true);
+  assert.equal(new InheritedNode().onNodeCreated(), "base");
+  assert.equal(Object.hasOwn(InheritedNode.prototype, "onNodeCreated"), true);
+
+  let staleTimerCalls = 0;
+  first.runtime.schedule(() => { staleTimerCalls += 1; }, 80);
+  assert.deepEqual([...first.timers.values()].map((entry) => entry.delay), [80]);
+
+  const second = createRuntime(hostWindow, hostDocument, "second");
+  assert.equal(second.runtime.install(), true, "a new owner must replace the previous owner");
+  assert.equal(first.calls.disposedInputs, 1);
+  assert.equal(first.calls.disposedUi, 1);
+  assert.equal(first.timers.size, 0, "owner replacement must cancel retry timers");
+  assert.equal(staleTimerCalls, 0);
+  assert.equal(NodeType.prototype.onNodeCreated, originalCreated, "replacement must restore old wrappers");
+  assert.equal(NodeType.prototype.onConfigure, originalConfigure);
+  assert.equal(
+    Object.hasOwn(InheritedNode.prototype, "onNodeCreated"),
+    false,
+    "teardown must restore an inherited hook without leaving an own property",
+  );
+  assert.equal(hostDocument.listenerCount(), 6, "replacement must leave one document listener set");
+  assert.equal(hostWindow.listenerCount(), 2, "replacement must leave one window listener set");
+  assert.equal(hostWindow.easyuseAnimaAutocompleteEntryTooltip({ tag: "tag" }), "second:tag");
+  hostWindow.emit("easyuse-anima-settings-updated");
+  assert.equal(first.calls.settings, 0);
+  assert.equal(second.calls.settings, 1, "only the current owner may receive settings events");
+
+  assert.equal(second.runtime.installNodeTypeHooks(NodeType, nodeData), true);
+  assert.equal(second.runtime.installNodeTypeHooks(InheritedNode, nodeData), true);
+  const secondWrapper = NodeType.prototype.onNodeCreated;
+  first.runtime.dispose();
+  assert.equal(NodeType.prototype.onNodeCreated, secondWrapper, "a stale disposer must not clear the new wrapper");
+  assert.equal(hostDocument.listenerCount(), 6);
+  assert.equal(hostWindow.listenerCount(), 2);
+
+  second.runtime.dispose();
+  second.runtime.dispose();
+  assert.equal(hostDocument.listenerCount(), 0);
+  assert.equal(hostWindow.listenerCount(), 0);
+  assert.equal(NodeType.prototype.onNodeCreated, originalCreated);
+  assert.equal(NodeType.prototype.onConfigure, originalConfigure);
+  assert.equal(Object.hasOwn(InheritedNode.prototype, "onNodeCreated"), false);
+  assert.equal(hostWindow.easyuseAnimaHookAutocompleteInput, undefined);
+  assert.equal(hostWindow.easyuseAnimaAutocompleteEntryTooltip, undefined);
+  assert.equal(second.calls.disposedInputs, 1, "teardown must be idempotent");
+  assert.equal(second.calls.disposedUi, 1);
+  externalDispose();
+  pendingDispose();
+}
+
+{
+  const hostWindow = {};
+  const pendingInput = {};
+  const pendingDispose = registerExternalAutocompleteInput(hostWindow, pendingInput, { node: 1 });
+  assert.equal(hostWindow.__easyuseAnimaPendingAutocompleteInputs.length, 1);
+  pendingDispose();
+  assert.equal(hostWindow.__easyuseAnimaPendingAutocompleteInputs.length, 0, "pending disposal must remove its queue entry");
+
+  let oldDisposed = 0;
+  let oldDone = false;
+  const boundInput = {};
+  hostWindow.easyuseAnimaHookAutocompleteInput = (input) => {
+    const dispose = () => {
+      if (!oldDone) {
+        oldDone = true;
+        oldDisposed += 1;
+      }
+    };
+    input.__easyuseAnimaAutocompleteDispose = dispose;
+    return dispose;
+  };
+  const callSiteDispose = registerExternalAutocompleteInput(hostWindow, boundInput, {});
+  assert.equal(typeof callSiteDispose, "function");
+  let replacementDisposed = 0;
+  boundInput.__easyuseAnimaAutocompleteDispose = () => { replacementDisposed += 1; };
+  callSiteDispose();
+  assert.equal(oldDisposed, 1, "the call site must release its originally bound owner");
+  assert.equal(replacementDisposed, 1, "the call site must also release a replacement entry binding");
+  assert.equal(boundInput.__easyuseAnimaExternalAutocompleteDispose, undefined);
+
+  const first = {};
+  const second = {};
+  let firstDisposed = 0;
+  let secondDisposed = 0;
+  first.__easyuseAnimaAutocompleteDispose = () => { firstDisposed += 1; };
+  second.__easyuseAnimaAutocompleteDispose = () => { secondDisposed += 1; };
+  disposeExternalAutocompleteInputs(hostWindow, {
+    querySelectorAll() {
+      return [first, second];
+    },
+  });
+  assert.equal(firstDisposed, 1);
+  assert.equal(secondDisposed, 1);
+  disposeExternalAutocompleteInput(hostWindow, null);
+}
+
+console.log("Autocomplete entry lifecycle smoke passed.");

--- a/tests/frontend_regional_runtime_smoke.mjs
+++ b/tests/frontend_regional_runtime_smoke.mjs
@@ -53,6 +53,9 @@ const serializationUrl = dataModule("../web/js/prompt_studio/regional/serializat
   "./schema.js": schemaUrl,
 });
 const queueSeedBridgeUrl = dataModule("../web/js/prompt_studio/queue_seed_bridge.js");
+const autocompleteEntryLifecycleUrl = dataModule(
+  "../web/js/autocomplete/entry_lifecycle.js",
+);
 const lifecycleUrl = dataModule("../web/js/prompt_studio/regional/lifecycle.js");
 const layoutUrl = dataModule("../web/js/prompt_studio/regional/layout.js", {
   "./lifecycle.js": lifecycleUrl,
@@ -62,6 +65,7 @@ const extensionUrl = dataModule("../web/js/prompt_studio/regional/extension.js",
   "./lifecycle.js": lifecycleUrl,
   "./layout.js": layoutUrl,
   "../queue_seed_bridge.js": queueSeedBridgeUrl,
+  "../../autocomplete/entry_lifecycle.js": autocompleteEntryLifecycleUrl,
 });
 const regionalRuntimeUrl = dataModule("../web/js/prompt_studio/regional/runtime.js", {
   "./constants.js": constantsUrl,
@@ -75,6 +79,7 @@ const fieldEditorUrl = dataModule("../web/js/prompt_studio/regional/field_editor
   "./schema.js": schemaUrl,
   "./lifecycle.js": lifecycleUrl,
   "../wildcard_seed_contract.js": wildcardSeedContractUrl,
+  "../../autocomplete/entry_lifecycle.js": autocompleteEntryLifecycleUrl,
 });
 
 const lifecycle = await import(lifecycleUrl);

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -53,6 +53,9 @@ AUTOCOMPLETE_INPUT_CONTROLLER_JS = (
 AUTOCOMPLETE_INPUT_BINDING_JS = (
     ROOT / "web" / "js" / "autocomplete" / "input_binding.js"
 )
+AUTOCOMPLETE_ENTRY_LIFECYCLE_JS = (
+    ROOT / "web" / "js" / "autocomplete" / "entry_lifecycle.js"
+)
 AUTOCOMPLETE_TEXT_MODEL_JS = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -1022,15 +1025,28 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("resetActiveAutocompleteMenu(ensurePopup());", update_body)
 
         start = source.index("function handleOutsideAutocompletePointer")
-        end = source.index("\ndocument.addEventListener(\"pointerdown\"", start)
+        end = source.index("\nfunction handleAutocompleteSettingsUpdated", start)
         pointer_body = source[start:end]
 
         self.assertIn("popup?.contains(event.target)", pointer_body)
         self.assertIn("event.target === input", pointer_body)
         self.assertIn("markAutocompleteInputInactive(input);", pointer_body)
         self.assertIn("hidePopup();", pointer_body)
-        self.assertIn('document.addEventListener("pointerdown", handleOutsideAutocompletePointer, true);', source)
-        self.assertIn('document.addEventListener("mousedown", handleOutsideAutocompletePointer, true);', source)
+        self.assertIn(
+            "handleOutsidePointer: handleOutsideAutocompletePointer",
+            source,
+        )
+        lifecycle_source = AUTOCOMPLETE_ENTRY_LIFECYCLE_JS.read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            'listen(hostDocument, "pointerdown", handleOutsidePointer, true);',
+            lifecycle_source,
+        )
+        self.assertIn(
+            'listen(hostDocument, "mousedown", handleOutsidePointer, true);',
+            lifecycle_source,
+        )
 
     def test_autocomplete_wildcards_accept_empty_and_unicode_queries(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
@@ -1131,7 +1147,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
     def test_autocomplete_hooks_focused_nodes_v2_dom_inputs(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
         start = source.index("function hookFocusedDomInput")
-        end = source.index("\nfunction installExternalInputHook", start)
+        end = source.index("\nfunction handleAutocompleteScroll", start)
         focus_body = source[start:end]
 
         self.assertIn("isAutocompleteDomInput(input)", focus_body)
@@ -1140,8 +1156,15 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("const targets = nodeData ? targetWidgets(nodeData) : null;", focus_body)
         self.assertIn("const widget = widgetForDomInput(node, input);", focus_body)
         self.assertIn("hookInput(input", focus_body)
-        self.assertIn('document.addEventListener("focusin"', source)
-        self.assertIn("hookFocusedDomInput(document.activeElement);", source)
+        self.assertIn("hookFocusedInput: hookFocusedDomInput", source)
+        lifecycle_source = AUTOCOMPLETE_ENTRY_LIFECYCLE_JS.read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            'listen(hostDocument, "focusin", focusHook, true);',
+            lifecycle_source,
+        )
+        self.assertIn("hookFocusedInput(hostDocument.activeElement);", lifecycle_source)
         self.assertNotIn("easyuseAnimaDebugAutocomplete", source)
 
     def test_prompt_highlight_wildcards_accept_unicode_keys(self):

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -191,10 +191,10 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
         )
 
         settings_start = entry_source.index(
-            'window.addEventListener("easyuse-anima-settings-updated"'
+            "function handleAutocompleteSettingsUpdated"
         )
         settings_end = entry_source.index(
-            "\n\napp.registerExtension({", settings_start
+            "\nfunction disposeAutocompleteEntryInputs", settings_start
         )
         settings_body = entry_source[settings_start:settings_end]
         self.assertIn("let dataRequestsInvalidated = false;", settings_body)
@@ -535,7 +535,8 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
             2,
         )
         self.assertIn("app.registerExtension({", entry_source)
-        self.assertIn('document.addEventListener("pointerdown"', entry_source)
+        self.assertIn("createAutocompleteEntryLifecycle({", entry_source)
+        self.assertIn("handleOutsidePointer: handleOutsideAutocompletePointer", entry_source)
         self.assertIn("function hookInput(", entry_source)
 
     def test_data_adapter_is_in_static_and_semantic_runners(self):
@@ -707,7 +708,8 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
 
         self.assertEqual(source.count("planAutocompleteInsertion("), 2)
         self.assertIn("app.registerExtension({", source)
-        self.assertIn('document.addEventListener("pointerdown"', source)
+        self.assertIn("createAutocompleteEntryLifecycle({", source)
+        self.assertIn("handleOutsidePointer: handleOutsideAutocompletePointer", source)
         self.assertIn("function hookInput(", source)
 
     def test_text_model_is_in_static_and_semantic_runners(self):

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -28,6 +28,12 @@ AUTOCOMPLETE_INPUT_BINDING = (
 AUTOCOMPLETE_INPUT_BINDING_SMOKE = (
     ROOT / "tests" / "frontend_autocomplete_input_binding_smoke.mjs"
 )
+AUTOCOMPLETE_ENTRY_LIFECYCLE = (
+    ROOT / "web" / "js" / "autocomplete" / "entry_lifecycle.js"
+)
+AUTOCOMPLETE_ENTRY_LIFECYCLE_SMOKE = (
+    ROOT / "tests" / "frontend_autocomplete_entry_lifecycle_smoke.mjs"
+)
 AUTOCOMPLETE_TEXT_MODEL = (
     ROOT / "web" / "js" / "autocomplete" / "text_model.js"
 )
@@ -271,6 +277,15 @@ class AutocompleteFrontendBoundaryTests(unittest.TestCase):
 
         if completed.returncode != 0:
             self.fail((completed.stdout + completed.stderr).strip())
+
+    def test_entry_lifecycle_is_in_semantic_runner(self):
+        self.assertTrue(AUTOCOMPLETE_ENTRY_LIFECYCLE.is_file())
+        self.assertTrue(AUTOCOMPLETE_ENTRY_LIFECYCLE_SMOKE.is_file())
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn(
+            r'node "tests\frontend_autocomplete_entry_lifecycle_smoke.mjs"',
+            frontend_check_source,
+        )
 
     def test_input_binding_has_exact_listener_lifecycle_boundary(self):
         module_source = AUTOCOMPLETE_INPUT_BINDING.read_text(encoding="utf-8")

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -204,6 +204,11 @@ try {
         throw "Frontend autocomplete input binding smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_autocomplete_entry_lifecycle_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend autocomplete entry lifecycle smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_popup_geometry_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete popup geometry smoke failed with exit code $LASTEXITCODE."

--- a/web/js/autocomplete/entry_lifecycle.js
+++ b/web/js/autocomplete/entry_lifecycle.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const AUTOCOMPLETE_ENTRY_OWNER = "__easyuseAnimaAutocompleteEntryOwner";
+const AUTOCOMPLETE_ENTRY_GENERATION = "__easyuseAnimaAutocompleteEntryGeneration";
 const EXTERNAL_AUTOCOMPLETE_DISPOSE = "__easyuseAnimaExternalAutocompleteDispose";
 
 /**
@@ -138,6 +139,8 @@ export function createAutocompleteEntryLifecycle(dependencies) {
   const listeners = [];
   const timers = new Set();
   const wrappers = new Map();
+  const generation = (Number(hostWindow[AUTOCOMPLETE_ENTRY_GENERATION]) || 0) + 1;
+  hostWindow[AUTOCOMPLETE_ENTRY_GENERATION] = generation;
   let installed = false;
 
   const externalHook = (input, options = {}) => hookInput(input, options);
@@ -154,6 +157,9 @@ export function createAutocompleteEntryLifecycle(dependencies) {
   }
 
   function install() {
+    if (hostWindow[AUTOCOMPLETE_ENTRY_GENERATION] !== generation) {
+      return false;
+    }
     if (isActive()) {
       return false;
     }

--- a/web/js/autocomplete/entry_lifecycle.js
+++ b/web/js/autocomplete/entry_lifecycle.js
@@ -1,0 +1,292 @@
+// @ts-check
+
+const AUTOCOMPLETE_ENTRY_OWNER = "__easyuseAnimaAutocompleteEntryOwner";
+const EXTERNAL_AUTOCOMPLETE_DISPOSE = "__easyuseAnimaExternalAutocompleteDispose";
+
+/**
+ * Register a Prompt Studio or other externally-created DOM input with the
+ * autocomplete entry. The call site keeps one stable disposer even when the
+ * entry is installed after the input or replaced by a newer entry owner.
+ *
+ * @param {any} hostWindow
+ * @param {any} input
+ * @param {any} [options]
+ * @returns {null | (() => void)}
+ */
+export function registerExternalAutocompleteInput(hostWindow, input, options = {}) {
+  if (!input) {
+    return null;
+  }
+  disposeExternalAutocompleteInput(hostWindow, input);
+
+  let disposed = false;
+  let boundDispose = null;
+  const pendingEntry = {
+    input,
+    options,
+    onBound(dispose) {
+      if (disposed) {
+        dispose?.();
+        return;
+      }
+      boundDispose = typeof dispose === "function" ? dispose : null;
+    },
+  };
+
+  const dispose = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    const pending = hostWindow.__easyuseAnimaPendingAutocompleteInputs;
+    if (Array.isArray(pending)) {
+      hostWindow.__easyuseAnimaPendingAutocompleteInputs = pending.filter(
+        (entry) => entry !== pendingEntry,
+      );
+    }
+    const currentDispose = input.__easyuseAnimaAutocompleteDispose;
+    const ownedDispose = boundDispose;
+    ownedDispose?.();
+    boundDispose = null;
+    if (typeof currentDispose === "function" && currentDispose !== ownedDispose) {
+      currentDispose();
+    }
+    if (input[EXTERNAL_AUTOCOMPLETE_DISPOSE] === dispose) {
+      delete input[EXTERNAL_AUTOCOMPLETE_DISPOSE];
+    }
+  };
+
+  input[EXTERNAL_AUTOCOMPLETE_DISPOSE] = dispose;
+  if (typeof hostWindow.easyuseAnimaHookAutocompleteInput === "function") {
+    pendingEntry.onBound(hostWindow.easyuseAnimaHookAutocompleteInput(input, options));
+  } else {
+    hostWindow.__easyuseAnimaPendingAutocompleteInputs ||= [];
+    hostWindow.__easyuseAnimaPendingAutocompleteInputs.push(pendingEntry);
+  }
+  return dispose;
+}
+
+/** @param {any} hostWindow @param {any} input */
+export function disposeExternalAutocompleteInput(hostWindow, input) {
+  if (!input) {
+    return;
+  }
+  const dispose = input[EXTERNAL_AUTOCOMPLETE_DISPOSE];
+  if (typeof dispose === "function") {
+    dispose();
+    return;
+  }
+  const pending = hostWindow?.__easyuseAnimaPendingAutocompleteInputs;
+  if (Array.isArray(pending)) {
+    hostWindow.__easyuseAnimaPendingAutocompleteInputs = pending.filter(
+      (entry) => entry?.input !== input,
+    );
+  }
+  input.__easyuseAnimaAutocompleteDispose?.();
+}
+
+/** @param {any} hostWindow @param {any} container */
+export function disposeExternalAutocompleteInputs(hostWindow, container) {
+  for (const input of container?.querySelectorAll?.("textarea, input") || []) {
+    disposeExternalAutocompleteInput(hostWindow, input);
+  }
+}
+
+/**
+ * Owns the Autocomplete entry's process-wide hooks. Installation is
+ * idempotent for one owner; a newer owner disposes the previous listener,
+ * timer, input, and prototype-wrapper closure before taking authority.
+ *
+ * @param {{
+ *   hostWindow: any,
+ *   hostDocument: any,
+ *   hookInput: (input: any, options?: any) => any,
+ *   hookFocusedInput: (input: any) => void,
+ *   entryTooltip: (entry: any) => any,
+ *   handleScroll: (event: any) => void,
+ *   handleWheel: (event: any) => void,
+ *   handleOutsidePointer: (event: any) => void,
+ *   handleSelectionChange: (event: any) => void,
+ *   handleResize: (event: any) => void,
+ *   handleSettingsUpdated: (event: any) => void,
+ *   hookNode: (node: any, nodeData: any) => void,
+ *   disposeInputs: () => void,
+ *   disposeUi: () => void,
+ *   setTimer?: (callback: () => void, delay: number) => any,
+ *   clearTimer?: (handle: any) => void,
+ * }} dependencies
+ */
+export function createAutocompleteEntryLifecycle(dependencies) {
+  const {
+    hostWindow,
+    hostDocument,
+    hookInput,
+    hookFocusedInput,
+    entryTooltip,
+    handleScroll,
+    handleWheel,
+    handleOutsidePointer,
+    handleSelectionChange,
+    handleResize,
+    handleSettingsUpdated,
+    hookNode,
+    disposeInputs,
+    disposeUi,
+    setTimer = (callback, delay) => setTimeout(callback, delay),
+    clearTimer = (handle) => clearTimeout(handle),
+  } = dependencies;
+  const listeners = [];
+  const timers = new Set();
+  const wrappers = new Map();
+  let installed = false;
+
+  const externalHook = (input, options = {}) => hookInput(input, options);
+  const tooltipHook = (entry) => entryTooltip(entry);
+  const focusHook = (event) => hookFocusedInput(event?.target);
+
+  function listen(target, type, listener, options = false) {
+    target.addEventListener(type, listener, options);
+    listeners.push([target, type, listener, options]);
+  }
+
+  function isActive() {
+    return installed && hostWindow[AUTOCOMPLETE_ENTRY_OWNER] === lifecycle;
+  }
+
+  function install() {
+    if (isActive()) {
+      return false;
+    }
+    const previousOwner = hostWindow[AUTOCOMPLETE_ENTRY_OWNER];
+    if (previousOwner && previousOwner !== lifecycle) {
+      previousOwner.dispose?.();
+    }
+    installed = true;
+    hostWindow[AUTOCOMPLETE_ENTRY_OWNER] = lifecycle;
+    hostWindow.__easyuseAnimaPendingAutocompleteInputs ||= [];
+    hostWindow.easyuseAnimaHookAutocompleteInput = externalHook;
+    hostWindow.easyuseAnimaAutocompleteEntryTooltip = tooltipHook;
+
+    listen(hostDocument, "focusin", focusHook, true);
+    listen(hostDocument, "scroll", handleScroll, true);
+    listen(hostDocument, "wheel", handleWheel, true);
+    listen(hostDocument, "pointerdown", handleOutsidePointer, true);
+    listen(hostDocument, "mousedown", handleOutsidePointer, true);
+    listen(hostDocument, "selectionchange", handleSelectionChange);
+    listen(hostWindow, "resize", handleResize);
+    listen(hostWindow, "easyuse-anima-settings-updated", handleSettingsUpdated);
+
+    const pending = hostWindow.__easyuseAnimaPendingAutocompleteInputs || [];
+    hostWindow.__easyuseAnimaPendingAutocompleteInputs = [];
+    for (const item of pending) {
+      const dispose = hookInput(item?.input, item?.options || {});
+      item?.onBound?.(dispose);
+    }
+    hookFocusedInput(hostDocument.activeElement);
+    return true;
+  }
+
+  function schedule(callback, delay) {
+    if (!isActive()) {
+      return null;
+    }
+    let handle = null;
+    handle = setTimer(() => {
+      timers.delete(handle);
+      if (isActive()) {
+        callback();
+      }
+    }, delay);
+    timers.add(handle);
+    return handle;
+  }
+
+  function installNodeTypeHooks(nodeType, nodeData) {
+    if (!isActive() || !nodeType?.prototype || wrappers.has(nodeType)) {
+      return false;
+    }
+    const prototype = nodeType.prototype;
+    const hadOwnCreated = Object.prototype.hasOwnProperty.call(prototype, "onNodeCreated");
+    const hadOwnConfigure = Object.prototype.hasOwnProperty.call(prototype, "onConfigure");
+    const originalCreated = prototype.onNodeCreated;
+    const originalConfigure = prototype.onConfigure;
+    const wrappedCreated = function (...args) {
+      const result = originalCreated?.apply(this, args);
+      if (isActive()) {
+        hookNode(this, nodeData);
+      }
+      return result;
+    };
+    const wrappedConfigure = function (...args) {
+      const result = originalConfigure?.apply(this, args);
+      if (isActive()) {
+        hookNode(this, nodeData);
+      }
+      return result;
+    };
+    prototype.onNodeCreated = wrappedCreated;
+    prototype.onConfigure = wrappedConfigure;
+    wrappers.set(nodeType, {
+      prototype,
+      hadOwnCreated,
+      hadOwnConfigure,
+      originalCreated,
+      originalConfigure,
+      wrappedCreated,
+      wrappedConfigure,
+    });
+    return true;
+  }
+
+  function dispose() {
+    if (!installed) {
+      return;
+    }
+    installed = false;
+    for (const handle of timers) {
+      clearTimer(handle);
+    }
+    timers.clear();
+    for (const [target, type, listener, options] of listeners) {
+      target.removeEventListener(type, listener, options);
+    }
+    listeners.length = 0;
+    for (const record of wrappers.values()) {
+      if (record.prototype.onNodeCreated === record.wrappedCreated) {
+        if (record.hadOwnCreated) {
+          record.prototype.onNodeCreated = record.originalCreated;
+        } else {
+          delete record.prototype.onNodeCreated;
+        }
+      }
+      if (record.prototype.onConfigure === record.wrappedConfigure) {
+        if (record.hadOwnConfigure) {
+          record.prototype.onConfigure = record.originalConfigure;
+        } else {
+          delete record.prototype.onConfigure;
+        }
+      }
+    }
+    wrappers.clear();
+    disposeInputs();
+    disposeUi();
+    if (hostWindow.easyuseAnimaHookAutocompleteInput === externalHook) {
+      delete hostWindow.easyuseAnimaHookAutocompleteInput;
+    }
+    if (hostWindow.easyuseAnimaAutocompleteEntryTooltip === tooltipHook) {
+      delete hostWindow.easyuseAnimaAutocompleteEntryTooltip;
+    }
+    if (hostWindow[AUTOCOMPLETE_ENTRY_OWNER] === lifecycle) {
+      delete hostWindow[AUTOCOMPLETE_ENTRY_OWNER];
+    }
+  }
+
+  const lifecycle = {
+    dispose,
+    install,
+    installNodeTypeHooks,
+    isActive,
+    schedule,
+  };
+  return lifecycle;
+}

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -1807,8 +1807,14 @@ autocompleteEntryLifecycle = createAutocompleteEntryLifecycle({
 
 app.registerExtension({
   name: "easyuse-anima.autocomplete",
+  async init() {
+    autocompleteEntryLifecycle.install();
+  },
   async setup() {
     autocompleteEntryLifecycle.install();
+    if (!autocompleteEntryLifecycle.isActive()) {
+      return;
+    }
     await refreshAutocompleteSettings();
   },
   async beforeRegisterNodeDef(nodeType, nodeData) {

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -11,6 +11,7 @@ import {
   invalidateAutocompleteControllerStates,
 } from "./autocomplete/input_controller.js";
 import { createAutocompleteInputBinding } from "./autocomplete/input_binding.js";
+import { createAutocompleteEntryLifecycle } from "./autocomplete/entry_lifecycle.js";
 import {
   calculateAutocompletePopupGeometry,
   calculateCaretMirrorGeometry,
@@ -188,7 +189,7 @@ let activeRefreshFrame = null;
 let middlePanForwardCleanup = null;
 const autocompleteInputOwner = {};
 const hookedAutocompleteInputs = new Set();
-window.__easyuseAnimaPendingAutocompleteInputs ||= [];
+let autocompleteEntryLifecycle = null;
 
 const autocompleteData = createAutocompleteDataAdapter({
   fetchJson: easyuseAnimaFetchJson,
@@ -1663,23 +1664,24 @@ function hookFocusedDomInput(input) {
   });
 }
 
-function installExternalInputHook() {
-  window.easyuseAnimaHookAutocompleteInput = (input, options = {}) => {
-    return hookInput(input, options);
-  };
-  window.easyuseAnimaAutocompleteEntryTooltip = (entry) => autocompleteEntryTooltip(entry);
-  const pending = window.__easyuseAnimaPendingAutocompleteInputs || [];
-  window.__easyuseAnimaPendingAutocompleteInputs = [];
-  for (const item of pending) {
-    hookInput(item?.input, item?.options || {});
+function handleAutocompleteScroll(event) {
+  if (popup?.contains(event.target)) {
+    return;
   }
-  document.addEventListener("focusin", (event) => {
-    hookFocusedDomInput(event.target);
-  }, true);
-  hookFocusedDomInput(document.activeElement);
+  scheduleActiveRefresh();
+}
+
+function handleAutocompleteWheel(event) {
+  if (popup?.contains(event.target)) {
+    return;
+  }
+  scheduleActiveRefresh();
 }
 
 function hookNode(node, nodeData, attempt = 0) {
+  if (!autocompleteEntryLifecycle?.isActive()) {
+    return;
+  }
   const names = targetWidgets(nodeData);
   if (!names || (!hasExplicitTargets(nodeData) && shouldSkipNode(node, nodeData))) {
     return;
@@ -1696,22 +1698,10 @@ function hookNode(node, nodeData, attempt = 0) {
     }
   }
   if (pendingInput && attempt < 12) {
-    setTimeout(() => hookNode(node, nodeData, attempt + 1), 80);
+    autocompleteEntryLifecycle.schedule(() => hookNode(node, nodeData, attempt + 1), 80);
   }
 }
 
-document.addEventListener("scroll", (event) => {
-  if (popup?.contains(event.target)) {
-    return;
-  }
-  scheduleActiveRefresh();
-}, true);
-document.addEventListener("wheel", (event) => {
-  if (popup?.contains(event.target)) {
-    return;
-  }
-  scheduleActiveRefresh();
-}, true);
 function handleOutsideAutocompletePointer(event) {
   if (!activeState || popup?.contains(event.target)) {
     return;
@@ -1724,11 +1714,7 @@ function handleOutsideAutocompletePointer(event) {
   hidePopup();
 }
 
-document.addEventListener("pointerdown", handleOutsideAutocompletePointer, true);
-document.addEventListener("mousedown", handleOutsideAutocompletePointer, true);
-document.addEventListener("selectionchange", scheduleActiveRefresh);
-window.addEventListener("resize", scheduleActiveRefresh);
-window.addEventListener("easyuse-anima-settings-updated", (event) => {
+function handleAutocompleteSettingsUpdated(event) {
   const detail = event?.detail || {};
   let dataRequestsInvalidated = false;
   if ("autocomplete.mode" in detail) {
@@ -1780,12 +1766,49 @@ window.addEventListener("easyuse-anima-settings-updated", (event) => {
   } else {
     scheduleActiveRefresh();
   }
+}
+
+function disposeAutocompleteEntryInputs() {
+  for (const input of [...hookedAutocompleteInputs]) {
+    disposeAutocompleteInput(input);
+  }
+  hookedAutocompleteInputs.clear();
+}
+
+function disposeAutocompleteEntryUi() {
+  if (activeRefreshFrame != null) {
+    cancelAnimationFrame(activeRefreshFrame);
+    activeRefreshFrame = null;
+  }
+  middlePanForwardCleanup?.();
+  middlePanForwardCleanup = null;
+  hidePopup();
+  popup?.remove?.();
+  popup = null;
+  document.getElementById("easyuse-anima-autocomplete-style")?.remove?.();
+}
+
+autocompleteEntryLifecycle = createAutocompleteEntryLifecycle({
+  hostWindow: window,
+  hostDocument: document,
+  hookInput,
+  hookFocusedInput: hookFocusedDomInput,
+  entryTooltip: autocompleteEntryTooltip,
+  handleScroll: handleAutocompleteScroll,
+  handleWheel: handleAutocompleteWheel,
+  handleOutsidePointer: handleOutsideAutocompletePointer,
+  handleSelectionChange: scheduleActiveRefresh,
+  handleResize: scheduleActiveRefresh,
+  handleSettingsUpdated: handleAutocompleteSettingsUpdated,
+  hookNode: (node, nodeData) => hookNode(node, nodeData),
+  disposeInputs: disposeAutocompleteEntryInputs,
+  disposeUi: disposeAutocompleteEntryUi,
 });
 
 app.registerExtension({
   name: "easyuse-anima.autocomplete",
   async setup() {
-    installExternalInputHook();
+    autocompleteEntryLifecycle.install();
     await refreshAutocompleteSettings();
   },
   async beforeRegisterNodeDef(nodeType, nodeData) {
@@ -1793,16 +1816,6 @@ app.registerExtension({
       return;
     }
 
-    const onNodeCreated = nodeType.prototype.onNodeCreated;
-    nodeType.prototype.onNodeCreated = function () {
-      onNodeCreated?.apply(this, arguments);
-      hookNode(this, nodeData);
-    };
-
-    const onConfigure = nodeType.prototype.onConfigure;
-    nodeType.prototype.onConfigure = function () {
-      onConfigure?.apply(this, arguments);
-      hookNode(this, nodeData);
-    };
+    autocompleteEntryLifecycle.installNodeTypeHooks(nodeType, nodeData);
   },
 });

--- a/web/js/prompt_studio/advanced_highlights.js
+++ b/web/js/prompt_studio/advanced_highlights.js
@@ -19,6 +19,7 @@ import {
   getAdvancedEditorElement,
   getAdvancedFields,
 } from "./state.js";
+import { registerExternalAutocompleteInput } from "../autocomplete/entry_lifecycle.js";
 
 /** @typedef {import("./types.js").PromptStudioAdvancedTextarea} PromptStudioAdvancedTextarea */
 /** @typedef {import("./types.js").PromptStudioWindow} PromptStudioWindow */
@@ -124,12 +125,7 @@ function registerAdvancedAutocompleteInput(node, field, textarea) {
     forceArtistOnly: field?.type === "artist",
   };
   const hostWindow = promptStudioWindow();
-  if (typeof hostWindow.easyuseAnimaHookAutocompleteInput === "function") {
-    hostWindow.easyuseAnimaHookAutocompleteInput(textarea, options);
-    return;
-  }
-  hostWindow.__easyuseAnimaPendingAutocompleteInputs ||= [];
-  hostWindow.__easyuseAnimaPendingAutocompleteInputs.push({ input: textarea, options });
+  registerExternalAutocompleteInput(hostWindow, textarea, options);
 }
 
 function refreshAdvancedHighlights(node, { classify = true, forceCopyMetrics = false } = {}) {

--- a/web/js/prompt_studio/advanced_node_ui.js
+++ b/web/js/prompt_studio/advanced_node_ui.js
@@ -42,6 +42,7 @@ import {
 import {
   guardAdvancedEditorNativeControlEvent,
 } from "./wheel.js";
+import { disposeExternalAutocompleteInputs } from "../autocomplete/entry_lifecycle.js";
 
 function advancedControlHooks(hooks = {}) {
   return {
@@ -64,6 +65,10 @@ function advancedFieldsUiHooks(hooks = {}) {
   };
 }
 
+function disposeAdvancedAutocompleteInputs(node) {
+  disposeExternalAutocompleteInputs(window, getAdvancedEditorElement(node));
+}
+
 function renderAdvancedEditor(node, hooks = {}) {
   const {
     scheduleAdvancedLayout = () => {},
@@ -75,6 +80,7 @@ function renderAdvancedEditor(node, hooks = {}) {
   }
   const fields = setAdvancedFields(node, parseAdvancedFields(node));
   applyAdvancedNaiaGeneralAutoToggle(fields);
+  disposeAdvancedAutocompleteInputs(node);
   editor.innerHTML = "";
   updateAdvancedEditorWidth(node);
   const panes = document.createElement("div");
@@ -144,6 +150,7 @@ function scheduleHookAdvancedNode(node, hooks = {}) {
 }
 
 export {
+  disposeAdvancedAutocompleteInputs,
   hookAdvancedNode,
   renderAdvancedEditor,
   scheduleHookAdvancedNode,

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -96,6 +96,7 @@ import {
   remeasureAdvancedTextareaHeightsForWidth as remeasureAdvancedTextareaHeightsForWidthWithHooks,
 } from "./advanced_fields_ui.js";
 import {
+  disposeAdvancedAutocompleteInputs,
   renderAdvancedEditor as renderAdvancedEditorWithHooks,
   scheduleHookAdvancedNode as scheduleHookAdvancedNodeWithHooks,
 } from "./advanced_node_ui.js";
@@ -507,6 +508,7 @@ function createPromptStudioExtensionRuntime(app, api = null) {
           captureAdvancedConfigure(node, serialized, advancedWidget(node))
         ),
         disconnectAdvancedEditorWidthObserver,
+        disposeAdvancedAutocompleteInputs,
         detachAdvancedQueueSeedNode: advancedQueueSeedRuntime.detachNode,
         hookWildcardSeedWidget,
         hookStudioNode,

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -120,6 +120,11 @@ function registerPromptStudioNodeHooks(nodeType, nodeData, hooks) {
         // Cleanup failures must not replace the node's original lifecycle result.
       }
       try {
+        hooks.disposeAdvancedAutocompleteInputs?.(this);
+      } catch {
+        // Autocomplete cleanup remains isolated from other node removal handlers.
+      }
+      try {
         hooks.detachAdvancedQueueSeedNode?.(this);
       } catch {
         // State cleanup remains isolated from other node removal handlers.

--- a/web/js/prompt_studio/regional/editor_adapter.js
+++ b/web/js/prompt_studio/regional/editor_adapter.js
@@ -9,6 +9,7 @@ import {
   syncOverlayBounds,
 } from "../highlight_overlay_core.js";
 import { PROMPT_STUDIO_VARIANT_FIELD_LABELS } from "./constants.js";
+import { registerExternalAutocompleteInput } from "../../autocomplete/entry_lifecycle.js";
 
 /** @typedef {import("../types.js").PromptStudioInputElement} PromptStudioInputElement */
 /** @typedef {import("../types.js").PromptStudioWindow} PromptStudioWindow */
@@ -1322,12 +1323,7 @@ function registerPromptStudioAutocompleteInput(node, field, textarea) {
     forceArtistOnly: field?.type === "artist",
   };
   const hostWindow = promptStudioWindow();
-  if (typeof hostWindow.easyuseAnimaHookAutocompleteInput === "function") {
-    hostWindow.easyuseAnimaHookAutocompleteInput(textarea, options);
-    return;
-  }
-  hostWindow.__easyuseAnimaPendingAutocompleteInputs ||= [];
-  hostWindow.__easyuseAnimaPendingAutocompleteInputs.push({ input: textarea, options });
+  registerExternalAutocompleteInput(hostWindow, textarea, options);
 }
 
 /** @param {RegionalPromptStudioTextarea} textarea */

--- a/web/js/prompt_studio/regional/extension.js
+++ b/web/js/prompt_studio/regional/extension.js
@@ -17,6 +17,7 @@ import {
 import {
   promptStudioQueueSeedBridge,
 } from "../queue_seed_bridge.js";
+import { disposeExternalAutocompleteInputs } from "../../autocomplete/entry_lifecycle.js";
 
 /**
  * @param {any} nodeType
@@ -197,6 +198,7 @@ function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks
   function cleanupRegionalEditor(node) {
     const editor = node?.__easyuseAnimaRegionalEditorEl;
     if (editor) {
+      disposeExternalAutocompleteInputs(globalThis, editor);
       for (const textarea of editor.querySelectorAll("textarea")) {
         const frame = Number(textarea.__easyuseAnimaHighlightSyncRaf) || 0;
         if (frame) {

--- a/web/js/prompt_studio/regional/field_editor.js
+++ b/web/js/prompt_studio/regional/field_editor.js
@@ -27,6 +27,7 @@ import {
 import {
   bindWildcardSeedInput,
 } from "../wildcard_seed_contract.js";
+import { disposeExternalAutocompleteInputs } from "../../autocomplete/entry_lifecycle.js";
 
 /**
  * Move a field within its current pane without changing its id or crossing the
@@ -634,6 +635,7 @@ function createRegionalFieldEditor(runtime, layout, maskEditor, hooks) {
     const fields = node.__easyuseAnimaRegionalFields || createDefaultRegionalFields();
     const config = node.__easyuseAnimaRegionalConfig || runtime.defaultConfig(node);
     maskEditor.closeMaskPopover(node);
+    disposeExternalAutocompleteInputs(window, editor);
     editor.innerHTML = "";
 
     const toolbar = document.createElement("div");

--- a/web/js/prompt_studio/types.js
+++ b/web/js/prompt_studio/types.js
@@ -33,6 +33,7 @@
  * @typedef {(HTMLTextAreaElement | HTMLInputElement) & {
  *   __easyuseAnimaHighlightOverlay?: HTMLElement | null,
  *   __easyuseAnimaHighlightRefresh?: (force?: boolean) => void,
+ *   __easyuseAnimaExternalAutocompleteDispose?: () => void,
  *   __easyuseAnimaStudioResizable?: boolean
  * }} PromptStudioInputElement
  */
@@ -56,9 +57,13 @@
  *   __easyuseAnimaHighlightOverlayRefreshInstalled?: boolean,
  *   __easyuseAnimaMiddlePanForwarderInstalled?: boolean,
  *   __easyuseAnimaWheelForwarderInstalled?: boolean,
- *   __easyuseAnimaPendingAutocompleteInputs?: Array<{ input: Element, options: unknown }>,
+ *   __easyuseAnimaPendingAutocompleteInputs?: Array<{
+ *     input: Element,
+ *     options: unknown,
+ *     onBound?: (dispose: (() => void) | null) => void
+ *   }>,
  *   easyuseAnimaAutocompleteEntryTooltip?: (entry: unknown) => PromptStudioAutocompleteTooltip | null | undefined,
- *   easyuseAnimaHookAutocompleteInput?: (input: Element, options: unknown) => void
+ *   easyuseAnimaHookAutocompleteInput?: (input: Element, options: unknown) => (() => void) | null
  * }} PromptStudioWindow
  */
 


### PR DESCRIPTION
## 변경 요약

- Autocomplete의 process-wide listener, window hook, prototype wrapper 소유권을 `entry_lifecycle.js` 경계로 분리했습니다.
- ComfyUI의 실제 `init → beforeRegisterNodeDef → setup` 순서에서 최초 노드와 재진입이 모두 바인딩되도록 했습니다.
- 새 generation만 활성 owner가 되게 해 stale setup이 최신 wrapper를 회수하거나 해제하지 못하게 했습니다.
- Prompt Studio Advanced/Regional의 외부 textarea가 rerender·제거될 때 autocomplete disposer를 명시적으로 소유하도록 정리했습니다.
- lifecycle smoke와 source-boundary/runner 계약을 추가했습니다.

Refs #56

## 주요 파일

- `web/js/autocomplete/entry_lifecycle.js`
- `web/js/easyuse_anima_autocomplete.js`
- `web/js/prompt_studio/**`
- `tests/frontend_autocomplete_entry_lifecycle_smoke.mjs`
- `tests/test_autocomplete_frontend.py`
- `tests/test_aio_frontend.py`
- `tools/check_frontend.ps1`

## 검증

- Official full runner
  - Python unittest: 406/406
  - frontend: 107 JavaScript files
  - TypeScript 6.0.3
  - diff checks 통과
- Legacy canvas
  - suggestion popup 1개, 결과 20개
  - ArrowDown/Enter 삽입
  - Escape 및 외부 클릭 닫기
  - reload 뒤 값 복원·재트리거·키보드 삽입 통과
- Node 2.0
  - 동일 popup/keyboard/close/reload matrix 통과
- Runtime/module
  - entry와 `autocomplete/entry_lifecycle.js`가 reload 전후 모두 로드됨
  - 두 모듈 HTTP 200, `Cache-Control: no-store`
  - source·설치본·served body 일치
  - EasyUse Anima 관련 신규 browser warning/error 없음

## 호환성과 남은 범위

- 기존 parser/text replacement 경로와 #98 범위는 변경하지 않았습니다.
- 실제 IME composition event는 browser 자동화로 재현하지 않았고, 기존 deterministic controller/binding smoke가 해당 계약을 소유합니다.
- 사용자 v0.27.0 인스턴스의 최종 호환 묶음 확인은 전체 maintenance/release gate에서 수행합니다.
