### PR TITLE
fix: API 불리언과 설정 scalar 파싱 계약 강화

### DIFF
--- a/api.py
+++ b/api.py
@@ -61,6 +61,15 @@ AIO_RESERVED_PROFILE_NAMES = {
 }
 
 
+def _parse_json_boolean(data: dict, key: str, *, default: bool = False) -> bool:
+    if key not in data:
+        return default
+    value = data[key]
+    if type(value) is not bool:
+        raise ValueError(f"{key} must be a JSON boolean")
+    return value
+
+
 def _sanitize_lora_profile_name(name: str) -> str:
     safe_name = INVALID_PROFILE_NAME_CHARS.sub("_", str(name or "")).strip(" ._")
     if not safe_name:
@@ -661,10 +670,11 @@ if web is not None and routes is not None:
     async def save_aio_profile_handler(request):
         data = await request.json()
         try:
+            overwrite = _parse_json_boolean(data, "overwrite")
             payload = _save_aio_profile(
                 str(data.get("name") or ""),
                 data,
-                overwrite=bool(data.get("overwrite", False)),
+                overwrite=overwrite,
             )
         except FileExistsError as exc:
             return web.json_response({"status": "error", "message": str(exc)}, status=409)
@@ -697,10 +707,11 @@ if web is not None and routes is not None:
     async def rename_aio_profile_handler(request):
         data = await request.json()
         try:
+            overwrite = _parse_json_boolean(data, "overwrite")
             payload = _rename_aio_profile(
                 str(data.get("old_name") or ""),
                 str(data.get("new_name") or ""),
-                overwrite=bool(data.get("overwrite", False)),
+                overwrite=overwrite,
             )
         except FileExistsError as exc:
             return web.json_response({"status": "error", "message": str(exc)}, status=409)

--- a/settings.py
+++ b/settings.py
@@ -357,7 +357,7 @@ def save_setting(key: str, value) -> dict:
     if key not in DEFAULT_SETTINGS:
         raise KeyError(f"Unknown setting: {key}")
     settings = get_settings()
