### PR TITLE
fix: use extracted AiO choice helper at every call site

### DIFF
--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -1581,6 +1581,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertNotIn("const GENERATOR_BACKEND_DEPENDENCIES", entry_source)
         self.assertNotIn("function choiceSpecValues", entry_source)
         self.assertNotIn("function optionsWithCurrent", entry_source)
+        self.assertNotRegex(entry_source, r"\boptionsWithCurrent\s*\(")
         self.assertNotIn("function upscaleBackendDependencyKeys", entry_source)
 
         for delegation in (

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -2081,11 +2081,11 @@ function sanitizeGeneratorSettingsForOptionalDependencies(settings) {
 }
 
 function samplerNameOptions(current) {
-  return optionsWithCurrent(generatorSamplerOptionState.samplerNames, current);
+  return aioChoiceOptionsWithCurrent(generatorSamplerOptionState.samplerNames, current);
 }
 
 function schedulerNameOptions(current) {
-  return optionsWithCurrent(generatorSamplerOptionState.schedulerNames, current);
+  return aioChoiceOptionsWithCurrent(generatorSamplerOptionState.schedulerNames, current);
 }
 
 function refreshGeneratorPanels() {
@@ -3376,7 +3376,7 @@ function widgetOptions(node, name, fallback = []) {
   const widget = findWidget(node, name);
   const values = widget?.options?.values;
   const options = Array.isArray(values) ? values : fallback;
-  return optionsWithCurrent(options, current);
+  return aioChoiceOptionsWithCurrent(options, current);
 }
 
 function setWidgetValueIfChanged(node, name, value) {


### PR DESCRIPTION
## 변경 요약

PR #147 병합 후 실제 ComfyUI 워크플로우를 새 문서에서 로드했을 때 발생한 `ReferenceError: optionsWithCurrent is not defined`를 수정합니다.

- helper 추출 뒤 남아 있던 sampler, scheduler, widget option의 3개 기존 호출을 imported `aioChoiceOptionsWithCurrent`로 통일했습니다.
- entry source에 이전 free identifier 호출이 남으면 실패하도록 정적 회귀 테스트를 추가했습니다.

## 재현과 원인

- 최신 `dev`를 Codex test instance에 mirror하고 `Codex 54 AiO Hook Smoke`를 로드하면 `/extensions/comfyui-easyuse-anima/js/easyuse_anima_aio.js`에서 즉시 ReferenceError가 발생했습니다.
- catalog parser 자체가 아니라 helper 추출 시 일부 호출부가 이전 이름으로 남은 참조 누락이 원인이었습니다.

## 검증

- `node --check web/js/easyuse_anima_aio.js` 통과
- focused unittest 1/1
- official full:
  - Python unittest 412/412
  - frontend 110 JavaScript files
  - TypeScript 6.0.3
  - diff check 통과

## 남은 확인

병합 후 최신 `dev`를 test instance에 다시 mirror하고, 중단됐던 #66 live matrix를 새 브라우저 문서에서 재개합니다. Legacy/Node 2.0은 실제로 달라질 수 있는 DOM·직렬화 표면만 비교하고 공통 queue는 중복하지 않습니다.