### PR TITLE
fix: reserve concurrent AiO API seeds

### DIFF
--- a/tests/frontend_aio_generator_queue_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_queue_runtime_smoke.mjs
@@ -499,6 +499,53 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
 }
 
 {
+  const fixture = createFixture({ seed: 7, seedControl: "increment" });
+  const queuedSeeds = [];
+  const gates = [deferred(), deferred(), deferred(), deferred()];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queuedSeeds.push(
+      JSON.parse(prompt.output["42"].inputs.generation_settings).sampler.seed,
+    );
+    return gates[queuedSeeds.length - 1].promise;
+  });
+  const pending = [
+    wrapped(0, createPrompt()),
+    wrapped(0, createPrompt()),
+    wrapped(0, createPrompt()),
+  ];
+  await Promise.resolve();
+  await Promise.resolve();
+
+  gates[1].resolve({ prompt_id: "", node_errors: {} });
+  await pending[1];
+  const rejection = new Error("rejected-tail");
+  gates[2].reject(rejection);
+  let caught = null;
+  try {
+    await pending[2];
+  } catch (error) {
+    caught = error;
+  }
+  assert.equal(caught, rejection);
+
+  const retry = wrapped(0, createPrompt());
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    queuedSeeds,
+    [7, 8, 9, 8],
+    "contiguous rejected tail reservations must collapse to the earliest reusable seed",
+  );
+  gates[3].resolve({ prompt_id: "retry", node_errors: {} });
+  await retry;
+  assert.equal(fixture.node.settings.sampler.seed, 7);
+  gates[0].resolve({ prompt_id: "first", node_errors: {} });
+  await pending[0];
+  assert.equal(fixture.node.settings.sampler.seed, 9);
+  assert.equal(fixture.node.lastSeed, 8);
+}
+
+{
   const fixture = createFixture({ seed: 10, seedControl: "increment" });
   const host = {
     calls: 0,
@@ -697,7 +744,13 @@ for (const failAt of ["getSettings", "sanitize", "serialize", "output", "workflo
     commitError,
   });
   const result = { prompt_id: "accepted-despite-local-commit", node_errors: {} };
-  const wrapped = fixture.runtime.wrapQueuePrompt(() => result);
+  const queuedSeeds = [];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queuedSeeds.push(
+      JSON.parse(prompt.output["42"].inputs.generation_settings).sampler.seed,
+    );
+    return result;
+  });
   assert.equal(
     await wrapped(0, createPrompt()),
     result,
@@ -706,6 +759,14 @@ for (const failAt of ["getSettings", "sanitize", "serialize", "output", "workflo
   assert.equal(fixture.node.settings.sampler.seed, 18);
   assert.equal(fixture.node.lastSeed, 18);
   assert.equal(fixture.trace.includes("commit:19:18:false"), true);
+  assert.equal(await wrapped(0, createPrompt()), result);
+  assert.deepEqual(
+    queuedSeeds,
+    [18, 19],
+    "an accepted reservation remains authoritative after updateSeed fails",
+  );
+  assert.equal(fixture.node.settings.sampler.seed, 18);
+  assert.equal(fixture.node.lastSeed, 19);
 }
 
 for (const nodeErrors of [
@@ -782,11 +843,20 @@ for (const result of [
 for (const failureMode of ["throw", "reject"]) {
   const fixture = createFixture({ seed: 15, seedControl: "decrement" });
   const failure = new Error(`queue-${failureMode}`);
-  const wrapped = fixture.runtime.wrapQueuePrompt(() => {
-    if (failureMode === "throw") {
+  const queuedSeeds = [];
+  let queueCalls = 0;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queueCalls += 1;
+    queuedSeeds.push(
+      JSON.parse(prompt.output["42"].inputs.generation_settings).sampler.seed,
+    );
+    if (queueCalls === 1 && failureMode === "throw") {
       throw failure;
     }
-    return Promise.reject(failure);
+    if (queueCalls === 1) {
+      return Promise.reject(failure);
+    }
+    return { prompt_id: `retry-${failureMode}`, node_errors: {} };
   });
   let caught = null;
   try {
@@ -798,6 +868,14 @@ for (const failureMode of ["throw", "reject"]) {
   assert.equal(fixture.node.lastSeed, undefined);
   assert.equal(fixture.node.settings.sampler.seed, 15);
   assert.equal(fixture.trace.some((item) => item.startsWith("commit:")), false);
+  await wrapped(0, createPrompt());
+  assert.deepEqual(
+    queuedSeeds,
+    [15, 15],
+    `${failureMode}: rejected tail seed must remain reusable`,
+  );
+  assert.equal(fixture.node.lastSeed, 15);
+  assert.equal(fixture.node.settings.sampler.seed, 14);
 }
 
 {

--- a/tests/frontend_aio_generator_queue_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_queue_runtime_smoke.mjs
@@ -10,6 +10,16 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 const queueModule = await import(dataModule("../web/js/aio/generator_queue_runtime.js"));
 assert.deepEqual(
   Object.keys(queueModule),
@@ -387,6 +397,105 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
   );
   assert.equal(JSON.parse(receivedArgs[1].output["42"].inputs.generation_settings).sampler.seed, 40);
   assert.equal(prompt.output["42"].inputs.generation_settings, "live-settings");
+}
+
+{
+  const fixture = createFixture({ seed: 7, seedControl: "increment" });
+  assert.ok(fixture.runtime.preparePrompt(createPrompt()));
+  let queuedSeed = null;
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queuedSeed = JSON.parse(
+      prompt.output["42"].inputs.generation_settings,
+    ).sampler.seed;
+    return { prompt_id: "after-standalone-prepare", node_errors: {} };
+  });
+
+  await wrapped(0, createPrompt());
+  assert.equal(queuedSeed, 7, "standalone preparation must not consume a queue reservation");
+  assert.equal(fixture.node.settings.sampler.seed, 8);
+}
+
+{
+  const fixture = createFixture({ seed: 7, seedControl: "increment" });
+  const calls = [];
+  const gates = [deferred(), deferred(), deferred()];
+  const wrapped = fixture.runtime.wrapQueuePrompt(function (...args) {
+    calls.push({ owner: this, args });
+    return gates[calls.length - 1].promise;
+  });
+  const owner = { name: "direct-api-owner" };
+  const options = { partialExecutionTargets: [42], previewMethod: "latent2rgb" };
+  const tail = { preserve: true };
+  const prompt = createPrompt();
+  const originalPrompt = clone(prompt);
+
+  const pending = [
+    wrapped.call(owner, 0, prompt, options, tail),
+    wrapped.call(owner, 0, prompt, options, tail),
+    wrapped.call(owner, 0, prompt, options, tail),
+  ];
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(calls.length, 3, "direct API submissions must remain concurrent");
+  assert.deepEqual(
+    calls.map(({ args }) => JSON.parse(args[1].output["42"].inputs.generation_settings).sampler.seed),
+    [7, 8, 9],
+    "concurrent direct API submissions must reserve distinct sequential seeds",
+  );
+  assert.deepEqual(prompt, originalPrompt, "concurrent reservations must not mutate the caller prompt");
+  assert.equal(fixture.node.settings.sampler.seed, 7, "live seed changes only after FIFO settlement");
+  for (const call of calls) {
+    assert.equal(call.owner, owner);
+    assert.equal(call.args.length, 4);
+    assert.equal(call.args[0], 0);
+    assert.equal(call.args[2], options, "queue options identity must survive reservation");
+    assert.equal(call.args[3], tail, "queue argument tail identity must survive reservation");
+  }
+
+  gates[1].resolve({ prompt_id: "second", node_errors: {} });
+  await pending[1];
+  assert.equal(
+    fixture.node.settings.sampler.seed,
+    7,
+    "an accepted later reservation must wait for earlier direct API settlement",
+  );
+
+  gates[0].resolve({ prompt_id: "   ", node_errors: {} });
+  await pending[0];
+  assert.equal(
+    fixture.node.settings.sampler.seed,
+    9,
+    "a blank prompt id must reject only its reservation and release the accepted successor",
+  );
+  assert.equal(fixture.node.lastSeed, 8);
+
+  gates[2].resolve({ prompt_id: "third", node_errors: {} });
+  await pending[2];
+  assert.equal(fixture.node.settings.sampler.seed, 10);
+  assert.equal(fixture.node.lastSeed, 9);
+}
+
+{
+  const fixture = createFixture({ seed: 7, seedControl: "increment" });
+  const queuedSeeds = [];
+  const results = [
+    { prompt_id: "", node_errors: {} },
+    { prompt_id: "retry", node_errors: {} },
+  ];
+  const wrapped = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queuedSeeds.push(
+      JSON.parse(prompt.output["42"].inputs.generation_settings).sampler.seed,
+    );
+    return results.shift();
+  });
+
+  await wrapped(0, createPrompt());
+  assert.equal(fixture.node.settings.sampler.seed, 7);
+  await wrapped(0, createPrompt());
+  assert.deepEqual(queuedSeeds, [7, 7], "a rejected tail reservation must remain reusable");
+  assert.equal(fixture.node.settings.sampler.seed, 8);
+  assert.equal(fixture.node.lastSeed, 7);
 }
 
 {

--- a/web/js/aio/generator_queue_runtime.js
+++ b/web/js/aio/generator_queue_runtime.js
@@ -76,6 +76,10 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     specialSeedIncrement,
     specialSeedDecrement,
   ]);
+  // Direct api.queuePrompt callers can overlap outside the higher-level queue
+  // lifecycle. Keep per-node reservations weakly owned and settle them FIFO so
+  // request concurrency does not duplicate or regress seed state.
+  const nodeReservationStates = new WeakMap();
 
   function isRecord(value) {
     return !!value && typeof value === "object" && !Array.isArray(value);
@@ -103,12 +107,11 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     return clampConcreteSeed(value);
   }
 
-  function resolveQueuedSeed(node, inputSeed) {
+  function resolveQueuedSeed(inputSeed, lastSeed = null) {
     const seed = normalizeSeedValue(inputSeed, specialSeedRandom);
     if (!specialSeeds.has(seed)) {
       return clampConcreteSeed(seed);
     }
-    const lastSeed = lastConcreteSeed(node);
     if (lastSeed != null && seed === specialSeedIncrement) {
       return clampConcreteSeed(lastSeed + 1);
     }
@@ -129,6 +132,72 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
       default:
         return normalizeSeedValue(inputSeed, specialSeedRandom);
     }
+  }
+
+  function reservationStateForNode(node, liveInputSeed) {
+    const normalizedLiveSeed = normalizeSeedValue(liveInputSeed, specialSeedRandom);
+    let state = nodeReservationStates.get(node);
+    if (!state) {
+      state = {
+        node,
+        liveSeed: normalizedLiveSeed,
+        lastQueuedSeed: lastConcreteSeed(node),
+        publishFailed: false,
+        reservations: [],
+      };
+      nodeReservationStates.set(node, state);
+      return state;
+    }
+    if (!state.reservations.length && !state.publishFailed) {
+      state.liveSeed = normalizedLiveSeed;
+      state.lastQueuedSeed = lastConcreteSeed(node);
+    }
+    return state;
+  }
+
+  function reservationBasis(state) {
+    const tail = state.reservations[state.reservations.length - 1];
+    return tail
+      ? { inputSeed: tail.liveSeed, lastQueuedSeed: tail.queuedSeed }
+      : { inputSeed: state.liveSeed, lastQueuedSeed: state.lastQueuedSeed };
+  }
+
+  function flushSettledReservations(state) {
+    while (state.reservations.length && state.reservations[0].status !== "pending") {
+      const reservation = state.reservations.shift();
+      if (reservation.status !== "accepted") {
+        continue;
+      }
+      state.lastQueuedSeed = reservation.queuedSeed;
+      state.liveSeed = reservation.liveSeed;
+      try {
+        commitLastQueuedSeed(reservation.node, reservation.queuedSeed);
+      } catch {
+        state.publishFailed = true;
+        continue;
+      }
+      try {
+        updateSeed(reservation.node, reservation.liveSeed, { markDirty: false });
+        state.publishFailed = false;
+      } catch {
+        // Keep the accepted reservation authoritative even when the local
+        // panel/widget cannot publish it. A following direct API call must not
+        // reuse a seed that ComfyUI already accepted.
+        state.publishFailed = true;
+      }
+    }
+  }
+
+  function settleReservation(reservation, accepted) {
+    if (reservation.status !== "pending") {
+      return;
+    }
+    reservation.status = accepted ? "accepted" : "rejected";
+    const { state } = reservation;
+    if (!accepted && state.reservations[state.reservations.length - 1] === reservation) {
+      state.reservations.pop();
+    }
+    flushSettledReservations(state);
   }
 
   function findWorkflowNode(workflow, id) {
@@ -251,8 +320,9 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
    *
    * @param {any} prompt
    * @param {any} [options]
+   * @param {boolean} [reserve]
    */
-  function preparePrompt(prompt, options = null) {
+  function preparePrompt(prompt, options = null, reserve = false) {
     const nodes = candidateNodes(prompt, options);
     if (!nodes.length) {
       return null;
@@ -280,11 +350,14 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
         if (!isRecord(queuedSettings) || !isRecord(queuedSettings.sampler)) {
           continue;
         }
-        const inputSeed = normalizeSeedValue(
+        const liveInputSeed = normalizeSeedValue(
           queuedSettings.sampler.seed,
           specialSeedRandom,
         );
-        const queuedSeed = resolveQueuedSeed(node, inputSeed);
+        const state = reservationStateForNode(node, liveInputSeed);
+        const basis = reservationBasis(state);
+        const inputSeed = basis.inputSeed;
+        const queuedSeed = resolveQueuedSeed(inputSeed, basis.lastQueuedSeed);
         queuedSettings.sampler.seed = queuedSeed;
         const serializedSettings = settingsToCompactJson(queuedSettings);
         if (typeof serializedSettings !== "string") {
@@ -303,16 +376,22 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
           serializedSettings,
           workflowWrite,
         );
-        commits.push({
+        const reservation = {
           node,
           nodeId: String(node.id),
+          state,
           queuedSeed,
           liveSeed: nextLiveSeed(
             queuedSettings.sampler.seed_after_generate,
             inputSeed,
             queuedSeed,
           ),
-        });
+          status: "pending",
+        };
+        if (reserve) {
+          state.reservations.push(reservation);
+        }
+        commits.push(reservation);
       } catch {
         // One malformed generator must not prevent unrelated prompt nodes from
         // queueing. It remains untouched in the cloned payload.
@@ -354,27 +433,19 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     }
   }
 
-  function commitPreparedSeeds(transaction, result) {
+  function settlePreparedSeeds(transaction, result) {
     const invalidTargets = invalidCommitTargetIds(result);
-    if (!invalidTargets) {
-      return;
+    for (const reservation of transaction.commits) {
+      settleReservation(
+        reservation,
+        !!invalidTargets && !invalidTargets.has(reservation.nodeId),
+      );
     }
-    for (const commit of transaction.commits) {
-      if (invalidTargets.has(commit.nodeId)) {
-        continue;
-      }
-      try {
-        commitLastQueuedSeed(commit.node, commit.queuedSeed);
-      } catch {
-        continue;
-      }
-      try {
-        updateSeed(commit.node, commit.liveSeed, { markDirty: false });
-      } catch {
-        // The durable last-seed reservation is already committed. A local
-        // panel/widget failure cannot reject the accepted queue result or block
-        // another node's reservation and live-seed update.
-      }
+  }
+
+  function rejectPreparedSeeds(transaction) {
+    for (const reservation of transaction.commits) {
+      settleReservation(reservation, false);
     }
   }
 
@@ -387,14 +458,22 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
   function wrapQueuePrompt(queuePrompt) {
     return async function (...args) {
       await loadOptionalDependencies({ retryErrors: true });
-      const transaction = preparePrompt(args[1], args[2]);
+      const transaction = preparePrompt(args[1], args[2], true);
       const queueArgs = transaction ? [...args] : args;
       if (transaction) {
         queueArgs[1] = transaction.prompt;
       }
-      const result = await queuePrompt.apply(this, queueArgs);
+      let result;
+      try {
+        result = await queuePrompt.apply(this, queueArgs);
+      } catch (error) {
+        if (transaction) {
+          rejectPreparedSeeds(transaction);
+        }
+        throw error;
+      }
       if (transaction) {
-        commitPreparedSeeds(transaction, result);
+        settlePreparedSeeds(transaction, result);
       }
       return result;
     };

--- a/web/js/aio/generator_queue_runtime.js
+++ b/web/js/aio/generator_queue_runtime.js
@@ -194,7 +194,7 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     }
     reservation.status = accepted ? "accepted" : "rejected";
     const { state } = reservation;
-    if (!accepted && state.reservations[state.reservations.length - 1] === reservation) {
+    while (state.reservations[state.reservations.length - 1]?.status === "rejected") {
       state.reservations.pop();
     }
     flushSettledReservations(state);


### PR DESCRIPTION
## 변경 요약

- 표준 앱 lifecycle 밖에서 `api.queuePrompt`가 직접 동시에 호출될 때 node별 seed를 중복 없이 예약합니다.
- 서버 요청 자체는 병렬로 유지하면서 응답 순서와 무관하게 FIFO로 accepted reservation만 live seed/last seed에 반영합니다.
- blank/missing `prompt_id`, synchronous throw, Promise rejection은 commit하지 않으며 연속 rejected tail의 가장 이른 seed를 다음 호출이 재사용합니다.
- `updateSeed` publication 실패 뒤에도 서버가 accepted한 reservation을 authoritative 상태로 유지합니다.
- caller prompt, wrapper `this`, options/tail 인수, result/error identity와 foreign-wrapper no-restack 계약을 보존합니다.

## 변경 파일

- `web/js/aio/generator_queue_runtime.js`
- `tests/frontend_aio_generator_queue_runtime_smoke.mjs`

## 검증

- `node --check` 변경 JavaScript 2개: 통과
- `node tests/frontend_aio_generator_queue_runtime_smoke.mjs`: 통과
  - 3개 동시 호출 seed `7, 8, 9`
  - 역순 settlement와 FIFO commit
  - blank/missing `prompt_id`, throw/rejection no-commit
  - rejected tail 및 contiguous rejected tail 재사용
  - `updateSeed` 실패 후 다음 예약 연속성
  - caller prompt와 receiver/options/tail/result/error identity
  - foreign wrapper composition/no-restack
- `python -m unittest tests.test_aio_frontend`: 34/34 통과
- official full runner:
  - Python unittest 406/406
  - frontend 107 JavaScript files
  - TypeScript 6.0.3
  - git diff check 통과
- exact clean HEAD `151877d13e5e1abaf7e26827d37ec6a310c08239` 독립 최종 감사: GO

## Browser / 사용자 인스턴스

이번 diff는 UI/canvas나 workflow schema를 바꾸지 않는 direct API reservation 계약이며 deterministic smoke가 동시성·settlement를 직접 소유하므로 browser matrix는 반복하지 않았습니다. #54 종료용 최종 Legacy/Node 2.0 load/queue/save-reload matrix는 기존 ledger대로 후속 gate에 남깁니다. 사용자 `ComfyUI_v0.27.0` 인스턴스는 수정하지 않았습니다.

## 남은 위험

queue 진행 중 node 객체 제거/교체는 기존 동작이며 이번 명시 계약 밖의 비차단 후속입니다. #62 threshold와 다른 AiO 동작은 이 PR에 포함하지 않았습니다.