### PR TITLE
refactor: extract LoRA preset entry lifecycle

### DIFF
--- a/tests/frontend_lora_preset_entry_lifecycle_smoke.mjs
+++ b/tests/frontend_lora_preset_entry_lifecycle_smoke.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { createLoraPresetEntryLifecycle } from "../web/js/lora_preset/entry_lifecycle.js";
+
+function captureOf(options) {
+  return options === true || !!options?.capture;
+}
+
+class FakeTarget {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener, options = false) {
+    const records = this.listeners.get(type) || [];
+    records.push({ listener, options });
+    this.listeners.set(type, records);
+  }
+
+  removeEventListener(type, listener, options = false) {
+    const capture = captureOf(options);
+    const records = this.listeners.get(type) || [];
+    this.listeners.set(
+      type,
+      records.filter((record) => record.listener !== listener || captureOf(record.options) !== capture),
+    );
+  }
+
+  listenerCount(type) {
+    return (this.listeners.get(type) || []).length;
+  }
+
+  emit(type, values = {}) {
+    const event = { type, target: this, ...values };
+    for (const { listener } of [...(this.listeners.get(type) || [])]) {
+      listener(event);
+    }
+    return event;
+  }
+}
+
+function pointInArea([x, y], [left, top, width, height]) {
+  return x >= left && x <= left + width && y >= top && y <= top + height;
+}
+
+function createRuntime(hostWindow, hostDocument, app) {
+  const calls = {
+    applySettings: [],
+    beforeRegister: [],
+    disposedLocale: 0,
+    hidden: 0,
+    loadSettings: 0,
+    menuDisposed: 0,
+    menuInstalled: 0,
+    refresh: 0,
+    saveSync: 0,
+  };
+  let localeCallback = null;
+  let now = 100;
+  const lifecycle = createLoraPresetEntryLifecycle({
+    app,
+    hostDocument,
+    hostWindow,
+    nodeTypeName: "EasyUseAnimaLoraPreset",
+    canvasWidgets: {
+      pointInArea,
+      profileVisibleRows: 2,
+    },
+    clientPointToCanvas: (event) => [event.clientX, event.clientY],
+    profileCount: (node) => node.profileCount,
+    saveSync: { install() { calls.saveSync += 1; } },
+    async loadSettings() { calls.loadSettings += 1; },
+    refreshNodes() { calls.refresh += 1; },
+    watchLocale(callback) {
+      localeCallback = callback;
+      return () => { calls.disposedLocale += 1; };
+    },
+    applySettings(settings) { calls.applySettings.push(settings); },
+    previewLifecycle: { hidePreview() { calls.hidden += 1; } },
+    menuLifecycle: {
+      install() { calls.menuInstalled += 1; },
+      dispose() { calls.menuDisposed += 1; },
+    },
+    nodeRuntime: {
+      beforeRegisterNodeDef(nodeType, nodeData) {
+        calls.beforeRegister.push([nodeType, nodeData]);
+      },
+    },
+    now: () => now,
+  });
+  return {
+    calls,
+    lifecycle,
+    tick() { now += 1; },
+    triggerLocale() { localeCallback?.(); },
+  };
+}
+
+const hostWindow = new FakeTarget();
+const hostDocument = new FakeTarget();
+const app = {
+  canvas: {
+    canvas: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 100, bottom: 100 }) },
+  },
+  graph: { _nodes: [] },
+};
+const runtime = createRuntime(hostWindow, hostDocument, app);
+const node = {
+  comfyClass: "EasyUseAnimaLoraPreset",
+  pos: [20, 20],
+  profileCount: 4,
+  dirty: 0,
+  setDirtyCanvas() { this.dirty += 1; },
+};
+const bar = {
+  listClientArea: [20, 20, 20, 20],
+  listArea: [0, 0, 20, 20],
+  scrollOffset: 0,
+  scrollByWheel(deltaY) {
+    this.directWheels = (this.directWheels || 0) + deltaY;
+    return true;
+  },
+};
+node.__easyuseAnimaProfileBar = bar;
+app.graph._nodes.push(node);
+
+assert.equal(runtime.lifecycle.extension.init(), true);
+await Promise.resolve();
+assert.equal(runtime.calls.saveSync, 1);
+assert.equal(runtime.calls.loadSettings, 1);
+assert.equal(runtime.calls.refresh, 1, "settings completion must refresh nodes");
+assert.equal(runtime.calls.menuInstalled, 1);
+assert.equal(hostDocument.listenerCount("wheel"), 1);
+assert.equal(hostDocument.listenerCount("pointerdown"), 1);
+assert.equal(hostWindow.listenerCount("easyuse-anima-settings-updated"), 1);
+assert.equal(runtime.lifecycle.extension.init(), false, "same owner must not duplicate global listeners");
+assert.equal(hostDocument.listenerCount("wheel"), 1);
+
+let prevented = 0;
+let stopped = 0;
+const directWheel = hostDocument.emit("wheel", {
+  clientX: 25,
+  clientY: 25,
+  deltaY: 3,
+  preventDefault() { prevented += 1; },
+  stopPropagation() { stopped += 1; },
+});
+assert.equal(directWheel.type, "wheel");
+assert.equal(bar.directWheels, 3, "client-area wheel must use the profile-bar handler");
+assert.equal(prevented, 1);
+assert.equal(stopped, 1);
+assert.equal(runtime.lifecycle.getActiveProfileWheelTarget().node, node);
+
+runtime.lifecycle.setActiveProfileWheelTarget(null);
+bar.listClientArea = [60, 60, 10, 10];
+hostDocument.emit("wheel", {
+  clientX: 25,
+  clientY: 25,
+  deltaY: 1,
+  preventDefault() { prevented += 1; },
+  stopPropagation() { stopped += 1; },
+});
+assert.equal(bar.scrollOffset, 1, "canvas hit-testing fallback must preserve profile-list scrolling");
+assert.equal(node.dirty, 1);
+assert.equal(prevented, 2);
+assert.equal(stopped, 2);
+
+hostWindow.emit("easyuse-anima-settings-updated", { detail: { menuMode: "list" } });
+assert.deepEqual(runtime.calls.applySettings, [{ menuMode: "list" }]);
+assert.equal(runtime.calls.refresh, 2);
+runtime.triggerLocale();
+assert.equal(runtime.calls.refresh, 3);
+await runtime.lifecycle.extension.beforeRegisterNodeDef("NodeType", { name: "LoRA" });
+assert.deepEqual(runtime.calls.beforeRegister, [["NodeType", { name: "LoRA" }]]);
+
+const replacement = createRuntime(hostWindow, hostDocument, app);
+assert.equal(replacement.lifecycle.extension.init(), true, "a newer entry owner must replace stale document listeners");
+assert.equal(runtime.lifecycle.isActive(), false);
+assert.equal(runtime.calls.disposedLocale, 1);
+assert.equal(runtime.calls.menuDisposed, 1);
+assert.equal(hostDocument.listenerCount("wheel"), 1);
+assert.equal(hostDocument.listenerCount("pointerdown"), 1);
+assert.equal(hostWindow.listenerCount("easyuse-anima-settings-updated"), 1);
+
+replacement.lifecycle.dispose();
+replacement.lifecycle.dispose();
+assert.equal(hostDocument.listenerCount("wheel"), 0);
+assert.equal(hostDocument.listenerCount("pointerdown"), 0);
+assert.equal(hostWindow.listenerCount("easyuse-anima-settings-updated"), 0);
+assert.equal(replacement.calls.disposedLocale, 1, "entry disposal must be idempotent");
+assert.equal(replacement.calls.menuDisposed, 1);
+
+console.log("LoRA preset entry lifecycle smoke passed.");

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -21,6 +21,12 @@ LORA_PRESET_CANVAS_WIDGETS = (
 LORA_PRESET_CANVAS_WIDGETS_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_canvas_widgets_smoke.mjs"
 )
