### PR TITLE
fix: autocomplete cache와 요청 취소 수명주기 보강

### DIFF
--- a/tests/frontend_autocomplete_data_adapter_smoke.mjs
+++ b/tests/frontend_autocomplete_data_adapter_smoke.mjs
@@ -20,11 +20,33 @@ function deferred() {
 }
 
 function controlledFetch(requests) {
-  return (url) => {
-    const request = { url, ...deferred() };
+  return (url, options = {}) => {
+    const request = { url, signal: options.signal || null, ...deferred() };
     requests.push(request);
     return request.promise;
   };
+}
+
+function abortableControlledFetch(requests) {
+  return (url, options = {}) => {
+    const request = { url, signal: options.signal || null, ...deferred() };
+    requests.push(request);
+    const rejectAbort = () => {
+      const error = new Error("request aborted");
+      error.name = "AbortError";
+      request.reject(error);
+    };
+    if (request.signal?.aborted) {
+      rejectAbort();
+    } else {
+      request.signal?.addEventListener("abort", rejectAbort, { once: true });
+    }
+    return request.promise;
+  };
+}
+
+function isAbortError(error) {
+  return error?.name === "AbortError";
 }
 
 async function flushMicrotasks(turns = 4) {
@@ -590,5 +612,143 @@ assert.equal(
 assert.notEqual(wildcardRetryFreshDifferentResults, wildcardRetryFreshResults);
 assert.deepEqual(wildcardRetryFreshResults.map((item) => item.tag), ["folder/retried"]);
 assert.deepEqual(wildcardRetryFreshDifferentResults.map((item) => item.tag), ["other/retried"]);
+
+let cacheNow = 0;
+const boundedCacheFetchCounts = new Map();
+const boundedCacheAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: async (url) => {
+    const count = (boundedCacheFetchCounts.get(url) || 0) + 1;
+    boundedCacheFetchCounts.set(url, count);
+    return { results: [{ tag: `${url}:${count}` }] };
+  },
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 20,
+  now: () => cacheNow,
+});
+const firstLruResult = await boundedCacheAdapter.search("lru-0");
+for (let index = 1; index < 256; index += 1) {
+  await boundedCacheAdapter.search(`lru-${index}`);
+}
+assert.equal(
+  await boundedCacheAdapter.search("lru-0"),
+  firstLruResult,
+  "a cache hit must promote the entry to the most-recently-used slot",
+);
+await boundedCacheAdapter.search("lru-256");
+const evictedLruUrl = "/easyuse_anima/autocomplete?q=lru-1&limit=20";
+await boundedCacheAdapter.search("lru-1");
+assert.equal(
+  boundedCacheFetchCounts.get(evictedLruUrl),
+  2,
+  "the 257th unique result must evict the least-recently-used entry from the 256-entry cache",
+);
+cacheNow = (5 * 60 * 1000) - 1;
+assert.equal(
+  await boundedCacheAdapter.search("lru-0"),
+  firstLruResult,
+  "LRU promotion must not shorten an unexpired five-minute TTL",
+);
+cacheNow += 1;
+const expiredLruResult = await boundedCacheAdapter.search("lru-0");
+assert.notEqual(
+  expiredLruResult,
+  firstLruResult,
+  "a resolved result must expire five minutes after it was cached",
+);
+
+const consumerAbortRequests = [];
+const consumerAbortAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: abortableControlledFetch(consumerAbortRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 20,
+});
+const sharedAbortFirst = consumerAbortAdapter.search("shared-abort");
+const sharedAbortSecond = consumerAbortAdapter.search("SHARED-ABORT");
+await flushMicrotasks();
+assert.equal(consumerAbortRequests.length, 1);
+const sharedAbortFirstAssertion = assert.rejects(sharedAbortFirst, isAbortError);
+sharedAbortFirst.abort();
+assert.equal(
+  consumerAbortRequests[0].signal.aborted,
+  false,
+  "one stale consumer must not abort a same-query request still owned by the latest consumer",
+);
+consumerAbortRequests[0].resolve({ results: [{ tag: "shared-current" }] });
+await sharedAbortFirstAssertion;
+assert.deepEqual(await sharedAbortSecond, [{ tag: "shared-current" }]);
+
+const soleAbortRequest = consumerAbortAdapter.search("sole-abort");
+await flushMicrotasks();
+const soleAbortOwner = consumerAbortRequests.at(-1);
+const soleAbortAssertion = assert.rejects(soleAbortRequest, isAbortError);
+soleAbortRequest.abort();
+assert.equal(
+  soleAbortOwner.signal.aborted,
+  true,
+  "the final consumer must abort its actual fetch signal",
+);
+await soleAbortAssertion;
+const soleAbortRetry = consumerAbortAdapter.search("sole-abort");
+await flushMicrotasks();
+assert.equal(
+  consumerAbortRequests.length,
+  3,
+  "an aborted final consumer must release pending ownership for an immediate retry",
+);
+consumerAbortRequests[2].resolve({ results: [{ tag: "sole-retry" }] });
+assert.deepEqual(await soleAbortRetry, [{ tag: "sole-retry" }]);
+
+const sourceAbortRequests = [];
+const sourceAbortAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: abortableControlledFetch(sourceAbortRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 20,
+});
+sourceAbortAdapter.syncSourceSettings(
+  { "autocomplete.source": "source-a" },
+  { initialize: true },
+);
+const obsoleteSourceRequest = sourceAbortAdapter.search("source-change");
+await flushMicrotasks();
+const obsoleteSourceAssertion = assert.rejects(obsoleteSourceRequest, isAbortError);
+assert.equal(
+  sourceAbortAdapter.syncSourceSettings({ "autocomplete.source": "source-b" }),
+  true,
+);
+assert.equal(
+  sourceAbortRequests[0].signal.aborted,
+  true,
+  "autocomplete source changes must abort the pending HTTP request",
+);
+await obsoleteSourceAssertion;
+const currentSourceRequest = sourceAbortAdapter.search("source-change");
+await flushMicrotasks();
+assert.equal(sourceAbortRequests.length, 2);
+sourceAbortRequests[1].resolve({ results: [{ tag: "source-b-result" }] });
+assert.deepEqual(await currentSourceRequest, [{ tag: "source-b-result" }]);
+
+const wildcardSourceAbortRequests = [];
+const wildcardSourceAbortAdapter = dataAdapterModule.createAutocompleteDataAdapter({
+  fetchJson: abortableControlledFetch(wildcardSourceAbortRequests),
+  normalizeWildcardSearchText: textModel.normalizeWildcardSearchText,
+  getLimit: () => 20,
+});
+wildcardSourceAbortAdapter.syncSourceSettings(
+  { "wildcard.extra_paths": "path-a" },
+  { initialize: true },
+);
+const obsoleteWildcardSource = wildcardSourceAbortAdapter.searchWildcards("folder");
+await flushMicrotasks();
+const obsoleteWildcardAssertion = assert.rejects(obsoleteWildcardSource, isAbortError);
+assert.equal(
+  wildcardSourceAbortAdapter.syncSourceSettings({ "wildcard.extra_paths": "path-b" }),
+  true,
+);
+assert.equal(
+  wildcardSourceAbortRequests[0].signal.aborted,
+  true,
+  "wildcard source changes must abort the pending source fetch",
+);
+await obsoleteWildcardAssertion;
 
 console.log("Autocomplete data adapter smoke passed.");

