### PR TITLE
fix: Legacy 자동완성 입력 mount 지연 처리

### DIFF
--- a/tests/frontend_autocomplete_input_binding_smoke.mjs
+++ b/tests/frontend_autocomplete_input_binding_smoke.mjs
@@ -567,4 +567,107 @@ function replacementBinding(input, state, owner, registry, controller) {
   assert.equal(input.listenerCount(), 0);
 }
 
+{
+  class FakeTextAreaElement extends FakeInput {}
+  class FakeHtmlInputElement extends FakeInput {}
+  class FakeContainer {
+    constructor(nested = null) {
+      this.nested = nested;
+    }
+
+    querySelector(selector) {
+      assert.equal(selector, "textarea, input");
+      return this.nested;
+    }
+  }
+
+  const findStart = entrySource.indexOf("function findInputEl");
+  const findEnd = entrySource.indexOf("\nfunction currentToken", findStart);
+  assert.ok(findStart >= 0 && findEnd > findStart);
+  const findInputEl = new Function(
+    "HTMLTextAreaElement",
+    "HTMLInputElement",
+    `"use strict";\n${entrySource.slice(findStart, findEnd)}\nreturn findInputEl;`,
+  )(FakeTextAreaElement, FakeHtmlInputElement);
+
+  const disconnected = new FakeTextAreaElement();
+  disconnected.isConnected = false;
+  assert.equal(
+    findInputEl({ inputEl: disconnected, element: disconnected }),
+    null,
+    "a pre-mount legacy textarea must stay pending instead of receiving a disposable binding",
+  );
+
+  const connectedFallback = new FakeTextAreaElement();
+  const fallbackContainer = new FakeContainer(connectedFallback);
+  assert.equal(
+    findInputEl({ inputEl: disconnected, element: fallbackContainer }),
+    connectedFallback,
+    "a connected nested element must win over a stale direct inputEl",
+  );
+
+  const direct = new FakeHtmlInputElement();
+  assert.equal(findInputEl({ inputEl: direct }), direct);
+
+  const hookStart = entrySource.indexOf("function hookNode");
+  const hookEnd = entrySource.indexOf("\nfunction handleOutsideAutocompletePointer", hookStart);
+  assert.ok(hookStart >= 0 && hookEnd > hookStart);
+
+  const scheduled = [];
+  const hooked = [];
+  const lifecycle = {
+    isActive: () => true,
+    schedule(callback, delay) {
+      scheduled.push({ callback, delay });
+    },
+  };
+  const targetWidgets = () => new Set(["text", "populated_text"]);
+  const hookNode = new Function(
+    "autocompleteEntryLifecycle",
+    "targetWidgets",
+    "hasExplicitTargets",
+    "shouldSkipNode",
+    "artistOnlyWidgets",
+    "findInputEl",
+    "hookWidget",
+    `"use strict";\n${entrySource.slice(hookStart, hookEnd)}\nreturn hookNode;`,
+  )(
+    lifecycle,
+    targetWidgets,
+    () => true,
+    () => false,
+    () => new Set(),
+    findInputEl,
+    (_node, widget) => {
+      const input = findInputEl(widget);
+      if (input) {
+        hooked.push(input);
+      }
+    },
+  );
+
+  const textInput = new FakeTextAreaElement();
+  const populatedInput = new FakeTextAreaElement();
+  textInput.isConnected = false;
+  populatedInput.isConnected = false;
+  const node = {
+    widgets: [
+      { name: "text", inputEl: textInput, element: textInput },
+      { name: "populated_text", inputEl: populatedInput, element: populatedInput },
+    ],
+  };
+
+  hookNode(node, { name: "EasyUseAnimaWildcard" });
+  assert.equal(hooked.length, 0);
+  assert.equal(scheduled.length, 1);
+  assert.equal(scheduled[0].delay, 80);
+
+  textInput.isConnected = true;
+  populatedInput.isConnected = true;
+  scheduled.shift().callback();
+
+  assert.deepEqual(hooked, [textInput, populatedInput]);
+  assert.equal(scheduled.length, 0, "both ready inputs must stop the bounded retry loop");
+}
+
 console.log("Autocomplete input binding smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -1144,8 +1144,13 @@ class AIOFrontendSourceTests(unittest.TestCase):
         end = source.index("\nfunction currentToken", start)
         input_body = source[start:end]
 
-        self.assertIn("widget?.inputEl || widget?.element", input_body)
-        self.assertIn('querySelector?.("textarea, input")', input_body)
+        self.assertIn(
+            "for (const candidate of [widget?.inputEl, widget?.element])",
+            input_body,
+        )
+        self.assertIn("candidate.isConnected !== false", input_body)
+        self.assertIn('candidate?.querySelector?.("textarea, input")', input_body)
+        self.assertIn("nested.isConnected !== false", input_body)
 
     def test_autocomplete_avoids_double_callback_for_nodes_v2_dom_widgets(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -701,13 +701,20 @@ function shouldSkipNode(node, nodeData) {
 }
 
 function findInputEl(widget) {
-  const input = widget?.inputEl || widget?.element;
-  if (input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement) {
-    return input;
-  }
-  const nested = input?.querySelector?.("textarea, input");
-  if (nested instanceof HTMLTextAreaElement || nested instanceof HTMLInputElement) {
-    return nested;
+  for (const candidate of [widget?.inputEl, widget?.element]) {
+    if (
+      (candidate instanceof HTMLTextAreaElement || candidate instanceof HTMLInputElement)
+      && candidate.isConnected !== false
+    ) {
+      return candidate;
+    }
+    const nested = candidate?.querySelector?.("textarea, input");
+    if (
+      (nested instanceof HTMLTextAreaElement || nested instanceof HTMLInputElement)
+      && nested.isConnected !== false
+    ) {
+      return nested;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## 변경 요약

- Legacy canvas에서 DOM textarea가 아직 연결되기 전에 autocomplete가 listener를 소유하던 경로를 수정했습니다.
- `widget.inputEl` 또는 `widget.element`가 실제 DOM에 연결된 경우에만 bind하고, 기존의 제한된 node hook 재시도가 mount 완료 후 bind를 수행하도록 했습니다.
- 두 textarea가 pre-mount 상태였다가 연결되는 경우를 semantic smoke로 고정했습니다.

관련 이슈: #56

## 주요 파일

- `web/js/easyuse_anima_autocomplete.js`
- `tests/frontend_autocomplete_input_binding_smoke.mjs`
- `tests/test_aio_frontend.py`

## 검증

- `node tests\frontend_autocomplete_input_binding_smoke.mjs` — 통과
- `python -m unittest tests.test_autocomplete_frontend tests.test_aio_frontend` — 46/46
- official full runner — Python 412/412, frontend 110 JavaScript files, TypeScript 6.0.3, diff check 통과
- ComfyUI 0.27.0 / frontend 1.45.20 / Legacy canvas + LoRA Manager 전체 활성 — 실제 node textarea에서 `hatsu` 추천 팝업과 결과 표시 확인
- Node 2.0은 동일 current-code에서 이미 정상인 표면이며, 이번 결함이 Legacy pre-mount DOM 경계로 분리되어 중복 browser run은 수행하지 않았습니다.

## 남은 위험

- 기존 재시도 한도(12회, 80ms)는 변경하지 않았습니다.
- 사용자 workflow 저장이나 backend queue는 이 frontend 입력 lifecycle 수정에서 수행하지 않았습니다.