+LORA_PRESET_ENTRY_LIFECYCLE = (
+    ROOT / "web" / "js" / "lora_preset" / "entry_lifecycle.js"
+)
+LORA_PRESET_ENTRY_LIFECYCLE_SMOKE = (
+    ROOT / "tests" / "frontend_lora_preset_entry_lifecycle_smoke.mjs"
+)
 LORA_PRESET_PREVIEW_LIFECYCLE = (
     ROOT / "web" / "js" / "lora_preset" / "preview_lifecycle.js"
 )
@@ -148,10 +154,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                     module_source,
                     rf"\bfunction\s+{re.escape(moved_declaration)}\b",
                 )
-        self.assertIn(
-            "loraPresetNodeRuntime.beforeRegisterNodeDef(nodeType, nodeData);",
-            entry_source,
-        )
+        self.assertIn("nodeRuntime: loraPresetNodeRuntime,", entry_source)
         self.assertTrue(LORA_PRESET_NODE_RUNTIME_SMOKE.is_file())
         self.assertIn("web/js/lora_preset/**/*.js", config["include"])
 
@@ -356,8 +359,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 "fixProfileLoras",
                 "switchProfile",
                 "nodePosToClient",
-                "getActiveProfileWheelTarget",
-                "setActiveProfileWheelTarget",
+                "getActiveProfileWheelTarget: () => loraPresetEntryLifecycle?.getActiveProfileWheelTarget() || null",
+                "setActiveProfileWheelTarget: (target) => loraPresetEntryLifecycle?.setActiveProfileWheelTarget(target)",
                 "enforceNodeLayout",
             },
         )