--- a/tests/frontend_autocomplete_input_controller_smoke.mjs
+++ b/tests/frontend_autocomplete_input_controller_smoke.mjs
@@ -201,6 +201,7 @@ const {
 {
   const scheduler = createScheduler();
   const pending = new Map();
+  const requestSignals = new Map();
   const loaderCalls = new Map();
   const applied = [];
   const errors = [];
@@ -210,8 +211,9 @@ const {
     ...scheduler,
     async onUpdate(context) {
       const key = requestKey;
-      const result = await context.request(key, () => {
+      const result = await context.request(key, (signal) => {
         loaderCalls.set(key, (loaderCalls.get(key) || 0) + 1);
+        requestSignals.set(key, signal);
         const request = deferred();
         pending.set(key, request);
         return request.promise;
@@ -228,6 +230,11 @@ const {
   const sameFirst = controller.updateNow();
   const sameSecond = controller.updateNow();
   assert.equal(loaderCalls.get("same"), 1, "same-signature in-flight requests must be shared");
+  assert.equal(
+    requestSignals.get("same").aborted,
+    false,
+    "the latest same-key waiter must retain the shared request",
+  );
   pending.get("same").resolve("same-result");
   await Promise.all([sameFirst, sameSecond]);
   assert.deepEqual(applied, ["same-result"], "only the latest waiter may publish shared results");
@@ -236,6 +243,12 @@ const {
   const oldUpdate = controller.updateNow();
   requestKey = "new";
   const newUpdate = controller.updateNow();
+  assert.equal(
+    requestSignals.get("old").aborted,
+    true,
+    "a distinct replacement query must abort the obsolete loader signal",
+  );
+  assert.equal(requestSignals.get("new").aborted, false);
   pending.get("new").resolve("new-result");
   await newUpdate;
   pending.get("old").reject(new Error("stale failure"));
@@ -252,6 +265,11 @@ const {
   requestKey = "closed";
   const closedUpdate = controller.updateNow();
   controller.invalidate();
+  assert.equal(
+    requestSignals.get("closed").aborted,
+    true,
+    "invalidate must abort pending loader ownership",
+  );
   pending.get("closed").resolve("closed-result");
   await closedUpdate;
   assert.deepEqual(
@@ -263,9 +281,103 @@ const {
   requestKey = "disposed";
   const disposedUpdate = controller.updateNow();
   controller.dispose();
+  assert.equal(
+    requestSignals.get("disposed").aborted,
+    true,
+    "dispose must abort pending loader ownership",
+  );
   pending.get("disposed").resolve("disposed-result");
   await disposedUpdate;
   assert.deepEqual(applied, ["same-result", "new-result"]);
+}
+
+{
+  const scheduler = createScheduler();
+  const requests = new Map();
+  const abortCalls = new Map();
+  const applied = [];
+  const errors = [];
+  let requestKey = "adapter-old";
+  let shouldRequest = true;
+
+  function cancellableRequest(key) {
+    const request = deferred();
+    const promise = Object.assign(request.promise, {
+      abort() {
+        abortCalls.set(key, (abortCalls.get(key) || 0) + 1);
+        const error = new Error(`${key} aborted`);
+        error.name = "AbortError";
+        request.reject(error);
+      },
+    });
+    requests.set(key, { ...request, promise });
+    return promise;
+  }
+
+  const controller = createAutocompleteInputController({
+    ...scheduler,
+    async onUpdate(context) {
+      if (!shouldRequest) {
+        return;
+      }
+      const key = requestKey;
+      const result = await context.request(key, () => cancellableRequest(key));
+      if (context.isCurrent()) {
+        applied.push(result);
+      }
+    },
+    onError(error) {
+      errors.push(error.message);
+    },
+  });
+
+  const oldUpdate = controller.updateNow();
+  requestKey = "adapter-current";
+  const currentUpdate = controller.updateNow();
+  assert.equal(
+    abortCalls.get("adapter-old"),
+    1,
+    "a replacement key must invoke the adapter consumer's abort hook",
+  );
+  requests.get("adapter-current").resolve("adapter-current-result");
+  await Promise.all([oldUpdate, currentUpdate]);
+  assert.deepEqual(applied, ["adapter-current-result"]);
+  assert.deepEqual(errors, [], "a canceled stale request must not enter popup error handling");
+
+  requestKey = "source-abort";
+  const sourceAbortUpdate = controller.updateNow();
+  const sourceAbortError = new Error("source changed");
+  sourceAbortError.name = "AbortError";
+  requests.get("source-abort").reject(sourceAbortError);
+  await sourceAbortUpdate;
+  assert.deepEqual(
+    errors,
+    [],
+    "a current AbortError must not hide the popup or surface a user error",
+  );
+
+  requestKey = "no-query";
+  const noQueryPending = controller.updateNow();
+  shouldRequest = false;
+  await controller.updateNow();
+  assert.equal(
+    abortCalls.get("no-query"),
+    1,
+    "a current generation that produces no query must cancel obsolete pending work",
+  );
+  await noQueryPending;
+
+  shouldRequest = true;
+  requestKey = "dispose-abort";
+  const disposePending = controller.updateNow();
+  controller.dispose();
+  assert.equal(
+    abortCalls.get("dispose-abort"),
+    1,
+    "dispose must release the adapter consumer and its fetch ownership",
+  );
+  await disposePending;
+  assert.deepEqual(errors, []);
 }
 
 console.log("Autocomplete input controller smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -1083,7 +1083,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn('replaceAll("\\\\", "/")', normalize_body)
         self.assertIn('replace(/[ _]+/g, "-")', normalize_body)
 
-        start = data_adapter_source.index("async function searchWildcards")
+        start = data_adapter_source.index("function searchWildcards")
         end = data_adapter_source.index("\n\n  return {", start)
         search_body = data_adapter_source[start:end]
 

--- a/web/js/autocomplete/data_adapter.js
+++ b/web/js/autocomplete/data_adapter.js
@@ -2,22 +2,49 @@
 
 /**
  * @typedef {object} AutocompleteDataAdapterDependencies
- * @property {(url: string) => Promise<any>} fetchJson
+ * @property {(url: string, options?: {signal?: AbortSignal}) => Promise<any>} fetchJson
  * @property {(value: any) => string} normalizeWildcardSearchText
  * @property {() => number} getLimit
+ * @property {() => number} [now]
+ */
+
+/**
+ * @typedef {object} ResolvedResultCacheEntry
+ * @property {any[]} results
+ * @property {number} expiresAt
  */
 
 /**
  * @typedef {object} ResultRequestOwner
+ * @property {string} key
  * @property {number} epoch
  * @property {Promise<any[]>} promise
+ * @property {AbortController} controller
+ * @property {number} consumers
+ * @property {boolean} settled
  */
 
 /**
  * @typedef {object} WildcardSourceRequestOwner
  * @property {number} epoch
  * @property {Promise<string[]>} promise
+ * @property {AbortController} controller
+ * @property {boolean} settled
  */
+
+/** @typedef {Promise<any[]> & {abort: () => void}} AbortableResultPromise */
+
+// A 256-entry cap bounds arrays of up to 100 suggestions while retaining a
+// useful editing-session working set; five minutes keeps warm-query latency low
+// without preserving resolved backend data for an entire long-running session.
+const RESOLVED_CACHE_MAX_ENTRIES = 256;
+const RESOLVED_CACHE_TTL_MS = 5 * 60 * 1000;
+
+function createAbortError() {
+  const error = new Error("The autocomplete request was aborted.");
+  error.name = "AbortError";
+  return error;
+}
 
 /**
  * Own autocomplete result caching, wildcard source loading, and source-setting
@@ -30,8 +57,9 @@ export function createAutocompleteDataAdapter(dependencies) {
     fetchJson,
     normalizeWildcardSearchText,
     getLimit,
+    now = Date.now,
   } = dependencies;
-  /** @type {Map<string, any[]>} */
+  /** @type {Map<string, ResolvedResultCacheEntry>} */
   const cache = new Map();
   /** @type {Map<string, ResultRequestOwner>} */
   const pendingResults = new Map();
@@ -55,20 +83,138 @@ export function createAutocompleteDataAdapter(dependencies) {
   }
 
   /**
+   * Read one unexpired result and promote it to the most-recently-used slot.
+   * TTL is measured from resolution rather than extended by cache hits.
+   *
    * @param {string} key
-   * @param {() => Promise<any[]>} load
-   * @returns {Promise<any[]>}
+   * @returns {any[] | null}
+   */
+  function getCachedResults(key) {
+    const entry = cache.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt <= now()) {
+      cache.delete(key);
+      return null;
+    }
+    cache.delete(key);
+    cache.set(key, entry);
+    return entry.results;
+  }
+
+  /**
+   * @param {string} key
+   * @param {any[]} results
+   */
+  function cacheResults(key, results) {
+    cache.delete(key);
+    cache.set(key, {
+      results,
+      expiresAt: now() + RESOLVED_CACHE_TTL_MS,
+    });
+    while (cache.size > RESOLVED_CACHE_MAX_ENTRIES) {
+      const oldestKey = cache.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      cache.delete(oldestKey);
+    }
+  }
+
+  /**
+   * @param {any[]} results
+   * @returns {AbortableResultPromise}
+   */
+  function resolvedResults(results) {
+    const promise = /** @type {AbortableResultPromise} */ (Promise.resolve(results));
+    promise.abort = () => {};
+    return promise;
+  }
+
+  /**
+   * Give each caller independent cancellation while retaining one shared load.
+   * The underlying request is aborted only after its final consumer releases it.
+   *
+   * @param {ResultRequestOwner} owner
+   * @returns {AbortableResultPromise}
+   */
+  function consumeResults(owner) {
+    /** @type {(value: any[]) => void} */
+    let resolveConsumer = () => {};
+    /** @type {(reason?: any) => void} */
+    let rejectConsumer = () => {};
+    let consumerSettled = false;
+    let released = false;
+    owner.consumers += 1;
+
+    const release = (abortWhenUnused) => {
+      if (released) {
+        return;
+      }
+      released = true;
+      owner.consumers = Math.max(0, owner.consumers - 1);
+      if (abortWhenUnused && owner.consumers === 0 && !owner.settled) {
+        owner.controller.abort();
+        if (pendingResults.get(owner.key) === owner) {
+          pendingResults.delete(owner.key);
+        }
+      }
+    };
+
+    const consumerPromise = /** @type {AbortableResultPromise} */ (new Promise(
+      (resolve, reject) => {
+        resolveConsumer = resolve;
+        rejectConsumer = reject;
+      },
+    ));
+    owner.promise.then(
+      (results) => {
+        if (consumerSettled) {
+          return;
+        }
+        consumerSettled = true;
+        release(false);
+        resolveConsumer(results);
+      },
+      (error) => {
+        if (consumerSettled) {
+          return;
+        }
+        consumerSettled = true;
+        release(false);
+        rejectConsumer(error);
+      },
+    );
+    consumerPromise.abort = () => {
+      if (consumerSettled) {
+        return;
+      }
+      consumerSettled = true;
+      release(true);
+      rejectConsumer(createAbortError());
+    };
+    return consumerPromise;
+  }
+
+  /**
+   * @param {string} key
+   * @param {(signal: AbortSignal) => Promise<any[]>} load
+   * @returns {AbortableResultPromise}
    */
   function requestResults(key, load) {
-    const cachedResults = cache.get(key);
-    if (cachedResults) {
-      return Promise.resolve(cachedResults);
+    const cachedResults = getCachedResults(key);
+    if (cachedResults !== null) {
+      return resolvedResults(cachedResults);
     }
 
     const epoch = resultsEpoch;
     const existingOwner = pendingResults.get(key);
-    if (existingOwner?.epoch === epoch) {
-      return existingOwner.promise;
+    if (
+      existingOwner?.epoch === epoch
+      && !existingOwner.controller.signal.aborted
+    ) {
+      return consumeResults(existingOwner);
     }
 
     /** @type {(value: any[]) => void} */
@@ -80,25 +226,39 @@ export function createAutocompleteDataAdapter(dependencies) {
       resolveRequest = resolve;
       rejectRequest = reject;
     });
-    const owner = { epoch, promise };
+    const controller = new AbortController();
+    const owner = {
+      key,
+      epoch,
+      promise,
+      controller,
+      consumers: 0,
+      settled: false,
+    };
     pendingResults.set(key, owner);
 
     /** @type {Promise<any[]>} */
     let loadPromise;
     try {
-      loadPromise = load();
+      loadPromise = load(controller.signal);
     } catch (error) {
+      owner.settled = true;
       if (pendingResults.get(key) === owner) {
         pendingResults.delete(key);
       }
       rejectRequest(error);
-      return promise;
+      return consumeResults(owner);
     }
 
     Promise.resolve(loadPromise).then(
       (results) => {
-        if (resultsEpoch === epoch && pendingResults.get(key) === owner) {
-          cache.set(key, results);
+        owner.settled = true;
+        if (
+          resultsEpoch === epoch
+          && pendingResults.get(key) === owner
+          && !controller.signal.aborted
+        ) {
+          cacheResults(key, results);
         }
         if (pendingResults.get(key) === owner) {
           pendingResults.delete(key);
@@ -106,6 +266,7 @@ export function createAutocompleteDataAdapter(dependencies) {
         resolveRequest(results);
       },
       (error) => {
+        owner.settled = true;
         if (pendingResults.get(key) === owner) {
           pendingResults.delete(key);
         }
@@ -113,18 +274,26 @@ export function createAutocompleteDataAdapter(dependencies) {
       },
     );
 
-    return promise;
+    return consumeResults(owner);
   }
 
   function clearResults() {
     resultsEpoch += 1;
     cache.clear();
+    for (const owner of pendingResults.values()) {
+      if (!owner.settled) {
+        owner.controller.abort();
+      }
+    }
     pendingResults.clear();
   }
 
   function clearWildcards() {
     wildcardSourceEpoch += 1;
     wildcardItemsCache = null;
+    if (wildcardLoadOwner && !wildcardLoadOwner.settled) {
+      wildcardLoadOwner.controller.abort();
+    }
     wildcardLoadOwner = null;
     clearResults();
   }
@@ -179,7 +348,7 @@ export function createAutocompleteDataAdapter(dependencies) {
     return resultsChanged || wildcardSourceChanged;
   }
 
-  async function search(query, category = "") {
+  function search(query, category = "") {
     const limit = getLimit();
     const normalizedCategory = category || "";
     const key = JSON.stringify([
@@ -194,8 +363,8 @@ export function createAutocompleteDataAdapter(dependencies) {
     const url = "/easyuse_anima/autocomplete"
       + `?q=${encodeURIComponent(query)}`
       + `&limit=${limit}${categoryParam}`;
-    return requestResults(key, async () => {
-      const data = await fetchJson(url);
+    return requestResults(key, async (signal) => {
+      const data = await fetchJson(url, { signal });
       return Array.isArray(data.results) ? data.results : [];
     });
   }
@@ -206,7 +375,10 @@ export function createAutocompleteDataAdapter(dependencies) {
     }
 
     const epoch = wildcardSourceEpoch;
-    if (wildcardLoadOwner?.epoch === epoch) {
+    if (
+      wildcardLoadOwner?.epoch === epoch
+      && !wildcardLoadOwner.controller.signal.aborted
+    ) {
       return wildcardLoadOwner.promise;
     }
 
@@ -219,14 +391,23 @@ export function createAutocompleteDataAdapter(dependencies) {
       resolveRequest = resolve;
       rejectRequest = reject;
     });
-    const owner = { epoch, promise };
+    const controller = new AbortController();
+    const owner = {
+      epoch,
+      promise,
+      controller,
+      settled: false,
+    };
     wildcardLoadOwner = owner;
 
     /** @type {Promise<any>} */
     let loadPromise;
     try {
-      loadPromise = fetchJson("/easyuse_anima/wildcards");
+      loadPromise = fetchJson("/easyuse_anima/wildcards", {
+        signal: controller.signal,
+      });
     } catch (error) {
+      owner.settled = true;
       if (wildcardLoadOwner === owner) {
         wildcardLoadOwner = null;
       }
@@ -236,10 +417,15 @@ export function createAutocompleteDataAdapter(dependencies) {
 
     Promise.resolve(loadPromise).then(
       (data) => {
+        owner.settled = true;
         const items = Array.isArray(data.items)
           ? data.items.map((item) => String(item || "")).filter(Boolean)
           : [];
-        if (wildcardSourceEpoch === epoch && wildcardLoadOwner === owner) {
+        if (
+          wildcardSourceEpoch === epoch
+          && wildcardLoadOwner === owner
+          && !controller.signal.aborted
+        ) {
           wildcardItemsCache = items;
         }
         if (wildcardLoadOwner === owner) {
@@ -248,6 +434,7 @@ export function createAutocompleteDataAdapter(dependencies) {
         resolveRequest(items);
       },
       (error) => {
+        owner.settled = true;
         if (wildcardLoadOwner === owner) {
           wildcardLoadOwner = null;
         }
@@ -258,7 +445,7 @@ export function createAutocompleteDataAdapter(dependencies) {
     return promise;
   }
 
-  async function searchWildcards(query) {
+  function searchWildcards(query) {
     const normalized = normalizeWildcardSearchText(query);
     const limit = getLimit();
     const key = JSON.stringify(["wildcard", limit, normalized]);

--- a/web/js/autocomplete/input_controller.js
+++ b/web/js/autocomplete/input_controller.js
@@ -3,7 +3,7 @@
 /**
  * @typedef {object} AutocompleteInputUpdateContext
  * @property {() => boolean} isCurrent
- * @property {(key: string, loader: () => Promise<any>) => Promise<any>} request
+ * @property {(key: string, loader: (signal: AbortSignal) => Promise<any>) => Promise<any>} request
  */
 
 /**
@@ -26,6 +26,17 @@
  * @typedef {object} AutocompleteControllerState
  * @property {AutocompleteInputControllerHandle | null | undefined} [controller]
  */
+
+/**
+ * @typedef {object} InFlightRequestOwner
+ * @property {Promise<any>} promise
+ * @property {AbortController} controller
+ * @property {() => void} abortLoaded
+ */
+
+function isAbortError(error) {
+  return !!error && typeof error === "object" && error.name === "AbortError";
+}
 
 /**
  * Invalidate every distinct input controller that can still publish results.
@@ -73,6 +84,7 @@ export function createAutocompleteInputController(dependencies) {
   let pendingTimer = null;
   let pendingFrame = null;
   let compositionEndFramePending = false;
+  /** @type {Map<string, InFlightRequestOwner>} */
   const inFlight = new Map();
 
   function cancelScheduledUpdate() {
@@ -91,6 +103,33 @@ export function createAutocompleteInputController(dependencies) {
     generation += 1;
   }
 
+  /**
+   * Cancel obsolete request owners without disturbing a same-key single flight.
+   * Starting the replacement loader first lets shared adapter loads retain a
+   * current consumer before the stale consumer releases its ownership.
+   *
+   * @param {string | null} keptKey
+   */
+  function cancelInFlightExcept(keptKey) {
+    for (const [key, owner] of inFlight) {
+      if (key === keptKey) {
+        continue;
+      }
+      inFlight.delete(key);
+      owner.controller.abort();
+      owner.abortLoaded();
+    }
+  }
+
+  function cancelInFlightRequests() {
+    cancelInFlightExcept(null);
+  }
+
+  /**
+   * @param {string} key
+   * @param {(signal: AbortSignal) => Promise<any>} loader
+   * @returns {Promise<any>}
+   */
   function request(key, loader) {
     if (disposed) {
       return Promise.resolve(undefined);
@@ -98,17 +137,26 @@ export function createAutocompleteInputController(dependencies) {
     const requestKey = String(key);
     const pending = inFlight.get(requestKey);
     if (pending) {
-      return pending;
+      cancelInFlightExcept(requestKey);
+      return pending.promise;
     }
-    let promise;
+    const controller = new AbortController();
+    /** @type {any} */
+    let loaded;
     try {
-      promise = Promise.resolve(loader());
+      loaded = loader(controller.signal);
     } catch (error) {
-      promise = Promise.reject(error);
+      loaded = Promise.reject(error);
     }
-    inFlight.set(requestKey, promise);
+    const abortLoaded = typeof loaded?.abort === "function"
+      ? () => loaded.abort()
+      : () => {};
+    const promise = Promise.resolve(loaded);
+    const owner = { promise, controller, abortLoaded };
+    inFlight.set(requestKey, owner);
+    cancelInFlightExcept(requestKey);
     const release = () => {
-      if (inFlight.get(requestKey) === promise) {
+      if (inFlight.get(requestKey) === owner) {
         inFlight.delete(requestKey);
       }
     };
@@ -122,15 +170,23 @@ export function createAutocompleteInputController(dependencies) {
     }
     cancelScheduledUpdate();
     const updateGeneration = ++generation;
+    let requestCalled = false;
     const context = {
       isCurrent: () => !disposed && updateGeneration === generation,
-      request,
+      request: (key, loader) => {
+        requestCalled = true;
+        return request(key, loader);
+      },
     };
     try {
       await onUpdate(context);
     } catch (error) {
-      if (context.isCurrent()) {
+      if (context.isCurrent() && !isAbortError(error)) {
         await onError(error, context);
+      }
+    } finally {
+      if (context.isCurrent() && !requestCalled) {
+        cancelInFlightRequests();
       }
     }
   }
@@ -179,6 +235,7 @@ export function createAutocompleteInputController(dependencies) {
     composing = true;
     supersedeCurrentUpdate();
     cancelScheduledUpdate();
+    cancelInFlightRequests();
   }
 
   function endComposition() {
@@ -199,7 +256,7 @@ export function createAutocompleteInputController(dependencies) {
     }
     supersedeCurrentUpdate();
     cancelScheduledUpdate();
-    inFlight.clear();
+    cancelInFlightRequests();
   }
 
   function dispose() {
@@ -210,7 +267,7 @@ export function createAutocompleteInputController(dependencies) {
     generation += 1;
     composing = false;
     cancelScheduledUpdate();
-    inFlight.clear();
+    cancelInFlightRequests();
   }
 
   return {


### PR DESCRIPTION
## 변경 요약
- 자동완성 resolved 결과 캐시를 256-entry LRU와 5분 TTL로 제한합니다.
- 같은 query의 in-flight 요청은 공유하되 caller별 취소 ownership을 분리합니다.
- 마지막 consumer가 사라질 때만 실제 HTTP fetch를 abort합니다.
- query 교체, source 설정 변경, invalidate/dispose에서 불필요한 요청과 캐시 상태를 정리합니다.
- AbortError가 popup 오류나 stale 결과 갱신으로 노출되지 않도록 합니다.
- abortable promise 계약에 맞춰 기존 source-contract 테스트를 async 수식어에 비의존적으로 보정합니다.

## 주요 파일
- `web/js/autocomplete/data_adapter.js`
- `web/js/autocomplete/input_controller.js`
- `tests/frontend_autocomplete_data_adapter_smoke.mjs`
- `tests/frontend_autocomplete_input_controller_smoke.mjs`
- `tests/test_aio_frontend.py`

## 검증
- 관련 focused Node smoke 2개: 통과
- 해당 Python wrapper: 11 tests OK
- TypeScript 6.0.3 및 syntax/diff check: 통과
- 저장소 공식 full runner 최종 실행: 통과
  - Python unittest: 414 tests OK
  - Frontend: 110 JavaScript files 통과
- 첫 full runner에서는 기존 테스트가 `async function searchWildcards` 문자열에 고정되어 1건 실패했습니다. abort hook 보존을 위해 non-async 반환 계약을 유지하고 assertion 한 줄을 선언 수식어에 비의존적으로 수정한 뒤 full runner를 재실행해 통과했습니다.

## 테스트 표면
- ComfyUI Codex test instance의 Python/프론트엔드 정적·semantic smoke
- 기존 #56 Legacy canvas/Node 2.0 lifecycle 감사 증거 재사용
- 이번 PR에서 live browser/server smoke: 반복 실행하지 않음

## 남은 위험
- 실제 네트워크 지연 중 브라우저별 AbortController 동작은 live browser로 새로 반복하지 않았습니다. fetch signal 전달과 consumer ownership은 결정적 smoke로 고정했습니다.

Closes #56