### PR TITLE
fix: expose AiO detailer threshold in external panel

### DIFF
--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -26,6 +26,10 @@ function findByText(root, textContent) {
   return find(root, (element) => element.textContent === textContent);
 }
 
+function findField(root, label) {
+  return find(root, (element) => element.getAttribute("data-test-label") === label);
+}
+
 const PANEL_EVENT_NAMES = [
   "pointerdown",
   "mousedown",
@@ -962,6 +966,66 @@ assert.ok(
   "settings write must complete before summary/profile refresh",
 );
 assert.notEqual(panel.children[0], main, "rerendering a stage toggle must replace panel children");
+
+while (fixture.animationFrames.length) {
+  fixture.animationFrames.shift()();
+}
+
+const detailerScroll = panel.querySelector(".easyuse-anima-aio-node-settings-scroll");
+const detailerStage = detailerScroll.children[2];
+const faceTitle = findByText(detailerStage, "1. Face Detailer");
+const faceBlock = faceTitle.parentElement.parentElement;
+const faceThreshold = findField(faceBlock, "text:field.threshold");
+const faceThresholdInput = faceThreshold.children[0].children[0];
+assert.equal(faceThresholdInput.value, "0.52");
+assert.equal(faceThresholdInput.min, "0");
+assert.equal(faceThresholdInput.max, "1");
+assert.equal(faceThresholdInput.step, "0.01");
+assert.equal(faceThreshold.getAttribute("data-test-tooltip"), "tip.detailerThreshold");
+
+faceThresholdInput.value = "0.63";
+faceThresholdInput.emit("input");
+assert.equal(node.settings.detailer.face.threshold, 0.63);
+
+const serializedDetailerSettings = JSON.stringify(node.settings);
+node.settings = JSON.parse(serializedDetailerSettings);
+fixture.runtime.renderPanel(node);
+let reloadedDetailerStage = panel.querySelector(
+  ".easyuse-anima-aio-node-settings-scroll",
+).children[2];
+let reloadedFaceTitle = findByText(reloadedDetailerStage, "1. Face Detailer");
+let reloadedFaceBlock = reloadedFaceTitle.parentElement.parentElement;
+assert.equal(
+  findField(reloadedFaceBlock, "text:field.threshold").children[0].children[0].value,
+  "0.63",
+  "serialized Detailer threshold must reload into the external target card",
+);
+
+const reloadedFaceEnabled = findField(reloadedFaceBlock, "text:label.enabled").children[0];
+reloadedFaceEnabled.checked = false;
+reloadedFaceEnabled.emit("change");
+reloadedDetailerStage = panel.querySelector(
+  ".easyuse-anima-aio-node-settings-scroll",
+).children[2];
+reloadedFaceTitle = findByText(reloadedDetailerStage, "1. Face Detailer");
+reloadedFaceBlock = reloadedFaceTitle.parentElement.parentElement;
+assert.equal(node.settings.detailer.face.enabled, false);
+assert.equal(findField(reloadedFaceBlock, "text:field.threshold"), null);
+
+const disabledFaceEnabled = findField(reloadedFaceBlock, "text:label.enabled").children[0];
+disabledFaceEnabled.checked = true;
+disabledFaceEnabled.emit("change");
+reloadedDetailerStage = panel.querySelector(
+  ".easyuse-anima-aio-node-settings-scroll",
+).children[2];
+reloadedFaceTitle = findByText(reloadedDetailerStage, "1. Face Detailer");
+reloadedFaceBlock = reloadedFaceTitle.parentElement.parentElement;
+assert.equal(node.settings.detailer.face.enabled, true);
+assert.equal(
+  findField(reloadedFaceBlock, "text:field.threshold").children[0].children[0].value,
+  "0.63",
+  "re-enabling a Detailer target must preserve its threshold",
+);
 
 while (fixture.animationFrames.length) {
   fixture.animationFrames.shift()();

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -224,6 +224,19 @@ class AIOSettingsStorageTests(unittest.TestCase):
         self.assertEqual(settings["detailer"]["custom_1"]["spectrum"]["window_size"], 4.0)
         self.assertEqual(settings["detailer"]["custom_1"]["dit_corrections"]["dcw_mode"], "manual")
 
+    def test_generation_settings_clamp_detailer_thresholds(self):
+        settings = nodes._normalize_aio_generation_settings(json.dumps({
+            "detailer": {
+                "face": {"threshold": -1},
+                "eye": {"threshold": 2},
+                "custom_1": {"threshold": 0.63},
+            },
+        }))
+
+        self.assertEqual(settings["detailer"]["face"]["threshold"], 0.0)
+        self.assertEqual(settings["detailer"]["eye"]["threshold"], 1.0)
+        self.assertEqual(settings["detailer"]["custom_1"]["threshold"], 0.63)
+
     def test_legacy_filename_prefix_is_not_kept_in_generation_settings(self):
         settings = nodes._normalize_aio_generation_settings(json.dumps({
             "save": {
@@ -1433,6 +1446,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
             "detailer": {
                 "face": {
                     "enabled": True,
+                    "threshold": 0.63,
                     "spectrum": {
                         "enabled": True,
                         "window_size": 4,
@@ -1468,6 +1482,7 @@ class AIOHighresDetailerStageTests(unittest.TestCase):
         self.assertTrue(metadata["detected"])
         self.assertEqual(detailer.call_args.kwargs["model"], "detail_model")
         self.assertEqual(detailer.call_args.kwargs["scheduler"], settings["sampler"]["scheduler"])
+        self.assertEqual(detailer.call_args.kwargs["threshold"], 0.63)
         stage_sampler = comfy_patch.call_args.args[3]
         self.assertTrue(stage_sampler["spectrum"]["enabled"])
         self.assertEqual(stage_sampler["spectrum"]["window_size"], 4.0)

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -1470,6 +1470,21 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
               "tip.detailerFollow",
             ),
             createNodeField(
+              aioText("field.threshold"),
+              createDomSettingsSliderNumberControl(
+                node,
+                target.threshold,
+                { min: 0, max: 1, step: 0.01, decimals: 2 },
+                (nextSettings, value) => {
+                  nextSettings.detailer ||= {};
+                  nextSettings.detailer[targetName] ||= {};
+                  nextSettings.detailer[targetName].threshold = value;
+                },
+              ),
+              "wide",
+              "tip.detailerThreshold",
+            ),
+            createNodeField(
               aioText("label.steps"),
               createDomSettingsSliderNumberControl(
                 node,


### PR DESCRIPTION
## 변경 요약

- 활성화된 AiO Detailer 대상 카드에 SAM3 감지 임계값 슬라이더를 노출합니다.
- 외부 카드와 상세 설정 대화상자가 같은 `settings.detailer[target].threshold` 값을 사용해 양방향 동기화와 workflow 저장/복원을 유지합니다.
- face/eye/custom target의 0~1 경계 정규화와 실제 SAM3 delegate 전달을 회귀 테스트로 고정합니다.

## 주요 파일

- `web/js/aio/generator_panel_runtime.js`
- `tests/frontend_aio_generator_panel_runtime_smoke.mjs`
- `tests/test_aio_nodes.py`

## 검증

### Focused

- `node --check web/js/aio/generator_panel_runtime.js`
- `node tests/frontend_aio_generator_panel_runtime_smoke.mjs`: 통과
- `python -m unittest tests.test_aio_nodes`: 70/70
- `git diff --check`: 통과

### Official full

- Python unittest: 409/409
- Frontend syntax/semantic: 109 JavaScript files
- TypeScript: 6.0.3
- diff check: 통과

### ComfyUI 0.27.0 Codex test instance

- Legacy canvas: 외부 기본값 0.52 확인, 외부 0.63 → 상세 설정 동기화, 상세 0.71 → 외부 동기화, workflow 저장/재로드 0.71 복원
- 실제 queue: `/history`에서 `success/completed=true`, 제출된 face threshold 0.71 확인
- Node 2.0: 표면 차이가 있는 DOM/직렬화만 검증. 저장값 0.71 재로드, 외부 0.68 → 상세 설정, 상세 0.66 → 외부, 저장 파일 및 재로드 0.66 복원
- 동일 backend queue는 양 표면의 저장 payload 계약을 확인한 뒤 중복 실행하지 않았습니다.
- EasyUseAnima 관련 browser error: 0

## 남은 위험

- 브라우저 수동 검증은 대표 face target으로 수행했습니다. 공통 target 렌더 루프와 Python 회귀 테스트가 eye/custom target 경계를 함께 검증합니다.
- 사용자 인스턴스의 최종 호환 확인은 유지보수 Goal의 release gate에서 별도로 진행합니다.
