### PR TITLE
fix: keep Node 2.0 profile wheel ownership

### DIFF
--- a/tests/frontend_lora_preset_canvas_widgets_smoke.mjs
+++ b/tests/frontend_lora_preset_canvas_widgets_smoke.mjs
@@ -237,6 +237,8 @@ assert.deepEqual(addWidget.computeSize(), [520, 36]);
 {
   const node = makeNode({ profileCount: 8 });
   const widget = new runtime.ProfileBarWidget();
+  let drawRequests = 0;
+  widget.triggerDraw = () => { drawRequests += 1; };
   const ctx = fakeContext();
   widget.draw(ctx, node, 520, 0, 170);
   assert.deepEqual(widget.hitAreas.slice(0, 5).map((area) => area[4]), [
@@ -270,6 +272,7 @@ assert.deepEqual(addWidget.computeSize(), [520, 36]);
 
   assert.equal(widget.mouse({ type: "wheel", deltaY: 1 }, [20, 50], node), true);
   assert.equal(widget.scrollOffset, 1);
+  assert.equal(drawRequests, 1, "Node 2.0 custom-widget canvas must redraw after wheel scrolling");
   assert.equal(widget.mouse({ type: "pointermove" }, [20, 50], node), false);
   assert.equal(activeProfileWheelTarget.node, node);
   assert.equal(activeProfileWheelTarget.widget, widget);
@@ -281,6 +284,7 @@ assert.deepEqual(addWidget.computeSize(), [520, 36]);
   assert.equal(widget.mouse({ type: "pointerdown", button: 0 }, thumbPos, node), true);
   assert.equal(widget.scrollDragging, true);
   assert.equal(widget.mouse({ type: "pointermove" }, [thumbPos[0], widget.scrollTrackArea[1] + widget.scrollTrackArea[3]], node), true);
+  assert.equal(drawRequests, 2, "Node 2.0 custom-widget canvas must redraw after scrollbar dragging");
   assert.equal(widget.mouse({ type: "pointerup" }, thumbPos, node), true);
   assert.equal(widget.scrollDragging, false);
 }

--- a/tests/frontend_lora_preset_entry_lifecycle_smoke.mjs
+++ b/tests/frontend_lora_preset_entry_lifecycle_smoke.mjs
@@ -105,22 +105,27 @@ const app = {
 };
 const runtime = createRuntime(hostWindow, hostDocument, app);
 const node = {
+  id: 1,
   comfyClass: "EasyUseAnimaLoraPreset",
   pos: [20, 20],
+  size: [100, 100],
   profileCount: 4,
   dirty: 0,
   setDirtyCanvas() { this.dirty += 1; },
 };
 const bar = {
+  type: "custom",
   listClientArea: [20, 20, 20, 20],
   listArea: [0, 0, 20, 20],
   scrollOffset: 0,
+  computeSize() { return [100, 100]; },
   scrollByWheel(deltaY) {
     this.directWheels = (this.directWheels || 0) + deltaY;
     return true;
   },
 };
 node.__easyuseAnimaProfileBar = bar;
+node.widgets = [bar, { type: "custom" }];
 app.graph._nodes.push(node);
 
 assert.equal(runtime.lifecycle.extension.init(), true);
@@ -163,6 +168,65 @@ assert.equal(bar.scrollOffset, 1, "canvas hit-testing fallback must preserve pro
 assert.equal(node.dirty, 1);
 assert.equal(prevented, 2);
 assert.equal(stopped, 2);
+
+runtime.lifecycle.setActiveProfileWheelTarget(null);
+bar.listArea = [8, 32, 84, 50];
+const node2Element = {
+  dataset: { nodeId: "1" },
+  querySelectorAll(selector) {
+    assert.equal(selector, ".lg-node-widget canvas");
+    return [profileCanvas, addLoraCanvas];
+  },
+};
+const profileCanvas = {
+  tagName: "CANVAS",
+  clientWidth: 100,
+  clientHeight: 100,
+  closest(selector) {
+    if (selector === "canvas") return this;
+    if (selector === ".lg-node[data-node-id]") return node2Element;
+    return null;
+  },
+  getBoundingClientRect() {
+    return { left: 300, top: 400, width: 200, height: 200 };
+  },
+};
+const addLoraCanvas = {
+  ...profileCanvas,
+  closest: profileCanvas.closest,
+};
+hostDocument.emit("wheel", {
+  target: profileCanvas,
+  clientX: 340,
+  clientY: 500,
+  deltaY: 2,
+  preventDefault() { prevented += 1; },
+  stopPropagation() { stopped += 1; },
+});
+assert.equal(bar.directWheels, 5, "Node 2.0 profile canvas must map its local list area");
+assert.equal(prevented, 3);
+assert.equal(stopped, 3);
+
+runtime.lifecycle.setActiveProfileWheelTarget(null);
+hostDocument.emit("wheel", {
+  target: addLoraCanvas,
+  clientX: 340,
+  clientY: 500,
+  deltaY: 2,
+  preventDefault() { prevented += 1; },
+  stopPropagation() { stopped += 1; },
+});
+hostDocument.emit("wheel", {
+  target: profileCanvas,
+  clientX: 340,
+  clientY: 420,
+  deltaY: 2,
+  preventDefault() { prevented += 1; },
+  stopPropagation() { stopped += 1; },
+});
+assert.equal(bar.directWheels, 5, "other Node 2.0 widgets and profile controls must not capture wheel");
+assert.equal(prevented, 3);
+assert.equal(stopped, 3);
 
 hostWindow.emit("easyuse-anima-settings-updated", { detail: { menuMode: "list" } });
 assert.deepEqual(runtime.calls.applySettings, [{ menuMode: "list" }]);

--- a/web/js/lora_preset/canvas_widgets.js
+++ b/web/js/lora_preset/canvas_widgets.js
@@ -254,6 +254,8 @@ export function createLoraPresetCanvasWidgets(dependencies) {
       this.scrollThumbArea = null;
       this.scrollDragging = false;
       this.scrollDragDelta = 0;
+      /** @type {null | (() => void)} */
+      this.triggerDraw = null;
     }
 
     computeSize(_width, node) {
@@ -422,6 +424,7 @@ export function createLoraPresetCanvasWidgets(dependencies) {
       if (nextOffset !== this.scrollOffset) {
         this.scrollOffset = nextOffset;
         node.setDirtyCanvas?.(true, true);
+        this.triggerDraw?.();
       }
       return true;
     }
@@ -437,6 +440,7 @@ export function createLoraPresetCanvasWidgets(dependencies) {
       if (nextOffset !== this.scrollOffset) {
         this.scrollOffset = nextOffset;
         node.setDirtyCanvas?.(true, true);
+        this.triggerDraw?.();
       }
       return true;
     }

--- a/web/js/lora_preset/entry_lifecycle.js
+++ b/web/js/lora_preset/entry_lifecycle.js
@@ -75,6 +75,65 @@ export function createLoraPresetEntryLifecycle(dependencies) {
     activeProfileWheelTarget = target;
   }
 
+  /**
+   * Node 2.0 renders each custom widget into its own DOM canvas. The profile
+   * bar's draw coordinates are local to that canvas, so the legacy graph-to-
+   * client conversion cannot identify its wheel area after a Vue canvas zoom.
+   *
+   * @param {any} event
+   * @param {any} node
+   * @param {any} bar
+   */
+  function pointInNode2ProfileList(event, node, bar) {
+    if (!Array.isArray(bar?.listArea) || !Array.isArray(node?.widgets)) {
+      return false;
+    }
+    const eventPath = event?.composedPath?.() || [];
+    const targetCanvas = eventPath.find((target) => target?.tagName === "CANVAS")
+      || event?.target?.closest?.("canvas");
+    const nodeElement = targetCanvas?.closest?.(".lg-node[data-node-id]");
+    const nodeId = nodeElement?.dataset?.nodeId
+      ?? nodeElement?.getAttribute?.("data-node-id");
+    if (!targetCanvas || !nodeElement || String(nodeId) !== String(node.id)) {
+      return false;
+    }
+
+    const customWidgets = node.widgets.filter((widget) => widget?.type === "custom");
+    const profileWidgetIndex = customWidgets.indexOf(bar);
+    const widgetCanvases = nodeElement.querySelectorAll?.(".lg-node-widget canvas") || [];
+    const profileCanvas = widgetCanvases[profileWidgetIndex];
+    if (profileWidgetIndex < 0 || profileCanvas !== targetCanvas) {
+      return false;
+    }
+
+    const rect = profileCanvas.getBoundingClientRect?.();
+    const computedSize = bar.computeSize?.(node.size?.[0], node);
+    const logicalWidth = Number(profileCanvas.clientWidth)
+      || Number(node.size?.[0])
+      || Number(computedSize?.[0]);
+    const logicalHeight = Number(profileCanvas.clientHeight)
+      || Number(computedSize?.[1]);
+    if (
+      !rect
+      || !(Number(rect.width) > 0)
+      || !(Number(rect.height) > 0)
+      || !(logicalWidth > 0)
+      || !(logicalHeight > 0)
+    ) {
+      return false;
+    }
+    const localPos = [
+      (Number(event?.clientX || 0) - Number(rect.left || 0)) * logicalWidth / Number(rect.width),
+      (Number(event?.clientY || 0) - Number(rect.top || 0)) * logicalHeight / Number(rect.height),
+    ];
+    return canvasWidgets.pointInArea(localPos, bar.listArea);
+  }
+
+  function pointInProfileList(event, node, bar, clientPos) {
+    return canvasWidgets.pointInArea(clientPos, bar?.listClientArea)
+      || pointInNode2ProfileList(event, node, bar);
+  }
+
   function scrollProfileListFromWheel(event) {
     const clientPos = [Number(event?.clientX || 0), Number(event?.clientY || 0)];
     if (
@@ -83,7 +142,12 @@ export function createLoraPresetEntryLifecycle(dependencies) {
       && (now() - activeProfileWheelTarget.time) < 30000
       && (app.graph?._nodes || []).includes(activeProfileWheelTarget.node)
     ) {
-      if (!canvasWidgets.pointInArea(clientPos, activeProfileWheelTarget.widget.listClientArea)) {
+      if (!pointInProfileList(
+        event,
+        activeProfileWheelTarget.node,
+        activeProfileWheelTarget.widget,
+        clientPos,
+      )) {
         activeProfileWheelTarget = null;
       } else {
         activeProfileWheelTarget.time = now();
@@ -102,7 +166,7 @@ export function createLoraPresetEntryLifecycle(dependencies) {
     const nodesByZ = [...(app.graph?._nodes || [])].reverse();
     for (const node of nodesByZ) {
       const bar = node?.comfyClass === nodeTypeName ? node.__easyuseAnimaProfileBar : null;
-      if (!bar || !canvasWidgets.pointInArea(clientPos, bar.listClientArea)) {
+      if (!bar || !pointInProfileList(event, node, bar, clientPos)) {
         continue;
       }
       const handled = bar.scrollByWheel(event.deltaY, node);


### PR DESCRIPTION
## 변경 요약

- Node 2.0의 독립 custom-widget canvas에서 LoRA profile list 좌표를 실제 DOM canvas 기준으로 판정합니다.
- profile bar canvas와 list 영역에서 처리된 wheel만 소유하고, 다른 custom widget·profile control·빈 canvas wheel은 기존 ComfyUI zoom 흐름으로 전달합니다.
- profile offset 변경 시 ComfyUI Node 2.0 `WidgetLegacy.triggerDraw` 계약으로 해당 custom-widget canvas를 즉시 다시 그립니다.
- 기존 Legacy canvas의 client/graph 좌표 fallback은 변경하지 않았습니다.

## 원인

Node 2.0은 custom widget마다 별도 DOM canvas를 렌더링하지만, 기존 document-level wheel handler는 Legacy graph 좌표 변환으로 계산한 client 영역만 사용했습니다. Vue canvas zoom 이후 실제 profile list와 계산 영역이 어긋나 wheel이 전체 canvas zoom으로 누출됐습니다.

DOM hit-testing을 바로잡은 뒤에는 offset이 내부적으로 변경돼도 `node.setDirtyCanvas()`만으로 독립 widget canvas가 갱신되지 않는 두 번째 차이가 확인됐습니다. ComfyUI가 Node 2.0 legacy custom widget에 주입하는 `triggerDraw`를 호출해 이 redraw 계약을 맞췄습니다.

## 주요 파일

- `web/js/lora_preset/entry_lifecycle.js`
- `web/js/lora_preset/canvas_widgets.js`
- `tests/frontend_lora_preset_entry_lifecycle_smoke.mjs`
- `tests/frontend_lora_preset_canvas_widgets_smoke.mjs`

## 검증

- focused JavaScript smoke:
  - LoRA preset entry lifecycle 통과
  - LoRA preset canvas widgets 통과
- `python -m unittest tests.test_frontend_lora_preset`: 19/19
- official full runner:
  - Python unittest 412/412
  - frontend 110 JavaScript files
  - TypeScript 6.0.3
  - diff check 통과
- ComfyUI Codex test instance, Node 2.0:
  - active 7 overflow list가 wheel로 2–7 → 1–6 이동
  - list wheel 동안 canvas zoom 110% 유지
  - 빈 canvas wheel은 zoom 110% → 121%로 전달
  - EasyUse Anima 관련 browser error 없음

## 영향 및 남은 위험

- backend queue와 profile serialization은 변경하지 않았습니다.
- Legacy canvas 계약은 기존 통과 증거를 재사용했으며, Node 2.0에서만 달라지는 DOM hit-testing/redraw 표면만 추가 검증했습니다.