### PR TITLE
fix: LoRA profile save-sync 직렬화 경계 보강

### DIFF
--- a/tests/frontend_lora_preset_node_runtime_smoke.mjs
+++ b/tests/frontend_lora_preset_node_runtime_smoke.mjs
@@ -13,6 +13,7 @@ const { createLoraPresetNodeRuntime } = await import(
 const events = [];
 const animationFrames = [];
 const widgetIndex = {
+  profileIndex: 1,
   profileCount: 2,
   loraName: 3,
   loras: 4,
@@ -165,7 +166,7 @@ const serialized = { widgets_values: Array(6).fill("") };
 node.onSerialize(serialized);
 assert.deepEqual(serialized.widgets_values, [
   "",
-  "",
+  1,
   "4",
   "None",
   JSON.stringify([{ name: "styles/example.safetensors", on: true, strength: 1 }]),

--- a/tests/frontend_lora_preset_node_runtime_smoke.mjs
+++ b/tests/frontend_lora_preset_node_runtime_smoke.mjs
@@ -162,7 +162,8 @@ for (const index of [2, 3, 4, 5]) {
   assert.equal(node.widgets[index].options.hidden, true);
 }
 
-const serialized = { widgets_values: Array(6).fill("") };
+node.widgets.splice(3, 0, { name: "easyuse_anima_profile_bar", value: null, serialize: false });
+const serialized = { widgets_values: ["", 1, "4", null, "legacy", "[]", "{}"] };
 node.onSerialize(serialized);
 assert.deepEqual(serialized.widgets_values, [
   "",
@@ -172,6 +173,7 @@ assert.deepEqual(serialized.widgets_values, [
   JSON.stringify([{ name: "styles/example.safetensors", on: true, strength: 1 }]),
   "{}",
 ]);
+assert.equal(serialized.widgets_values.length, 6);
 assert.ok(events.indexOf("save-current:node-a") < events.indexOf("serialized:node-a"));
 
 node.widgets = [node.widgets[0], node.widgets[1]];

--- a/tests/frontend_lora_preset_profile_mutations_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_mutations_smoke.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { createLoraPresetProfileMutations } from "../web/js/lora_preset/profile_mutations.js";
+import { MAX_PROFILES } from "../web/js/lora_preset/profile_data.js";
 import { createLoraPresetSaveSync } from "../web/js/lora_preset/save_sync.js";
 
 function createProfileNode() {
@@ -70,6 +71,70 @@ assert.equal(mutations.profileCount(node), 1);
 assert.equal(widgetValue(findWidget(node, "style_prompt")), "second prompt");
 assert.ok(renderCalls.profile > 0);
 
+const apiCalls = { save: [], load: [] };
+const apiMutations = createLoraPresetProfileMutations({
+  findWidget,
+  widgetValue,
+  setWidgetValue,
+  lorasWidgetValue,
+  setLorasWidgetValue,
+  getCanvasWidgets: () => canvasWidgets,
+  text: (key) => key,
+  formatText: (key) => key,
+  apiClient: {
+    async saveProfile(name, payload) {
+      apiCalls.save.push({ name, payload });
+      return { profile: { name } };
+    },
+    async loadProfile(name) {
+      apiCalls.load.push(name);
+      return {
+        profile: {
+          name,
+          profile_count: 2,
+          profile_index: 2,
+          profile_data: {
+            "1": { style_prompt: "loaded first", loras: [] },
+            "2": { style_prompt: "loaded second", loras: [{ name: "loaded.safetensors" }] },
+          },
+        },
+      };
+    },
+  },
+  host: { ...host, prompt: () => " saved profile " },
+});
+await apiMutations.saveProfileSet(node);
+assert.equal(apiCalls.save[0].name, "saved profile");
+assert.equal(apiCalls.save[0].payload.profile_count, 1);
+assert.equal(apiMutations.profileSaveStatus(node, 1).state, "saved");
+await apiMutations.loadProfileSet(node, "loaded profile");
+assert.deepEqual(apiCalls.load, ["loaded profile"]);
+assert.equal(apiMutations.profileCount(node), 3);
+assert.equal(apiMutations.activeProfileIndex(node), 3);
+assert.equal(widgetValue(findWidget(node, "style_prompt")), "loaded second");
+
+const partialNode = createProfileNode();
+while (mutations.profileCount(partialNode) < MAX_PROFILES - 1) {
+  mutations.addProfile(partialNode);
+}
+host.alerts.length = 0;
+mutations.appendProfilePayload(partialNode, {
+  profile_count: 2,
+  profile_index: 2,
+  profile_data: {
+    "1": { style_prompt: "partial first", loras: [] },
+    "2": { style_prompt: "partial second", loras: [] },
+  },
+});
+assert.equal(mutations.profileCount(partialNode), MAX_PROFILES);
+assert.equal(widgetValue(findWidget(partialNode, "style_prompt")), "partial first");
+assert.equal(host.alerts.at(-1), "profile.partialLoad");
+mutations.appendProfilePayload(partialNode, {
+  profile_count: 1,
+  profile_data: { "1": { style_prompt: "ignored", loras: [] } },
+});
+assert.equal(host.alerts.at(-1), "profile.maxReached");
+
 const syncCalls = [];
 const graphPrototype = {
   serialize(value) {
@@ -131,12 +196,18 @@ app.queuePrompt = function () {
   return previousQueuePrompt.apply(this, arguments);
 };
 
-saveSync.install();
-saveSync.install();
+const replacementSaveSync = createLoraPresetSaveSync({
+  app,
+  nodeTypeName: "EasyUseAnimaLoraPreset",
+  saveCurrentProfile: (profileNode) => syncCalls.push(profileNode.id),
+  getGraphPrototype: () => graphPrototype,
+});
+replacementSaveSync.install();
+replacementSaveSync.install();
 syncCalls.length = 0;
 const reinstalledSerialized = graphPrototype.serialize.call(secondaryGraph, "reinstall-value");
 const reinstalledQueued = app.queuePrompt.call(app, "reinstall-queue");
-assert.deepEqual(syncCalls, [3, 1], "reinstall must not stack stale synchronization wrappers");
+assert.deepEqual(syncCalls, [3, 1], "new lifecycle installation must not stack stale synchronization wrappers");
 assert.strictEqual(serializeWrapperThis, secondaryGraph);
 assert.deepEqual(serializeWrapperArgs, ["reinstall-value"]);
 assert.strictEqual(reinstalledSerialized.receiver, secondaryGraph);

--- a/tests/frontend_lora_preset_profile_mutations_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_mutations_smoke.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { createLoraPresetProfileMutations } from "../web/js/lora_preset/profile_mutations.js";
+import { createLoraPresetSaveSync } from "../web/js/lora_preset/save_sync.js";
+
+function createProfileNode() {
+  const widgets = new Map([
+    ["style_prompt", { value: "first prompt" }],
+    ["profile_index", { value: 1 }],
+    ["profile_count", { value: "2" }],
+    ["loras", { value: '[{"name":"first.safetensors","on":true,"strength":1,"strengthTwo":null}]' }],
+    ["profile_data", { value: JSON.stringify({
+      "1": {
+        style_prompt: "first prompt",
+        loras: [{ name: "first.safetensors", on: true, strength: 1, strengthTwo: null }],
+        saved_name: "saved-set",
+        saved_snapshot: "old snapshot",
+      },
+      "2": { style_prompt: "second prompt", loras: [] },
+    }) }],
+  ]);
+  return {
+    widgets,
+    dirty: 0,
+    __easyuseAnimaProfileBar: { scrollOffset: 0 },
+    setDirtyCanvas() { this.dirty += 1; },
+  };
+}
+
+const renderCalls = { profile: 0, loras: 0 };
+const canvasWidgets = {
+  profileVisibleRows: 2,
+  renderProfileBar() { renderCalls.profile += 1; },
+  renderLoraWidgets() { renderCalls.loras += 1; },
+};
+const host = { alerts: [], confirm: () => true, alert(message) { this.alerts.push(message); } };
+const findWidget = (node, name) => node.widgets.get(name);
+const widgetValue = (widget, fallback) => widget?.value ?? fallback;
+const setWidgetValue = (widget, value) => { widget.value = value; };
+const lorasWidgetValue = (node) => JSON.parse(widgetValue(findWidget(node, "loras"), "[]"));
+const setLorasWidgetValue = (node, loras) => {
+  setWidgetValue(findWidget(node, "loras"), JSON.stringify(loras));
+};
+const mutations = createLoraPresetProfileMutations({
+  findWidget,
+  widgetValue,
+  setWidgetValue,
+  lorasWidgetValue,
+  setLorasWidgetValue,
+  getCanvasWidgets: () => canvasWidgets,
+  text: (key) => key,
+  formatText: (key) => key,
+  apiClient: {},
+  host,
+});
+
+const node = createProfileNode();
+mutations.mutateLoras(node, (loras) => { loras[0].strength = 0.75; });
+let profileData = mutations.parseProfileData(findWidget(node, "profile_data"));
+assert.equal(profileData["1"].loras[0].strength, 0.75);
+assert.equal(profileData["1"].saved_name, "saved-set");
+assert.equal(profileData["1"].saved_snapshot, "old snapshot");
+
+mutations.switchProfile(node, 2);
+assert.equal(widgetValue(findWidget(node, "style_prompt")), "second prompt");
+mutations.addLoraEntry(node, { name: "second.safetensors", strength: 0.5 });
+profileData = mutations.parseProfileData(findWidget(node, "profile_data"));
+assert.equal(profileData["2"].loras[0].name, "second.safetensors");
+mutations.deleteProfile(node, 1);
+assert.equal(mutations.profileCount(node), 1);
+assert.equal(widgetValue(findWidget(node, "style_prompt")), "second prompt");
+assert.ok(renderCalls.profile > 0);
+
+const syncCalls = [];
+const graphPrototype = {
+  serialize(value) { return { receiver: this, value }; },
+};
+const graph = { _nodes: [{ comfyClass: "EasyUseAnimaLoraPreset", id: 1 }, { comfyClass: "Other", id: 2 }] };
+const app = {
+  graph,
+  queuePrompt(value) { return { receiver: this, value }; },
+};
+const saveSync = createLoraPresetSaveSync({
+  app,
+  nodeTypeName: "EasyUseAnimaLoraPreset",
+  saveCurrentProfile: (profileNode) => syncCalls.push(profileNode.id),
+  getGraphPrototype: () => graphPrototype,
+});
+saveSync.install();
+saveSync.install();
+const serialized = graphPrototype.serialize.call(graph, "serialize-value");
+const queued = app.queuePrompt.call(app, "queue-value");
+assert.deepEqual(syncCalls, [1, 1]);
+assert.strictEqual(serialized.receiver, graph);
+assert.equal(serialized.value, "serialize-value");
+assert.strictEqual(queued.receiver, app);
+assert.equal(queued.value, "queue-value");
+
+console.log("LoRA profile mutation and save-sync smoke passed");

--- a/tests/frontend_lora_preset_profile_mutations_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_mutations_smoke.mjs
@@ -72,12 +72,31 @@ assert.ok(renderCalls.profile > 0);
 
 const syncCalls = [];
 const graphPrototype = {
-  serialize(value) { return { receiver: this, value }; },
+  serialize(value) {
+    if (value === "throw") {
+      throw new Error("serialize failure");
+    }
+    return { receiver: this, value };
+  },
 };
 const graph = { _nodes: [{ comfyClass: "EasyUseAnimaLoraPreset", id: 1 }, { comfyClass: "Other", id: 2 }] };
+const secondaryGraph = { _nodes: [{ comfyClass: "EasyUseAnimaLoraPreset", id: 3 }] };
+const pendingResult = Promise.resolve({ queued: true });
+const rejectedResult = Promise.reject(new Error("queue failure"));
 const app = {
   graph,
-  queuePrompt(value) { return { receiver: this, value }; },
+  queuePrompt(value) {
+    if (value === "throw") {
+      throw new Error("queue throw");
+    }
+    if (value === "promise") {
+      return pendingResult;
+    }
+    if (value === "reject") {
+      return rejectedResult;
+    }
+    return { receiver: this, value };
+  },
 };
 const saveSync = createLoraPresetSaveSync({
   app,
@@ -87,12 +106,51 @@ const saveSync = createLoraPresetSaveSync({
 });
 saveSync.install();
 saveSync.install();
-const serialized = graphPrototype.serialize.call(graph, "serialize-value");
+const serialized = graphPrototype.serialize.call(secondaryGraph, "serialize-value");
 const queued = app.queuePrompt.call(app, "queue-value");
-assert.deepEqual(syncCalls, [1, 1]);
-assert.strictEqual(serialized.receiver, graph);
+assert.deepEqual(syncCalls, [3, 1]);
+assert.strictEqual(serialized.receiver, secondaryGraph);
 assert.equal(serialized.value, "serialize-value");
 assert.strictEqual(queued.receiver, app);
 assert.equal(queued.value, "queue-value");
+
+const previousSerialize = graphPrototype.serialize;
+let serializeWrapperThis = null;
+let serializeWrapperArgs = null;
+graphPrototype.serialize = function () {
+  serializeWrapperThis = this;
+  serializeWrapperArgs = [...arguments];
+  return previousSerialize.apply(this, arguments);
+};
+const previousQueuePrompt = app.queuePrompt;
+let queueWrapperThis = null;
+let queueWrapperArgs = null;
+app.queuePrompt = function () {
+  queueWrapperThis = this;
+  queueWrapperArgs = [...arguments];
+  return previousQueuePrompt.apply(this, arguments);
+};
+
+saveSync.install();
+saveSync.install();
+syncCalls.length = 0;
+const reinstalledSerialized = graphPrototype.serialize.call(secondaryGraph, "reinstall-value");
+const reinstalledQueued = app.queuePrompt.call(app, "reinstall-queue");
+assert.deepEqual(syncCalls, [3, 1], "reinstall must not stack stale synchronization wrappers");
+assert.strictEqual(serializeWrapperThis, secondaryGraph);
+assert.deepEqual(serializeWrapperArgs, ["reinstall-value"]);
+assert.strictEqual(reinstalledSerialized.receiver, secondaryGraph);
+assert.strictEqual(queueWrapperThis, app);
+assert.deepEqual(queueWrapperArgs, ["reinstall-queue"]);
+assert.strictEqual(reinstalledQueued.receiver, app);
+
+assert.throws(() => graphPrototype.serialize.call(secondaryGraph, "throw"), /serialize failure/);
+assert.throws(() => app.queuePrompt.call(app, "throw"), /queue throw/);
+const returnedPromise = app.queuePrompt.call(app, "promise");
+assert.strictEqual(returnedPromise, pendingResult);
+assert.deepEqual(await returnedPromise, { queued: true });
+const returnedRejection = app.queuePrompt.call(app, "reject");
+assert.strictEqual(returnedRejection, rejectedResult);
+await assert.rejects(returnedRejection, /queue failure/);
 
 console.log("LoRA profile mutation and save-sync smoke passed");

--- a/tests/frontend_lora_preset_profile_mutations_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_mutations_smoke.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { createLoraPresetProfileMutations } from "../web/js/lora_preset/profile_mutations.js";
-import { MAX_PROFILES } from "../web/js/lora_preset/profile_data.js";
+import {
+  INTERNAL_WIDGET_DEFAULTS,
+  MAX_PROFILES,
+  WIDGET_INDEX,
+} from "../web/js/lora_preset/profile_data.js";
+import { createLoraPresetNodeRuntime } from "../web/js/lora_preset/node_runtime.js";
 import { createLoraPresetSaveSync } from "../web/js/lora_preset/save_sync.js";
 
 function createProfileNode() {
@@ -134,6 +139,135 @@ mutations.appendProfilePayload(partialNode, {
   profile_data: { "1": { style_prompt: "ignored", loras: [] } },
 });
 assert.equal(host.alerts.at(-1), "profile.maxReached");
+
+function createWorkflowNode() {
+  return {
+    id: "workflow-node",
+    comfyClass: "EasyUseAnimaLoraPreset",
+    widgets: [
+      { name: "style_prompt", value: "" },
+      { name: "profile_index", value: 1 },
+      { name: "profile_count", value: "2" },
+      { name: "lora_name", value: "None" },
+      { name: "loras", value: "[]" },
+      { name: "profile_data", value: JSON.stringify({
+        "1": { style_prompt: "profile-alpha", loras: [] },
+        "2": { style_prompt: "profile-beta", loras: [] },
+      }) },
+    ],
+    inputs: [],
+    addInput(name, type) { this.inputs.push({ name, type }); },
+    setDirtyCanvas() {},
+  };
+}
+
+const workflowFindWidget = (profileNode, name) => profileNode.__easyuseAnimaHiddenWidgets?.[name]
+  || profileNode.widgets.find((widget) => widget.name === name);
+const workflowWidgetValue = (widget, fallback) => widget?.value ?? fallback;
+const workflowSetWidgetValue = (widget, value) => {
+  widget.value = value;
+  widget.callback?.(value);
+};
+const workflowLoras = (profileNode) => JSON.parse(workflowWidgetValue(workflowFindWidget(profileNode, "loras"), "[]"));
+const workflowSetLoras = (profileNode, loras) => {
+  workflowSetWidgetValue(workflowFindWidget(profileNode, "loras"), JSON.stringify(loras));
+};
+const workflowCanvasWidgets = {
+  profileVisibleRows: 2,
+  ensureProfileBar() {},
+  renderProfileBar() {},
+  renderLoraWidgets() {},
+};
+const workflowMutations = createLoraPresetProfileMutations({
+  findWidget: workflowFindWidget,
+  widgetValue: workflowWidgetValue,
+  setWidgetValue: workflowSetWidgetValue,
+  lorasWidgetValue: workflowLoras,
+  setLorasWidgetValue: workflowSetLoras,
+  getCanvasWidgets: () => workflowCanvasWidgets,
+  text: (key) => key,
+  formatText: (key) => key,
+  apiClient: {},
+  host: { confirm: () => true },
+});
+function WorkflowNodeType() {}
+const workflowRuntime = createLoraPresetNodeRuntime({
+  nodeTypeName: "EasyUseAnimaLoraPreset",
+  internalWidgetDefaults: INTERNAL_WIDGET_DEFAULTS,
+  widgetIndex: WIDGET_INDEX,
+  findWidget: workflowFindWidget,
+  findInputEl: () => null,
+  widgetValue: workflowWidgetValue,
+  ensureWidgetValue(profileNode, name) {
+    const widget = workflowFindWidget(profileNode, name);
+    if (widget && (widget.value == null || widget.value === "")) {
+      workflowSetWidgetValue(widget, INTERNAL_WIDGET_DEFAULTS[name]);
+    }
+  },
+  resetInternalLoraSelector(profileNode) {
+    workflowSetWidgetValue(workflowFindWidget(profileNode, "lora_name"), INTERNAL_WIDGET_DEFAULTS.lora_name);
+  },
+  normalizeSerializedWidgets() {},
+  profileCount: workflowMutations.profileCount,
+  selectedProfileIndex: workflowMutations.selectedProfileIndex,
+  activeProfileIndex: workflowMutations.activeProfileIndex,
+  wrapProfileIndex(index, count) { return ((Number(index) - 1) % count + count) % count + 1; },
+  setProfileIndex: workflowMutations.setProfileIndex,
+  lorasWidgetValue: workflowLoras,
+  saveProfile: workflowMutations.saveProfile,
+  saveCurrentProfile: workflowMutations.saveCurrentProfile,
+  loadProfile: workflowMutations.loadProfile,
+  scrollProfileBarTo: workflowMutations.scrollProfileBarTo,
+  refreshLoraAvailability() {},
+  canvasWidgets: workflowCanvasWidgets,
+  enforceNodeLayout() {},
+  requestAnimationFrame(callback) { callback(); },
+});
+workflowRuntime.beforeRegisterNodeDef(WorkflowNodeType, { name: "EasyUseAnimaLoraPreset" });
+const workflowNode = Object.assign(new WorkflowNodeType(), createWorkflowNode());
+workflowNode.onNodeCreated();
+assert.equal(workflowWidgetValue(workflowFindWidget(workflowNode, "style_prompt")), "profile-alpha");
+workflowMutations.addProfile(workflowNode);
+assert.equal(workflowMutations.activeProfileIndex(workflowNode), 3);
+workflowMutations.switchProfile(workflowNode, 1);
+assert.equal(workflowWidgetValue(workflowFindWidget(workflowNode, "style_prompt")), "profile-alpha");
+workflowMutations.switchProfile(workflowNode, 3);
+workflowMutations.deleteProfile(workflowNode, 3);
+assert.equal(workflowMutations.activeProfileIndex(workflowNode), 2);
+assert.equal(workflowMutations.profileCount(workflowNode), 2);
+assert.equal(workflowWidgetValue(workflowFindWidget(workflowNode, "style_prompt")), "profile-beta");
+
+// The canvas-owned active index is authoritative even when a property-panel
+// snapshot still exposes the deleted profile index.
+workflowFindWidget(workflowNode, "profile_index").value = 3;
+const workflowGraphPrototype = {
+  serialize() {
+    const workflowNodeSnapshot = {
+      widgets_values: ["profile-alpha", 3, "3", "None", "[]", JSON.stringify({
+        "1": { style_prompt: "profile-alpha", loras: [] },
+        "2": { style_prompt: "profile-beta", loras: [] },
+        "3": { style_prompt: "", loras: [] },
+      })],
+    };
+    workflowNode.onSerialize(workflowNodeSnapshot);
+    return workflowNodeSnapshot;
+  },
+};
+const workflowGraph = { _nodes: [workflowNode] };
+const workflowSaveSync = createLoraPresetSaveSync({
+  app: { graph: workflowGraph, queuePrompt() {} },
+  nodeTypeName: "EasyUseAnimaLoraPreset",
+  saveCurrentProfile: workflowMutations.saveCurrentProfile,
+  getGraphPrototype: () => workflowGraphPrototype,
+});
+workflowSaveSync.install();
+const savedWorkflowNode = workflowGraphPrototype.serialize.call(workflowGraph);
+assert.equal(savedWorkflowNode.widgets_values[WIDGET_INDEX.profileIndex], 2);
+assert.equal(savedWorkflowNode.widgets_values[WIDGET_INDEX.profileCount], "2");
+const savedProfileData = JSON.parse(savedWorkflowNode.widgets_values[WIDGET_INDEX.profileData]);
+assert.deepEqual(Object.keys(savedProfileData), ["1", "2"]);
+assert.equal(savedProfileData["1"].style_prompt, "profile-alpha");
+assert.equal(savedProfileData["2"].style_prompt, "profile-beta");
 
 const syncCalls = [];
 const graphPrototype = {

--- a/tests/frontend_lora_preset_profile_mutations_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_mutations_smoke.mjs
@@ -240,15 +240,21 @@ assert.equal(workflowWidgetValue(workflowFindWidget(workflowNode, "style_prompt"
 // The canvas-owned active index is authoritative even when a property-panel
 // snapshot still exposes the deleted profile index.
 workflowFindWidget(workflowNode, "profile_index").value = 3;
+workflowNode.widgets.splice(WIDGET_INDEX.loraName, 0, {
+  name: "easyuse_anima_profile_bar",
+  value: null,
+  serialize: false,
+});
 const workflowGraphPrototype = {
   serialize() {
-    const workflowNodeSnapshot = {
-      widgets_values: ["profile-alpha", 3, "3", "None", "[]", JSON.stringify({
-        "1": { style_prompt: "profile-alpha", loras: [] },
-        "2": { style_prompt: "profile-beta", loras: [] },
-        "3": { style_prompt: "", loras: [] },
-      })],
-    };
+    const widgetsValues = [];
+    for (const [index, widget] of workflowNode.widgets.entries()) {
+      if (widget.serialize === false) {
+        continue;
+      }
+      widgetsValues[index] = widget.value ?? null;
+    }
+    const workflowNodeSnapshot = { widgets_values: widgetsValues };
     workflowNode.onSerialize(workflowNodeSnapshot);
     return workflowNodeSnapshot;
   },
@@ -264,6 +270,7 @@ workflowSaveSync.install();
 const savedWorkflowNode = workflowGraphPrototype.serialize.call(workflowGraph);
 assert.equal(savedWorkflowNode.widgets_values[WIDGET_INDEX.profileIndex], 2);
 assert.equal(savedWorkflowNode.widgets_values[WIDGET_INDEX.profileCount], "2");
+assert.equal(savedWorkflowNode.widgets_values.length, WIDGET_INDEX.profileData + 1);
 const savedProfileData = JSON.parse(savedWorkflowNode.widgets_values[WIDGET_INDEX.profileData]);
 assert.deepEqual(Object.keys(savedProfileData), ["1", "2"]);
 assert.equal(savedProfileData["1"].style_prompt, "profile-alpha");

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -47,6 +47,13 @@ LORA_PRESET_LORA_STATE = ROOT / "web" / "js" / "lora_preset" / "lora_state.js"
 LORA_PRESET_LORA_STATE_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_lora_state_smoke.mjs"
 )
+LORA_PRESET_PROFILE_MUTATIONS = (
+    ROOT / "web" / "js" / "lora_preset" / "profile_mutations.js"
+)
+LORA_PRESET_SAVE_SYNC = ROOT / "web" / "js" / "lora_preset" / "save_sync.js"
+LORA_PRESET_PROFILE_MUTATIONS_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_profile_mutations_smoke.mjs"
+)
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
@@ -238,17 +245,10 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 self.assertEqual(module_source.count(route), 1)
 
         self.assertEqual(entry_source.count("loraPresetApi.listProfiles()"), 1)
-        self.assertEqual(entry_source.count("loraPresetApi.loadProfile(name)"), 1)
-        self.assertEqual(entry_source.count("loraPresetApi.saveProfile("), 1)
+        self.assertEqual(entry_source.count("loraPresetApi.loadProfile(name)"), 0)
+        self.assertEqual(entry_source.count("loraPresetApi.saveProfile("), 0)
         self.assertEqual(entry_source.count("loraPresetApi.fixProfile("), 2)
         self.assertEqual(entry_source.count("loraPresetApi.listLoras()"), 1)
-        self.assertRegex(
-            entry_source,
-            (
-                r"loraPresetApi\.saveProfile\(\s*"
-                r"trimmedName,\s*selectedProfilePayload\(node\),?\s*\)"
-            ),
-        )
         self.assertIn(
             "loraPresetApi.fixProfile(fullProfilePayload(node))",
             entry_source,
@@ -312,7 +312,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
         )
 
         factory_match = re.search(
-            r"const\s+loraCanvasWidgets\s*=\s*"
+            r"loraCanvasWidgets\s*=\s*"
             r"createLoraPresetCanvasWidgets"
             r"\(\{(?P<dependencies>.*?)\}\);",
             entry_source,
@@ -419,11 +419,6 @@ class LoraPresetFrontendTests(unittest.TestCase):
         self.assertIn("loraMenuLifecycle.install()", entry_source)
         self.assertNotIn("loraMenuLifecycle.install()", module_source)
         for entry_owned_token in (
-            "function addProfile(",
-            "function deleteProfile(",
-            "function saveCurrentProfile(",
-            "function mutateLoras(",
-            "function installLoraPresetSaveSync(",
             "function scrollProfileListFromWheel(",
             "function installProfileWheelListener(",
             "app.registerExtension({",
@@ -431,8 +426,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
             with self.subTest(entry_owned_token=entry_owned_token):
                 self.assertIn(entry_owned_token, entry_source)
                 self.assertNotIn(entry_owned_token, module_source)
-        self.assertGreater(entry_source.count("loraCanvasWidgets.renderProfileBar("), 0)
-        self.assertGreater(entry_source.count("loraCanvasWidgets.renderLoraWidgets("), 0)
+        self.assertIn("let loraCanvasWidgets;", entry_source)
+        self.assertIn("getCanvasWidgets: () => loraCanvasWidgets", entry_source)
         self.assertTrue(LORA_PRESET_CANVAS_WIDGETS_SMOKE.is_file())
         self.assertIn("web/js/lora_preset/**/*.js", config["include"])
 
@@ -821,7 +816,20 @@ class LoraPresetFrontendTests(unittest.TestCase):
             for name in import_match.group("names").splitlines()
             if name.strip()
         }
-        self.assertEqual(imported_names, expected_exports)
+        self.assertEqual(
+            imported_names,
+            {
+                "INTERNAL_WIDGET_DEFAULTS",
+                "MAX_PROFILES",
+                "WIDGET_INDEX",
+                "normalizeLoraEntry",
+                "normalizeProfileDataValue",
+                "normalizeSerializedWidgets",
+                "profileKey",
+                "profileSavedName",
+                "wrapProfileIndex",
+            },
+        )
 
         self.assertEqual(module_source.splitlines()[0], "// @ts-check")
         self.assertNotRegex(
@@ -862,6 +870,64 @@ class LoraPresetFrontendTests(unittest.TestCase):
         if completed.returncode != 0:
             self.fail((completed.stdout + completed.stderr).strip())
 
+    def test_profile_mutations_and_save_sync_module_boundary(self):
+        mutations_source = LORA_PRESET_PROFILE_MUTATIONS.read_text(encoding="utf-8")
+        save_sync_source = LORA_PRESET_SAVE_SYNC.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(mutations_source.splitlines()[0], "import {")
+        self.assertEqual(save_sync_source.splitlines()[0], "/** Installs the graph-save and queue-preparation synchronization hooks. */")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                mutations_source,
+                re.MULTILINE,
+            ),
+            ["createLoraPresetProfileMutations"],
+        )
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                save_sync_source,
+                re.MULTILINE,
+            ),
+            ["createLoraPresetSaveSync"],
+        )
+        self.assertIn(
+            'import { createLoraPresetProfileMutations } from '
+            '"./lora_preset/profile_mutations.js";',
+            entry_source,
+        )
+        self.assertIn(
+            'import { createLoraPresetSaveSync } from "./lora_preset/save_sync.js";',
+            entry_source,
+        )
+        self.assertIn("const loraProfileMutations = createLoraPresetProfileMutations({", entry_source)
+        self.assertIn("const loraPresetSaveSync = createLoraPresetSaveSync({", entry_source)
+        self.assertIn("loraPresetSaveSync.install();", entry_source)
+        self.assertTrue(LORA_PRESET_PROFILE_MUTATIONS_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_lora_preset_profile_mutations_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_profile_mutations_and_save_sync_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_PROFILE_MUTATIONS_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
     def test_lora_row_controls_and_api_wiring_runtime(self):
         node_bin = shutil.which("node")
         if not node_bin:
@@ -881,6 +947,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const menuLifecyclePath = process.argv[6];
             const canvasWidgetsPath = process.argv[7];
             const nodeRuntimePath = process.argv[8];
+            const profileMutationsPath = process.argv[9];
+            const saveSyncPath = process.argv[10];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -916,9 +984,20 @@ class LoraPresetFrontendTests(unittest.TestCase):
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let profileMutationsSource = fs.readFileSync(profileMutationsPath, "utf8");
+            profileMutationsSource = profileMutationsSource.replace(/^import[\s\S]*?;\r?\n/gm, "");
+            profileMutationsSource = profileMutationsSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
+            let saveSyncSource = fs.readFileSync(saveSyncPath, "utf8");
+            saveSyncSource = saveSyncSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${source}`;
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${profileMutationsSource}\n${saveSyncSource}\n${source}`;
             source += "\nglobalThis.__loraPresetTest = { loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
@@ -1251,6 +1330,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_MENU_LIFECYCLE),
                 str(LORA_PRESET_CANVAS_WIDGETS),
                 str(LORA_PRESET_NODE_RUNTIME),
+                str(LORA_PRESET_PROFILE_MUTATIONS),
+                str(LORA_PRESET_SAVE_SYNC),
             ],
             cwd=ROOT,
             text=True,

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3277,6 +3277,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn(
             r'& node "tests\frontend_aio_settings_core_smoke.mjs"', source
         )
+        self.assertIn(
+            r'& node "tests\frontend_lora_preset_profile_mutations_smoke.mjs"',
+            source,
+        )
         self.assertIn('"typescript@$TypeScriptVersion"', source)
         self.assertIn("tsc -p jsconfig.json", source)
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -189,6 +189,11 @@ try {
         throw "Frontend LoRA preset node runtime smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_profile_mutations_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset profile mutation and save-sync smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_data_adapter_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -6,21 +6,18 @@ import { createLoraPresetApiClient } from "./lora_preset/api_client.js";
 import { createLoraPresetCanvasWidgets } from "./lora_preset/canvas_widgets.js";
 import { createLoraPresetMenuLifecycle } from "./lora_preset/menu_lifecycle.js";
 import { createLoraPresetNodeRuntime } from "./lora_preset/node_runtime.js";
+import { createLoraPresetProfileMutations } from "./lora_preset/profile_mutations.js";
 import { createLoraPresetPreviewLifecycle } from "./lora_preset/preview_lifecycle.js";
+import { createLoraPresetSaveSync } from "./lora_preset/save_sync.js";
 import {
   INTERNAL_WIDGET_DEFAULTS,
   MAX_PROFILES,
   WIDGET_INDEX,
-  emptyProfile,
-  isMeaningfulProfile,
   normalizeLoraEntry,
   normalizeProfileDataValue,
   normalizeSerializedWidgets,
-  profileContent,
   profileKey,
   profileSavedName,
-  profileSnapshot,
-  withSavedMeta,
   wrapProfileIndex,
 } from "./lora_preset/profile_data.js";
 import {
@@ -319,7 +316,49 @@ const loraMenuLifecycle = createLoraPresetMenuLifecycle({
   nodeType: NODE_TYPE,
   previewSize: PREVIEW_SIZE,
 });
-const loraCanvasWidgets = createLoraPresetCanvasWidgets({
+let loraCanvasWidgets;
+const loraProfileMutations = createLoraPresetProfileMutations({
+  findWidget,
+  widgetValue,
+  setWidgetValue,
+  lorasWidgetValue,
+  setLorasWidgetValue,
+  getCanvasWidgets: () => loraCanvasWidgets,
+  text: lpText,
+  formatText: lpFormat,
+  apiClient: loraPresetApi,
+  errorMessage,
+  host: window,
+});
+const {
+  parseProfileData,
+  writeProfileData,
+  profileCount,
+  selectedProfileIndex,
+  activeProfileIndex,
+  setProfileIndex,
+  setProfileCount,
+  scrollProfileBarTo,
+  currentProfileContent,
+  saveProfile,
+  saveCurrentProfile,
+  loadProfile,
+  switchProfile,
+  addProfile,
+  deleteProfile,
+  selectedProfilePayload,
+  profileSaveStatus,
+  appendProfilePayload,
+  saveProfileSet,
+  loadProfileSet,
+  fullProfilePayload,
+  mutateLoras,
+  addLoraEntry,
+  updateLoraEntry,
+  removeLoraEntry,
+  moveLoraEntry,
+} = loraProfileMutations;
+loraCanvasWidgets = createLoraPresetCanvasWidgets({
   getCanvas: () => app.canvas,
   getLiteGraph: () => LiteGraph,
   getSettings: () => LORA_PRESET_SETTINGS,
@@ -377,6 +416,11 @@ const loraPresetNodeRuntime = createLoraPresetNodeRuntime({
   canvasWidgets: loraCanvasWidgets,
   enforceNodeLayout,
   requestAnimationFrame: (callback) => window.requestAnimationFrame(callback),
+});
+const loraPresetSaveSync = createLoraPresetSaveSync({
+  app,
+  nodeTypeName: NODE_TYPE,
+  saveCurrentProfile,
 });
 
 function findWidget(node, name) {
@@ -440,59 +484,6 @@ function resetInternalLoraSelector(node) {
   }
 }
 
-function parseProfileData(widget) {
-  return normalizeProfileDataValue(widgetValue(widget, "{}"));
-}
-
-function writeProfileData(widget, data) {
-  setWidgetValue(widget, JSON.stringify(data));
-}
-
-function profileCount(node) {
-  return Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(widgetValue(findWidget(node, "profile_count"), 4), 10) || 4));
-}
-
-function selectedProfileIndex(node) {
-  return wrapProfileIndex(widgetValue(findWidget(node, "profile_index"), 1), profileCount(node));
-}
-
-function activeProfileIndex(node) {
-  return wrapProfileIndex(node.__easyuseAnimaActiveProfileIndex || selectedProfileIndex(node), profileCount(node));
-}
-
-function setProfileIndex(node, index) {
-  node.__easyuseAnimaSuppressProfileIndexCallback = true;
-  try {
-    setWidgetValue(findWidget(node, "profile_index"), wrapProfileIndex(index, profileCount(node)));
-  } finally {
-    node.__easyuseAnimaSuppressProfileIndexCallback = false;
-  }
-}
-
-function setProfileCount(node, count) {
-  node.__easyuseAnimaSuppressProfileCountCallback = true;
-  try {
-    setWidgetValue(findWidget(node, "profile_count"), Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(count, 10) || 1)));
-  } finally {
-    node.__easyuseAnimaSuppressProfileCountCallback = false;
-  }
-}
-
-function scrollProfileBarTo(node, index) {
-  const bar = node.__easyuseAnimaProfileBar;
-  if (!bar) {
-    return;
-  }
-  const count = profileCount(node);
-  const maxOffset = Math.max(0, count - loraCanvasWidgets.profileVisibleRows);
-  const target = wrapProfileIndex(index, count);
-  if (target <= (bar.scrollOffset || 0)) {
-    bar.scrollOffset = Math.max(0, target - 1);
-  } else if (target > (bar.scrollOffset || 0) + loraCanvasWidgets.profileVisibleRows) {
-    bar.scrollOffset = Math.max(0, Math.min(maxOffset, target - loraCanvasWidgets.profileVisibleRows));
-  }
-}
-
 function lorasWidgetValue(node) {
   const value = widgetValue(findWidget(node, "loras"), "[]");
   if (Array.isArray(value)) {
@@ -525,248 +516,6 @@ function setLorasWidgetValue(node, loras, options = {}) {
   }
 }
 
-function currentProfileContent(node) {
-  return {
-    style_prompt: String(widgetValue(findWidget(node, "style_prompt"), "")),
-    loras: lorasWidgetValue(node).map(normalizeLoraEntry).filter((entry) => entry.name),
-  };
-}
-
-function saveProfile(node, index) {
-  if (node.__easyuseAnimaLoadingProfile) {
-    return;
-  }
-  const dataWidget = findWidget(node, "profile_data");
-  if (!dataWidget) {
-    return;
-  }
-  const data = parseProfileData(dataWidget);
-  const key = profileKey(index);
-  data[key] = withSavedMeta(currentProfileContent(node), data[key]);
-  writeProfileData(dataWidget, data);
-}
-
-function saveCurrentProfile(node) {
-  saveProfile(node, activeProfileIndex(node));
-}
-
-function loadProfile(node, index, options = {}) {
-  const dataWidget = findWidget(node, "profile_data");
-  if (!dataWidget) {
-    return;
-  }
-  const data = parseProfileData(dataWidget);
-  const key = profileKey(index);
-  if (!Object.prototype.hasOwnProperty.call(data, key)) {
-    data[key] = options.initializeFromCurrent ? currentProfileContent(node) : emptyProfile(index);
-    writeProfileData(dataWidget, data);
-  }
-  const profile = data[key] || emptyProfile(index);
-  node.__easyuseAnimaLoadingProfile = true;
-  try {
-    setWidgetValue(findWidget(node, "style_prompt"), String(profile.style_prompt || ""));
-    setLorasWidgetValue(node, Array.isArray(profile.loras) ? profile.loras : []);
-  } finally {
-    node.__easyuseAnimaLoadingProfile = false;
-  }
-}
-
-function switchProfile(node, index) {
-  const nextIndex = wrapProfileIndex(index, profileCount(node));
-  const currentIndex = activeProfileIndex(node);
-  if (nextIndex === currentIndex) {
-    loraCanvasWidgets.renderProfileBar(node);
-    return;
-  }
-  saveProfile(node, currentIndex);
-  setProfileIndex(node, nextIndex);
-  node.__easyuseAnimaActiveProfileIndex = nextIndex;
-  loadProfile(node, nextIndex);
-  scrollProfileBarTo(node, nextIndex);
-  loraCanvasWidgets.renderProfileBar(node);
-  node.setDirtyCanvas?.(true, true);
-}
-
-function addProfile(node) {
-  const count = profileCount(node);
-  if (count >= MAX_PROFILES) {
-    return;
-  }
-  saveCurrentProfile(node);
-  const nextIndex = count + 1;
-  const dataWidget = findWidget(node, "profile_data");
-  const data = parseProfileData(dataWidget);
-  data[profileKey(nextIndex)] = emptyProfile(nextIndex);
-  writeProfileData(dataWidget, data);
-  setProfileCount(node, nextIndex);
-  switchProfile(node, nextIndex);
-}
-
-function deleteProfile(node, index) {
-  const count = profileCount(node);
-  if (count <= 1) {
-    return;
-  }
-  if (!window.confirm(lpFormat("profile.deleteConfirm", { index }))) {
-    return;
-  }
-  const data = parseProfileData(findWidget(node, "profile_data"));
-  const nextData = {};
-  let nextWriteIndex = 1;
-  for (let sourceIndex = 1; sourceIndex <= count; sourceIndex += 1) {
-    if (sourceIndex === index) {
-      continue;
-    }
-    nextData[profileKey(nextWriteIndex)] = data[profileKey(sourceIndex)] || emptyProfile(nextWriteIndex);
-    nextWriteIndex += 1;
-  }
-  writeProfileData(findWidget(node, "profile_data"), nextData);
-  setProfileCount(node, count - 1);
-  const nextActive = Math.min(index, count - 1);
-  node.__easyuseAnimaActiveProfileIndex = nextActive;
-  setProfileIndex(node, nextActive);
-  loadProfile(node, nextActive);
-  scrollProfileBarTo(node, nextActive);
-  loraCanvasWidgets.renderProfileBar(node);
-  node.setDirtyCanvas?.(true, true);
-}
-
-function selectedProfilePayload(node) {
-  saveCurrentProfile(node);
-  const index = activeProfileIndex(node);
-  const data = parseProfileData(findWidget(node, "profile_data"));
-  const profile = profileContent(data[profileKey(index)]);
-  return {
-    profile_count: 1,
-    profile_index: 1,
-    profile_data: {
-      "1": profile,
-    },
-  };
-}
-
-function profileSaveStatus(node, index) {
-  const profile = parseProfileData(findWidget(node, "profile_data"))[profileKey(index)] || {};
-  const savedName = profileSavedName(profile);
-  if (!savedName) {
-    return { state: "unsaved", labelKey: "profile.unsaved", savedName: "" };
-  }
-  const dirty = String(profile.saved_snapshot || "") !== profileSnapshot(profile);
-  return {
-    state: dirty ? "changed" : "saved",
-    labelKey: dirty ? "profile.changed" : "profile.saved",
-    savedName,
-  };
-}
-
-function markSelectedProfileSaved(node, name) {
-  const savedName = String(name || "").trim();
-  if (!savedName) {
-    return;
-  }
-  saveCurrentProfile(node);
-  const dataWidget = findWidget(node, "profile_data");
-  const data = parseProfileData(dataWidget);
-  const key = profileKey(activeProfileIndex(node));
-  const content = profileContent(data[key]);
-  data[key] = {
-    ...content,
-    saved_name: savedName,
-    saved_snapshot: profileSnapshot(content),
-  };
-  writeProfileData(dataWidget, data);
-  loadProfile(node, activeProfileIndex(node));
-}
-
-function appendProfilePayload(node, payload) {
-  saveCurrentProfile(node);
-  const profile = payload?.profile || payload || {};
-  const incomingData = normalizeProfileDataValue(profile.profile_data);
-  const savedName = String(profile.name || "").trim();
-  const incomingCount = Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(profile.profile_count, 10) || Object.keys(incomingData).length || 1));
-  const incomingProfiles = [];
-  for (let sourceIndex = 1; sourceIndex <= incomingCount; sourceIndex += 1) {
-    const sourceProfile = incomingData[profileKey(sourceIndex)];
-    if (isMeaningfulProfile(sourceProfile)) {
-      incomingProfiles.push({
-        sourceIndex,
-        content: profileContent(sourceProfile),
-      });
-    }
-  }
-  if (!incomingProfiles.length) {
-    window.alert(lpText("profile.noNonEmpty"));
-    return;
-  }
-  const currentCount = profileCount(node);
-  const available = MAX_PROFILES - currentCount;
-  if (available <= 0) {
-    window.alert(lpFormat("profile.maxReached", { max: MAX_PROFILES }));
-    return;
-  }
-  const appendCount = Math.min(incomingProfiles.length, available);
-  const targetStart = currentCount + 1;
-  const data = parseProfileData(findWidget(node, "profile_data"));
-  for (let offset = 0; offset < appendCount; offset += 1) {
-    const targetIndex = targetStart + offset;
-    const content = incomingProfiles[offset].content;
-    data[profileKey(targetIndex)] = savedName
-      ? {
-        ...content,
-        saved_name: savedName,
-        saved_snapshot: profileSnapshot(content),
-      }
-      : content;
-  }
-  if (appendCount < incomingProfiles.length) {
-    window.alert(lpFormat("profile.partialLoad", { count: appendCount, max: MAX_PROFILES }));
-  }
-  const selectedSourceIndex = wrapProfileIndex(profile.profile_index || 1, incomingCount);
-  const selectedOffset = incomingProfiles.findIndex((item) => item.sourceIndex === selectedSourceIndex);
-  const nextIndex = targetStart + Math.max(0, Math.min(appendCount - 1, selectedOffset < 0 ? 0 : selectedOffset));
-  setProfileCount(node, currentCount + appendCount);
-  writeProfileData(findWidget(node, "profile_data"), data);
-  setProfileIndex(node, nextIndex);
-  node.__easyuseAnimaActiveProfileIndex = nextIndex;
-  loadProfile(node, nextIndex);
-  scrollProfileBarTo(node, nextIndex);
-  loraCanvasWidgets.renderProfileBar(node);
-  loraCanvasWidgets.renderLoraWidgets(node);
-  node.setDirtyCanvas?.(true, true);
-}
-
-async function saveProfileSet(node) {
-  const name = window.prompt(lpText("profile.savePrompt"));
-  if (name == null) {
-    return;
-  }
-  const trimmedName = name.trim();
-  if (!trimmedName) {
-    window.alert(lpText("profile.nameRequired"));
-    return;
-  }
-  try {
-    const data = await loraPresetApi.saveProfile(
-      trimmedName,
-      selectedProfilePayload(node),
-    );
-    markSelectedProfileSaved(node, data?.profile?.name || trimmedName);
-    loraCanvasWidgets.renderProfileBar(node);
-    node.setDirtyCanvas?.(true, true);
-  } catch (error) {
-    window.alert(lpFormat("profile.saveFailed", { message: errorMessage(error) }));
-  }
-}
-
-async function loadProfileSet(node, name) {
-  try {
-    const data = await loraPresetApi.loadProfile(name);
-    appendProfilePayload(node, data.profile);
-  } catch (error) {
-    window.alert(lpFormat("profile.loadFailed", { message: errorMessage(error) }));
-  }
-}
-
 async function openProfileLoadMenu(node, event, pos) {
   let profiles = [];
   try {
@@ -794,15 +543,6 @@ async function openProfileLoadMenu(node, event, pos) {
       }
     },
   });
-}
-
-function fullProfilePayload(node) {
-  saveCurrentProfile(node);
-  return {
-    profile_count: profileCount(node),
-    profile_index: activeProfileIndex(node),
-    profile_data: parseProfileData(findWidget(node, "profile_data")),
-  };
 }
 
 function profileHasLoraPathProblems(node) {
@@ -997,61 +737,6 @@ function loraEntryFromName(name, base = {}) {
   });
 }
 
-function mutateLoras(node, mutator, options = {}) {
-  const loras = lorasWidgetValue(node).map(normalizeLoraEntry);
-  mutator(loras);
-  setLorasWidgetValue(node, loras, options);
-  saveCurrentProfile(node);
-}
-
-function addLoraEntry(node, entry) {
-  const nextEntry = normalizeLoraEntry(entry);
-  if (!nextEntry.name) {
-    return;
-  }
-  mutateLoras(node, (loras) => {
-    const existing = loras.find((lora) => lora.name === nextEntry.name);
-    if (existing) {
-      Object.assign(existing, nextEntry);
-    } else {
-      loras.push(nextEntry);
-    }
-  });
-}
-
-function updateLoraEntry(node, index, patch, options = {}) {
-  mutateLoras(node, (loras) => {
-    if (!loras[index]) {
-      return;
-    }
-    const current = loras[index];
-    const oldStrength = Number(current.strength ?? 1);
-    const oldClip = current.strengthTwo == null ? oldStrength : Number(current.strengthTwo);
-    Object.assign(current, patch);
-    if (Object.prototype.hasOwnProperty.call(patch, "strength") && Math.abs(oldClip - oldStrength) < 0.0001) {
-      current.strengthTwo = null;
-    }
-  }, options);
-}
-
-function removeLoraEntry(node, index) {
-  mutateLoras(node, (loras) => {
-    loras.splice(index, 1);
-  });
-}
-
-function moveLoraEntry(node, index, direction) {
-  mutateLoras(node, (loras) => {
-    const from = Number(index);
-    const to = from + Number(direction || 0);
-    if (!Number.isInteger(from) || !Number.isInteger(to) || !loras[from] || to < 0 || to >= loras.length) {
-      return;
-    }
-    const [entry] = loras.splice(from, 1);
-    loras.splice(to, 0, entry);
-  });
-}
-
 function openLoraEntryMenu(node, event, index) {
   const lora = normalizeLoraEntry(lorasWidgetValue(node)[index]);
   if (!lora.name) {
@@ -1225,40 +910,6 @@ async function openLoraMenu(node, event, pos, onChoose) {
   });
 }
 
-function syncLoraPresetNode(node) {
-  if (!node || node.comfyClass !== NODE_TYPE) {
-    return;
-  }
-  saveCurrentProfile(node);
-}
-
-function syncAllLoraPresetNodes() {
-  for (const node of app.graph?._nodes || []) {
-    syncLoraPresetNode(node);
-  }
-}
-
-function installLoraPresetSaveSync() {
-  const graphProto = globalThis.LGraph?.prototype || app.graph?.constructor?.prototype;
-  if (graphProto?.serialize && !graphProto.serialize.__easyuseAnimaLoraPresetWrapped) {
-    const serialize = graphProto.serialize;
-    graphProto.serialize = function () {
-      syncAllLoraPresetNodes();
-      return serialize.apply(this, arguments);
-    };
-    graphProto.serialize.__easyuseAnimaLoraPresetWrapped = true;
-  }
-
-  if (app.queuePrompt && !app.queuePrompt.__easyuseAnimaLoraPresetWrapped) {
-    const queuePrompt = app.queuePrompt;
-    app.queuePrompt = function () {
-      syncAllLoraPresetNodes();
-      return queuePrompt.apply(this, arguments);
-    };
-    app.queuePrompt.__easyuseAnimaLoraPresetWrapped = true;
-  }
-}
-
 function refreshLoraPresetNodes() {
   const nodes = app.graph?._nodes || [];
   for (const node of nodes) {
@@ -1365,7 +1016,7 @@ function installProfileWheelListener() {
 app.registerExtension({
   name: "EasyUseAnima.LoraPreset",
   init() {
-    installLoraPresetSaveSync();
+    loraPresetSaveSync.install();
     loadLoraPresetSettings().then(refreshLoraPresetNodes);
     easyuseAnimaWatchLocale(refreshLoraPresetNodes);
     window.addEventListener("easyuse-anima-settings-updated", (event) => {
@@ -1377,7 +1028,7 @@ app.registerExtension({
     loraMenuLifecycle.install();
   },
   setup() {
-    installLoraPresetSaveSync();
+    loraPresetSaveSync.install();
   },
   async beforeRegisterNodeDef(nodeType, nodeData) {
     loraPresetNodeRuntime.beforeRegisterNodeDef(nodeType, nodeData);

--- a/web/js/lora_preset/node_runtime.js
+++ b/web/js/lora_preset/node_runtime.js
@@ -175,7 +175,8 @@ export function createLoraPresetNodeRuntime({
       originalOnSerialize?.apply(this, arguments);
       const dataWidget = findWidget(this, "profile_data");
       if (workflowNode?.widgets_values && dataWidget) {
-        workflowNode.widgets_values[widgetIndex.profileCount] = String(widgetValue(findWidget(this, "profile_count"), profileCount(this)) || "4");
+        workflowNode.widgets_values[widgetIndex.profileIndex] = activeProfileIndex(this);
+        workflowNode.widgets_values[widgetIndex.profileCount] = String(profileCount(this));
         workflowNode.widgets_values[widgetIndex.loraName] = internalWidgetDefaults.lora_name;
         workflowNode.widgets_values[widgetIndex.loras] = JSON.stringify(lorasWidgetValue(this));
         workflowNode.widgets_values[widgetIndex.profileData] = widgetValue(dataWidget, "{}");

--- a/web/js/lora_preset/node_runtime.js
+++ b/web/js/lora_preset/node_runtime.js
@@ -31,6 +31,30 @@ export function createLoraPresetNodeRuntime({
   enforceNodeLayout,
   requestAnimationFrame,
 }) {
+  function compactSerializedWidgetValues(node, workflowNode) {
+    const values = workflowNode?.widgets_values;
+    const widgets = node?.widgets;
+    if (!Array.isArray(values) || !Array.isArray(widgets)) {
+      return values;
+    }
+    const serializableCount = widgets.reduce(
+      (count, widget) => count + (widget?.serialize === false ? 0 : 1),
+      0,
+    );
+    if (values.length <= serializableCount) {
+      return values.slice(0, serializableCount);
+    }
+    const compact = [];
+    for (let widgetIndex = 0; widgetIndex < widgets.length; widgetIndex += 1) {
+      const widget = widgets[widgetIndex];
+      if (widget?.serialize === false) {
+        continue;
+      }
+      compact.push(values[widgetIndex] ?? widgetValue(widget, null));
+    }
+    return compact;
+  }
+
   function hideInternalWidget(node, name) {
     const widget = findWidget(node, name);
     if (!widget) {
@@ -175,11 +199,13 @@ export function createLoraPresetNodeRuntime({
       originalOnSerialize?.apply(this, arguments);
       const dataWidget = findWidget(this, "profile_data");
       if (workflowNode?.widgets_values && dataWidget) {
-        workflowNode.widgets_values[widgetIndex.profileIndex] = activeProfileIndex(this);
-        workflowNode.widgets_values[widgetIndex.profileCount] = String(profileCount(this));
-        workflowNode.widgets_values[widgetIndex.loraName] = internalWidgetDefaults.lora_name;
-        workflowNode.widgets_values[widgetIndex.loras] = JSON.stringify(lorasWidgetValue(this));
-        workflowNode.widgets_values[widgetIndex.profileData] = widgetValue(dataWidget, "{}");
+        const values = compactSerializedWidgetValues(this, workflowNode);
+        workflowNode.widgets_values = values;
+        values[widgetIndex.profileIndex] = activeProfileIndex(this);
+        values[widgetIndex.profileCount] = String(profileCount(this));
+        values[widgetIndex.loraName] = internalWidgetDefaults.lora_name;
+        values[widgetIndex.loras] = JSON.stringify(lorasWidgetValue(this));
+        values[widgetIndex.profileData] = widgetValue(dataWidget, "{}");
       }
     };
 

--- a/web/js/lora_preset/profile_mutations.js
+++ b/web/js/lora_preset/profile_mutations.js
@@ -1,0 +1,403 @@
+import {
+  MAX_PROFILES,
+  emptyProfile,
+  isMeaningfulProfile,
+  normalizeLoraEntry,
+  normalizeProfileDataValue,
+  profileContent,
+  profileKey,
+  profileSavedName,
+  profileSnapshot,
+  withSavedMeta,
+  wrapProfileIndex,
+} from "./profile_data.js";
+
+/**
+ * Owns profile and LoRA-row mutations while leaving canvas rendering and node
+ * lifecycle installation with their existing owners.
+ */
+export function createLoraPresetProfileMutations({
+  findWidget,
+  widgetValue,
+  setWidgetValue,
+  lorasWidgetValue,
+  setLorasWidgetValue,
+  getCanvasWidgets,
+  text,
+  formatText,
+  apiClient,
+  errorMessage = (error) => error?.message || String(error),
+  host = globalThis.window,
+}) {
+  function renderProfileBar(node) {
+    getCanvasWidgets()?.renderProfileBar(node);
+  }
+
+  function renderLoraWidgets(node) {
+    getCanvasWidgets()?.renderLoraWidgets(node);
+  }
+
+  function parseProfileData(widget) {
+    return normalizeProfileDataValue(widgetValue(widget, "{}"));
+  }
+
+  function writeProfileData(widget, data) {
+    setWidgetValue(widget, JSON.stringify(data));
+  }
+
+  function profileCount(node) {
+    return Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(widgetValue(findWidget(node, "profile_count"), 4), 10) || 4));
+  }
+
+  function selectedProfileIndex(node) {
+    return wrapProfileIndex(widgetValue(findWidget(node, "profile_index"), 1), profileCount(node));
+  }
+
+  function activeProfileIndex(node) {
+    return wrapProfileIndex(node.__easyuseAnimaActiveProfileIndex || selectedProfileIndex(node), profileCount(node));
+  }
+
+  function setProfileIndex(node, index) {
+    node.__easyuseAnimaSuppressProfileIndexCallback = true;
+    try {
+      setWidgetValue(findWidget(node, "profile_index"), wrapProfileIndex(index, profileCount(node)));
+    } finally {
+      node.__easyuseAnimaSuppressProfileIndexCallback = false;
+    }
+  }
+
+  function setProfileCount(node, count) {
+    node.__easyuseAnimaSuppressProfileCountCallback = true;
+    try {
+      setWidgetValue(findWidget(node, "profile_count"), Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(count, 10) || 1)));
+    } finally {
+      node.__easyuseAnimaSuppressProfileCountCallback = false;
+    }
+  }
+
+  function scrollProfileBarTo(node, index) {
+    const bar = node.__easyuseAnimaProfileBar;
+    if (!bar) {
+      return;
+    }
+    const canvasWidgets = getCanvasWidgets();
+    const visibleRows = canvasWidgets?.profileVisibleRows || 1;
+    const count = profileCount(node);
+    const maxOffset = Math.max(0, count - visibleRows);
+    const target = wrapProfileIndex(index, count);
+    if (target <= (bar.scrollOffset || 0)) {
+      bar.scrollOffset = Math.max(0, target - 1);
+    } else if (target > (bar.scrollOffset || 0) + visibleRows) {
+      bar.scrollOffset = Math.max(0, Math.min(maxOffset, target - visibleRows));
+    }
+  }
+
+  function currentProfileContent(node) {
+    return {
+      style_prompt: String(widgetValue(findWidget(node, "style_prompt"), "")),
+      loras: lorasWidgetValue(node).map(normalizeLoraEntry).filter((entry) => entry.name),
+    };
+  }
+
+  function saveProfile(node, index) {
+    if (node.__easyuseAnimaLoadingProfile) {
+      return;
+    }
+    const dataWidget = findWidget(node, "profile_data");
+    if (!dataWidget) {
+      return;
+    }
+    const data = parseProfileData(dataWidget);
+    const key = profileKey(index);
+    data[key] = withSavedMeta(currentProfileContent(node), data[key]);
+    writeProfileData(dataWidget, data);
+  }
+
+  function saveCurrentProfile(node) {
+    saveProfile(node, activeProfileIndex(node));
+  }
+
+  function loadProfile(node, index, options = {}) {
+    const dataWidget = findWidget(node, "profile_data");
+    if (!dataWidget) {
+      return;
+    }
+    const data = parseProfileData(dataWidget);
+    const key = profileKey(index);
+    if (!Object.prototype.hasOwnProperty.call(data, key)) {
+      data[key] = options.initializeFromCurrent ? currentProfileContent(node) : emptyProfile(index);
+      writeProfileData(dataWidget, data);
+    }
+    const profile = data[key] || emptyProfile(index);
+    node.__easyuseAnimaLoadingProfile = true;
+    try {
+      setWidgetValue(findWidget(node, "style_prompt"), String(profile.style_prompt || ""));
+      setLorasWidgetValue(node, Array.isArray(profile.loras) ? profile.loras : []);
+    } finally {
+      node.__easyuseAnimaLoadingProfile = false;
+    }
+  }
+
+  function switchProfile(node, index) {
+    const nextIndex = wrapProfileIndex(index, profileCount(node));
+    const currentIndex = activeProfileIndex(node);
+    if (nextIndex === currentIndex) {
+      renderProfileBar(node);
+      return;
+    }
+    saveProfile(node, currentIndex);
+    setProfileIndex(node, nextIndex);
+    node.__easyuseAnimaActiveProfileIndex = nextIndex;
+    loadProfile(node, nextIndex);
+    scrollProfileBarTo(node, nextIndex);
+    renderProfileBar(node);
+    node.setDirtyCanvas?.(true, true);
+  }
+
+  function addProfile(node) {
+    const count = profileCount(node);
+    if (count >= MAX_PROFILES) {
+      return;
+    }
+    saveCurrentProfile(node);
+    const nextIndex = count + 1;
+    const dataWidget = findWidget(node, "profile_data");
+    const data = parseProfileData(dataWidget);
+    data[profileKey(nextIndex)] = emptyProfile(nextIndex);
+    writeProfileData(dataWidget, data);
+    setProfileCount(node, nextIndex);
+    switchProfile(node, nextIndex);
+  }
+
+  function deleteProfile(node, index) {
+    const count = profileCount(node);
+    if (count <= 1 || !host.confirm?.(formatText("profile.deleteConfirm", { index }))) {
+      return;
+    }
+    const data = parseProfileData(findWidget(node, "profile_data"));
+    const nextData = {};
+    let nextWriteIndex = 1;
+    for (let sourceIndex = 1; sourceIndex <= count; sourceIndex += 1) {
+      if (sourceIndex === index) {
+        continue;
+      }
+      nextData[profileKey(nextWriteIndex)] = data[profileKey(sourceIndex)] || emptyProfile(nextWriteIndex);
+      nextWriteIndex += 1;
+    }
+    writeProfileData(findWidget(node, "profile_data"), nextData);
+    setProfileCount(node, count - 1);
+    const nextActive = Math.min(index, count - 1);
+    node.__easyuseAnimaActiveProfileIndex = nextActive;
+    setProfileIndex(node, nextActive);
+    loadProfile(node, nextActive);
+    scrollProfileBarTo(node, nextActive);
+    renderProfileBar(node);
+    node.setDirtyCanvas?.(true, true);
+  }
+
+  function selectedProfilePayload(node) {
+    saveCurrentProfile(node);
+    const index = activeProfileIndex(node);
+    const data = parseProfileData(findWidget(node, "profile_data"));
+    return {
+      profile_count: 1,
+      profile_index: 1,
+      profile_data: { "1": profileContent(data[profileKey(index)]) },
+    };
+  }
+
+  function profileSaveStatus(node, index) {
+    const profile = parseProfileData(findWidget(node, "profile_data"))[profileKey(index)] || {};
+    const savedName = profileSavedName(profile);
+    if (!savedName) {
+      return { state: "unsaved", labelKey: "profile.unsaved", savedName: "" };
+    }
+    const dirty = String(profile.saved_snapshot || "") !== profileSnapshot(profile);
+    return { state: dirty ? "changed" : "saved", labelKey: dirty ? "profile.changed" : "profile.saved", savedName };
+  }
+
+  function markSelectedProfileSaved(node, name) {
+    const savedName = String(name || "").trim();
+    if (!savedName) {
+      return;
+    }
+    saveCurrentProfile(node);
+    const dataWidget = findWidget(node, "profile_data");
+    const data = parseProfileData(dataWidget);
+    const key = profileKey(activeProfileIndex(node));
+    const content = profileContent(data[key]);
+    data[key] = { ...content, saved_name: savedName, saved_snapshot: profileSnapshot(content) };
+    writeProfileData(dataWidget, data);
+    loadProfile(node, activeProfileIndex(node));
+  }
+
+  function appendProfilePayload(node, payload) {
+    saveCurrentProfile(node);
+    const profile = payload?.profile || payload || {};
+    const incomingData = normalizeProfileDataValue(profile.profile_data);
+    const savedName = String(profile.name || "").trim();
+    const incomingCount = Math.max(1, Math.min(MAX_PROFILES, Number.parseInt(profile.profile_count, 10) || Object.keys(incomingData).length || 1));
+    const incomingProfiles = [];
+    for (let sourceIndex = 1; sourceIndex <= incomingCount; sourceIndex += 1) {
+      const sourceProfile = incomingData[profileKey(sourceIndex)];
+      if (isMeaningfulProfile(sourceProfile)) {
+        incomingProfiles.push({ sourceIndex, content: profileContent(sourceProfile) });
+      }
+    }
+    if (!incomingProfiles.length) {
+      host.alert?.(text("profile.noNonEmpty"));
+      return;
+    }
+    const currentCount = profileCount(node);
+    const available = MAX_PROFILES - currentCount;
+    if (available <= 0) {
+      host.alert?.(formatText("profile.maxReached", { max: MAX_PROFILES }));
+      return;
+    }
+    const appendCount = Math.min(incomingProfiles.length, available);
+    const targetStart = currentCount + 1;
+    const data = parseProfileData(findWidget(node, "profile_data"));
+    for (let offset = 0; offset < appendCount; offset += 1) {
+      const targetIndex = targetStart + offset;
+      const content = incomingProfiles[offset].content;
+      data[profileKey(targetIndex)] = savedName
+        ? { ...content, saved_name: savedName, saved_snapshot: profileSnapshot(content) }
+        : content;
+    }
+    if (appendCount < incomingProfiles.length) {
+      host.alert?.(formatText("profile.partialLoad", { count: appendCount, max: MAX_PROFILES }));
+    }
+    const selectedSourceIndex = wrapProfileIndex(profile.profile_index || 1, incomingCount);
+    const selectedOffset = incomingProfiles.findIndex((item) => item.sourceIndex === selectedSourceIndex);
+    const nextIndex = targetStart + Math.max(0, Math.min(appendCount - 1, selectedOffset < 0 ? 0 : selectedOffset));
+    setProfileCount(node, currentCount + appendCount);
+    writeProfileData(findWidget(node, "profile_data"), data);
+    setProfileIndex(node, nextIndex);
+    node.__easyuseAnimaActiveProfileIndex = nextIndex;
+    loadProfile(node, nextIndex);
+    scrollProfileBarTo(node, nextIndex);
+    renderProfileBar(node);
+    renderLoraWidgets(node);
+    node.setDirtyCanvas?.(true, true);
+  }
+
+  async function saveProfileSet(node) {
+    const name = host.prompt?.(text("profile.savePrompt"));
+    if (name == null) {
+      return;
+    }
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      host.alert?.(text("profile.nameRequired"));
+      return;
+    }
+    try {
+      const data = await apiClient.saveProfile(trimmedName, selectedProfilePayload(node));
+      markSelectedProfileSaved(node, data?.profile?.name || trimmedName);
+      renderProfileBar(node);
+      node.setDirtyCanvas?.(true, true);
+    } catch (error) {
+      host.alert?.(formatText("profile.saveFailed", { message: errorMessage(error) }));
+    }
+  }
+
+  async function loadProfileSet(node, name) {
+    try {
+      const data = await apiClient.loadProfile(name);
+      appendProfilePayload(node, data.profile);
+    } catch (error) {
+      host.alert?.(formatText("profile.loadFailed", { message: errorMessage(error) }));
+    }
+  }
+
+  function fullProfilePayload(node) {
+    saveCurrentProfile(node);
+    return {
+      profile_count: profileCount(node),
+      profile_index: activeProfileIndex(node),
+      profile_data: parseProfileData(findWidget(node, "profile_data")),
+    };
+  }
+
+  function mutateLoras(node, mutator, options = {}) {
+    const loras = lorasWidgetValue(node).map(normalizeLoraEntry);
+    mutator(loras);
+    setLorasWidgetValue(node, loras, options);
+    saveCurrentProfile(node);
+  }
+
+  function addLoraEntry(node, entry) {
+    const nextEntry = normalizeLoraEntry(entry);
+    if (!nextEntry.name) {
+      return;
+    }
+    mutateLoras(node, (loras) => {
+      const existing = loras.find((lora) => lora.name === nextEntry.name);
+      if (existing) {
+        Object.assign(existing, nextEntry);
+      } else {
+        loras.push(nextEntry);
+      }
+    });
+  }
+
+  function updateLoraEntry(node, index, patch, options = {}) {
+    mutateLoras(node, (loras) => {
+      if (!loras[index]) {
+        return;
+      }
+      const current = loras[index];
+      const oldStrength = Number(current.strength ?? 1);
+      const oldClip = current.strengthTwo == null ? oldStrength : Number(current.strengthTwo);
+      Object.assign(current, patch);
+      if (Object.prototype.hasOwnProperty.call(patch, "strength") && Math.abs(oldClip - oldStrength) < 0.0001) {
+        current.strengthTwo = null;
+      }
+    }, options);
+  }
+
+  function removeLoraEntry(node, index) {
+    mutateLoras(node, (loras) => loras.splice(index, 1));
+  }
+
+  function moveLoraEntry(node, index, direction) {
+    mutateLoras(node, (loras) => {
+      const from = Number(index);
+      const to = from + Number(direction || 0);
+      if (!Number.isInteger(from) || !Number.isInteger(to) || !loras[from] || to < 0 || to >= loras.length) {
+        return;
+      }
+      const [entry] = loras.splice(from, 1);
+      loras.splice(to, 0, entry);
+    });
+  }
+
+  return {
+    parseProfileData,
+    writeProfileData,
+    profileCount,
+    selectedProfileIndex,
+    activeProfileIndex,
+    setProfileIndex,
+    setProfileCount,
+    scrollProfileBarTo,
+    currentProfileContent,
+    saveProfile,
+    saveCurrentProfile,
+    loadProfile,
+    switchProfile,
+    addProfile,
+    deleteProfile,
+    selectedProfilePayload,
+    profileSaveStatus,
+    appendProfilePayload,
+    saveProfileSet,
+    loadProfileSet,
+    fullProfilePayload,
+    mutateLoras,
+    addLoraEntry,
+    updateLoraEntry,
+    removeLoraEntry,
+    moveLoraEntry,
+  };
+}

--- a/web/js/lora_preset/save_sync.js
+++ b/web/js/lora_preset/save_sync.js
@@ -11,30 +11,39 @@ export function createLoraPresetSaveSync({
     }
   }
 
-  function syncAllNodes() {
-    for (const node of app.graph?._nodes || []) {
+  function syncAllNodes(graph = app.graph) {
+    for (const node of graph?._nodes || []) {
       syncNode(node);
     }
   }
 
+  const serializeInstall = { target: null, wrapper: null };
+  const queueInstall = { target: null, wrapper: null };
+
+  function installWrapper(state, target, methodName, syncBeforeCall) {
+    const current = target?.[methodName];
+    if (typeof current !== "function" || (state.target === target && current === state.wrapper)) {
+      return;
+    }
+    const wrapper = function () {
+      // A host extension can wrap our previous function between installs.  Only
+      // the outermost current wrapper owns synchronization, so reinstalling
+      // composes with that extension without double-saving profiles.
+      if (state.target === target && state.wrapper === wrapper) {
+        syncBeforeCall(this);
+      }
+      return current.apply(this, arguments);
+    };
+    wrapper.__easyuseAnimaLoraPresetWrapped = true;
+    state.target = target;
+    state.wrapper = wrapper;
+    target[methodName] = wrapper;
+  }
+
   function install() {
     const graphPrototype = getGraphPrototype();
-    if (graphPrototype?.serialize && !graphPrototype.serialize.__easyuseAnimaLoraPresetWrapped) {
-      const serialize = graphPrototype.serialize;
-      graphPrototype.serialize = function () {
-        syncAllNodes();
-        return serialize.apply(this, arguments);
-      };
-      graphPrototype.serialize.__easyuseAnimaLoraPresetWrapped = true;
-    }
-    if (app.queuePrompt && !app.queuePrompt.__easyuseAnimaLoraPresetWrapped) {
-      const queuePrompt = app.queuePrompt;
-      app.queuePrompt = function () {
-        syncAllNodes();
-        return queuePrompt.apply(this, arguments);
-      };
-      app.queuePrompt.__easyuseAnimaLoraPresetWrapped = true;
-    }
+    installWrapper(serializeInstall, graphPrototype, "serialize", (graph) => syncAllNodes(graph));
+    installWrapper(queueInstall, app, "queuePrompt", () => syncAllNodes());
   }
 
   return { install, syncNode, syncAllNodes };

--- a/web/js/lora_preset/save_sync.js
+++ b/web/js/lora_preset/save_sync.js
@@ -1,4 +1,20 @@
 /** Installs the graph-save and queue-preparation synchronization hooks. */
+const installStates = new WeakMap();
+
+function installStateFor(target, methodName) {
+  let states = installStates.get(target);
+  if (!states) {
+    states = new Map();
+    installStates.set(target, states);
+  }
+  let state = states.get(methodName);
+  if (!state) {
+    state = { wrapper: null, syncBeforeCall: null };
+    states.set(methodName, state);
+  }
+  return state;
+}
+
 export function createLoraPresetSaveSync({
   app,
   nodeTypeName,
@@ -17,33 +33,35 @@ export function createLoraPresetSaveSync({
     }
   }
 
-  const serializeInstall = { target: null, wrapper: null };
-  const queueInstall = { target: null, wrapper: null };
-
-  function installWrapper(state, target, methodName, syncBeforeCall) {
+  function installWrapper(target, methodName, syncBeforeCall) {
     const current = target?.[methodName];
-    if (typeof current !== "function" || (state.target === target && current === state.wrapper)) {
+    if (typeof current !== "function") {
+      return;
+    }
+    const state = installStateFor(target, methodName);
+    state.syncBeforeCall = syncBeforeCall;
+    if (current === state.wrapper) {
       return;
     }
     const wrapper = function () {
       // A host extension can wrap our previous function between installs.  Only
-      // the outermost current wrapper owns synchronization, so reinstalling
-      // composes with that extension without double-saving profiles.
-      if (state.target === target && state.wrapper === wrapper) {
-        syncBeforeCall(this);
+      // the outermost current wrapper owns synchronization.  The target-level
+      // state also survives a new lifecycle instance after another extension
+      // hides our marker by wrapping the previous function.
+      if (state.wrapper === wrapper) {
+        state.syncBeforeCall(this);
       }
       return current.apply(this, arguments);
     };
     wrapper.__easyuseAnimaLoraPresetWrapped = true;
-    state.target = target;
     state.wrapper = wrapper;
     target[methodName] = wrapper;
   }
 
   function install() {
     const graphPrototype = getGraphPrototype();
-    installWrapper(serializeInstall, graphPrototype, "serialize", (graph) => syncAllNodes(graph));
-    installWrapper(queueInstall, app, "queuePrompt", () => syncAllNodes());
+    installWrapper(graphPrototype, "serialize", (graph) => syncAllNodes(graph));
+    installWrapper(app, "queuePrompt", () => syncAllNodes());
   }
 
   return { install, syncNode, syncAllNodes };

--- a/web/js/lora_preset/save_sync.js
+++ b/web/js/lora_preset/save_sync.js
@@ -1,0 +1,41 @@
+/** Installs the graph-save and queue-preparation synchronization hooks. */
+export function createLoraPresetSaveSync({
+  app,
+  nodeTypeName,
+  saveCurrentProfile,
+  getGraphPrototype = () => globalThis.LGraph?.prototype || app.graph?.constructor?.prototype,
+}) {
+  function syncNode(node) {
+    if (node?.comfyClass === nodeTypeName) {
+      saveCurrentProfile(node);
+    }
+  }
+
+  function syncAllNodes() {
+    for (const node of app.graph?._nodes || []) {
+      syncNode(node);
+    }
+  }
+
+  function install() {
+    const graphPrototype = getGraphPrototype();
+    if (graphPrototype?.serialize && !graphPrototype.serialize.__easyuseAnimaLoraPresetWrapped) {
+      const serialize = graphPrototype.serialize;
+      graphPrototype.serialize = function () {
+        syncAllNodes();
+        return serialize.apply(this, arguments);
+      };
+      graphPrototype.serialize.__easyuseAnimaLoraPresetWrapped = true;
+    }
+    if (app.queuePrompt && !app.queuePrompt.__easyuseAnimaLoraPresetWrapped) {
+      const queuePrompt = app.queuePrompt;
+      app.queuePrompt = function () {
+        syncAllNodes();
+        return queuePrompt.apply(this, arguments);
+      };
+      app.queuePrompt.__easyuseAnimaLoraPresetWrapped = true;
+    }
+  }
+
+  return { install, syncNode, syncAllNodes };
+}


### PR DESCRIPTION
## 변경 요약

- profile 추가·전환·삭제·저장·불러오기 mutation을 `profile_mutations.js`로 분리해 entry의 DOM/UI 조립과 데이터 변경 책임을 나눴습니다.
- workflow save 직전 현재 profile 상태를 receiver graph 기준으로 동기화하는 `save_sync.js`를 추가하고, lifecycle 재설치와 외부 wrapper 조합에서도 중복 적층 없이 원래 `this`·인자·반환값·Promise·오류를 보존합니다.
- LoRA Preset `onSerialize`가 `serialize=false` canvas widget 때문에 생긴 sparse `widgets_values`를 실제 serializable widget 순서로 정규화하도록 보강했습니다.
- profile mutation/save-sync/node runtime 회귀 smoke와 official frontend runner 계약을 추가·갱신했습니다.

## 원인

ComfyUI/LiteGraph는 `serialize=false` widget을 건너뛰면서도 원래 widget index에 값을 기록합니다. profile bar가 backend의 여섯 저장 widget 사이에 들어오면 sparse 배열과 trailing 값이 남았고, 기존 고정-index overwrite는 중복된 profile data tail을 제거하지 못했습니다.

또한 save wrapper의 graph 소유권과 lifecycle 재설치 경계가 entry에 결합돼 있어 receiver graph 격리와 외부 wrapper 조합을 독립적으로 고정하기 어려웠습니다.

## 주요 파일

- `web/js/lora_preset/profile_mutations.js`
- `web/js/lora_preset/save_sync.js`
- `web/js/lora_preset/node_runtime.js`
- `web/js/easyuse_anima_lora_preset.js`
- 관련 frontend smoke, unittest, runner 등록

## 검증

- Official full project gate
  - Python unittest 408/408
  - frontend 109 JavaScript files
  - TypeScript 6.0.3
  - git diff check 통과
- ComfyUI v0.27.0 Codex test instance — Legacy canvas
  - profile add/switch/delete 후 2/2 상태 저장
  - workflow `widgets_values` 6개와 profile data 디스크 read-back
  - reload 후 active profile/style 복원
  - LoRA Preset → PreviewAny 실제 queue 성공, prompt 입력과 출력 read-back
- ComfyUI v0.27.0 Codex test instance — Node 2.0
  - profile style 편집·저장 후 `widgets_values` 6개와 profile 2/2 read-back
  - reload 후 Vue surface, active index, style 복원
  - 동일 실제 queue 성공
- 두 canvas 모두 EasyUse Anima 관련 새 browser error 없음

## 남은 범위

- document wheel listener와 extension entry 경계는 Issue #55의 후속 범위로 남겨 두며 이 PR에서 재구성하지 않습니다.
- 사용자 ComfyUI v0.27.0 인스턴스는 전체 유지보수 Goal의 최종 호환 묶음 확인 전까지 변경하지 않았습니다.