### PR TITLE
fix: autocomplete ranking과 source cache 정합성 보장

### DIFF
--- a/autocomplete_dataset.py
+++ b/autocomplete_dataset.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import csv
+import heapq
 import itertools
 import re
+import stat
+import threading
 import time
 import unicodedata
+from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
 
 try:
     from .anima_prompt.knowledge import PACKAGE_DATA_DIR
@@ -82,12 +88,9 @@ _MERGED_E621_CATEGORY_NAMES = {
     "14": "meta",
     "15": "general",
 }
-_CACHE = {
-    "path": None,
-    "mtime": None,
-    "entries": None,
-    "entry_map": None,
-}
+_AUTOCOMPLETE_CACHE_SCHEMA_VERSION = 1
+_AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS = 4
+_MISSING_FILE_STAT = -1
 _COUNT_RE = re.compile(
     r"^\d+\s*(girl|girls|boy|boys|person|people|other|others|animal|animals|"
     r"female|females|male|males|child|children)s?$",
@@ -110,6 +113,30 @@ class AutocompleteEntry:
     count: int
     description: str
     search: str
+
+
+@dataclass(frozen=True)
+class _AutocompleteCacheKey:
+    resolved_path: str
+    mtime_ns: int
+    size: int
+    schema_version: int
+
+
+@dataclass(frozen=True)
+class _AutocompleteSnapshot:
+    key: _AutocompleteCacheKey
+    entries: tuple[AutocompleteEntry, ...]
+    entry_map: Mapping[str, AutocompleteEntry]
+
+
+class _AutocompleteSourceChanged(RuntimeError):
+    pass
+
+
+_CACHE_LOCK = threading.Lock()
+_CACHE: dict[str, _AutocompleteSnapshot] = {}
+_INFLIGHT: dict[_AutocompleteCacheKey, Future[_AutocompleteSnapshot]] = {}
 
 
 def resolve_autocomplete_source(source: str | None = None) -> tuple[str, Path]:
@@ -270,28 +297,117 @@ def _load_entries(path: Path = AUTOCOMPLETE_CSV) -> tuple[AutocompleteEntry, ...
     return tuple(entries)
 
 
+def _cache_key_from_resolved_path(path: Path) -> _AutocompleteCacheKey:
+    try:
+        file_stat = path.stat()
+    except (FileNotFoundError, NotADirectoryError):
+        mtime_ns = _MISSING_FILE_STAT
+        size = _MISSING_FILE_STAT
+    else:
+        if stat.S_ISREG(file_stat.st_mode):
+            mtime_ns = file_stat.st_mtime_ns
+            size = file_stat.st_size
+        else:
+            mtime_ns = _MISSING_FILE_STAT
+            size = _MISSING_FILE_STAT
+    return _AutocompleteCacheKey(
+        resolved_path=str(path),
+        mtime_ns=mtime_ns,
+        size=size,
+        schema_version=_AUTOCOMPLETE_CACHE_SCHEMA_VERSION,
+    )
+
+
+def _cache_key(path: Path) -> _AutocompleteCacheKey:
+    return _cache_key_from_resolved_path(Path(path).resolve(strict=False))
+
+
+def _build_snapshot(key: _AutocompleteCacheKey) -> _AutocompleteSnapshot:
+    if key.mtime_ns == _MISSING_FILE_STAT:
+        entries: tuple[AutocompleteEntry, ...] = ()
+    else:
+        entries = _load_entries(Path(key.resolved_path))
+    entry_map = MappingProxyType({entry.tag_key: entry for entry in entries})
+    return _AutocompleteSnapshot(key=key, entries=entries, entry_map=entry_map)
+
+
+def _await_snapshot(future: Future[_AutocompleteSnapshot]) -> _AutocompleteSnapshot:
+    return future.result()
+
+
+def _snapshot_for_key(key: _AutocompleteCacheKey) -> _AutocompleteSnapshot:
+    with _CACHE_LOCK:
+        cached = _CACHE.get(key.resolved_path)
+        if cached is not None and cached.key == key:
+            return cached
+        future = _INFLIGHT.get(key)
+        is_loader = future is None
+        if future is None:
+            future = Future()
+            _INFLIGHT[key] = future
+
+    if not is_loader:
+        return _await_snapshot(future)
+
+    try:
+        try:
+            snapshot = _build_snapshot(key)
+        except Exception as load_error:
+            current_key = _cache_key_from_resolved_path(Path(key.resolved_path))
+            if current_key != key:
+                raise _AutocompleteSourceChanged(key.resolved_path) from load_error
+            raise
+        current_key = _cache_key_from_resolved_path(Path(key.resolved_path))
+        if current_key != key:
+            raise _AutocompleteSourceChanged(key.resolved_path)
+        with _CACHE_LOCK:
+            current_cached = _CACHE.get(key.resolved_path)
+            if current_cached is not cached and (
+                current_cached is None or current_cached.key != key
+            ):
+                raise _AutocompleteSourceChanged(key.resolved_path)
+            _CACHE[key.resolved_path] = snapshot
+            _INFLIGHT.pop(key, None)
+    except BaseException as error:
+        with _CACHE_LOCK:
+            if _INFLIGHT.get(key) is future:
+                _INFLIGHT.pop(key, None)
+        future.set_exception(error)
+        raise
+
+    future.set_result(snapshot)
+    return snapshot
+
+
+def _snapshot(path: Path = AUTOCOMPLETE_CSV) -> _AutocompleteSnapshot:
+    for _attempt in range(_AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS):
+        key = _cache_key(path)
+        try:
+            return _snapshot_for_key(key)
+        except _AutocompleteSourceChanged:
+            continue
+    resolved_path = Path(path).resolve(strict=False)
+    raise RuntimeError(
+        f"Autocomplete dataset changed repeatedly while loading: {resolved_path}"
+    ) from None
+
+
 def _entries(path: Path = AUTOCOMPLETE_CSV) -> tuple[AutocompleteEntry, ...]:
-    mtime = path.stat().st_mtime_ns if path.is_file() else 0
-    if (
-        _CACHE["entries"] is None
-        or _CACHE["path"] != str(path)
-        or _CACHE["mtime"] != mtime
-    ):
-        _CACHE["path"] = str(path)
-        _CACHE["mtime"] = mtime
-        _CACHE["entries"] = _load_entries(path)
-        _CACHE["entry_map"] = None
-    return _CACHE["entries"] or ()
+    return _snapshot(path).entries
 
 
-def _entry_map(path: Path = AUTOCOMPLETE_CSV) -> dict[str, AutocompleteEntry]:
-    _entries(path)
-    if _CACHE["entry_map"] is None:
-        _CACHE["entry_map"] = {
-            _normalize(entry.tag): entry
-            for entry in (_CACHE["entries"] or [])
-        }
-    return _CACHE["entry_map"] or {}
+def _entry_map(path: Path = AUTOCOMPLETE_CSV) -> Mapping[str, AutocompleteEntry]:
+    return _snapshot(path).entry_map
+
+
+def _snapshot_status(snapshot: _AutocompleteSnapshot, path: Path) -> dict:
+    exists = snapshot.key.mtime_ns != _MISSING_FILE_STAT
+    return {
+        "path": str(path),
+        "exists": exists,
+        "count": len(snapshot.entries),
+        "mtime": snapshot.key.mtime_ns / 1_000_000_000 if exists else 0,
+    }
 
 
 def _token_base(token: str) -> str:
@@ -531,7 +647,8 @@ def _token_section(token: str, entry: AutocompleteEntry | None) -> tuple[str, st
 
 
 def classify_prompt_text(text: str, limit: int = 240, path: Path = AUTOCOMPLETE_CSV) -> dict:
-    entries = _entry_map(path)
+    snapshot = _snapshot(path)
+    entries = snapshot.entry_map
     tokens: list[tuple[str, bool, bool, bool]] = []
 
     last_idx = 0
@@ -604,19 +721,48 @@ def classify_prompt_text(text: str, limit: int = 240, path: Path = AUTOCOMPLETE_
 
     return {
         "tokens": classified,
-        "status": autocomplete_status(path),
+        "status": _snapshot_status(snapshot, path),
     }
 
 
 def autocomplete_status(path: Path = AUTOCOMPLETE_CSV) -> dict:
-    exists = path.is_file()
-    entries = _entries(path) if exists else []
-    return {
-        "path": str(path),
-        "exists": exists,
-        "count": len(entries),
-        "mtime": path.stat().st_mtime if exists else 0,
-    }
+    return _snapshot_status(_snapshot(path), path)
+
+
+def _autocomplete_match_score(
+    entry: AutocompleteEntry,
+    normalized_query: str,
+) -> int | None:
+    if entry.tag_key == normalized_query:
+        return 0
+    if entry.tag_key.startswith(normalized_query):
+        return 1
+    if normalized_query in entry.tag_key:
+        return 2
+    if normalized_query in entry.search:
+        return 3
+    return None
+
+
+def _top_autocomplete_matches(
+    entries: tuple[AutocompleteEntry, ...],
+    normalized_query: str,
+    categories: set[str],
+    limit: int,
+) -> list[tuple[int, AutocompleteEntry]]:
+    def matches():
+        for entry in entries:
+            if categories and entry.category not in categories:
+                continue
+            score = _autocomplete_match_score(entry, normalized_query)
+            if score is not None:
+                yield (score, entry)
+
+    return heapq.nsmallest(
+        limit,
+        matches(),
+        key=lambda item: (item[0], -item[1].count, item[1].tag),
+    )
 
 
 def search_autocomplete(
@@ -638,27 +784,13 @@ def search_autocomplete(
             "elapsed_ms": 0,
         }
 
-    results: list[tuple[int, AutocompleteEntry]] = []
-    for entry in _entries(path):
-        if categories and entry.category not in categories:
-            continue
-        tag_key = entry.tag_key
-        if tag_key == normalized_query:
-            score = 0
-        elif tag_key.startswith(normalized_query):
-            score = 1
-        elif normalized_query in tag_key:
-            score = 2
-        elif normalized_query in entry.search:
-            score = 3
-        else:
-            continue
-        results.append((score, entry))
-        if len(results) >= max(effective_limit * 8, effective_limit):
-            break
-
-    results.sort(key=lambda item: (item[0], -item[1].count, item[1].tag))
-    limited = results[:effective_limit]
+    snapshot = _snapshot(path)
+    limited = _top_autocomplete_matches(
+        snapshot.entries,
+        normalized_query,
+        categories,
+        effective_limit,
+    )
     return {
         "query": query,
         "category": category,
@@ -671,6 +803,6 @@ def search_autocomplete(
             }
             for _, entry in limited
         ],
-        "status": autocomplete_status(path),
+        "status": _snapshot_status(snapshot, path),
         "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
     }

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import itertools
 import json
 import os
 import shutil
 import tempfile
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import patch
 
@@ -3079,7 +3082,36 @@ class DetailerHookTests(unittest.TestCase):
 
 
 class AutocompleteDatasetTests(unittest.TestCase):
-    def test_search_autocomplete_normalizes_result_limit_and_bounds_scanning(self):
+    def test_search_autocomplete_ranks_exact_before_prefix_substring_and_description(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tags.csv"
+            path.write_text(
+                "\n".join(
+                    [
+                        'target prefix popular,0,1000,"[일반] prefix"',
+                        'popular target middle,0,900,"[일반] substring"',
+                        'description only,0,800,"[일반] target description"',
+                        'target,0,1,"[일반] exact"',
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = search_autocomplete("target", limit=4, path=path)
+
+        self.assertEqual(
+            [item["tag"] for item in result["results"]],
+            [
+                "target",
+                "target prefix popular",
+                "popular target middle",
+                "description only",
+            ],
+        )
+        self.assertEqual(result["results"][0]["count"], 1)
+
+    def test_search_autocomplete_normalizes_limit_and_matches_exhaustive_reference(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tags.csv"
             path.write_text(
@@ -3100,26 +3132,74 @@ class AutocompleteDatasetTests(unittest.TestCase):
             self.assertEqual(len(search_autocomplete("limit match", limit=-1, path=path)["results"]), 1)
             self.assertEqual(len(search_autocomplete("limit match", limit=10_000, path=path)["results"]), 100)
 
-        scanned = 0
-
-        def entries():
-            nonlocal scanned
-            for index in range(801):
-                scanned += 1
-                yield autocomplete_dataset.AutocompleteEntry(
-                    tag=f"scan match {index:03d}",
-                    tag_key=f"scan match {index:03d}",
-                    category="general",
-                    count=1000 - index,
-                    description="[일반] 스캔 제한 테스트",
-                    search=f"scan match {index:03d}",
+            path.write_text(
+                "\n".join(
+                    itertools.chain(
+                        ('needle,0,1,"[일반] low count exact"',),
+                        (
+                            f'needle prefix {index:03d},{index % 2},{2000 - index},"[일반] prefix"'
+                            for index in range(130)
+                        ),
+                        (
+                            f'popular needle middle {index:03d},{index % 2},{1800 - index},"[일반] substring"'
+                            for index in range(130)
+                        ),
+                        (
+                            f'description only {index:03d},{index % 2},{1600 - index},"[일반] needle description"'
+                            for index in range(130)
+                        ),
+                    )
                 )
+                + "\n",
+                encoding="utf-8",
+            )
+            next_mtime = path.stat().st_mtime_ns + 1_000_000_000
+            os.utime(path, ns=(next_mtime, next_mtime))
 
-        with patch.object(autocomplete_dataset, "_entries", return_value=entries()):
-            result = search_autocomplete("scan match", limit=10_000, path=Path("missing.csv"))
+            entries = autocomplete_dataset._entries(path)
 
-        self.assertEqual(len(result["results"]), 100)
-        self.assertEqual(scanned, 800)
+            def exhaustive(query, requested_limit, category=""):
+                normalized_query = autocomplete_dataset._normalize(query)
+                categories = {item.strip() for item in category.split(",") if item.strip()}
+                ranked = []
+                for entry in entries:
+                    if categories and entry.category not in categories:
+                        continue
+                    if entry.tag_key == normalized_query:
+                        score = 0
+                    elif entry.tag_key.startswith(normalized_query):
+                        score = 1
+                    elif normalized_query in entry.tag_key:
+                        score = 2
+                    elif normalized_query in entry.search:
+                        score = 3
+                    else:
+                        continue
+                    ranked.append((score, entry))
+                ranked.sort(key=lambda item: (item[0], -item[1].count, item[1].tag))
+                limit = max(1, min(requested_limit, 100))
+                return [
+                    {
+                        "tag": entry.tag,
+                        "category": entry.category,
+                        "count": entry.count,
+                        "description": entry.description,
+                    }
+                    for _, entry in ranked[:limit]
+                ]
+
+            for requested_limit, category in ((1, ""), (7, "artist"), (100, "artist,general")):
+                with self.subTest(requested_limit=requested_limit, category=category):
+                    optimized = search_autocomplete(
+                        "needle",
+                        limit=requested_limit,
+                        path=path,
+                        category=category,
+                    )["results"]
+                    self.assertEqual(
+                        optimized,
+                        exhaustive("needle", requested_limit, category),
+                    )
 
     def test_searches_english_tags_and_korean_descriptions(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -3181,19 +3261,232 @@ class AutocompleteDatasetTests(unittest.TestCase):
 
         self.assertEqual(result["results"][0]["tag"], "asuna (blue archive)")
 
-    def test_autocomplete_cache_reloads_when_csv_mtime_changes(self):
+    def test_autocomplete_cache_key_and_mtime_or_size_invalidation(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tags.csv"
             path.write_text('alpha tag,0,100,"[일반] 첫 태그"\n', encoding="utf-8")
 
             first = search_autocomplete("alpha", path=path)
-            path.write_text('beta tag,0,100,"[일반] 두 번째 태그"\n', encoding="utf-8")
-            next_mtime = path.stat().st_mtime_ns + 1_000_000_000
-            os.utime(path, ns=(next_mtime, next_mtime))
+            first_stat = path.stat()
+            first_key = autocomplete_dataset._cache_key(path.parent / "." / path.name)
+
+            path.write_text('beta longer tag,0,100,"[일반] 두 번째 태그"\n', encoding="utf-8")
+            os.utime(path, ns=(first_stat.st_atime_ns, first_stat.st_mtime_ns))
             second = search_autocomplete("beta", path=path)
+            second_stat = path.stat()
+            second_key = autocomplete_dataset._cache_key(path)
+
+            path.write_text('zeta longer tag,0,100,"[일반] 세 번째 태그"\n', encoding="utf-8")
+            next_mtime = second_stat.st_mtime_ns + 1_000_000_000
+            os.utime(path, ns=(next_mtime, next_mtime))
+            third = search_autocomplete("zeta", path=path)
+
+            with patch.object(
+                autocomplete_dataset,
+                "_AUTOCOMPLETE_CACHE_SCHEMA_VERSION",
+                first_key.schema_version + 1,
+            ):
+                schema_key = autocomplete_dataset._cache_key(path)
 
         self.assertEqual(first["results"][0]["tag"], "alpha tag")
-        self.assertEqual(second["results"][0]["tag"], "beta tag")
+        self.assertEqual(second["results"][0]["tag"], "beta longer tag")
+        self.assertEqual(third["results"][0]["tag"], "zeta longer tag")
+        self.assertEqual(first_key.resolved_path, str(path.resolve(strict=False)))
+        self.assertEqual(first_key.mtime_ns, second_key.mtime_ns)
+        self.assertNotEqual(first_key.size, second_key.size)
+        self.assertEqual(schema_key.schema_version, first_key.schema_version + 1)
+
+    def test_autocomplete_cache_coalesces_concurrent_same_key_loads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tags.csv"
+            path.write_text('shared tag,0,100,"[일반] shared"\n', encoding="utf-8")
+            start = threading.Barrier(3)
+            load_started = threading.Event()
+            waiter_joined = threading.Event()
+            release_load = threading.Event()
+            original_load = autocomplete_dataset._load_entries
+            original_await = autocomplete_dataset._await_snapshot
+
+            def blocking_load(load_path):
+                load_started.set()
+                if not release_load.wait(timeout=5):
+                    raise AssertionError("timed out waiting to release dataset load")
+                return original_load(load_path)
+
+            def observed_await(future):
+                waiter_joined.set()
+                return original_await(future)
+
+            def fetch_entries():
+                start.wait(timeout=5)
+                return autocomplete_dataset._entries(path)
+
+            with (
+                patch.object(
+                    autocomplete_dataset,
+                    "_load_entries",
+                    side_effect=blocking_load,
+                ) as load_entries,
+                patch.object(
+                    autocomplete_dataset,
+                    "_await_snapshot",
+                    side_effect=observed_await,
+                ),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                futures = [executor.submit(fetch_entries) for _ in range(2)]
+                start.wait(timeout=5)
+                self.assertTrue(load_started.wait(timeout=5))
+                try:
+                    self.assertTrue(waiter_joined.wait(timeout=5))
+                finally:
+                    release_load.set()
+                loaded = [future.result(timeout=5) for future in futures]
+
+        self.assertEqual(load_entries.call_count, 1)
+        self.assertIs(loaded[0], loaded[1])
+        self.assertEqual(loaded[0][0].tag, "shared tag")
+
+    def test_autocomplete_cache_loads_different_sources_in_parallel_without_pollution(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first_path = Path(tmp) / "first.csv"
+            second_path = Path(tmp) / "second.csv"
+            first_path.write_text('first tag,0,100,"[일반] first"\n', encoding="utf-8")
+            second_path.write_text('second tag,0,90,"[일반] second"\n', encoding="utf-8")
+            loads_meet = threading.Barrier(2)
+            original_load = autocomplete_dataset._load_entries
+
+            def parallel_load(load_path):
+                loads_meet.wait(timeout=5)
+                return original_load(load_path)
+
+            with (
+                patch.object(
+                    autocomplete_dataset,
+                    "_load_entries",
+                    side_effect=parallel_load,
+                ) as load_entries,
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                first_future = executor.submit(autocomplete_dataset._snapshot, first_path)
+                second_future = executor.submit(autocomplete_dataset._snapshot, second_path)
+                first_snapshot = first_future.result(timeout=5)
+                second_snapshot = second_future.result(timeout=5)
+
+        self.assertEqual(load_entries.call_count, 2)
+        self.assertEqual([entry.tag for entry in first_snapshot.entries], ["first tag"])
+        self.assertEqual([entry.tag for entry in second_snapshot.entries], ["second tag"])
+        self.assertEqual(set(first_snapshot.entry_map), {"first tag"})
+        self.assertEqual(set(second_snapshot.entry_map), {"second tag"})
+        self.assertIsInstance(first_snapshot.entries, tuple)
+        with self.assertRaises(TypeError):
+            first_snapshot.entry_map["mutated"] = first_snapshot.entries[0]
+
+    def test_autocomplete_cache_retries_replacement_and_treats_deletion_as_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            replacement_path = Path(tmp) / "replacement.csv"
+            replacement_path.write_text('old tag,0,100,"[일반] old"\n', encoding="utf-8")
+            replacement_started = threading.Event()
+            replacement_done = threading.Event()
+            original_load = autocomplete_dataset._load_entries
+            load_count = 0
+            load_count_lock = threading.Lock()
+
+            def replacement_load(load_path):
+                nonlocal load_count
+                with load_count_lock:
+                    load_count += 1
+                    current_load = load_count
+                if current_load == 1:
+                    replacement_started.set()
+                    if not replacement_done.wait(timeout=5):
+                        raise AssertionError("timed out waiting for dataset replacement")
+                return original_load(load_path)
+
+            with (
+                patch.object(
+                    autocomplete_dataset,
+                    "_load_entries",
+                    side_effect=replacement_load,
+                ),
+                ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                replacement_future = executor.submit(
+                    search_autocomplete,
+                    "new replacement",
+                    20,
+                    replacement_path,
+                )
+                self.assertTrue(replacement_started.wait(timeout=5))
+                replacement_path.write_text(
+                    'new replacement tag,0,80,"[일반] replacement with a different size"\n',
+                    encoding="utf-8",
+                )
+                replacement_done.set()
+                replacement = replacement_future.result(timeout=5)
+
+            deletion_path = Path(tmp) / "deletion.csv"
+            deletion_path.write_text('deleted tag,0,100,"[일반] delete"\n', encoding="utf-8")
+            deletion_started = threading.Event()
+            deletion_done = threading.Event()
+            deletion_load_count = 0
+
+            def deletion_load(load_path):
+                nonlocal deletion_load_count
+                deletion_load_count += 1
+                if deletion_load_count == 1:
+                    deletion_started.set()
+                    if not deletion_done.wait(timeout=5):
+                        raise AssertionError("timed out waiting for dataset deletion")
+                    raise FileNotFoundError(load_path)
+                return original_load(load_path)
+
+            with (
+                patch.object(
+                    autocomplete_dataset,
+                    "_load_entries",
+                    side_effect=deletion_load,
+                ),
+                ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                deletion_future = executor.submit(
+                    search_autocomplete,
+                    "deleted",
+                    20,
+                    deletion_path,
+                )
+                self.assertTrue(deletion_started.wait(timeout=5))
+                deletion_path.unlink()
+                deletion_done.set()
+                deletion = deletion_future.result(timeout=5)
+
+        self.assertEqual(load_count, 2)
+        self.assertEqual(replacement["results"][0]["tag"], "new replacement tag")
+        self.assertTrue(replacement["status"]["exists"])
+        self.assertEqual(deletion_load_count, 1)
+        self.assertEqual(deletion["results"], [])
+        self.assertFalse(deletion["status"]["exists"])
+        self.assertEqual(deletion["status"]["count"], 0)
+
+    def test_autocomplete_cache_has_a_bounded_repeated_change_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "unstable.csv"
+            path.write_text('unstable tag,0,100,"[일반] unstable"\n', encoding="utf-8")
+            with patch.object(
+                autocomplete_dataset,
+                "_snapshot_for_key",
+                side_effect=autocomplete_dataset._AutocompleteSourceChanged(str(path)),
+            ) as snapshot_for_key:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Autocomplete dataset changed repeatedly while loading",
+                ):
+                    autocomplete_dataset._snapshot(path)
+
+        self.assertEqual(
+            snapshot_for_key.call_count,
+            autocomplete_dataset._AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS,
+        )
 
     def test_can_limit_autocomplete_to_artist_tags(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 변경 요약
- 자동완성 검색을 전체 후보 기준으로 평가해 exact > prefix > substring > description 순위를 보장합니다.
- 낮은 count의 exact tag도 조기 종료에 잘리지 않고 top-1에 오도록 합니다.
- top N 선택은 exhaustive reference와 같은 정렬 키를 쓰는 bounded heap으로 계산합니다.
- source cache를 resolved path, mtime_ns, size, schema version key의 immutable snapshot으로 전환합니다.
- entries와 read-only entry_map을 완성한 뒤 짧은 lock 구간에서 atomic publish합니다.
- 동일 key 최초 로딩은 Future로 합치고 다른 source I/O는 lock 밖에서 병렬 진행합니다.
- 로딩 중 파일 교체는 재시도, 삭제는 기존의 빈 dataset 의미를 유지하며 반복 교체는 결정적 오류로 종료합니다.

## 주요 파일
- `autocomplete_dataset.py`
- `tests/test_prompt_corrector.py`

## 검증
- focused backend: 31 tests OK
- 저장소 공식 full runner: 통과
  - Python unittest: 419 tests OK
  - Frontend: 110 JavaScript files, TypeScript 6.0.3 통과
- compile 및 `git diff --check`: 통과

## 테스트 표면
- exact/prefix/substring/description ranking parity
- 서로 다른 source 병렬 최초 로딩
- 같은 source single-flight
- 파일 교체·삭제·반복 변경 정책
- ComfyUI Codex test instance의 Python/프론트엔드 정적·semantic smoke
- Live ComfyUI smoke: 실행하지 않음

## 남은 위험
- 같은 경로의 파일이 mtime_ns와 size를 모두 보존한 채 교체되는 비정상 환경은 cache key로 구분되지 않습니다. 이는 이슈에서 정한 key 계약과 같습니다.
- source path별 snapshot map은 현재 설정 가능한 source 수가 작다는 전제이며 별도 eviction은 두지 않았습니다.

Closes #161