### PR TITLE
fix: NAIA 해상도 1MP 상한 강제

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -723,6 +723,7 @@ HTTP_TIMEOUT = NAIA_REQUEST_TIMEOUT + 5.0
 
 NAI_1MP = 1024 * 1024
 LATENT_ALIGN = 8
+NAIA_MAX_RESOLUTION = 8192
 IMAGE_UPSCALE_METHODS = ["nearest-exact", "bilinear", "area", "bicubic", "lanczos"]
 IMAGE_SCALE_MULTIPLES = ["8", "16", "32", "64"]
 AIO_FINAL_UPSCALE_BACKENDS = ("usdu", "resshift")
@@ -7635,16 +7636,14 @@ def _fit_to_1mp(width: int, height: int) -> tuple[int, int]:
     if width * height <= NAI_1MP:
         return width, height
 
-    ratio = width / height
-    target_w = (NAI_1MP * ratio) ** 0.5
-    target_h = (NAI_1MP / ratio) ** 0.5
-    new_w = max(LATENT_ALIGN, round(target_w / LATENT_ALIGN) * LATENT_ALIGN)
-    new_h = max(LATENT_ALIGN, round(target_h / LATENT_ALIGN) * LATENT_ALIGN)
-    while new_w * new_h > NAI_1MP and new_w > LATENT_ALIGN and new_h > LATENT_ALIGN:
+    scale = sqrt(NAI_1MP / (width * height))
+    new_w = max(LATENT_ALIGN, round(width * scale / LATENT_ALIGN) * LATENT_ALIGN)
+    new_h = max(LATENT_ALIGN, round(height * scale / LATENT_ALIGN) * LATENT_ALIGN)
+    if new_w * new_h > NAI_1MP:
         if new_w >= new_h:
-            new_w -= LATENT_ALIGN
+            new_w = (NAI_1MP // new_h // LATENT_ALIGN) * LATENT_ALIGN
         else:
-            new_h -= LATENT_ALIGN
+            new_h = (NAI_1MP // new_w // LATENT_ALIGN) * LATENT_ALIGN
     return new_w, new_h
 
 
@@ -7706,6 +7705,14 @@ def _parse_random_response(resp: dict) -> tuple[str, str, int, int]:
         raw_width, raw_height = int(w_raw), int(h_raw)
     except (TypeError, ValueError):
         raise RuntimeError(f"[EasyUse Anima] Invalid NAIA width/height: {w_raw!r}, {h_raw!r}")
+    if not (
+        1 <= raw_width <= NAIA_MAX_RESOLUTION
+        and 1 <= raw_height <= NAIA_MAX_RESOLUTION
+    ):
+        raise RuntimeError(
+            f"[EasyUse Anima] Invalid NAIA width/height: {w_raw!r}, {h_raw!r}; "
+            f"expected values from 1 to {NAIA_MAX_RESOLUTION}."
+        )
     width, height = _fit_to_1mp(raw_width, raw_height)
     return prompt, negative, width, height
 
@@ -12151,11 +12158,11 @@ class EasyUseAnimaNAIARandomPrompt:
                 "tooltip": "Stored negative prompt used for frozen output and saved-image reproduction.",
             }),
             "cached_width": ("INT", {
-                "default": 0, "min": 0, "max": 8192, "step": 8,
+                "default": 0, "min": 0, "max": NAIA_MAX_RESOLUTION, "step": 8,
                 "tooltip": "Stored width used for frozen output and saved-image reproduction.",
             }),
             "cached_height": ("INT", {
-                "default": 0, "min": 0, "max": 8192, "step": 8,
+                "default": 0, "min": 0, "max": NAIA_MAX_RESOLUTION, "step": 8,
                 "tooltip": "Stored height used for frozen output and saved-image reproduction.",
             }),
             "cached_signature": ("STRING", {
@@ -12184,7 +12191,7 @@ class EasyUseAnimaNAIARandomPrompt:
                 "tooltip": "true: use NAIA negative prompt. false: preserve input negative_prompt.",
             }),
             "width": ("INT", {
-                "default": 1024, "min": 64, "max": 8192, "step": 8,
+                "default": 1024, "min": 64, "max": NAIA_MAX_RESOLUTION, "step": 8,
                 "tooltip": "Returned as-is when bypassed or when override_width is false.",
             }),
             "override_width": ("BOOLEAN", {
@@ -12192,7 +12199,7 @@ class EasyUseAnimaNAIARandomPrompt:
                 "tooltip": "true: use NAIA width. false: preserve input width.",
             }),
             "height": ("INT", {
-                "default": 1024, "min": 64, "max": 8192, "step": 8,
+                "default": 1024, "min": 64, "max": NAIA_MAX_RESOLUTION, "step": 8,
                 "tooltip": "Returned as-is when bypassed or when override_height is false.",
             }),
             "override_height": ("BOOLEAN", {

--- a/tests/test_naia_settings.py
+++ b/tests/test_naia_settings.py
@@ -1,7 +1,15 @@
 import unittest
 from unittest.mock import patch
 
-from nodes import EasyUseAnimaNAIARandomPrompt, _build_naia_random_url
+from nodes import (
+    LATENT_ALIGN,
+    NAI_1MP,
+    NAIA_MAX_RESOLUTION,
+    EasyUseAnimaNAIARandomPrompt,
+    _build_naia_random_url,
+    _fit_to_1mp,
+    _parse_random_response,
+)
 
 
 def settings(**overrides):
@@ -24,6 +32,55 @@ def settings(**overrides):
 
 
 class NaiaSettingsTests(unittest.TestCase):
+    def test_fit_to_1mp_preserves_normal_shapes(self):
+        self.assertEqual(_fit_to_1mp(4096, 4096), (1024, 1024))
+        self.assertEqual(_fit_to_1mp(832, 1216), (832, 1216))
+        self.assertEqual(_fit_to_1mp(1216, 832), (1216, 832))
+        self.assertEqual(_fit_to_1mp(4096, 2048), (1440, 728))
+        self.assertEqual(_fit_to_1mp(2048, 4096), (728, 1440))
+
+    def test_fit_to_1mp_caps_extreme_aspect_ratios_after_alignment(self):
+        cases = (
+            ((1_000_000, 2), (131_072, LATENT_ALIGN)),
+            ((2, 1_000_000), (LATENT_ALIGN, 131_072)),
+            ((1_000_000_000, 1), (131_072, LATENT_ALIGN)),
+            ((1, 1_000_000_000), (LATENT_ALIGN, 131_072)),
+        )
+
+        for source, expected in cases:
+            with self.subTest(source=source):
+                fitted = _fit_to_1mp(*source)
+                self.assertEqual(fitted, expected)
+                self.assertLessEqual(fitted[0] * fitted[1], NAI_1MP)
+                self.assertEqual(fitted[0] % LATENT_ALIGN, 0)
+                self.assertEqual(fitted[1] % LATENT_ALIGN, 0)
+
+    def test_parse_random_response_rejects_invalid_resolution_bounds(self):
+        cases = (
+            (0, 1024),
+            (-1, 1024),
+            (1024, 0),
+            (1024, -1),
+            (NAIA_MAX_RESOLUTION + 1, 1024),
+            (1024, NAIA_MAX_RESOLUTION + 1),
+            (1_000_000, 2),
+            (1_000_000_000, 1),
+        )
+
+        for width, height in cases:
+            with self.subTest(width=width, height=height):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    rf"Invalid NAIA width/height.*1 to {NAIA_MAX_RESOLUTION}",
+                ):
+                    _parse_random_response({"width": width, "height": height})
+
+    def test_parse_random_response_accepts_absolute_resolution_boundary(self):
+        self.assertEqual(
+            _parse_random_response({"width": NAIA_MAX_RESOLUTION, "height": NAIA_MAX_RESOLUTION}),
+            ("", "", 1024, 1024),
+        )
+
     def test_request_uses_global_naia_settings_instead_of_node_values(self):
         calls = []
 


### PR DESCRIPTION
## 변경 요약
- NAIA 랜덤 응답 해상도를 node schema와 같은 축 범위 1..8192로 검증합니다.
- 1MP 초과 해상도는 비율을 유지해 축소하고 8단위로 정렬합니다.
- 정렬 뒤 상한을 넘는 극단 종횡비는 긴 축을 다시 낮춰 1,048,576 픽셀 이하를 보장합니다.
- 정상·세로·가로·극단 종횡비와 응답 경계 회귀 테스트를 추가합니다.

## 주요 파일
- `nodes.py`
- `tests/test_naia_settings.py`

## 검증
- 저장소 공식 full runner: 통과
- Python unittest: 418 tests OK
- Frontend: 110 JavaScript files, TypeScript 6.0.3 통과
- `git diff --check`: 통과

## 테스트 표면
- ComfyUI Codex test instance의 Python/프론트엔드 정적·semantic smoke
- 실제 NAIA API 호출 및 Live ComfyUI smoke: 실행하지 않음

## 남은 위험
- 실제 NAIA 서비스가 문서화된 축 상한과 다른 값을 반환하는 환경은 확인하지 않았습니다. 범위 밖 응답은 명시적으로 오류 처리합니다.

Closes #158