### PR TITLE
fix: hydrate AiO resource choices after catalog load

### DIFF
--- a/tests/frontend_aio_dependency_core_smoke.mjs
+++ b/tests/frontend_aio_dependency_core_smoke.mjs
@@ -35,6 +35,10 @@ assert(
   AIO_OPTIONAL_DEPENDENCY_SPECS.imageSaver.nodeId === "Image Saver",
   "The Image Saver object-info node id must remain stable",
 );
+assert(
+  AIO_OPTIONAL_DEPENDENCY_SPECS.checkpointLoader.nodeId === "CheckpointLoaderSimple",
+  "SAM3 choices must use the built-in checkpoint loader object-info catalog",
+);
 
 const queriedSpecs = {
   present: { nodeId: "PresentNode", pack: "Present Pack" },

--- a/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
@@ -80,7 +80,12 @@ assert.deepEqual(
   "Detailer settings dialog must expose only its lifecycle factory",
 );
 
-function createFixture({ settings = {}, available = {}, deferLoads = false } = {}) {
+function createFixture({
+  settings = {},
+  available = {},
+  choiceOptions = {},
+  deferLoads = false,
+} = {}) {
   let dependencyCalls = 0;
   let currentDialog = null;
   const trace = [];
@@ -90,6 +95,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   const writes = [];
   const renders = [];
   const stageCalls = [];
+  let catalogLoaded = !deferLoads;
   const document = createFakeDocument();
   const availabilityState = { ...available };
   const defaultSettings = clone(settingsModule.AIO_DEFAULT_GENERATION_SETTINGS);
@@ -175,6 +181,27 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     if (!select.options.some((option) => option.selected)) {
       select.value = String(value ?? "");
     }
+    return select;
+  }
+
+  function reconcileSelectInput(select, options) {
+    dependencyCalls += 1;
+    const current = String(select.value ?? "");
+    const values = [...new Set(options.map((option) => String(option?.value ?? option ?? "")))];
+    if (current && !values.includes(current)) {
+      values.unshift(current);
+    }
+    select.replaceChildren();
+    select.options = [];
+    for (const value of values) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      option.selected = value === current;
+      select.options.push(option);
+      select.append(option);
+    }
+    select.value = current;
     return select;
   }
 
@@ -326,6 +353,18 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     return [...new Set([...fallback, name === "sampler_name" ? "custom_sampler" : "custom_scheduler"])];
   }
 
+  function nodeInputChoiceOptions(dependencyKey, inputName, current, fallback = []) {
+    dependencyCalls += 1;
+    const key = `${dependencyKey}:${inputName}`;
+    const catalog = catalogLoaded ? (choiceOptions[key] || []) : [];
+    const values = [...new Set((catalog.length ? catalog : fallback).filter(Boolean))];
+    const normalizedCurrent = String(current ?? "");
+    if (normalizedCurrent && !values.includes(normalizedCurrent)) {
+      values.unshift(normalizedCurrent);
+    }
+    return values;
+  }
+
   function writeSettings(targetNode, widget, nextSettings) {
     dependencyCalls += 1;
     const snapshot = clone(nextSettings);
@@ -352,6 +391,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
       textInput,
       numberInput,
       selectInput,
+      reconcileSelectInput,
     },
     text: {
       staticText,
@@ -377,6 +417,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
       findWidget,
       getSettings,
       widgetOptions,
+      nodeInputChoiceOptions,
       writeSettings,
       renderPanel,
     },
@@ -393,6 +434,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
         dependencyCalls += 1;
         loadCalls.push(options);
         if (!deferLoads) {
+          catalogLoaded = true;
           return Promise.resolve();
         }
         return new Promise((resolve) => loadResolvers.push(resolve));
