### PR TITLE
fix: preserve AiO live catalog and wildcard contracts

### DIFF
--- a/tests/frontend_aio_dependency_core_smoke.mjs
+++ b/tests/frontend_aio_dependency_core_smoke.mjs
@@ -15,6 +15,8 @@ const dependencies = await import(dataModule("../web/js/aio/dependencies.js"));
 const {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
+  aioChoiceOptionsWithCurrent,
+  aioChoiceSpecValues,
   aioNodeInputMap,
   aioNodeInputSpec,
   aioNodeInputSupported,
@@ -38,6 +40,53 @@ assert(
 assert(
   AIO_OPTIONAL_DEPENDENCY_SPECS.checkpointLoader.nodeId === "CheckpointLoaderSimple",
   "SAM3 choices must use the built-in checkpoint loader object-info catalog",
+);
+
+const directCheckpointChoices = ["anima.safetensors", "portrait.safetensors"];
+assert(
+  JSON.stringify(aioChoiceSpecValues(directCheckpointChoices))
+    === JSON.stringify(directCheckpointChoices),
+  "Direct CheckpointLoaderSimple choice lists must stay intact",
+);
+assert(
+  JSON.stringify(aioChoiceSpecValues([
+    ["er_sde", "euler"],
+    { tooltip: "KSampler choices" },
+  ])) === JSON.stringify(["er_sde", "euler"]),
+  "Nested KSampler choice lists must ignore their metadata wrapper",
+);
+const comboSpec = [
+  "COMBO",
+  {
+    multiselect: false,
+    options: ["2x-AnimeSharpV4_Fast_RCAN_PU.safetensors"],
+  },
+];
+assert(
+  JSON.stringify(aioChoiceSpecValues(comboSpec))
+    === JSON.stringify(["2x-AnimeSharpV4_Fast_RCAN_PU.safetensors"]),
+  "COMBO object-info wrappers must expose only metadata.options",
+);
+assert(
+  JSON.stringify(aioChoiceSpecValues(["COMBO", { multiselect: false }])) === "[]",
+  "COMBO wrappers without options must not leak COMBO or object markers",
+);
+assert(
+  JSON.stringify(aioChoiceOptionsWithCurrent(
+    aioChoiceSpecValues(comboSpec),
+    "saved-model-missing-from-catalog.safetensors",
+  )) === JSON.stringify([
+    "saved-model-missing-from-catalog.safetensors",
+    "2x-AnimeSharpV4_Fast_RCAN_PU.safetensors",
+  ]),
+  "A saved current value missing from the live catalog must be preserved first",
+);
+assert(
+  JSON.stringify(aioChoiceOptionsWithCurrent(
+    aioChoiceSpecValues(comboSpec),
+    "2x-AnimeSharpV4_Fast_RCAN_PU.safetensors",
+  )) === JSON.stringify(["2x-AnimeSharpV4_Fast_RCAN_PU.safetensors"]),
+  "A current value already in the live catalog must not be duplicated",
 );
 
 const queriedSpecs = {

--- a/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
@@ -473,6 +473,7 @@ function createFixture({
 }
 
 {
+  const multilineFaceWildcard = "configured face wildcard\nsecond line";
   const fixture = createFixture({
     choiceOptions: {
       "checkpointLoader:ckpt_name": [
@@ -488,7 +489,7 @@ function createFixture({
         face: {
           enabled: true,
           guide_size_for: true,
-          wildcard: "configured face wildcard",
+          wildcard: multilineFaceWildcard,
           inpaint_model: true,
           tiled_encode: true,
           tiled_decode: true,
@@ -528,7 +529,7 @@ function createFixture({
   assert.ok(tabByLabel(cancelDialog, "Face Detailer").classList.contains("active"));
   assert.equal(controlIn(activeEditor(cancelDialog), "Block name").value, "Face Detailer");
   assert.equal(controlIn(activeEditor(cancelDialog), "Guide size basis").value, "bbox");
-  assert.equal(controlIn(activeEditor(cancelDialog), "Wildcard").value, "configured face wildcard");
+  assert.equal(controlIn(activeEditor(cancelDialog), "Wildcard").value, multilineFaceWildcard);
   assert.equal(controlIn(activeEditor(cancelDialog), "Wildcard").tagName, "TEXTAREA");
   assert.equal(controlIn(activeEditor(cancelDialog), "Inpaint model").checked, true);
   assert.equal(controlIn(activeEditor(cancelDialog), "Tiled encode").checked, true);
@@ -640,7 +641,7 @@ function createFixture({
   assert.equal(fixture.node.settings.preserved_root_key, "keep-root");
   assert.equal(fixture.node.settings.detailer.face.preserved_face_key, "keep-face");
   assert.equal(fixture.node.settings.detailer.face.guide_size_for, true);
-  assert.equal(fixture.node.settings.detailer.face.wildcard, "configured face wildcard");
+  assert.equal(fixture.node.settings.detailer.face.wildcard, multilineFaceWildcard);
   assert.equal(fixture.node.settings.detailer.face.inpaint_model, true);
   assert.equal(fixture.node.settings.detailer.face.tiled_encode, true);
   assert.equal(fixture.node.settings.detailer.face.tiled_decode, true);

--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -55,6 +55,16 @@ assert.deepEqual(
 );
 
 {
+  const document = createFakeDocument();
+  const input = document.createElement("input");
+  const textarea = document.createElement("textarea");
+  input.value = "first\nsecond";
+  textarea.value = "first\nsecond";
+  assert.equal(input.value, "firstsecond", "Fake input must model browser newline stripping");
+  assert.equal(textarea.value, "first\nsecond", "Fake textarea must preserve multiline values");
+}
+
+{
   const entrySource = readFileSync(
     new URL("../web/js/easyuse_anima_aio.js", import.meta.url),
     "utf8",
@@ -195,12 +205,11 @@ function createFixture() {
     return input;
   }
 
-  function textInput(value) {
+  function textareaInput(value) {
     dependencyCalls += 1;
-    const input = document.createElement("input");
-    input.type = "text";
-    input.value = String(value ?? "");
-    return input;
+    const textarea = document.createElement("textarea");
+    textarea.value = String(value ?? "");
+    return textarea;
   }
 
   function selectInput(options, value) {
@@ -441,7 +450,7 @@ function createFixture() {
     controls: {
       numberInput,
       checkbox,
-      textInput,
+      textareaInput,
       selectInput,
       createNodeField,
     },
@@ -995,14 +1004,25 @@ assert.equal(faceThresholdInput.max, "1");
 assert.equal(faceThresholdInput.step, "0.01");
 assert.equal(faceThreshold.getAttribute("data-test-tooltip"), "tip.detailerThreshold");
 assert.equal(faceWildcardInput.value, "");
+assert.equal(faceWildcardInput.tagName, "TEXTAREA");
+assert.equal(
+  faceWildcardInput.getAttribute("data-aio-focus-key"),
+  "detailer.face.wildcard",
+  "Detailer wildcard textarea must retain its stable focus key",
+);
 assert.equal(faceWildcard.getAttribute("data-test-tooltip"), "tip.detailerWildcard");
 
 faceThresholdInput.value = "0.63";
 faceThresholdInput.emit("input");
 assert.equal(node.settings.detailer.face.threshold, 0.63);
-faceWildcardInput.value = "__face_style__";
+const multilineFaceWildcard = "codex_live_face\nsecond_line";
+faceWildcardInput.value = multilineFaceWildcard;
 faceWildcardInput.emit("input");
-assert.equal(node.settings.detailer.face.wildcard, "__face_style__");
+assert.equal(
+  node.settings.detailer.face.wildcard,
+  multilineFaceWildcard,
+  "Detailer wildcard input must immediately write the exact multiline value",
+);
 assert.deepEqual(node.settings.detailer.face.preserved_unknown, { nested: "keep-panel" });
 
 const serializedDetailerSettings = JSON.stringify(node.settings);
@@ -1019,8 +1039,13 @@ assert.equal(
   "serialized Detailer threshold must reload into the external target card",
 );
 assert.equal(
+  findField(reloadedFaceBlock, "text:field.wildcard").children[0].tagName,
+  "TEXTAREA",
+  "serialized Detailer wildcard must reload into a textarea",
+);
+assert.equal(
   findField(reloadedFaceBlock, "text:field.wildcard").children[0].value,
-  "__face_style__",
+  multilineFaceWildcard,
   "serialized Detailer wildcard must reload into the external target card",
 );
 
@@ -1051,7 +1076,7 @@ assert.equal(
 );
 assert.equal(
   findField(reloadedFaceBlock, "text:field.wildcard").children[0].value,
-  "__face_style__",
+  multilineFaceWildcard,
   "re-enabling a Detailer target must preserve its wildcard",
 );
 

--- a/tests/frontend_support/fake_dom.mjs
+++ b/tests/frontend_support/fake_dom.mjs
@@ -146,6 +146,7 @@ class FakeElement {
     this.title = "";
     this.type = "";
     this.inputMode = "";
+    this._value = "";
     this.value = "";
     this.placeholder = "";
     this.rows = 0;
@@ -162,6 +163,17 @@ class FakeElement {
     this.scrollIntoViewCalls = [];
     this.boundingClientRect = { left: 0, top: 0, width: 100, height: 20 };
     this.pointerCaptures = new Set();
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(value) {
+    const normalized = value ?? "";
+    this._value = this.tagName === "INPUT" && typeof normalized === "string"
+      ? normalized.replace(/[\r\n]/g, "")
+      : normalized;
   }
 
   append(...children) {

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -497,7 +497,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "controls": [
                 "numberInput,",
                 "checkbox,",
-                "textInput,",
+                "textareaInput,",
                 "selectInput,",
                 "createNodeField,",
             ],
@@ -612,7 +612,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "createDomSettingsCheckboxControl",
             "createDomSettingsNumberControl",
             "createDomSettingsSelectControl",
-            "createDomSettingsTextControl",
+            "createDomSettingsTextareaControl",
             "createDomSelectControl",
             "updateGeneratorSeed",
             "setGeneratorSeedFromUi",
@@ -627,6 +627,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         for removed_function in (
             "createDomTextControl",
             "createDomCheckboxControl",
+            "createDomSettingsTextControl",
             "createSeedControlSelect",
         ):
             with self.subTest(removed_dead_function=removed_function):
@@ -1524,6 +1525,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertEqual(exported_constants, expected_constants)
 
         expected_functions = {
+            "aioChoiceOptionsWithCurrent",
+            "aioChoiceSpecValues",
             "aioNodeInputMap",
             "aioNodeInputSpec",
             "aioNodeInputSupported",
@@ -1557,6 +1560,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
             {
                 "AIO_BACKEND_DEPENDENCIES",
                 "AIO_OPTIONAL_DEPENDENCY_SPECS",
+                "aioChoiceOptionsWithCurrent",
+                "aioChoiceSpecValues",
                 "aioNodeInputMap",
                 "aioNodeInputSpec",
                 "aioNodeInputSupported",
@@ -1574,6 +1579,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertNotIn("fetch(", source)
         self.assertNotIn("const GENERATOR_OPTIONAL_DEPENDENCY_SPECS", entry_source)
         self.assertNotIn("const GENERATOR_BACKEND_DEPENDENCIES", entry_source)
+        self.assertNotIn("function choiceSpecValues", entry_source)
+        self.assertNotIn("function optionsWithCurrent", entry_source)
         self.assertNotIn("function upscaleBackendDependencyKeys", entry_source)
 
         for delegation in (

--- a/web/js/aio/dependencies.js
+++ b/web/js/aio/dependencies.js
@@ -145,6 +145,48 @@ export function aioNodeInputSpec(state, dependencyKey, inputName) {
   return aioNodeInputMap(state, dependencyKey)?.[inputName] || null;
 }
 
+function aioUniqueChoiceValues(values) {
+  const output = [];
+  for (const value of values || []) {
+    if (!["string", "number", "boolean"].includes(typeof value)) {
+      continue;
+    }
+    const normalized = String(value);
+    if (normalized && !output.includes(normalized)) {
+      output.push(normalized);
+    }
+  }
+  return output;
+}
+
+export function aioChoiceSpecValues(spec) {
+  if (!Array.isArray(spec)) {
+    return [];
+  }
+  if (Array.isArray(spec[0])) {
+    return aioUniqueChoiceValues(spec[0]);
+  }
+  if (spec[0] === "COMBO") {
+    const options = spec[1] && typeof spec[1] === "object"
+      ? spec[1].options
+      : null;
+    return Array.isArray(options) ? aioUniqueChoiceValues(options) : [];
+  }
+  if (spec.every((value) => ["string", "number", "boolean"].includes(typeof value))) {
+    return aioUniqueChoiceValues(spec);
+  }
+  return [];
+}
+
+export function aioChoiceOptionsWithCurrent(options, current) {
+  const merged = aioUniqueChoiceValues(options);
+  const normalized = String(current ?? "");
+  if (normalized && !merged.includes(normalized)) {
+    merged.unshift(normalized);
+  }
+  return merged;
+}
+
 export function aioNodeInputTooltip(state, dependencyKey, inputName) {
   const spec = aioNodeInputSpec(state, dependencyKey, inputName);
   const options = Array.isArray(spec) && spec[1] && typeof spec[1] === "object"

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -9,7 +9,7 @@ const GENERATOR_PANEL_CONTROL_SELECTOR = "input, select, textarea, button";
  * @typedef {object} AioGeneratorPanelControls
  * @property {(value: any, step?: string) => any} numberInput
  * @property {(value: any) => any} checkbox
- * @property {(value: any) => any} textInput
+ * @property {(value: any) => any} textareaInput
  * @property {(options: any[], value: any) => any} selectInput
  * @property {(label: any, control: any, className?: string, tooltipKey?: string) => any} createNodeField
  */
@@ -128,7 +128,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
   const {
     numberInput,
     checkbox,
-    textInput,
+    textareaInput,
     selectInput,
     createNodeField,
   } = controls;
@@ -1010,17 +1010,17 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
     return select;
   }
 
-  function createDomSettingsTextControl(node, value, updater, options = {}) {
-    const input = applyGeneratorControlFocusKey(textInput(value), options);
-    input.addEventListener("input", () => {
+  function createDomSettingsTextareaControl(node, value, updater, options = {}) {
+    const textarea = applyGeneratorControlFocusKey(textareaInput(value), options);
+    textarea.addEventListener("input", () => {
       updateGeneratorSettings(node, (settings) => {
-        updater?.(settings, String(input.value || ""));
+        updater?.(settings, String(textarea.value || ""));
       });
       updateGeneratorDomSummary(node);
       scheduleGeneratorLayout(node);
       markNodeDirty(node);
     });
-    return input;
+    return textarea;
   }
 
   function createDomSelectControl(node, name, value, fallbackOptions = []) {
@@ -1501,7 +1501,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
             ),
             createNodeField(
               aioText("field.wildcard"),
-              createDomSettingsTextControl(
+              createDomSettingsTextareaControl(
                 node,
                 target.wildcard,
                 (nextSettings, value) => {

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -37,6 +37,8 @@ import {
 import {
   AIO_BACKEND_DEPENDENCIES,
   AIO_OPTIONAL_DEPENDENCY_SPECS,
+  aioChoiceOptionsWithCurrent,
+  aioChoiceSpecValues,
   aioNodeInputMap,
   aioNodeInputSpec,
   aioNodeInputSupported,
@@ -1850,42 +1852,12 @@ const generatorOptionalDependencyState = {
   reportedSignature: "",
 };
 
-function uniqueStrings(values) {
-  const output = [];
-  for (const value of values || []) {
-    const normalized = String(value ?? "");
-    if (normalized && !output.includes(normalized)) {
-      output.push(normalized);
-    }
-  }
-  return output;
-}
-
-function choiceSpecValues(spec) {
-  if (!Array.isArray(spec)) {
-    return [];
-  }
-  if (Array.isArray(spec[0])) {
-    return uniqueStrings(spec[0]);
-  }
-  return uniqueStrings(spec);
-}
-
-function optionsWithCurrent(options, current) {
-  const merged = uniqueStrings(options);
-  const normalized = String(current ?? "");
-  if (normalized && !merged.includes(normalized)) {
-    merged.unshift(normalized);
-  }
-  return merged;
-}
-
 async function fetchGeneratorSamplerOptions() {
   const data = await easyuseAnimaFetchComfyJson(api, "/object_info/KSampler");
   const ksamplerInfo = data?.KSampler || data;
   const required = ksamplerInfo?.input?.required || {};
-  const samplerNames = choiceSpecValues(required.sampler_name);
-  const schedulerNames = choiceSpecValues(required.scheduler);
+  const samplerNames = aioChoiceSpecValues(required.sampler_name);
+  const schedulerNames = aioChoiceSpecValues(required.scheduler);
   if (samplerNames.length) {
     generatorSamplerOptionState.samplerNames = samplerNames;
   }
@@ -2036,8 +2008,8 @@ function nodeInputTooltip(dependencyKey, inputName) {
 }
 
 function nodeInputChoiceOptions(dependencyKey, inputName, current, fallback = []) {
-  const values = choiceSpecValues(nodeInputSpec(dependencyKey, inputName));
-  return optionsWithCurrent(values.length ? values : fallback, current);
+  const values = aioChoiceSpecValues(nodeInputSpec(dependencyKey, inputName));
+  return aioChoiceOptionsWithCurrent(values.length ? values : fallback, current);
 }
 
 function nodeInputSupported(dependencyKey, inputName) {
@@ -2721,7 +2693,8 @@ function ensureStyle() {
       min-width: 0;
     }
     .easyuse-anima-aio-node-field input,
-    .easyuse-anima-aio-node-field select {
+    .easyuse-anima-aio-node-field select,
+    .easyuse-anima-aio-node-field textarea {
       width: 100%;
       height: 24px;
       min-width: 0;
@@ -2732,6 +2705,11 @@ function ensureStyle() {
       border-radius: 5px;
       font: 12px "Segoe UI", sans-serif;
       outline: none;
+    }
+    .easyuse-anima-aio-node-field textarea {
+      height: 48px;
+      min-height: 48px;
+      resize: vertical;
     }
     .easyuse-anima-aio-node-mode-badge {
       width: 100%;
@@ -3994,7 +3972,7 @@ const generatorPanelRuntime = aioCreateGeneratorPanelRuntime({
   controls: {
     numberInput,
     checkbox,
-    textInput,
+    textareaInput,
     selectInput,
     createNodeField,
   },


### PR DESCRIPTION
## 변경 요약

최종 live matrix에서 확인된 Issue #66의 두 실제 runtime contract 불일치를 수정합니다.

- ComfyUI의 `["COMBO", {"options": [...]}]` object-info wrapper를 정상 catalog로 정규화합니다.
- direct choice list, `[[choices], metadata]`, COMBO wrapper와 catalog에서 사라진 현재값 보존을 DOM-free dependency helper로 고정합니다.
- schema token `COMBO`와 metadata `[object Object]`가 사용자 선택지로 노출되지 않습니다.
- Detailer external wildcard를 단일행 input에서 textarea로 바꿔 multiline 값을 dialog와 정확히 공유합니다.
- fake DOM의 single-line input도 실제 브라우저처럼 CR/LF를 제거하도록 보정해 이전 false-positive 테스트 조건을 제거합니다.
- PR #145의 catalog hydration과 PR #146의 Detailer field/unknown-key 보존 경로는 유지합니다.

## live 재현 증거

- 실제 `UpscaleModelLoader.model_name`: `["COMBO", {"multiselect": false, "options": ["2x-AnimeSharpV4_Fast_RCAN_PU.safetensors"]}]`
- 수정 전 dialog options: 정상 모델, `COMBO`, `[object Object]`
- 수정 전 dialog wildcard `codex_live_face\nsecond_line`이 external input에서 `codex_live_facesecond_line`으로 축약됨

## 검증

- 관련 JavaScript syntax check 통과
- AiO dependency/DOM/stage/Detailer/generator panel smoke 통과
- focused unittest 81/81
- TypeScript 6.0.3
- official full:
  - Python unittest 412/412
  - frontend 110 JavaScript files
  - diff check 통과

## 남은 확인

- 병합 후 최신 dev를 test instance에 mirror하고 동일 live matrix에서 실제 catalog와 multiline save/reload를 재확인합니다.
- Legacy/Node 2.0은 surface-sensitive DOM/serialization만 비교하며 동일 backend queue는 중복하지 않습니다.

Issue #66의 live completion blocker 보완입니다.