@@ -409,23 +412,18 @@ class LoraPresetFrontendTests(unittest.TestCase):
             module_source.count('this.options = { serialize: false };'),
             4,
         )
-        self.assertIn("let activeProfileWheelTarget = null;", entry_source)
         self.assertIn(
-            'document.addEventListener("wheel", scrollProfileListFromWheel, '
-            '{ capture: true, passive: false });',
+            'import { createLoraPresetEntryLifecycle } from '
+            '"./lora_preset/entry_lifecycle.js";',
             entry_source,
         )
-        self.assertIn("function scrollProfileListFromWheel(event)", entry_source)
-        self.assertIn("loraMenuLifecycle.install()", entry_source)
-        self.assertNotIn("loraMenuLifecycle.install()", module_source)
-        for entry_owned_token in (
-            "function scrollProfileListFromWheel(",
-            "function installProfileWheelListener(",
-            "app.registerExtension({",
-        ):
-            with self.subTest(entry_owned_token=entry_owned_token):
-                self.assertIn(entry_owned_token, entry_source)
-                self.assertNotIn(entry_owned_token, module_source)
+        self.assertIn(
+            "loraPresetEntryLifecycle = createLoraPresetEntryLifecycle({",
+            entry_source,
+        )
+        self.assertIn("app.registerExtension(loraPresetEntryLifecycle.extension);", entry_source)
+        self.assertNotIn('document.addEventListener("wheel"', entry_source)
+        self.assertNotIn("function scrollProfileListFromWheel(", entry_source)
         self.assertIn("let loraCanvasWidgets;", entry_source)
         self.assertIn("getCanvasWidgets: () => loraCanvasWidgets", entry_source)
         self.assertTrue(LORA_PRESET_CANVAS_WIDGETS_SMOKE.is_file())
