### PR TITLE
fix: 와일드카드 다중 선택 입력 안정화

### DIFF
--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -96,6 +96,53 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(len(values), 2)
         self.assertEqual(len(set(values)), 2)
 
+    def test_random_multiselect_excludes_zero_weight_options_in_both_backends(self):
+        numpy_module = wildcard_engine.np
+        self.assertIsNotNone(numpy_module)
+
+        for backend_name, backend in (("numpy", numpy_module), ("python", None)):
+            with self.subTest(backend=backend_name), patch.object(wildcard_engine, "np", backend):
+                result = expand_wildcards("{2$$0::zero|1::positive}", seed=0)
+
+            self.assertEqual(result.text, "positive")
+
+    def test_all_zero_weights_use_the_full_pool_deterministically_in_both_backends(self):
+        numpy_module = wildcard_engine.np
+        self.assertIsNotNone(numpy_module)
+        source = "{5$$0::red|0::blue|0::green}"
+
+        for backend_name, backend in (("numpy", numpy_module), ("python", None)):
+            with self.subTest(backend=backend_name), patch.object(wildcard_engine, "np", backend):
+                first = expand_wildcards(source, seed=7)
+                second = expand_wildcards(source, seed=7)
+
+            self.assertEqual(first.text, second.text)
+            values = [part.strip() for part in first.text.split(",")]
+            self.assertEqual(len(values), 3)
+            self.assertEqual(set(values), {"red", "blue", "green"})
+
+    def test_sequential_multiselect_keeps_zero_weight_candidates(self):
+        result = expand_wildcards(
+            "{3$$0::zero|1::positive}",
+            seed=0,
+            mode="순차",
+        )
+
+        self.assertEqual(result.text, "zero, positive")
+
+    def test_malformed_count_ranges_preserve_the_original_expression(self):
+        for source in (
+            "{a-b$$red|blue}",
+            "{1-x$$red|blue}",
+            "{-x$$red|blue}",
+            "{1-2-3$$red|blue}",
+        ):
+            with self.subTest(source=source):
+                result = expand_wildcards(source, seed=0)
+
+            self.assertEqual(result.text, source)
+            self.assertFalse(result.changed)
+
     def test_list_wildcards_returns_relative_keys_only(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -82,6 +82,9 @@ WILDCARD_QUANTIFIER_RE = re.compile(
     re.IGNORECASE,
 )
 WEIGHT_PREFIX_RE = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))::(.*)$", re.DOTALL)
+COUNT_SPEC_RE = re.compile(
+    r"(?:(?P<fixed>\d+)|(?P<minimum>\d*)\s*-\s*(?P<maximum>\d*))"
+)
 
 
 @dataclass(frozen=True)
@@ -402,22 +405,35 @@ class _Selector:
     def choose_many(self, options: list[WildcardOption], count: int) -> list[WildcardOption]:
         if not options or count <= 0:
             return []
-        count = min(count, len(options))
         if self.sequential:
+            count = min(count, len(options))
             start = self.seed % len(options)
             return [options[(start + offset) % len(options)] for offset in range(count)]
 
         weights = [max(0.0, option.weight) for option in options]
-        total = sum(weights)
-        if np is not None:
-            probabilities = [weight / total for weight in weights] if total > 0 else None
-            indices = self.rng.choice(len(options), size=count, replace=False, p=probabilities)
-            return [options[int(index)] for index in indices]
-
-        if total > 0:
-            selected = []
+        positive = [
+            (option, weight)
+            for option, weight in zip(options, weights)
+            if weight > 0
+        ]
+        if positive:
+            pool = [option for option, _weight in positive]
+            pool_weights = [weight for _option, weight in positive]
+        else:
             pool = list(options)
-            pool_weights = weights[:]
+            pool_weights = None
+
+        count = min(count, len(pool))
+        if np is not None:
+            probabilities = None
+            if pool_weights is not None:
+                total = sum(pool_weights)
+                probabilities = [weight / total for weight in pool_weights]
+            indices = self.rng.choice(len(pool), size=count, replace=False, p=probabilities)
+            return [pool[int(index)] for index in indices]
+
+        if pool_weights is not None:
+            selected = []
             for _ in range(count):
                 choice = self.rng.choices(pool, weights=pool_weights, k=1)[0]
                 index = pool.index(choice)
@@ -425,7 +441,7 @@ class _Selector:
                 pool.pop(index)
                 pool_weights.pop(index)
             return selected
-        return self.rng.sample(options, count)
+        return self.rng.sample(pool, count)
 
 
 class _WildcardLibrary:
@@ -505,19 +521,23 @@ def _parse_dynamic_options(value: str) -> list[WildcardOption]:
     return options
 
 
-def _parse_count_spec(spec: str, selector: _Selector) -> int:
+def _parse_count_spec(spec: str, selector: _Selector) -> int | None:
     text = str(spec or "").strip()
     if not text:
         return 1
-    if "-" in text:
-        left, _, right = text.partition("-")
-        minimum = int(left) if left.strip() else 0
-        maximum = int(right) if right.strip() else minimum
-        return selector.count_from_range(minimum, maximum)
-    try:
-        return max(0, int(text))
-    except ValueError:
-        return 1
+    match = COUNT_SPEC_RE.fullmatch(text)
+    if match is None:
+        return None
+    fixed = match.group("fixed")
+    if fixed is not None:
+        return int(fixed)
+    left = match.group("minimum")
+    right = match.group("maximum")
+    if not left and not right:
+        return None
+    minimum = int(left) if left else 0
+    maximum = int(right) if right else minimum
+    return selector.count_from_range(minimum, maximum)
 
 
 def _expand_multiselect_options(options: list[WildcardOption], library: _WildcardLibrary) -> list[WildcardOption]:
@@ -538,6 +558,8 @@ def _replace_dynamic(text: str, selector: _Selector, library: _WildcardLibrary) 
         first_parts = raw_options[0].split("$$")
         if len(first_parts) > 1:
             count = _parse_count_spec(first_parts[0], selector)
+            if count is None:
+                return match.group(0)
             separator = ", "
             if len(first_parts) == 2:
                 first_candidate = first_parts[1]


### PR DESCRIPTION
## 변경 요약
- 가중치가 0인 와일드카드 후보를 양수 가중치 후보가 있는 랜덤 선택에서 제외합니다.
- 모든 가중치가 0이면 전체 후보를 균등 무복원 선택합니다.
- 선택 개수를 실제 선택 가능한 후보 수로 제한하고 NumPy/Python 경로의 입력 전처리를 일치시킵니다.
- malformed count 범위는 기존 표현식을 보존합니다.

## 주요 파일
- `wildcard_engine.py`
- `tests/test_wildcards.py`

## 검증
- 저장소 공식 full runner: 통과
- Python unittest: 418 tests OK
- Frontend: 110 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과

## 테스트 표면
- ComfyUI Codex test instance의 Python/프론트엔드 정적·semantic smoke
- Live ComfyUI smoke: 실행하지 않음

## 남은 위험
- NumPy와 Python RNG는 같은 seed에서 선택 순서가 완전히 같다는 계약은 기존과 동일하게 두지 않습니다. 각 backend 내 결정성과 선택 정책은 회귀 테스트로 고정했습니다.

Closes #156