### PR TITLE
fix: 자동완성 교체 시 중첩 문법 보존

### DIFF
--- a/tests/frontend_autocomplete_text_model_smoke.mjs
+++ b/tests/frontend_autocomplete_text_model_smoke.mjs
@@ -123,6 +123,45 @@ assert.equal(
   "[[ @new_name:1.25]]",
 );
 
+for (const previewCompletion of [false, true]) {
+  for (const [value, typed, insert, expected, artistOnly] of [
+    ["((old_tag))", "old_tag", "new tag", "((new tag))", false],
+    ["(((old_tag)))", "old_tag", "new tag", "(((new tag)))", false],
+    ["((old_tag:1.2))", "old_tag", "new tag", "((new tag:1.2))", false],
+    ["((@old_artist))", "@old_artist", "@new artist", "((@new artist))", true],
+    ["manual_trigger, ((old_tag))", "old_tag", "new tag", "manual_trigger, ((new tag))", false],
+  ]) {
+    const start = value.indexOf(typed);
+    const caret = start + typed.length;
+    const token = currentToken(value, caret, {
+      detectNaturalSentences: false,
+      previewCompletion,
+    });
+    const query = autocompleteQuery(token);
+    assert.equal(token.start, start);
+    assert.equal(token.end, caret);
+    assert.equal(query.artistOnly, artistOnly);
+    assert.equal(query.query, typed.replace(/^@/, ""));
+    const applied = appliedPlan(token, insert);
+    assert.equal(applied.value, expected);
+    assert.equal(applied.caret, start + insert.length);
+    assert.equal(applied.value.slice(applied.caret), expected.slice(start + insert.length));
+  }
+}
+
+for (const previewCompletion of [false, true]) {
+  const value = "((old_tag:1.2))";
+  const start = value.indexOf("old_tag");
+  const token = currentToken(value, start + "old".length, {
+    detectNaturalSentences: false,
+    previewCompletion,
+  });
+  assert.equal(autocompleteQuery(token).query, "old");
+  assert.equal(token.start, start);
+  assert.equal(token.end, start + "old_tag".length);
+  assert.equal(appliedPlan(token, "new tag").value, "((new tag:1.2))");
+}
+
 const strictAtClosing = currentToken(
   weightedValue,
   weightedValue.length,
@@ -153,6 +192,10 @@ assert.deepEqual(parseAutocompleteText("(@artist_name):1.25"), {
   artistOnly: true,
 });
 assert.deepEqual(parseAutocompleteText("[[ (@artist_name)))"), {
+  query: "artist_name",
+  artistOnly: true,
+});
+assert.deepEqual(parseAutocompleteText("((@artist_name))"), {
   query: "artist_name",
   artistOnly: true,
 });

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -1097,8 +1097,10 @@ class AIOFrontendSourceTests(unittest.TestCase):
         end = source.index("\nexport function autocompleteQuery", start)
         parse_body = source[start:end]
 
-        self.assertIn('query = query.replace(/^\\[\\[\\s*/g, "");', parse_body)
-        self.assertIn('query = query.replace(/^\\(\\s*/g, "");', parse_body)
+        self.assertIn(
+            "query = query.slice(trimPromptSyntaxPrefix(query, 0, query.length));",
+            parse_body,
+        )
         self.assertIn("query = stripPromptSyntaxClosingParens(query);", parse_body)
         self.assertIn(
             'query = query.replace(/:\\s*[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*$/, "");',

--- a/web/js/autocomplete/text_model.js
+++ b/web/js/autocomplete/text_model.js
@@ -58,7 +58,7 @@ function trimPromptSyntaxPrefix(value, start, end) {
       cursor += 1;
     }
   }
-  if (value[cursor] === "(") {
+  while (value[cursor] === "(" && !isEscaped(value, cursor)) {
     cursor += 1;
     while (cursor < end && /[ \t]/.test(value[cursor])) {
       cursor += 1;
@@ -78,7 +78,7 @@ function trimPromptSyntaxSuffix(value, start, end) {
       cursor -= 1;
     }
   }
-  if (value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
+  while (value[cursor - 1] === ")" && !isEscaped(value, cursor - 1)) {
     cursor -= 1;
     while (cursor > start && /[ \t]/.test(value[cursor - 1])) {
       cursor -= 1;
@@ -227,8 +227,7 @@ function stripPromptSyntaxClosingParens(value) {
 
 export function parseAutocompleteText(value) {
   let query = String(value || "").trim();
-  query = query.replace(/^\[\[\s*/g, "");
-  query = query.replace(/^\(\s*/g, "");
+  query = query.slice(trimPromptSyntaxPrefix(query, 0, query.length));
   const artistOnly = query.startsWith("@");
   if (artistOnly) {
     query = query.slice(1).trimStart();


### PR DESCRIPTION
## 변경 요약

- 자동완성 교체 범위가 이스케이프되지 않은 중첩 괄호를 끝까지 제외하도록 prefix/suffix 경계를 수정했습니다.
- 검색용 텍스트 파싱도 동일한 prefix helper를 사용해 교체 계획과 artist 분류가 같은 문법 경계를 공유하도록 했습니다.
- 중첩 2·3중 괄호, 가중치, `@artist`, preview on/off, 부분 caret, 앞선 manual trigger 보존을 회귀 테스트로 고정했습니다.
- 구현 형태를 직접 검사하던 cross-cutting 정적 테스트는 구체 regex 줄 대신 shared helper 위임 계약을 확인하도록 갱신했습니다.

## 원인

기존 `trimPromptSyntaxPrefix` / `trimPromptSyntaxSuffix`는 괄호 wrapper를 한 겹만 건너뛰었습니다. 그 결과 replacement boundary가 남은 괄호와 weight suffix까지 포함했고, 후보 확정 시 중첩 깊이·가중치·artist 접두사가 손실됐습니다.

## 주요 파일

- `web/js/autocomplete/text_model.js`
- `tests/frontend_autocomplete_text_model_smoke.mjs`
- `tests/test_aio_frontend.py`

## 검증

- focused: JS syntax 및 text-model/controller/binding/entry-lifecycle smoke 통과
- focused Python unittest: 12/12
- official full runner: Python unittest 408/408
- frontend: 109 JavaScript files, TypeScript 6.0.3, diff check 통과
- ComfyUI v0.27.0 Legacy canvas: 실제 popup 표시 및 중첩/가중치/artist 교체 통과
- ComfyUI v0.27.0 Node 2.0: 동일 matrix 통과
- 두 surface의 새 문서에서 popup 재등록 확인, EasyUse Anima 관련 browser error 없음

## 남은 위험

이번 PR은 text-model 교체 경계만 수정합니다. 다른 autocomplete lifecycle과 데이터 소스 동작은 기존 계약을 유지합니다.

Resolves #98