@@ -438,6 +436,50 @@ class LoraPresetFrontendTests(unittest.TestCase):
 
         completed = subprocess.run(
             [node_bin, str(LORA_PRESET_CANVAS_WIDGETS_SMOKE)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            self.fail((completed.stdout + completed.stderr).strip())
+
+    def test_entry_lifecycle_module_boundary(self):
+        module_source = LORA_PRESET_ENTRY_LIFECYCLE.read_text(encoding="utf-8")
+        entry_source = LORA_PRESET_ENTRY.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(module_source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(
+                r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
+                module_source,
+                re.MULTILINE,
+            ),
+            ["createLoraPresetEntryLifecycle"],
+        )
+        self.assertNotRegex(module_source, re.compile(r"^\s*import\b", re.MULTILINE))
+        self.assertNotIn("registerExtension(", module_source)
+        self.assertIn('listen(hostDocument, "wheel", scrollProfileListFromWheel, { capture: true, passive: false });', module_source)
+        self.assertIn("target.removeEventListener(type, listener, options);", module_source)
+        self.assertIn("previousOwner.dispose?.();", module_source)
+        self.assertIn("runCleanup(() => menuLifecycle.dispose?.());", module_source)
+        self.assertIn("loraPresetEntryLifecycle = createLoraPresetEntryLifecycle({", entry_source)
+        self.assertIn("app.registerExtension(loraPresetEntryLifecycle.extension);", entry_source)
+        self.assertTrue(LORA_PRESET_ENTRY_LIFECYCLE_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_lora_preset_entry_lifecycle_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_entry_lifecycle_module_semantics(self):
+        node_bin = shutil.which("node")
+        if not node_bin:
+            self.skipTest("node executable is not available")
+
+        completed = subprocess.run(
+            [node_bin, str(LORA_PRESET_ENTRY_LIFECYCLE_SMOKE)],
             cwd=ROOT,
             text=True,
             capture_output=True,
@@ -518,7 +560,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
                     rf"\b(?:const|let|var|function|class)\s+{moved_name}\b",
                 )
         self.assertEqual(entry_source.count("loraPreviewLifecycle.showPreview"), 0)
-        self.assertEqual(entry_source.count("loraPreviewLifecycle.hidePreview"), 1)
+        self.assertEqual(entry_source.count("loraPreviewLifecycle.hidePreview"), 0)
+        self.assertIn("previewLifecycle: loraPreviewLifecycle,", entry_source)
         self.assertEqual(canvas_widgets_source.count("previewLifecycle.showPreview"), 2)
         self.assertEqual(canvas_widgets_source.count("previewLifecycle.hidePreview"), 3)
         self.assertEqual(
@@ -637,7 +680,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             ),
             1,
         )
-        self.assertEqual(entry_source.count("loraMenuLifecycle.install()"), 1)
+        self.assertIn("menuLifecycle: loraMenuLifecycle,", entry_source)
         self.assertNotIn("new MutationObserver", entry_source)
         self.assertNotIn("easyuse-anima-lora-search {", entry_source)
         self.assertIn("new MutationObserver", module_source)
@@ -905,7 +948,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
         )
         self.assertIn("const loraProfileMutations = createLoraPresetProfileMutations({", entry_source)
         self.assertIn("const loraPresetSaveSync = createLoraPresetSaveSync({", entry_source)
-        self.assertIn("loraPresetSaveSync.install();", entry_source)
+        self.assertIn("saveSync: loraPresetSaveSync,", entry_source)
         self.assertTrue(LORA_PRESET_PROFILE_MUTATIONS_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_lora_preset_profile_mutations_smoke.mjs"',
@@ -949,6 +992,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const nodeRuntimePath = process.argv[8];
             const profileMutationsPath = process.argv[9];
             const saveSyncPath = process.argv[10];
+            const entryLifecyclePath = process.argv[11];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -995,9 +1039,14 @@ class LoraPresetFrontendTests(unittest.TestCase):
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
+            let entryLifecycleSource = fs.readFileSync(entryLifecyclePath, "utf8");
+            entryLifecycleSource = entryLifecycleSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${profileMutationsSource}\n${saveSyncSource}\n${source}`;
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${profileMutationsSource}\n${saveSyncSource}\n${entryLifecycleSource}\n${source}`;
             source += "\nglobalThis.__loraPresetTest = { loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
@@ -1332,6 +1381,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_NODE_RUNTIME),
                 str(LORA_PRESET_PROFILE_MUTATIONS),
                 str(LORA_PRESET_SAVE_SYNC),
+                str(LORA_PRESET_ENTRY_LIFECYCLE),
             ],
             cwd=ROOT,
             text=True,

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -194,6 +194,11 @@ try {
         throw "Frontend LoRA preset profile mutation and save-sync smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_lora_preset_entry_lifecycle_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend LoRA preset entry lifecycle smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_autocomplete_data_adapter_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend autocomplete data adapter smoke failed with exit code $LASTEXITCODE."

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -4,6 +4,7 @@ import { easyuseAnimaEncodeRFC3986URIComponent as encodeRFC3986URIComponent, eas
 import { easyuseAnimaText, easyuseAnimaWatchLocale } from "./easyuse_anima_i18n.js";
 import { createLoraPresetApiClient } from "./lora_preset/api_client.js";
 import { createLoraPresetCanvasWidgets } from "./lora_preset/canvas_widgets.js";
+import { createLoraPresetEntryLifecycle } from "./lora_preset/entry_lifecycle.js";
 import { createLoraPresetMenuLifecycle } from "./lora_preset/menu_lifecycle.js";
 import { createLoraPresetNodeRuntime } from "./lora_preset/node_runtime.js";
 import { createLoraPresetProfileMutations } from "./lora_preset/profile_mutations.js";
@@ -36,8 +37,6 @@ const DEFAULT_STRENGTH_BUTTON_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_STEP = 0.05;
 const DEFAULT_STRENGTH_DRAG_PIXELS = 8;
 const PREVIEW_SIZE = 360;
-let activeProfileWheelTarget = null;
-let profileWheelListenerInstalled = false;
 const LORA_PRESET_SETTINGS = {
   nameDisplay: "name",
   menuMode: "tree",
@@ -45,14 +44,6 @@ const LORA_PRESET_SETTINGS = {
   strengthDragStep: DEFAULT_STRENGTH_DRAG_STEP,
   strengthDragPixels: DEFAULT_STRENGTH_DRAG_PIXELS,
 };
-
-function getActiveProfileWheelTarget() {
-  return activeProfileWheelTarget;
-}
-
-function setActiveProfileWheelTarget(target) {
-  activeProfileWheelTarget = target;
-}
 
 const LORA_PRESET_TEXT = {
   en: {
@@ -317,6 +308,7 @@ const loraMenuLifecycle = createLoraPresetMenuLifecycle({
   previewSize: PREVIEW_SIZE,
 });
 let loraCanvasWidgets;
+let loraPresetEntryLifecycle;
 const loraProfileMutations = createLoraPresetProfileMutations({
   findWidget,
   widgetValue,
@@ -388,8 +380,8 @@ loraCanvasWidgets = createLoraPresetCanvasWidgets({
   fixProfileLoras,
   switchProfile,
   nodePosToClient,
-  getActiveProfileWheelTarget,
-  setActiveProfileWheelTarget,
+  getActiveProfileWheelTarget: () => loraPresetEntryLifecycle?.getActiveProfileWheelTarget() || null,
+  setActiveProfileWheelTarget: (target) => loraPresetEntryLifecycle?.setActiveProfileWheelTarget(target),
   enforceNodeLayout,
 });
 const loraPresetNodeRuntime = createLoraPresetNodeRuntime({
@@ -421,6 +413,23 @@ const loraPresetSaveSync = createLoraPresetSaveSync({
   app,
   nodeTypeName: NODE_TYPE,
   saveCurrentProfile,
+});
+loraPresetEntryLifecycle = createLoraPresetEntryLifecycle({
+  app,
+  hostDocument: document,
+  hostWindow: window,
+  nodeTypeName: NODE_TYPE,
+  canvasWidgets: loraCanvasWidgets,
+  clientPointToCanvas,
+  profileCount,
+  saveSync: loraPresetSaveSync,
+  loadSettings: loadLoraPresetSettings,
+  refreshNodes: refreshLoraPresetNodes,
+  watchLocale: easyuseAnimaWatchLocale,
+  applySettings: applyLoraPresetSettings,
+  previewLifecycle: loraPreviewLifecycle,
+  menuLifecycle: loraMenuLifecycle,
+  nodeRuntime: loraPresetNodeRuntime,
 });
 
 function findWidget(node, name) {
@@ -922,115 +931,4 @@ function refreshLoraPresetNodes() {
   }
 }
 
-function scrollProfileListFromWheel(event) {
-  const clientPos = [Number(event?.clientX || 0), Number(event?.clientY || 0)];
-  if (
-    activeProfileWheelTarget?.node?.comfyClass === NODE_TYPE
-    && activeProfileWheelTarget?.widget
-    && (performance.now() - activeProfileWheelTarget.time) < 30000
-    && (app.graph?._nodes || []).includes(activeProfileWheelTarget.node)
-  ) {
-    if (!loraCanvasWidgets.pointInArea(clientPos, activeProfileWheelTarget.widget.listClientArea)) {
-      activeProfileWheelTarget = null;
-    } else {
-      activeProfileWheelTarget.time = performance.now();
-      const handled = activeProfileWheelTarget.widget.scrollByWheel(event.deltaY, activeProfileWheelTarget.node);
-      if (handled) {
-        event.preventDefault?.();
-        event.stopPropagation?.();
-        return true;
-      }
-    }
-  }
-
-  const nodesByZ = [...(app.graph?._nodes || [])].reverse();
-  for (const node of nodesByZ) {
-    const bar = node?.comfyClass === NODE_TYPE ? node.__easyuseAnimaProfileBar : null;
-    if (!bar || !loraCanvasWidgets.pointInArea(clientPos, bar.listClientArea)) {
-      continue;
-    }
-    const handled = bar.scrollByWheel(event.deltaY, node);
-    if (handled) {
-      activeProfileWheelTarget = {
-        node,
-        widget: bar,
-        time: performance.now(),
-      };
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      return true;
-    }
-  }
-
-  const canvas = app.canvas?.canvas;
-  const rect = canvas?.getBoundingClientRect?.();
-  if (
-    !canvas
-    || !rect
-    || Number(event?.clientX || 0) < rect.left
-    || Number(event?.clientX || 0) > rect.right
-    || Number(event?.clientY || 0) < rect.top
-    || Number(event?.clientY || 0) > rect.bottom
-  ) {
-    return false;
-  }
-  const graphPoint = clientPointToCanvas(event);
-  for (const node of nodesByZ) {
-    if (node?.comfyClass !== NODE_TYPE || !node.__easyuseAnimaProfileBar || !Array.isArray(node.pos)) {
-      continue;
-    }
-    const localPos = [
-      Number(graphPoint[0] || 0) - Number(node.pos[0] || 0),
-      Number(graphPoint[1] || 0) - Number(node.pos[1] || 0),
-    ];
-    const bar = node.__easyuseAnimaProfileBar;
-    if (!loraCanvasWidgets.pointInArea(localPos, bar.listArea)) {
-      continue;
-    }
-    const count = profileCount(node);
-    const maxOffset = Math.max(0, count - loraCanvasWidgets.profileVisibleRows);
-    if (maxOffset <= 0) {
-      return false;
-    }
-    const direction = Number(event.deltaY || 0) > 0 ? 1 : -1;
-    const nextOffset = Math.max(0, Math.min(maxOffset, (bar.scrollOffset || 0) + direction));
-    if (nextOffset !== bar.scrollOffset) {
-      bar.scrollOffset = nextOffset;
-      node.setDirtyCanvas?.(true, true);
-    }
-    event.preventDefault?.();
-    event.stopPropagation?.();
-    return true;
-  }
-  return false;
-}
-
-function installProfileWheelListener() {
-  if (profileWheelListenerInstalled) {
-    return;
-  }
-  profileWheelListenerInstalled = true;
-  document.addEventListener("wheel", scrollProfileListFromWheel, { capture: true, passive: false });
-}
-
-app.registerExtension({
-  name: "EasyUseAnima.LoraPreset",
-  init() {
-    loraPresetSaveSync.install();
-    loadLoraPresetSettings().then(refreshLoraPresetNodes);
-    easyuseAnimaWatchLocale(refreshLoraPresetNodes);
-    window.addEventListener("easyuse-anima-settings-updated", (event) => {
-      applyLoraPresetSettings(event.detail || {});
-      refreshLoraPresetNodes();
-    });
-    document.addEventListener("pointerdown", loraPreviewLifecycle.hidePreview, true);
-    installProfileWheelListener();
-    loraMenuLifecycle.install();
-  },
-  setup() {
-    loraPresetSaveSync.install();
-  },
-  async beforeRegisterNodeDef(nodeType, nodeData) {
-    loraPresetNodeRuntime.beforeRegisterNodeDef(nodeType, nodeData);
-  },
-});
+app.registerExtension(loraPresetEntryLifecycle.extension);

--- a/web/js/lora_preset/entry_lifecycle.js
+++ b/web/js/lora_preset/entry_lifecycle.js
@@ -1,0 +1,278 @@
+// @ts-check
+
+const LORA_PRESET_ENTRY_OWNER = Symbol.for(
+  "easyuse-anima.lora-preset.entry-lifecycle-owner",
+);
+
+/**
+ * Owns the LoRA Preset extension hooks that live outside an individual node.
+ * Node/profile mutation, save synchronization, menu, preview, and canvas
+ * behavior remain supplied by their existing owners.
+ *
+ * @param {{
+ *   app: any,
+ *   hostDocument: any,
+ *   hostWindow: any,
+ *   nodeTypeName: string,
+ *   canvasWidgets: any,
+ *   clientPointToCanvas: (event: any) => number[],
+ *   profileCount: (node: any) => number,
+ *   saveSync: {install: () => void},
+ *   loadSettings: () => Promise<any>,
+ *   refreshNodes: () => void,
+ *   watchLocale: (callback: () => void) => (() => void),
+ *   applySettings: (settings: any) => void,
+ *   previewLifecycle: {hidePreview: () => void},
+ *   menuLifecycle: {install: () => any, dispose?: () => any},
+ *   nodeRuntime: {beforeRegisterNodeDef: (nodeType: any, nodeData: any) => any},
+ *   now?: () => number,
+ * }} dependencies
+ */
+export function createLoraPresetEntryLifecycle(dependencies) {
+  const {
+    app,
+    hostDocument,
+    hostWindow,
+    nodeTypeName,
+    canvasWidgets,
+    clientPointToCanvas,
+    profileCount,
+    saveSync,
+    loadSettings,
+    refreshNodes,
+    watchLocale,
+    applySettings,
+    previewLifecycle,
+    menuLifecycle,
+    nodeRuntime,
+    now = () => performance.now(),
+  } = dependencies;
+  const listeners = [];
+  let activeProfileWheelTarget = null;
+  let installed = false;
+  let disposeLocaleWatch = null;
+
+  function isActive() {
+    return installed && hostWindow[LORA_PRESET_ENTRY_OWNER] === lifecycle;
+  }
+
+  /**
+   * @param {any} target
+   * @param {string} type
+   * @param {(event: any) => any} listener
+   * @param {boolean | AddEventListenerOptions} [options]
+   */
+  function listen(target, type, listener, options = false) {
+    target.addEventListener(type, listener, options);
+    listeners.push([target, type, listener, options]);
+  }
+
+  function getActiveProfileWheelTarget() {
+    return activeProfileWheelTarget;
+  }
+
+  function setActiveProfileWheelTarget(target) {
+    activeProfileWheelTarget = target;
+  }
+
+  function scrollProfileListFromWheel(event) {
+    const clientPos = [Number(event?.clientX || 0), Number(event?.clientY || 0)];
+    if (
+      activeProfileWheelTarget?.node?.comfyClass === nodeTypeName
+      && activeProfileWheelTarget?.widget
+      && (now() - activeProfileWheelTarget.time) < 30000
+      && (app.graph?._nodes || []).includes(activeProfileWheelTarget.node)
+    ) {
+      if (!canvasWidgets.pointInArea(clientPos, activeProfileWheelTarget.widget.listClientArea)) {
+        activeProfileWheelTarget = null;
+      } else {
+        activeProfileWheelTarget.time = now();
+        const handled = activeProfileWheelTarget.widget.scrollByWheel(
+          event.deltaY,
+          activeProfileWheelTarget.node,
+        );
+        if (handled) {
+          event.preventDefault?.();
+          event.stopPropagation?.();
+          return true;
+        }
+      }
+    }
+
+    const nodesByZ = [...(app.graph?._nodes || [])].reverse();
+    for (const node of nodesByZ) {
+      const bar = node?.comfyClass === nodeTypeName ? node.__easyuseAnimaProfileBar : null;
+      if (!bar || !canvasWidgets.pointInArea(clientPos, bar.listClientArea)) {
+        continue;
+      }
+      const handled = bar.scrollByWheel(event.deltaY, node);
+      if (handled) {
+        activeProfileWheelTarget = {
+          node,
+          widget: bar,
+          time: now(),
+        };
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        return true;
+      }
+    }
+
+    const canvas = app.canvas?.canvas;
+    const rect = canvas?.getBoundingClientRect?.();
+    if (
+      !canvas
+      || !rect
+      || Number(event?.clientX || 0) < rect.left
+      || Number(event?.clientX || 0) > rect.right
+      || Number(event?.clientY || 0) < rect.top
+      || Number(event?.clientY || 0) > rect.bottom
+    ) {
+      return false;
+    }
+    const graphPoint = clientPointToCanvas(event);
+    for (const node of nodesByZ) {
+      if (node?.comfyClass !== nodeTypeName || !node.__easyuseAnimaProfileBar || !Array.isArray(node.pos)) {
+        continue;
+      }
+      const localPos = [
+        Number(graphPoint[0] || 0) - Number(node.pos[0] || 0),
+        Number(graphPoint[1] || 0) - Number(node.pos[1] || 0),
+      ];
+      const bar = node.__easyuseAnimaProfileBar;
+      if (!canvasWidgets.pointInArea(localPos, bar.listArea)) {
+        continue;
+      }
+      const count = profileCount(node);
+      const maxOffset = Math.max(0, count - canvasWidgets.profileVisibleRows);
+      if (maxOffset <= 0) {
+        return false;
+      }
+      const direction = Number(event.deltaY || 0) > 0 ? 1 : -1;
+      const nextOffset = Math.max(0, Math.min(maxOffset, (bar.scrollOffset || 0) + direction));
+      if (nextOffset !== bar.scrollOffset) {
+        bar.scrollOffset = nextOffset;
+        node.setDirtyCanvas?.(true, true);
+      }
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      return true;
+    }
+    return false;
+  }
+
+  function dispose() {
+    if (!installed) {
+      if (hostWindow[LORA_PRESET_ENTRY_OWNER] === lifecycle) {
+        delete hostWindow[LORA_PRESET_ENTRY_OWNER];
+      }
+      return false;
+    }
+    installed = false;
+    activeProfileWheelTarget = null;
+    for (const [target, type, listener, options] of listeners) {
+      target.removeEventListener(type, listener, options);
+    }
+    listeners.length = 0;
+    let cleanupError = null;
+    const runCleanup = (callback) => {
+      try {
+        callback();
+      } catch (error) {
+        cleanupError ||= error;
+      }
+    };
+    runCleanup(() => disposeLocaleWatch?.());
+    disposeLocaleWatch = null;
+    runCleanup(() => menuLifecycle.dispose?.());
+    runCleanup(() => previewLifecycle.hidePreview());
+    if (hostWindow[LORA_PRESET_ENTRY_OWNER] === lifecycle) {
+      delete hostWindow[LORA_PRESET_ENTRY_OWNER];
+    }
+    if (cleanupError) {
+      throw cleanupError;
+    }
+    return true;
+  }
+
+  function install() {
+    if (isActive()) {
+      return false;
+    }
+    const previousOwner = hostWindow[LORA_PRESET_ENTRY_OWNER];
+    if (previousOwner && previousOwner !== lifecycle) {
+      previousOwner.dispose?.();
+    }
+    if (hostWindow[LORA_PRESET_ENTRY_OWNER]) {
+      return false;
+    }
+
+    installed = true;
+    hostWindow[LORA_PRESET_ENTRY_OWNER] = lifecycle;
+    try {
+      disposeLocaleWatch = watchLocale(() => {
+        if (isActive()) {
+          refreshNodes();
+        }
+      });
+      listen(hostWindow, "easyuse-anima-settings-updated", (event) => {
+        if (!isActive()) {
+          return;
+        }
+        applySettings(event.detail || {});
+        refreshNodes();
+      });
+      listen(hostDocument, "pointerdown", previewLifecycle.hidePreview, true);
+      listen(hostDocument, "wheel", scrollProfileListFromWheel, { capture: true, passive: false });
+      menuLifecycle.install();
+    } catch (error) {
+      try {
+        dispose();
+      } catch {
+        // Preserve the installation error after releasing every owned hook.
+      }
+      throw error;
+    }
+    return true;
+  }
+
+  function initialize() {
+    saveSync.install();
+    if (!install()) {
+      return false;
+    }
+    loadSettings().then(() => {
+      if (isActive()) {
+        refreshNodes();
+      }
+    });
+    return true;
+  }
+
+  function setup() {
+    saveSync.install();
+  }
+
+  async function beforeRegisterNodeDef(nodeType, nodeData) {
+    nodeRuntime.beforeRegisterNodeDef(nodeType, nodeData);
+  }
+
+  const lifecycle = {
+    beforeRegisterNodeDef,
+    dispose,
+    extension: {
+      name: "EasyUseAnima.LoraPreset",
+      init: initialize,
+      setup,
+      beforeRegisterNodeDef,
+    },
+    getActiveProfileWheelTarget,
+    initialize,
+    install,
+    isActive,
+    scrollProfileListFromWheel,
+    setActiveProfileWheelTarget,
+    setup,
+  };
+  return lifecycle;
+}


### PR DESCRIPTION
## 변경 요약

- LoRA Preset entry에 남아 있던 document wheel, pointer, settings, locale listener 소유권을 `lora_preset/entry_lifecycle.js`로 분리했습니다.
- extension owner 교체와 dispose 시 전역 listener, locale 구독, menu/preview 상태를 정리하고 중복 등록을 방지합니다.
- profile mutation, save-sync, sparse `widgets_values`, node/menu/canvas 동작은 기존 소유 모듈에 그대로 유지했습니다.
- 전용 lifecycle smoke와 Python module-boundary 회귀 테스트를 공식 frontend runner에 등록했습니다.

## 주요 파일

- `web/js/lora_preset/entry_lifecycle.js`
- `web/js/easyuse_anima_lora_preset.js`
- `tests/frontend_lora_preset_entry_lifecycle_smoke.mjs`
- `tests/test_frontend_lora_preset.py`
- `tools/check_frontend.ps1`

## 검증

- `node --check web/js/lora_preset/entry_lifecycle.js`
- `node --check web/js/easyuse_anima_lora_preset.js`
- `node tests/frontend_lora_preset_entry_lifecycle_smoke.mjs`
- focused unittest: 19/19
- TypeScript 6.0.3
- official full runner:
  - Python unittest 411/411
  - frontend 110 JavaScript files
  - diff check 통과

## 테스트 표면과 남은 확인

- deterministic smoke에서 listener 중복 방지, owner 교체/해제, client/canvas wheel ownership, settings/locale 갱신을 검증했습니다.
- 이 PR은 동작 보존형 lifecycle 추출입니다. Legacy canvas와 Node 2.0의 최종 surface-sensitive save/reload·wheel 확인은 현재 유지보수 묶음의 최종 통합 matrix에서 한 번만 수행합니다.
- backend/API/GPU queue 계약은 변경하지 않았습니다.

Closes no issue; Issue #55 ledger를 병합 후 갱신합니다.