@@ -414,6 +456,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     trace,
     dependencyCallCount: () => dependencyCalls,
     resolveLoads() {
+      catalogLoaded = true;
       for (const resolve of loadResolvers.splice(0)) {
         resolve();
       }
@@ -423,6 +466,12 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
 
 {
   const fixture = createFixture({
+    choiceOptions: {
+      "checkpointLoader:ckpt_name": [
+        "configured-sam3.safetensors",
+        "updated-sam3.safetensors",
+      ],
+    },
     settings: {
       detailer: {
         enabled: true,
@@ -482,7 +531,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     tabs(cancelDialog).some((tab) => tabLabel(tab) === "Detailer Block 2"),
     false,
   );
-  controlIn(cancelDialog.body, "SAM3 checkpoint").value = "cancelled-change.safetensors";
+  controlIn(cancelDialog.body, "SAM3 checkpoint").value = "updated-sam3.safetensors";
   action(cancelDialog, "button.cancel").emit("click");
   assert.deepEqual(fixture.node.settings, originalSettings, "Cancel must not mutate settings");
   assert.equal(fixture.node.widgets[0].value, originalWidget, "Cancel must not rewrite the hidden widget");
@@ -588,10 +637,14 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
 {
   const fixture = createFixture({
     available: { impactDetailer: true, impactMaskToSegs: true },
+    choiceOptions: {
+      "checkpointLoader:ckpt_name": ["installed-a.safetensors", "installed-b.safetensors"],
+    },
     deferLoads: true,
     settings: {
       detailer: {
         enabled: true,
+        sam3: { checkpoint: "legacy-missing.safetensors" },
         face: { enabled: true },
         eye: { enabled: true },
       },
@@ -601,16 +654,33 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   fixture.openDetailerSettings(fixture.node);
   const dialog = fixture.dialogs[0];
   const enabled = controlIn(dialog.body, "Enable detailer");
+  const checkpoint = controlIn(dialog.body, "SAM3 checkpoint");
   const warning = find(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-warning"));
   assert.equal(enabled.disabled, false);
   assert.equal(enabled.checked, true);
   assert.equal(warning.hidden, true);
   assert.equal(fixture.loadCalls.length, 1);
+  assert.equal(checkpoint.tagName, "SELECT", "SAM3 checkpoint must use a native catalog select");
+  assert.deepEqual(
+    checkpoint.options.map((option) => option.value),
+    ["legacy-missing.safetensors"],
+    "First-open SAM3 choices must initially preserve the saved fallback",
+  );
 
   fixture.availabilityState.impactDetailer = false;
   fixture.availabilityState.impactMaskToSegs = false;
   fixture.resolveLoads();
   await flushPromises();
+  assert.deepEqual(
+    checkpoint.options.map((option) => option.value),
+    ["legacy-missing.safetensors", "installed-a.safetensors", "installed-b.safetensors"],
+    "CheckpointLoaderSimple object info must hydrate installed SAM3 choices",
+  );
+  assert.equal(
+    checkpoint.value,
+    "legacy-missing.safetensors",
+    "SAM3 hydration must preserve a saved value missing from the current catalog",
+  );
   assert.equal(enabled.disabled, true, "Missing dependencies must lock Detailer after async refresh");
   assert.equal(enabled.checked, false, "Missing dependencies must clear an enabled Detailer toggle");
   assert.equal(warning.hidden, false);
@@ -624,6 +694,31 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   assert.equal(fixture.node.settings.detailer.enabled, false);
   assert.equal(fixture.node.settings.detailer.face.enabled, false);
   assert.equal(fixture.node.settings.detailer.eye.enabled, false);
+}
+
+{
+  const fixture = createFixture({
+    choiceOptions: {
+      "checkpointLoader:ckpt_name": ["installed-after-close.safetensors"],
+    },
+    deferLoads: true,
+    settings: {
+      detailer: {
+        sam3: { checkpoint: "saved-before-close.safetensors" },
+      },
+    },
+  });
+  fixture.openDetailerSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const checkpoint = controlIn(dialog.body, "SAM3 checkpoint");
+  action(dialog, "button.cancel").emit("click");
+  fixture.resolveLoads();
+  await flushPromises();
+  assert.deepEqual(
+    checkpoint.options.map((option) => option.value),
+    ["saved-before-close.safetensors"],
+    "A late checkpoint catalog callback must not mutate a closed dialog",
+  );
 }
 
 console.log("AiO Detailer settings dialog smoke passed.");

--- a/tests/frontend_aio_dom_controls_core_smoke.mjs
+++ b/tests/frontend_aio_dom_controls_core_smoke.mjs
@@ -40,6 +40,10 @@ class FakeElement {
   append(...children) {
     this.children.push(...children);
   }
+
+  replaceChildren(...children) {
+    this.children = [...children];
+  }
 }
 
 const previousDocument = globalThis.document;
@@ -55,6 +59,7 @@ const expectedExports = [
   "aioCreateTextareaInput",
   "aioNodeInputControlForSpec",
   "aioNodeInputDefault",
+  "aioReconcileSelectInput",
   "aioValueFromNodeInputControl",
 ];
 assertJsonEqual(
@@ -78,6 +83,7 @@ try {
     aioCreateTextareaInput,
     aioNodeInputControlForSpec,
     aioNodeInputDefault,
+    aioReconcileSelectInput,
     aioValueFromNodeInputControl,
   } = controlsModule;
 
@@ -158,6 +164,24 @@ try {
   assert(
     stringSelect.children[0].selected === true,
     "A string choice value must select the matching normalized option",
+  );
+
+  const hydratedSelect = aioCreateSelectInput(["catalog-old", "saved-missing"], "catalog-old");
+  hydratedSelect.value = "saved-missing";
+  aioReconcileSelectInput(hydratedSelect, [
+    "catalog-new",
+    { value: "catalog-old", label: "Old catalog entry" },
+    "catalog-new",
+  ]);
+  assertJsonEqual(
+    hydratedSelect.children.map((option) => option.value),
+    ["saved-missing", "catalog-new", "catalog-old"],
+    "Catalog reconciliation must deduplicate choices and retain a missing current value",
+  );
+  assert(
+    hydratedSelect.value === "saved-missing"
+      && hydratedSelect.children[0].selected === true,
+    "Late catalog reconciliation must not overwrite a newer current selection",
   );
 
   assert(

--- a/tests/frontend_aio_stage_settings_dialogs_smoke.mjs
+++ b/tests/frontend_aio_stage_settings_dialogs_smoke.mjs
@@ -70,6 +70,7 @@ function createFixture({
   settings = {},
   available = {},
   missingByBackend = {},
+  choiceOptions = {},
   deferLoads = false,
 } = {}) {
   let dependencyCalls = 0;
@@ -80,6 +81,7 @@ function createFixture({
   const loadResolvers = [];
   const optionCalls = [];
   const choiceCalls = [];
+  let catalogLoaded = !deferLoads;
   const writes = [];
   const renders = [];
   const document = createFakeDocument();
@@ -172,6 +174,27 @@ function createFixture({
     return select;
   }
 
+  function reconcileSelectInput(select, options) {
+    dependencyCalls += 1;
+    const current = String(select.value ?? "");
+    const values = [...new Set(options.map((option) => String(option?.value ?? option ?? "")))];
+    if (current && !values.includes(current)) {
+      values.unshift(current);
+    }
+    select.replaceChildren();
+    select.options = [];
+    for (const value of values) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      option.selected = value === current;
+      select.options.push(option);
+      select.append(option);
+    }
+    select.value = current;
+    return select;
+  }
+
   function staticText(value) {
     dependencyCalls += 1;
     return `static:${value}`;
@@ -233,7 +256,14 @@ function createFixture({
   function nodeInputChoiceOptions(dependencyKey, inputName, current, fallback = []) {
     dependencyCalls += 1;
     choiceCalls.push({ dependencyKey, inputName, current, fallback: [...fallback] });
-    return [...new Set([...fallback, current].filter(Boolean))];
+    const key = `${dependencyKey}:${inputName}`;
+    const catalog = catalogLoaded ? (choiceOptions[key] || []) : [];
+    const values = [...new Set((catalog.length ? catalog : fallback).filter(Boolean))];
+    const normalizedCurrent = String(current ?? "");
+    if (normalizedCurrent && !values.includes(normalizedCurrent)) {
+      values.unshift(normalizedCurrent);
+    }
+    return values;
   }
 
   function writeSettings(targetNode, widget, nextSettings) {
@@ -261,6 +291,7 @@ function createFixture({
       numberInput,
       checkbox,
       selectInput,
+      reconcileSelectInput,
     },
     text: {
       staticText,
@@ -301,6 +332,7 @@ function createFixture({
         dependencyCalls += 1;
         loadCalls.push(options);
         if (!deferLoads) {
+          catalogLoaded = true;
           return Promise.resolve();
         }
         return new Promise((resolve) => loadResolvers.push(resolve));
@@ -323,6 +355,7 @@ function createFixture({
     renders,
     trace,
     resolveLoads() {
+      catalogLoaded = true;
       for (const resolve of loadResolvers.splice(0)) {
         resolve();
       }
@@ -463,6 +496,10 @@ function createFixture({
 {
   const fixture = createFixture({
     missingByBackend: { resshift: [] },
+    choiceOptions: {
+      "upscaleModelLoader:model_name": ["installed-a.pth", "installed-b.pth"],
+      "resShiftLoader:student_name": ["student.safetensors", "other-student.safetensors"],
+    },
     deferLoads: true,
     settings: {
       upscale: {
@@ -472,6 +509,7 @@ function createFixture({
         inherit_sampler_settings: false,
         prompt_mode: "ignored-legacy-root",
         usdu: {
+          upscale_model_name: "legacy-missing.pth",
           auto_tile_size: false,
           prompt_mode: "quality_tags_only",
           auto_tile_target: 900,
@@ -497,6 +535,11 @@ function createFixture({
   const resshiftOption = backend.options.find((option) => option.value === "resshift");
   assert.equal(resshiftOption.disabled, false);
   assert.equal(control(dialog, "Enable upscale").checked, true);
+  assert.deepEqual(
+    control(dialog, "Upscale model").options.map((option) => option.value),
+    ["legacy-missing.pth"],
+    "First-open upscale choices must initially preserve the saved fallback",
+  );
   fixture.missingByBackendState.resshift = ["ComfyUI-ResShift"];
   fixture.resolveLoads();
   await flushPromises();
@@ -510,6 +553,16 @@ function createFixture({
   assert.equal(resshiftOption.disabled, true);
   assert.ok(resshiftOption.textContent.includes("ComfyUI-ResShift"));
   assert.equal(control(dialog, "Enable upscale").checked, false, "Missing selected backend must disable upscale");
+  assert.deepEqual(
+    control(dialog, "Upscale model").options.map((option) => option.value),
+    ["legacy-missing.pth", "installed-a.pth", "installed-b.pth"],
+    "Async object-info load must hydrate all installed upscale choices",
+  );
+  assert.equal(
+    control(dialog, "Upscale model").value,
+    "legacy-missing.pth",
+    "Hydration must preserve a saved value that is absent from the current catalog",
+  );
   assert.ok(findAll(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-warning"))
     .some((element) => element.textContent.includes("ComfyUI-ResShift")));
   assert.ok(sectionByHeading(dialog, "USDU Upscale").classList.contains("hidden"));
@@ -570,6 +623,7 @@ function createFixture({
   assert.equal(fixture.node.settings.upscale.usdu.auto_tile_target, 300);
   assert.equal(fixture.node.settings.upscale.usdu.auto_tile_min, 300);
   assert.equal(fixture.node.settings.upscale.usdu.auto_tile_max, 500);
+  assert.equal(fixture.node.settings.upscale.usdu.upscale_model_name, "legacy-missing.pth");
   assert.equal(fixture.node.settings.upscale.resshift.student_name, "student.safetensors");
   assert.equal(fixture.node.settings.upscale.preserved_upscale_key, "keep-upscale");
 
@@ -587,6 +641,31 @@ function createFixture({
   assert.deepEqual(fixture.node.settings, settingsBeforeCancel, "Upscale Cancel must not mutate settings");
   assert.equal(fixture.node.widgets[0].value, widgetBeforeCancel, "Upscale Cancel must not rewrite the hidden widget");
   assert.deepEqual(cancelDialog.trace, ["remove"]);
+}
+
+{
+  const fixture = createFixture({
+    choiceOptions: {
+      "upscaleModelLoader:model_name": ["installed-after-close.pth"],
+    },
+    deferLoads: true,
+    settings: {
+      upscale: {
+        usdu: { upscale_model_name: "saved-before-close.pth" },
+      },
+    },
+  });
+  fixture.runtime.openUpscaleSettings(fixture.node);
+  const dialog = fixture.dialogs[0];
+  const upscaleModel = control(dialog, "Upscale model");
+  action(dialog, "button.cancel").emit("click");
+  fixture.resolveLoads();
+  await flushPromises();
+  assert.deepEqual(
+    upscaleModel.options.map((option) => option.value),
+    ["saved-before-close.pth"],
+    "A late catalog callback must not mutate a closed dialog",
+  );
 }
 
 console.log("AiO stage settings dialogs smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -703,10 +703,23 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("max_megapixels: clampGeneratorNumber", body)
         self.assertIn('nodeInputChoiceOptions("upscaleModelLoader", "model_name"', body)
         self.assertIn('nodeInputChoiceOptions("resShiftLoader", "student_name"', body)
+        self.assertIn("reconcileSelectInput(", body)
+        self.assertIn("upscaleModel.value", body)
+        self.assertIn("closed || backdrop.isConnected === false", body)
         self.assertIn("upscaleBackendMissingPacks(backend.value)", body)
         self.assertIn("enabled: enabled.checked && missingPacks.length === 0", body)
         self.assertIn("resshiftSection", body)
         self.assertIn("resshift:", body)
+
+    def test_sam3_checkpoint_uses_checkpoint_loader_catalog_and_late_hydration(self):
+        body = AIO_DETAILER_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")
+
+        self.assertIn('"checkpointLoader"', body)
+        self.assertIn('"ckpt_name"', body)
+        self.assertIn("selectInput(", body)
+        self.assertIn("reconcileSelectInput(", body)
+        self.assertIn("checkpoint.value", body)
+        self.assertIn("closed || backdrop.isConnected === false", body)
 
     def test_postprocess_settings_own_final_fit_controls(self):
         body = AIO_POSTPROCESS_SETTINGS_DIALOG_JS.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -1190,6 +1190,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "normalizeUsduAutoTileRange: normalizeGeneratorUsduAutoTileRange,",
             "getSettings: generatorSettings,",
             "renderPanel: renderGeneratorPanel,",
+            "reconcileSelectInput,",
             "upscaleBackendMissingPacks,",
             "load: loadGeneratorOptionalDependencies,",
         ):
@@ -1241,6 +1242,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "normalizeDetailerOrder,",
             "stageOptimizationEditor: createStageOptimizationEditor,",
             "getSettings: generatorSettings,",
+            "nodeInputChoiceOptions,",
+            "reconcileSelectInput,",
             "renderPanel: renderGeneratorPanel,",
             "load: loadGeneratorOptionalDependencies,",
         ):
@@ -1760,6 +1763,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "aioCreateCheckboxInput",
             "aioCreateNumberInput",
             "aioCreateSelectInput",
+            "aioReconcileSelectInput",
             "aioCreateTextInput",
             "aioCreateTextareaInput",
             "aioNodeInputControlForSpec",

--- a/web/js/aio/dependencies.js
+++ b/web/js/aio/dependencies.js
@@ -33,6 +33,10 @@ export const AIO_OPTIONAL_DEPENDENCY_SPECS = {
     nodeId: "UpscaleModelLoader",
     pack: "ComfyUI built-in upscale model loader",
   },
+  checkpointLoader: {
+    nodeId: "CheckpointLoaderSimple",
+    pack: "ComfyUI built-in checkpoint loader",
+  },
   ultimateSdUpscale: {
     nodeId: "UltimateSDUpscale",
     pack: "ComfyUI_UltimateSDUpscale",

--- a/web/js/aio/detailer_settings_dialog.js
+++ b/web/js/aio/detailer_settings_dialog.js
@@ -8,6 +8,7 @@
  * @property {(value: any) => any} textInput
  * @property {(value: any, step?: string) => any} numberInput
  * @property {(options: any[], value: any) => any} selectInput
+ * @property {(select: any, options: any[]) => any} reconcileSelectInput
  */
 
 /**
@@ -38,6 +39,7 @@
  * @property {(node: any, name: string) => any} findWidget
  * @property {(node: any) => any} getSettings
  * @property {(node: any, name: string, fallback: any[]) => any[]} widgetOptions
+ * @property {(dependencyKey: string, inputName: string, current: any, fallback?: any[]) => any[]} nodeInputChoiceOptions
  * @property {(node: any, widget: any, settings: any) => void} writeSettings
  * @property {(node: any) => void} renderPanel
  */
@@ -85,6 +87,7 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
     textInput,
     numberInput,
     selectInput,
+    reconcileSelectInput,
   } = controls;
   const {
     staticText: aioStaticText,
@@ -109,6 +112,7 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
     findWidget,
     getSettings: generatorSettings,
     widgetOptions,
+    nodeInputChoiceOptions,
     writeSettings,
     renderPanel: renderGeneratorPanel,
   } = nodeAdapter;
@@ -251,11 +255,24 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
       "SAM3 detection and Impact detailer settings are saved with the node."
     );
     body.classList.add("easyuse-anima-aio-one-column");
+    let closed = false;
     const main = document.createElement("section");
     main.className = "easyuse-anima-aio-section full";
     main.append(Object.assign(document.createElement("h3"), { textContent: aioStaticText("Detailer") }));
     const enabled = field(main, "Enable detailer", checkbox(detailer.enabled));
-    const checkpoint = field(main, "SAM3 checkpoint", textInput(detailer.sam3.checkpoint));
+    const checkpoint = field(
+      main,
+      "SAM3 checkpoint",
+      selectInput(
+        nodeInputChoiceOptions(
+          "checkpointLoader",
+          "ckpt_name",
+          detailer.sam3.checkpoint,
+          [detailer.sam3.checkpoint],
+        ),
+        detailer.sam3.checkpoint,
+      ),
+    );
     const dependencyWarning = document.createElement("div");
     dependencyWarning.className = "easyuse-anima-aio-warning";
     dependencyWarning.hidden = true;
@@ -418,7 +435,21 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
         : "";
     };
     refreshDetailerDependencyLocks();
-    loadGeneratorOptionalDependencies().then(refreshDetailerDependencyLocks);
+    loadGeneratorOptionalDependencies().then(() => {
+      if (closed || backdrop.isConnected === false) {
+        return;
+      }
+      reconcileSelectInput(
+        checkpoint,
+        nodeInputChoiceOptions(
+          "checkpointLoader",
+          "ckpt_name",
+          checkpoint.value,
+          [checkpoint.value],
+        ),
+      );
+      refreshDetailerDependencyLocks();
+    });
 
     const cancel = document.createElement("button");
     cancel.textContent = aioText("button.cancel");
@@ -426,7 +457,10 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
     apply.className = "primary";
     apply.textContent = aioText("button.apply");
     actions.append(cancel, apply);
-    cancel.addEventListener("click", () => backdrop.remove());
+    cancel.addEventListener("click", () => {
+      closed = true;
+      backdrop.remove();
+    });
     apply.addEventListener("click", () => {
       const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
       const detailerEnabled = enabled.checked && !enabled.disabled;
@@ -458,6 +492,7 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
       next.detailer = nextDetailer;
       writeSettings(node, widget, next);
       renderGeneratorPanel(node);
+      closed = true;
       backdrop.remove();
     });
   }

--- a/web/js/aio/dom_controls.js
+++ b/web/js/aio/dom_controls.js
@@ -74,6 +74,54 @@ export function aioCreateSelectInput(options, value) {
 }
 
 /**
+ * Replace a native select's choices without losing the value selected after
+ * the control was created. A value missing from the refreshed catalog is kept
+ * as an explicit compatibility option.
+ *
+ * @param {HTMLSelectElement} select
+ * @param {any[]} options
+ * @returns {HTMLSelectElement}
+ */
+export function aioReconcileSelectInput(select, options) {
+  const currentValue = String(select?.value ?? "");
+  const normalizedOptions = [];
+  const seen = new Set();
+  for (const optionSpec of options || []) {
+    const optionValue = typeof optionSpec === "object" && optionSpec
+      ? String(optionSpec.value ?? "")
+      : String(optionSpec ?? "");
+    if (seen.has(optionValue)) {
+      continue;
+    }
+    seen.add(optionValue);
+    normalizedOptions.push(optionSpec);
+  }
+  if (currentValue && !seen.has(currentValue)) {
+    normalizedOptions.unshift(currentValue);
+  }
+
+  select.replaceChildren();
+  for (const optionSpec of normalizedOptions) {
+    const optionValue = typeof optionSpec === "object" && optionSpec
+      ? String(optionSpec.value ?? "")
+      : String(optionSpec ?? "");
+    const option = document.createElement("option");
+    option.value = optionValue;
+    option.textContent = typeof optionSpec === "object" && optionSpec
+      ? String(optionSpec.label ?? optionValue)
+      : optionValue;
+    option.disabled = !!(typeof optionSpec === "object" && optionSpec?.disabled);
+    if (typeof optionSpec === "object" && optionSpec?.title) {
+      option.title = String(optionSpec.title);
+    }
+    option.selected = optionValue === currentValue;
+    select.append(option);
+  }
+  select.value = currentValue;
+  return select;
+}
+
+/**
  * @param {any} spec
  * @param {any} [fallback]
  * @returns {any}

--- a/web/js/aio/stage_settings_dialogs.js
+++ b/web/js/aio/stage_settings_dialogs.js
@@ -7,6 +7,7 @@
  * @property {(value: any, step?: string) => any} numberInput
  * @property {(value: any) => any} checkbox
  * @property {(options: any[], value: any) => any} selectInput
+ * @property {(select: any, options: any[]) => any} reconcileSelectInput
  */
 
 /**
@@ -82,6 +83,7 @@ export function aioCreateStageSettingsDialogs(dependencies) {
     numberInput,
     checkbox,
     selectInput,
+    reconcileSelectInput,
   } = controls;
   const {
     staticText: aioStaticText,
@@ -338,6 +340,7 @@ export function aioCreateStageSettingsDialogs(dependencies) {
       "Final-stage upscale runs after Detailer and before Save. Choose USDU or ResShift."
     );
     body.classList.add("easyuse-anima-aio-one-column");
+    let closed = false;
 
     const main = document.createElement("section");
     main.className = "easyuse-anima-aio-section";
@@ -488,7 +491,30 @@ export function aioCreateStageSettingsDialogs(dependencies) {
     body.append(main, usduSection, usduSampler, optimization.section, resshiftSection);
     updateVisibility();
     refreshDependencyLocks();
-    loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
+    loadGeneratorOptionalDependencies().then(() => {
+      if (closed || backdrop.isConnected === false) {
+        return;
+      }
+      reconcileSelectInput(
+        upscaleModel,
+        nodeInputChoiceOptions(
+          "upscaleModelLoader",
+          "model_name",
+          upscaleModel.value,
+          [upscaleModel.value],
+        ),
+      );
+      reconcileSelectInput(
+        student,
+        nodeInputChoiceOptions(
+          "resShiftLoader",
+          "student_name",
+          student.value,
+          ["(auto-download)"],
+        ),
+      );
+      refreshDependencyLocks();
+    });
 
     const cancel = document.createElement("button");
     cancel.textContent = aioText("button.cancel");
@@ -496,7 +522,10 @@ export function aioCreateStageSettingsDialogs(dependencies) {
     apply.className = "primary";
     apply.textContent = aioText("button.apply");
     actions.append(cancel, apply);
-    cancel.addEventListener("click", () => backdrop.remove());
+    cancel.addEventListener("click", () => {
+      closed = true;
+      backdrop.remove();
+    });
     apply.addEventListener("click", () => {
       const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
       const missingPacks = upscaleBackendMissingPacks(backend.value);
@@ -545,6 +574,7 @@ export function aioCreateStageSettingsDialogs(dependencies) {
       };
       writeSettings(node, widget, next);
       renderGeneratorPanel(node);
+      closed = true;
       backdrop.remove();
     });
   }

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -6,6 +6,7 @@ import {
   aioCreateCheckboxInput as checkbox,
   aioCreateNumberInput as numberInput,
   aioCreateSelectInput as selectInput,
+  aioReconcileSelectInput as reconcileSelectInput,
   aioCreateTextareaInput as textareaInput,
   aioCreateTextInput as textInput,
   aioNodeInputControlForSpec as nodeInputControlForSpec,
@@ -3708,6 +3709,7 @@ const {
     numberInput,
     checkbox,
     selectInput,
+    reconcileSelectInput,
   },
   text: {
     staticText: aioStaticText,
@@ -3748,6 +3750,7 @@ const openDetailerSettings = aioCreateDetailerSettingsDialog({
     textInput,
     numberInput,
     selectInput,
+    reconcileSelectInput,
   },
   text: {
     staticText: aioStaticText,
@@ -3773,6 +3776,7 @@ const openDetailerSettings = aioCreateDetailerSettingsDialog({
     findWidget,
     getSettings: generatorSettings,
     widgetOptions,
+    nodeInputChoiceOptions,
     writeSettings,
     renderPanel: renderGeneratorPanel,
   },


### PR DESCRIPTION
## 변경 요약

- AiO upscale dialog가 catalog 로드 전에 열려도 비동기 object-info 도착 후 설치된 upscale model 목록을 다시 반영합니다.
- SAM3 checkpoint를 plain text가 아니라 `CheckpointLoaderSimple.ckpt_name` catalog 기반 select로 변경했습니다.
- catalog reconcile 시 callback 실행 시점의 현재 DOM 선택을 보존해 늦은 응답이 더 최신 사용자 선택을 덮어쓰지 않습니다.
- 현재 catalog에 없는 과거 저장값은 호환 option으로 유지하며, 닫힌 dialog의 늦은 callback은 무시합니다.
- ResShift의 기존 resource choice도 같은 hydration 경로로 정리했습니다.
- Detailer hidden field/wildcard 보존 계약은 이번 PR에 포함하지 않습니다.

## 주요 파일

- `web/js/aio/dom_controls.js`
- `web/js/aio/dependencies.js`
- `web/js/aio/stage_settings_dialogs.js`
- `web/js/aio/detailer_settings_dialog.js`
- `web/js/easyuse_anima_aio.js`
- 기존 AiO smoke 및 module-boundary unittest

## 검증

- 변경 JavaScript syntax check 통과
- 기존 AiO dependency/DOM/stage/Detailer smoke 통과
- focused unittest: 81/81
- TypeScript 6.0.3
- official full runner:
  - Python unittest 412/412
  - frontend 110 JavaScript files
  - diff check 통과

## 테스트 표면과 남은 확인

- async first-open hydration, stale response 사용자 선택 보존, 미설치 과거 값 보존, dialog close 후 callback 무시를 deterministic smoke로 검증했습니다.
- 이 계약은 Legacy canvas와 Node 2.0이 공유하는 DOM dialog/settings 경로이며 canvas별 구현 분기가 없습니다.
- live catalog와 save/reload는 Issue #66의 다음 Detailer 보존 PR까지 통합한 뒤 최종 surface-sensitive matrix에서 한 번 확인합니다.
- backend/API/GPU queue 계약은 변경하지 않았습니다.

Issue #66의 resource-choice hydration slice입니다. 병합 후 ledger를 갱신합니다.