-    settings[key] = str(value or "")
+    settings[key] = _stringify_setting_value(value)
     SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
     SETTINGS_FILE.write_text(
         json.dumps(settings, ensure_ascii=False, indent=2) + "\n",

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import shutil
 import subprocess
@@ -30,6 +31,46 @@ def load_api_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+class RouteRegistry:
+    def __init__(self):
+        self.handlers = {}
+
+    def get(self, path):
+        def register(handler):
+            self.handlers[path] = handler
+            return handler
+
+        return register
+
+    def post(self, path):
+        return self.get(path)
+
+
+class JsonRequest:
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def json(self):
+        return self.payload
+
+
+def load_api_routes():
+    routes = RouteRegistry()
+    fake_server = types.ModuleType("server")
+    fake_server.PromptServer = type(
+        "PromptServer",
+        (),
+        {"instance": types.SimpleNamespace(routes=routes)},
+    )
+    fake_aiohttp = types.ModuleType("aiohttp")
+    fake_aiohttp.web = types.SimpleNamespace(
+        json_response=lambda payload, status=200: {"payload": payload, "status": status},
+    )
+    with patch.dict(sys.modules, {"server": fake_server, "aiohttp": fake_aiohttp}):
+        api = load_api_module()
+    return api, routes
 
 
 class AIOProfileStorageTests(unittest.TestCase):
@@ -94,6 +135,61 @@ class AIOProfileStorageTests(unittest.TestCase):
                 (Path(tmp) / "Broken.json").write_text("{", encoding="utf-8")
                 with self.assertRaisesRegex(ValueError, "Profile data is invalid"):
                     api._load_aio_profile("Broken")
+
+
+class AIOProfileApiRouteTests(unittest.TestCase):
+    ENDPOINTS = (
+        (
+            "/easyuse_anima/aio_profiles/save",
+            {"name": "Saved", "settings": {}},
+            "_save_aio_profile",
+        ),
+        (
+            "/easyuse_anima/aio_profiles/rename",
+            {"old_name": "Old", "new_name": "Renamed"},
+            "_rename_aio_profile",
+        ),
+    )
+
+    def test_profile_overwrite_accepts_json_booleans_and_defaults_false(self):
+        api, routes = load_api_routes()
+        overwrite_cases = (({}, False), ({"overwrite": False}, False), ({"overwrite": True}, True))
+
+        for path, base_payload, function_name in self.ENDPOINTS:
+            handler = routes.handlers[path]
+            for overwrite_payload, expected in overwrite_cases:
+                with self.subTest(path=path, overwrite=overwrite_payload):
+                    with patch.object(
+                        api,
+                        function_name,
+                        return_value={"name": "Saved"},
+                    ) as operation:
+                        response = asyncio.run(
+                            handler(JsonRequest({**base_payload, **overwrite_payload}))
+                        )
+
+                    self.assertEqual(response["status"], 200)
+                    self.assertIs(operation.call_args.kwargs["overwrite"], expected)
+
+    def test_profile_overwrite_rejects_non_boolean_json_scalars_and_containers(self):
+        api, routes = load_api_routes()
+        invalid_values = ("false", "true", 0, 1, "", None, [], {})
+
+        for path, base_payload, function_name in self.ENDPOINTS:
+            handler = routes.handlers[path]
+            for overwrite in invalid_values:
+                with self.subTest(path=path, overwrite=overwrite):
+                    with patch.object(api, function_name) as operation:
+                        response = asyncio.run(
+                            handler(JsonRequest({**base_payload, "overwrite": overwrite}))
+                        )
+
+                    self.assertEqual(response["status"], 400)
+                    self.assertEqual(
+                        response["payload"]["message"],
+                        "overwrite must be a JSON boolean",
+                    )
+                    operation.assert_not_called()
 
 
 class AIOBuiltinProfileTests(unittest.TestCase):

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -2681,6 +2681,36 @@ class PromptBuilderTests(unittest.TestCase):
 
 
 class SettingsTests(unittest.TestCase):
+    def test_save_setting_round_trips_false_zero_empty_string_and_null(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            settings_file = Path(tmp) / "settings.json"
+            long_text_settings_file = Path(tmp) / "long_text_settings.json"
+            cases = (
+                ("autocomplete.append_separator", False, "false"),
+                ("autocomplete.limit", 0, "0"),
+                ("prompt_studio.font_family", "", ""),
+                ("prompt_studio.font_family", None, ""),
+            )
+
+            with (
+                patch.object(easyuse_settings, "SETTINGS_FILE", settings_file),
+                patch.object(
+                    easyuse_settings,
+                    "LONG_TEXT_SETTINGS_FILE",
+                    long_text_settings_file,
+                ),
+                patch.object(easyuse_settings, "_load_comfy_settings", return_value={}),
+            ):
+                for key, value, expected in cases:
+                    with self.subTest(key=key, value=value):
+                        saved = easyuse_settings.save_setting(key, value)
+                        persisted = json.loads(settings_file.read_text(encoding="utf-8"))
+                        reloaded = easyuse_settings.get_settings()
+
+                        self.assertEqual(saved[key], expected)
+                        self.assertEqual(persisted[key], expected)
+                        self.assertEqual(reloaded[key], expected)
+
     def test_public_settings_does_not_expose_token_file(self):
         settings = public_settings()
         self.assertEqual(


### PR DESCRIPTION
## 변경 요약
- AiO 프로필 저장·이름 변경 API의 불리언 필드를 JSON boolean으로 엄격히 검증합니다.
- 필드 누락 시에만 기존 기본값을 적용하고 잘못된 타입은 기존 400 응답 경로로 전달합니다.
- 설정 저장 시 `false`, `0`, 빈 문자열을 서로 구분해 문자열화합니다.
- API route와 설정 round-trip 회귀 테스트를 추가합니다.

## 주요 파일
- `api.py`
- `settings.py`
- `tests/test_aio_profiles.py`
- `tests/test_prompt_corrector.py`

## 검증
- 저장소 공식 full runner: 통과
- Python unittest: 417 tests OK
- Frontend: 110 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과

## 테스트 표면
- ComfyUI Codex test instance의 Python/프론트엔드 정적·semantic smoke
- Live ComfyUI smoke: 실행하지 않음

## 남은 위험
- 외부 클라이언트가 문자열 `"true"`/`"false"`를 보내던 비공식 사용 방식은 400으로 거부됩니다. JSON API 스키마에 맞춘 의도된 강화입니다.

Closes #157