### PR TITLE
fix: Legacy 자동완성 late-mounted 입력 복구

### DIFF
--- a/tests/frontend_autocomplete_input_binding_smoke.mjs
+++ b/tests/frontend_autocomplete_input_binding_smoke.mjs
@@ -609,6 +609,40 @@ function replacementBinding(input, state, owner, registry, controller) {
   const direct = new FakeHtmlInputElement();
   assert.equal(findInputEl({ inputEl: direct }), direct);
 
+  const graphNodesStart = entrySource.indexOf("function autocompleteGraphNodes");
+  const graphNodesEnd = entrySource.indexOf("\nfunction findGraphNodeById", graphNodesStart);
+  assert.ok(graphNodesStart >= 0 && graphNodesEnd > graphNodesStart);
+  const autocompleteGraphNodesFor = (app) => new Function(
+    "app",
+    `"use strict";\n${entrySource.slice(graphNodesStart, graphNodesEnd)}\nreturn autocompleteGraphNodes;`,
+  )(app)();
+  const legacyNode = { id: 1 };
+  const node2Node = { id: 2 };
+  assert.deepEqual(autocompleteGraphNodesFor({ graph: { _nodes: [legacyNode, null] } }), [legacyNode]);
+  assert.deepEqual(autocompleteGraphNodesFor({ graph: { nodes: [node2Node, null] } }), [node2Node]);
+  assert.deepEqual(
+    autocompleteGraphNodesFor({ graph: { _nodes_by_id: { 1: legacyNode, empty: null } } }),
+    [legacyNode],
+  );
+
+  let graphNodes = [];
+  const ownerStart = entrySource.indexOf("function autocompleteDomInputOwner");
+  const ownerEnd = entrySource.indexOf("\nfunction hookFocusedDomInput", ownerStart);
+  assert.ok(ownerStart >= 0 && ownerEnd > ownerStart);
+  const autocompleteDomInputOwner = new Function(
+    "nodeFromDomElement",
+    "autocompleteGraphNodes",
+    "widgetForDomInput",
+    `"use strict";\n${entrySource.slice(ownerStart, ownerEnd)}\nreturn autocompleteDomInputOwner;`,
+  )(
+    () => null,
+    () => graphNodes,
+    (node, input) => (node?.widgets || []).find((widget) => {
+      const widgetInput = findInputEl(widget);
+      return widgetInput === input || widget?.element?.contains?.(input);
+    }) || null,
+  );
+
   const hookStart = entrySource.indexOf("function hookNode");
   const hookEnd = entrySource.indexOf("\nfunction handleOutsideAutocompletePointer", hookStart);
   assert.ok(hookStart >= 0 && hookEnd > hookStart);
@@ -651,23 +685,62 @@ function replacementBinding(input, state, owner, registry, controller) {
   textInput.isConnected = false;
   populatedInput.isConnected = false;
   const node = {
+    constructor: { nodeData: { name: "EasyUseAnimaWildcard" } },
+    __easyuseAnimaArtistOnlyWidgets: new Set(),
     widgets: [
       { name: "text", inputEl: textInput, element: textInput },
       { name: "populated_text", inputEl: populatedInput, element: populatedInput },
     ],
   };
+  graphNodes = [node];
 
   hookNode(node, { name: "EasyUseAnimaWildcard" });
   assert.equal(hooked.length, 0);
-  assert.equal(scheduled.length, 1);
-  assert.equal(scheduled[0].delay, 80);
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    assert.equal(scheduled.length, 1);
+    const scheduledAttempt = scheduled.shift();
+    assert.equal(scheduledAttempt.delay, 80);
+    scheduledAttempt.callback();
+  }
+  assert.equal(scheduled.length, 0, "the existing bounded retry must be fully exhausted");
+  assert.equal(hooked.length, 0);
 
   textInput.isConnected = true;
-  populatedInput.isConnected = true;
-  scheduled.shift().callback();
+  const lateOwner = autocompleteDomInputOwner(textInput);
+  assert.equal(lateOwner?.node, node);
+  assert.equal(lateOwner?.widget, node.widgets[0]);
 
-  assert.deepEqual(hooked, [textInput, populatedInput]);
-  assert.equal(scheduled.length, 0, "both ready inputs must stop the bounded retry loop");
+  const focusStart = entrySource.indexOf("function hookFocusedDomInput");
+  const focusEnd = entrySource.indexOf("\nfunction handleAutocompleteScroll", focusStart);
+  assert.ok(focusStart >= 0 && focusEnd > focusStart);
+  const focusedHooks = [];
+  const hookFocusedDomInput = new Function(
+    "isAutocompleteDomInput",
+    "popup",
+    "autocompleteDomInputOwner",
+    "targetWidgets",
+    "hasExplicitTargets",
+    "shouldSkipNode",
+    "autocompleteScope",
+    "hookInput",
+    `"use strict";\n${entrySource.slice(focusStart, focusEnd)}\nreturn hookFocusedDomInput;`,
+  )(
+    () => true,
+    null,
+    autocompleteDomInputOwner,
+    targetWidgets,
+    () => true,
+    () => false,
+    () => "compatible",
+    (input, options) => focusedHooks.push({ input, options }),
+  );
+
+  hookFocusedDomInput(textInput);
+  assert.equal(focusedHooks.length, 1);
+  assert.equal(focusedHooks[0].input, textInput);
+  assert.equal(focusedHooks[0].options.node, node);
+  assert.equal(focusedHooks[0].options.widget, node.widgets[0]);
+  assert.equal(focusedHooks[0].options.scope, "easyuse");
 }
 
 console.log("Autocomplete input binding smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -1166,15 +1166,26 @@ class AIOFrontendSourceTests(unittest.TestCase):
 
     def test_autocomplete_hooks_focused_nodes_v2_dom_inputs(self):
         source = AUTOCOMPLETE_JS.read_text(encoding="utf-8")
+        owner_start = source.index("function autocompleteDomInputOwner")
+        owner_end = source.index("\nfunction hookFocusedDomInput", owner_start)
+        owner_body = source[owner_start:owner_end]
+
+        self.assertIn("const ancestryNode = nodeFromDomElement(input);", owner_body)
+        self.assertIn("for (const node of autocompleteGraphNodes())", owner_body)
+        self.assertIn("const widget = widgetForDomInput(node, input);", owner_body)
+        self.assertIn("return { node, widget };", owner_body)
+        self.assertIn("Array.isArray(graph?._nodes)", source)
+        self.assertIn("Object.values(graph?._nodes_by_id || {})", source)
+
         start = source.index("function hookFocusedDomInput")
         end = source.index("\nfunction handleAutocompleteScroll", start)
         focus_body = source[start:end]
 
         self.assertIn("isAutocompleteDomInput(input)", focus_body)
-        self.assertIn("const node = nodeFromDomElement(input);", focus_body)
-        self.assertIn("if (!node)", focus_body)
+        self.assertIn("const owner = autocompleteDomInputOwner(input);", focus_body)
+        self.assertIn("if (!owner)", focus_body)
+        self.assertIn("const { node, widget } = owner;", focus_body)
         self.assertIn("const targets = nodeData ? targetWidgets(nodeData) : null;", focus_body)
-        self.assertIn("const widget = widgetForDomInput(node, input);", focus_body)
         self.assertIn("hookInput(input", focus_body)
         self.assertIn("hookFocusedInput: hookFocusedDomInput", source)
         lifecycle_source = AUTOCOMPLETE_ENTRY_LIFECYCLE_JS.read_text(

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -1598,7 +1598,13 @@ function hookWidget(node, widget, scope = "compatible") {
 
 function autocompleteGraphNodes() {
   const graph = app?.canvas?.graph || app?.graph || app?.rootGraph;
-  return Array.isArray(graph?.nodes) ? graph.nodes.filter(Boolean) : [];
+  if (Array.isArray(graph?.nodes)) {
+    return graph.nodes.filter(Boolean);
+  }
+  if (Array.isArray(graph?._nodes)) {
+    return graph._nodes.filter(Boolean);
+  }
+  return Object.values(graph?._nodes_by_id || {}).filter(Boolean);
 }
 
 function findGraphNodeById(id) {
@@ -1645,20 +1651,40 @@ function widgetForDomInput(node, input) {
   return null;
 }
 
+function autocompleteDomInputOwner(input) {
+  const ancestryNode = nodeFromDomElement(input);
+  if (ancestryNode) {
+    const widget = widgetForDomInput(ancestryNode, input);
+    if (widget) {
+      return { node: ancestryNode, widget };
+    }
+  }
+  for (const node of autocompleteGraphNodes()) {
+    if (node === ancestryNode) {
+      continue;
+    }
+    const widget = widgetForDomInput(node, input);
+    if (widget) {
+      return { node, widget };
+    }
+  }
+  return ancestryNode ? { node: ancestryNode, widget: null } : null;
+}
+
 function hookFocusedDomInput(input) {
   if (!isAutocompleteDomInput(input) || popup?.contains(input)) {
     return;
   }
-  const node = nodeFromDomElement(input);
-  if (!node) {
+  const owner = autocompleteDomInputOwner(input);
+  if (!owner) {
     return;
   }
+  const { node, widget } = owner;
   const nodeData = node?.constructor?.nodeData || null;
   const targets = nodeData ? targetWidgets(nodeData) : null;
   if (nodeData && (!targets || (!hasExplicitTargets(nodeData) && shouldSkipNode(node, nodeData)))) {
     return;
   }
-  const widget = widgetForDomInput(node, input);
   if (targets && widget?.name && !targets.has(widget.name)) {
     return;
   }


### PR DESCRIPTION
## 변경 요약

- 제한된 mount 재시도 시간이 지난 뒤 나타난 Legacy DOM 입력도 focus 시 자동완성에 다시 연결합니다.
- DOM 조상만으로 노드를 찾지 못할 때 현재 graph의 widget input identity로 owner를 판별합니다.
- Legacy/Node 2.0 graph 저장 형태(`nodes`, `_nodes`, `_nodes_by_id`)를 모두 지원합니다.
- 재시도 12회를 완전히 소진한 뒤 input을 연결하고 focus로 복구되는 회귀 검사를 추가했습니다.

## 원인

기존 수정은 연결되지 않은 input에 listener를 설치하지 않도록 했지만, 복구 경로가 12 × 80ms의 제한 재시도뿐이었습니다. 그 시간이 지난 뒤 DOM input이 mount되면 영구 미바인딩될 수 있었고, Legacy 입력은 `[data-node-id]` 또는 `.lg-node` 조상이 없는 경우가 있어 focus fallback도 owner를 찾지 못했습니다.

## 주요 파일

- `web/js/easyuse_anima_autocomplete.js`
- `tests/frontend_autocomplete_input_binding_smoke.mjs`
- `tests/test_aio_frontend.py`

## 검증

- `node --check web/js/easyuse_anima_autocomplete.js`: 통과
- `node --check tests/frontend_autocomplete_input_binding_smoke.mjs`: 통과
- `node tests/frontend_autocomplete_input_binding_smoke.mjs`: 통과
- focused Python unittest: 2/2
- official full profile:
  - Python unittest 414/414
  - frontend 110 JavaScript files
  - TypeScript 6.0.3
  - diff check 통과
- ComfyUI v0.27.0 Legacy canvas: 자동완성 전용 workflow의 DOM 조상 없는 `prompt` 입력에서 `hatsu` 입력 후 popup 1개와 검색 결과 표시 확인

## 검증 범위 판단

변경 경계는 Legacy DOM owner fallback입니다. Node 2.0 live browser matrix는 반복하지 않았고, Node 2.0 `nodes` 및 Legacy `_nodes`/`_nodes_by_id` 형상은 deterministic smoke에서 함께 고정했습니다. queue, workflow save/reload, GPU 실행 경계는 변경되지 않았습니다.

Refs #56
