### PR TITLE
AiO Generator 정적 안내를 접근 가능한 정보 툴팁으로 정리

### DIFF
--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -812,6 +812,34 @@ highresFollowInfo.boundingClientRect = { left: 160, top: 40, width: 22, height: 
 fixture.dispatchWindow("resize");
 assert.equal(highresFollowTooltip.style.left, "160px");
 assert.equal(highresFollowTooltip.style.top, "68px");
+fixture.window.innerHeight = 320;
+highresFollowInfo.boundingClientRect = { left: 160, top: 280, width: 22, height: 22 };
+highresFollowTooltip.boundingClientRect = { left: 0, top: 0, width: 240, height: 80 };
+fixture.dispatchWindow("scroll");
+assert.equal(
+  highresFollowTooltip.style.top,
+  "194px",
+  "a bottom-edge tooltip must flip above its info icon",
+);
+assert.ok(
+  Number.parseInt(highresFollowTooltip.style.top, 10) + 80 <= fixture.window.innerHeight - 8,
+  "a flipped tooltip must retain the viewport bottom margin",
+);
+fixture.window.innerHeight = 100;
+highresFollowInfo.boundingClientRect = { left: 160, top: 90, width: 22, height: 22 };
+highresFollowTooltip.boundingClientRect = { left: 0, top: 0, width: 84, height: 84 };
+fixture.dispatchWindow("resize");
+assert.equal(
+  highresFollowTooltip.style.top,
+  "8px",
+  "a flipped tooltip must clamp to the viewport top margin",
+);
+assert.equal(
+  Number.parseInt(highresFollowTooltip.style.top, 10) + 84,
+  fixture.window.innerHeight - 8,
+  "the clamped tooltip must stay inside the viewport bottom margin when it fits",
+);
+fixture.window.innerHeight = 768;
 highresFollowInfo.emit("pointerleave");
 assert.equal(highresFollowTooltip.hidden, true);
 assert.equal(fixture.windowListenerCount("resize"), 0);

--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -26,6 +26,10 @@ function findByText(root, textContent) {
   return find(root, (element) => element.textContent === textContent);
 }
 
+function findByAttribute(root, name, value) {
+  return find(root, (element) => element.getAttribute(name) === value);
+}
+
 function findField(root, label) {
   return find(root, (element) => element.getAttribute("data-test-label") === label);
 }
@@ -69,6 +73,44 @@ assert.deepEqual(
     new URL("../web/js/easyuse_anima_aio.js", import.meta.url),
     "utf8",
   );
+  assert.match(
+    entrySource,
+    /\.easyuse-anima-aio-node-info-button:focus-visible\s*\{/,
+    "info icons must publish a keyboard-visible focus ring",
+  );
+  assert.match(
+    entrySource,
+    /\.easyuse-anima-aio-node-info-tooltip\s*\{[^}]*pointer-events:\s*none;/s,
+    "tooltip portals must not intercept panel wheel or pointer routing",
+  );
+  for (const removedTextKey of [
+    "text.highresDisabled",
+    "text.detailerDisabled",
+    "text.upscaleDisabled",
+    "text.postprocessDisabled",
+    "text.inheritsMainSampler",
+    "text.usesStageSamplerOverride",
+  ]) {
+    assert.equal(
+      entrySource.includes(`"${removedTextKey}"`),
+      false,
+      removedTextKey + " must not remain duplicated as inline text",
+    );
+  }
+  for (const localizedTipKey of [
+    "label.info",
+    "tip.highresDisabled",
+    "tip.detailerDisabled",
+    "tip.upscaleDisabled",
+    "tip.postprocessDisabled",
+    "tip.stageSamplerOverride",
+  ]) {
+    assert.equal(
+      entrySource.split(`"${localizedTipKey}"`).length - 1,
+      4,
+      localizedTipKey + " must preserve en/ko/ja/zh meaning",
+    );
+  }
   const functionStart = entrySource.indexOf("function commitGeneratorSeedValue");
   const functionEnd = entrySource.indexOf(
     "\nfunction syncGeneratorSerializedWidgets",
@@ -600,9 +642,28 @@ fixture.runtime.ensurePanel(node);
 const firstEnsureTrace = fixture.trace.slice(firstEnsureStart);
 const panel = node.__easyuseAnimaGeneratorPanelEl;
 const firstMain = panel.children[0];
+const firstInfoButtons = panel.querySelectorAll("[data-aio-info-button]");
+const firstInfoTooltips = fixture.document.querySelectorAll("[data-aio-info-tooltip]");
+assert.equal(firstInfoButtons.length, firstInfoTooltips.length);
+assert.equal(firstInfoButtons.length, 8, "each static stage/field hint must own one info icon");
 const secondEnsureStart = fixture.trace.length;
 fixture.runtime.ensurePanel(node);
 const secondEnsureTrace = fixture.trace.slice(secondEnsureStart);
+assert.equal(
+  firstInfoTooltips.every((tooltip) => tooltip.parentElement == null),
+  true,
+  "rerender must remove every tooltip portal owned by the previous render",
+);
+assert.equal(
+  firstInfoButtons.every((button) => button.listenerCount("click") === 0),
+  true,
+  "rerender must dispose old info-button listeners",
+);
+assert.equal(
+  panel.querySelectorAll("[data-aio-info-button]").length,
+  fixture.document.querySelectorAll("[data-aio-info-tooltip]").length,
+  "rerender must not duplicate info buttons or tooltip portals",
+);
 const initialPanelLifecycle = fixture.runtime.activatePanel(node);
 assert.equal(fixture.runtime.activatePanel(node), initialPanelLifecycle);
 const assertEnsureOrder = (runTrace) => {
@@ -714,6 +775,66 @@ assert.deepEqual(
     "text:title.postprocess",
   ],
 );
+const serializedBeforeInfoInteraction = node.widgets_values;
+const settingsBeforeInfoInteraction = clone(node.settings);
+const highresFollowInfo = findByAttribute(
+  panel,
+  "data-aio-focus-key",
+  "highres.follow-main.info",
+);
+assert.ok(highresFollowInfo, "Highres follow-main field must expose an info icon");
+assert.equal(highresFollowInfo.textContent, "i");
+assert.equal(highresFollowInfo.type, "button");
+assert.equal(highresFollowInfo.getAttribute("data-aio-info-key"), "tip.stageSamplerOverride");
+assert.equal(highresFollowInfo.getAttribute("aria-label"), "text:label.info");
+assert.equal(highresFollowInfo.getAttribute("aria-expanded"), "false");
+assert.equal(highresFollowInfo.title, "", "custom info tooltip must not compete with native title UI");
+const highresFollowTooltip = findByAttribute(
+  fixture.document.body,
+  "id",
+  highresFollowInfo.getAttribute("aria-describedby"),
+);
+assert.ok(highresFollowTooltip, "aria-describedby must own a live tooltip portal");
+assert.equal(highresFollowInfo.getAttribute("aria-controls"), highresFollowTooltip.getAttribute("id"));
+assert.equal(highresFollowTooltip.getAttribute("role"), "tooltip");
+assert.equal(highresFollowTooltip.textContent, "text:tip.stageSamplerOverride");
+assert.equal(highresFollowTooltip.hidden, true);
+highresFollowInfo.emit("pointerenter");
+assert.equal(highresFollowTooltip.hidden, false, "mouse/pointer hover must open the tooltip");
+assert.equal(highresFollowInfo.getAttribute("aria-expanded"), "true");
+assert.equal(fixture.windowListenerCount("resize"), 1);
+assert.equal(fixture.windowListenerCount("scroll", true), 1);
+highresFollowInfo.boundingClientRect = { left: 120, top: 80, width: 22, height: 22 };
+fixture.dispatchWindow("scroll");
+assert.equal(highresFollowTooltip.style.left, "120px");
+assert.equal(highresFollowTooltip.style.top, "108px");
+highresFollowInfo.boundingClientRect = { left: 160, top: 40, width: 22, height: 22 };
+fixture.dispatchWindow("resize");
+assert.equal(highresFollowTooltip.style.left, "160px");
+assert.equal(highresFollowTooltip.style.top, "68px");
+highresFollowInfo.emit("pointerleave");
+assert.equal(highresFollowTooltip.hidden, true);
+assert.equal(fixture.windowListenerCount("resize"), 0);
+assert.equal(fixture.windowListenerCount("scroll"), 0);
+highresFollowInfo.emit("focus");
+assert.equal(highresFollowTooltip.hidden, false, "keyboard focus must open the tooltip");
+highresFollowInfo.emit("keydown", { key: "Enter" });
+assert.equal(highresFollowTooltip.hidden, true, "Enter must close a focused open tooltip");
+highresFollowInfo.emit("keydown", { key: "Enter" });
+assert.equal(highresFollowTooltip.hidden, false, "a second Enter must reopen the tooltip");
+highresFollowInfo.emit("keydown", { key: " " });
+assert.equal(highresFollowTooltip.hidden, true, "Space must close the tooltip");
+highresFollowInfo.emit("keydown", { key: " " });
+assert.equal(highresFollowTooltip.hidden, false, "a second Space must reopen the tooltip");
+highresFollowInfo.emit("keydown", { key: "Escape" });
+assert.equal(highresFollowTooltip.hidden, true, "Escape must close the tooltip");
+highresFollowInfo.emit("blur");
+highresFollowInfo.emit("click");
+assert.equal(highresFollowTooltip.hidden, false, "click/touch activation must open the tooltip");
+highresFollowInfo.emit("click");
+assert.equal(highresFollowTooltip.hidden, true, "a second click must close the tooltip");
+assert.deepEqual(node.settings, settingsBeforeInfoInteraction);
+assert.equal(node.widgets_values, serializedBeforeInfoInteraction);
 assert.equal(
   panel.querySelector("[data-aio-preview-box]").className,
   "easyuse-anima-aio-node-preview-box",
@@ -985,6 +1106,22 @@ assert.ok(
   "settings write must complete before summary/profile refresh",
 );
 assert.notEqual(panel.children[0], main, "rerendering a stage toggle must replace panel children");
+const disabledHighresBlock = panel.querySelector(
+  ".easyuse-anima-aio-node-settings-scroll",
+).children[1];
+assert.equal(disabledHighresBlock.children[1].children.length, 0);
+assert.equal(findByText(disabledHighresBlock, "text:tip.highresDisabled"), null);
+assert.equal(
+  findByAttribute(disabledHighresBlock, "data-aio-focus-key", "highres.info")
+    .getAttribute("data-aio-info-key"),
+  "tip.highresDisabled",
+  "disabled Highres guidance must move from body note to the header info icon",
+);
+assert.equal(
+  panel.querySelectorAll("[data-aio-info-button]").length,
+  fixture.document.querySelectorAll("[data-aio-info-tooltip]").length,
+  "stage on/off rerender must keep one owned tooltip per icon",
+);
 
 while (fixture.animationFrames.length) {
   fixture.animationFrames.shift()();
@@ -1177,6 +1314,74 @@ for (const eventName of PANEL_EVENT_NAMES) {
 while (fixture.animationFrames.length) {
   fixture.animationFrames.shift()();
 }
+const tooltipSettingsSnapshot = clone(node.settings);
+const tooltipSerializedSnapshot = node.widgets_values;
+node.settings.highres.enabled = false;
+node.settings.detailer.enabled = false;
+node.settings.upscale.enabled = false;
+node.settings.postprocess.enabled = false;
+fixture.runtime.renderPanel(node);
+const disabledStages = panel.querySelector(
+  ".easyuse-anima-aio-node-settings-scroll",
+).children.slice(1);
+assert.equal(disabledStages.length, 4);
+assert.equal(
+  disabledStages.every((stage) => stage.children[1].children.length === 0),
+  true,
+  "disabled stages must not reserve body rows for static help notes",
+);
+assert.equal(
+  panel.querySelectorAll(".easyuse-anima-aio-node-stage-note").length,
+  0,
+  "static disabled guidance must not remain inline",
+);
+assert.deepEqual(
+  disabledStages.map(
+    (stage) => stage.children[0].children[0].children[0].getAttribute("data-aio-info-key"),
+  ),
+  [
+    "tip.highresDisabled",
+    "tip.detailerDisabled",
+    "tip.upscaleDisabled",
+    "tip.postprocessDisabled",
+  ],
+);
+
+node.settings.highres.enabled = true;
+node.settings.highres.inherit_sampler_settings = true;
+node.settings.sampler.backend = "spectrum_spd_speed";
+fixture.runtime.renderPanel(node);
+const inlineWarnings = panel.querySelectorAll("[data-aio-inline-warning]");
+assert.equal(inlineWarnings.length, 1, "the SPD/SPEED fallback must remain inline");
+assert.equal(inlineWarnings[0].textContent, "text:text.highresSpdManualRequired");
+assert.equal(inlineWarnings[0].classList.contains("warning"), true);
+assert.equal(
+  findByAttribute(panel, "data-aio-focus-key", "highres.follow-main.info")
+    .getAttribute("data-aio-info-key"),
+  "tip.highresFollow",
+);
+
+const profileTooltips = fixture.document.querySelectorAll("[data-aio-info-tooltip]");
+node.profileValue = "user:Tooltip profile";
+fixture.runtime.renderPanel(node);
+assert.equal(
+  profileTooltips.every((tooltip) => tooltip.parentElement == null),
+  true,
+  "profile-driven rerender must clean stale tooltip portals",
+);
+assert.equal(
+  panel.querySelectorAll("[data-aio-info-button]").length,
+  fixture.document.querySelectorAll("[data-aio-info-tooltip]").length,
+  "profile-driven rerender must not duplicate tooltips",
+);
+
+node.settings = tooltipSettingsSnapshot;
+fixture.runtime.renderPanel(node);
+assert.equal(node.widgets_values, tooltipSerializedSnapshot);
+assert.deepEqual(node.settings, tooltipSettingsSnapshot);
+while (fixture.animationFrames.length) {
+  fixture.animationFrames.shift()();
+}
 const summaryTraceStart = fixture.trace.length;
 fixture.runtime.scheduleSummary(node);
 fixture.runtime.scheduleSummary(node);
@@ -1202,6 +1407,10 @@ const pendingFrameIds = fixture.animationFrames
   .map((callback) => callback.__frameId)
   .sort((left, right) => left - right);
 const activeDisposeSlider = findByClass(panel, "easyuse-anima-aio-node-slider-track");
+const activeDisposeInfo = findByAttribute(panel, "data-aio-focus-key", "highres.info");
+activeDisposeInfo.emit("click");
+assert.equal(fixture.windowListenerCount("resize"), 1);
+assert.equal(fixture.windowListenerCount("scroll", true), 1);
 activeDisposeSlider.emit("pointerdown", {
   pointerId: 23,
   clientX: 60,
@@ -1239,6 +1448,8 @@ assert.equal(fixture.windowListenerCount("pointermove"), 0);
 assert.equal(fixture.windowListenerCount("pointerup"), 0);
 assert.equal(fixture.windowListenerCount("pointercancel"), 0);
 assert.equal(fixture.windowListenerCount("blur"), 0);
+assert.equal(fixture.windowListenerCount("resize"), 0);
+assert.equal(fixture.windowListenerCount("scroll"), 0);
 for (const eventName of PANEL_EVENT_NAMES) {
   assert.equal(panel.listenerCount(eventName), 0, eventName + " listener must be disposed");
 }
@@ -1250,6 +1461,11 @@ assert.equal(node.widgets.length, 0);
 assert.equal(panelWidget.onRemoveCalls, 1);
 assert.equal(fixture.domWidgetStore.size, 0);
 assert.equal(fixture.domWidgetStore.has(panelWidget), false);
+assert.equal(
+  fixture.document.querySelectorAll("[data-aio-info-tooltip]").length,
+  0,
+  "dispose must remove every tooltip portal",
+);
 assert.equal(node.widgets_values, serializedWidgetValues);
 assert.equal(node.__easyuseAnimaGeneratorPreviewImages, finalPreviewImages);
 

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -1179,13 +1179,23 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
         const rect = button.getBoundingClientRect?.() || {};
         const tooltipRect = tooltip.getBoundingClientRect?.() || {};
         const viewportWidth = Number(window?.innerWidth) || 0;
+        const viewportHeight = Number(window?.innerHeight) || 0;
         const tooltipWidth = Number(tooltipRect.width) || 280;
+        const tooltipHeight = Number(tooltipRect.height) || 0;
         let left = Number(rect.left) || 0;
         if (viewportWidth > 0) {
           left = Math.min(left, viewportWidth - tooltipWidth - 8);
         }
         tooltip.style.left = `${Math.max(8, Math.round(left))}px`;
-        tooltip.style.top = `${Math.round((Number(rect.top) || 0) + (Number(rect.height) || 0) + 6)}px`;
+        const anchorTop = Number(rect.top) || 0;
+        let top = anchorTop + (Number(rect.height) || 0) + 6;
+        if (viewportHeight > 0 && top + tooltipHeight > viewportHeight - 8) {
+          top = anchorTop - tooltipHeight - 6;
+        }
+        const maxTop = viewportHeight > 0
+          ? Math.floor(viewportHeight - tooltipHeight - 8)
+          : Number.POSITIVE_INFINITY;
+        tooltip.style.top = `${Math.max(8, Math.min(Math.round(top), maxTop))}px`;
       };
       const updatePositionTracking = (enabled) => {
         if (trackingPosition === enabled) {

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -195,10 +195,12 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
 
   const generatorPanelLifecycleStates = new WeakMap();
   const disposedGeneratorPanelNodes = new WeakSet();
+  let nextGeneratorInfoTooltipId = 1;
 
   function createGeneratorPanelLifecycleState() {
     return {
       frames: new Map(),
+      infoTooltipCleanups: new Set(),
       sliderDragCleanups: new Set(),
     };
   }
@@ -271,6 +273,25 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
     }
   }
 
+  function cleanupGeneratorInfoTooltips(state) {
+    let hasError = false;
+    let firstError = null;
+    for (const cleanup of [...(state?.infoTooltipCleanups || [])]) {
+      try {
+        cleanup();
+      } catch (error) {
+        if (!hasError) {
+          hasError = true;
+          firstError = error;
+        }
+      }
+    }
+    state?.infoTooltipCleanups?.clear?.();
+    if (hasError) {
+      throw firstError;
+    }
+  }
+
   function disposeGeneratorPanel(node) {
     if (!node || disposedGeneratorPanelNodes.has(node)) {
       return false;
@@ -294,6 +315,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
         cleanup(() => cancelAnimationFrame(pending.frame));
       }
       state.frames.clear();
+      cleanup(() => cleanupGeneratorInfoTooltips(state));
       cleanup(() => cleanupGeneratorSliderDrags(state));
     }
     generatorPanelLifecycleStates.delete(node);
@@ -1093,6 +1115,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       return;
     }
     const viewState = captureGeneratorPanelViewState(panel);
+    cleanupGeneratorInfoTooltips(lifecycleState);
     cleanupGeneratorSliderDrags(lifecycleState);
     const settings = generatorSettings(node);
     panel.replaceChildren();
@@ -1115,6 +1138,180 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       button.addEventListener("click", callback);
       return button;
     };
+    const makeInfoButton = (textKey, focusKey = "") => {
+      const button = document.createElement("button");
+      button.className = "easyuse-anima-aio-node-info-button";
+      button.type = "button";
+      button.textContent = "i";
+      button.setAttribute("data-aio-info-button", "");
+      button.setAttribute("data-aio-info-key", textKey);
+      if (focusKey) {
+        button.setAttribute("data-aio-focus-key", focusKey);
+      }
+      applyTooltip(button, textKey);
+      const tooltipText = String(button.title || aioText(textKey));
+      button.title = "";
+
+      const tooltip = document.createElement("div");
+      const tooltipId = `easyuse-anima-aio-info-tooltip-${nextGeneratorInfoTooltipId}`;
+      nextGeneratorInfoTooltipId += 1;
+      tooltip.className = "easyuse-anima-aio-node-info-tooltip";
+      tooltip.setAttribute("id", tooltipId);
+      tooltip.setAttribute("role", "tooltip");
+      tooltip.setAttribute("data-aio-info-tooltip", "");
+      tooltip.textContent = tooltipText;
+      tooltip.hidden = true;
+      document.body.append(tooltip);
+
+      button.setAttribute("aria-label", aioText("label.info"));
+      button.setAttribute("aria-controls", tooltipId);
+      button.setAttribute("aria-describedby", tooltipId);
+      button.setAttribute("aria-expanded", "false");
+
+      let disposed = false;
+      let dismissed = false;
+      let focused = false;
+      let hovered = false;
+      let pinned = false;
+      let trackingPosition = false;
+
+      const positionTooltip = () => {
+        const rect = button.getBoundingClientRect?.() || {};
+        const tooltipRect = tooltip.getBoundingClientRect?.() || {};
+        const viewportWidth = Number(window?.innerWidth) || 0;
+        const tooltipWidth = Number(tooltipRect.width) || 280;
+        let left = Number(rect.left) || 0;
+        if (viewportWidth > 0) {
+          left = Math.min(left, viewportWidth - tooltipWidth - 8);
+        }
+        tooltip.style.left = `${Math.max(8, Math.round(left))}px`;
+        tooltip.style.top = `${Math.round((Number(rect.top) || 0) + (Number(rect.height) || 0) + 6)}px`;
+      };
+      const updatePositionTracking = (enabled) => {
+        if (trackingPosition === enabled) {
+          return;
+        }
+        trackingPosition = enabled;
+        if (enabled) {
+          window.addEventListener("resize", positionTooltip);
+          window.addEventListener("scroll", positionTooltip, true);
+        } else {
+          window.removeEventListener("resize", positionTooltip);
+          window.removeEventListener("scroll", positionTooltip, true);
+        }
+      };
+      const syncVisibility = () => {
+        if (disposed) {
+          return;
+        }
+        const visible = !dismissed && (hovered || focused || pinned);
+        tooltip.hidden = !visible;
+        button.setAttribute("aria-expanded", visible ? "true" : "false");
+        updatePositionTracking(visible);
+        if (visible) {
+          positionTooltip();
+        }
+      };
+      const onPointerEnter = () => {
+        hovered = true;
+        dismissed = false;
+        syncVisibility();
+      };
+      const onPointerLeave = () => {
+        hovered = false;
+        if (!focused && !pinned) {
+          dismissed = false;
+        }
+        syncVisibility();
+      };
+      const onFocus = () => {
+        focused = true;
+        dismissed = false;
+        syncVisibility();
+      };
+      const onBlur = () => {
+        focused = false;
+        if (!hovered && !pinned) {
+          dismissed = false;
+        }
+        syncVisibility();
+      };
+      const togglePinned = (event) => {
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+        if (pinned) {
+          pinned = false;
+          dismissed = true;
+        } else {
+          pinned = true;
+          dismissed = false;
+        }
+        syncVisibility();
+      };
+      const onClick = (event) => togglePinned(event);
+      const onKeyDown = (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault?.();
+          event.stopPropagation?.();
+          if (tooltip.hidden) {
+            pinned = true;
+            dismissed = false;
+          } else {
+            pinned = false;
+            dismissed = true;
+          }
+          syncVisibility();
+        } else if (event.key === "Escape") {
+          event.preventDefault?.();
+          event.stopPropagation?.();
+          pinned = false;
+          dismissed = true;
+          syncVisibility();
+        }
+      };
+      const listeners = [
+        ["pointerenter", onPointerEnter],
+        ["pointerleave", onPointerLeave],
+        ["focus", onFocus],
+        ["blur", onBlur],
+        ["click", onClick],
+        ["keydown", onKeyDown],
+      ];
+      for (const [eventName, listener] of listeners) {
+        button.addEventListener(eventName, listener);
+      }
+
+      const cleanup = () => {
+        if (disposed) {
+          return;
+        }
+        disposed = true;
+        updatePositionTracking(false);
+        for (const [eventName, listener] of listeners) {
+          button.removeEventListener(eventName, listener);
+        }
+        tooltip.remove();
+        lifecycleState.infoTooltipCleanups.delete(cleanup);
+      };
+      lifecycleState.infoTooltipCleanups.add(cleanup);
+      return button;
+    };
+    const makeInfoField = (
+      label,
+      control,
+      className,
+      tooltipKey,
+      infoTextKey,
+      infoFocusKey,
+    ) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = `easyuse-anima-aio-node-info-field ${className || ""}`.trim();
+      wrapper.append(
+        createNodeField(label, control, "", tooltipKey),
+        makeInfoButton(infoTextKey, infoFocusKey),
+      );
+      return wrapper;
+    };
     const makeCardHeader = (title, actions = []) => {
       const header = document.createElement("div");
       header.className = "easyuse-anima-aio-node-card-header";
@@ -1127,13 +1324,23 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       header.append(titleEl, actionBox);
       return header;
     };
-    const makeStageHeader = (title, toggle, tooltipKey = "", actions = []) => {
+    const makeStageHeader = (
+      title,
+      toggle,
+      tooltipKey = "",
+      actions = [],
+      infoTextKey = "",
+      infoFocusKey = "",
+    ) => {
       const header = document.createElement("div");
       header.className = "easyuse-anima-aio-node-stage-header";
       const titleEl = document.createElement("div");
       titleEl.className = "easyuse-anima-aio-node-stage-title";
       titleEl.textContent = title;
       applyTooltip(titleEl, tooltipKey);
+      if (infoTextKey) {
+        titleEl.append(makeInfoButton(infoTextKey, infoFocusKey));
+      }
       const toggleLabel = document.createElement("label");
       toggleLabel.className = "easyuse-anima-aio-node-stage-toggle";
       toggleLabel.append(toggle, document.createTextNode(aioText("label.enabled")));
@@ -1150,6 +1357,12 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       note.textContent = aioText(textKey);
       applyTooltip(note, tooltipKey);
       return note;
+    };
+    const makeWarning = (textKey, tooltipKey = "") => {
+      const warning = makeNote(textKey, tooltipKey);
+      warning.classList.add("warning");
+      warning.setAttribute("data-aio-inline-warning", "");
+      return warning;
     };
     const moveDetailerTarget = (targetName, delta) => {
       updateGeneratorSettings(node, (nextSettings) => {
@@ -1312,6 +1525,8 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       highresEnabled,
       "tip.highresEnabled",
       [makeIconButton("⚙", () => openHighresSettings(node), "tip.highresSettings")],
+      settings.highres.enabled ? "tip.highresEnabled" : "tip.highresDisabled",
+      "highres.info",
     ));
     const highresBody = document.createElement("div");
     highresBody.className = "easyuse-anima-aio-node-stage-body";
@@ -1337,12 +1552,18 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
           },
         }),
       });
-      const noteKey = mainBackendIsSpd && highresFollowsMain
-        ? "text.highresSpdManualRequired"
-        : (highresFollowsMain ? "text.inheritsMainSampler" : "text.usesStageSamplerOverride");
       highresBody.append(
-        createNodeField(aioText("label.followMainSampler"), followMain, "wide", "tip.highresFollow"),
-        makeNote(noteKey, "tip.highresFollow"),
+        makeInfoField(
+          aioText("label.followMainSampler"),
+          followMain,
+          "wide",
+          "tip.highresFollow",
+          highresFollowsMain ? "tip.highresFollow" : "tip.stageSamplerOverride",
+          "highres.follow-main.info",
+        ),
+        ...(mainBackendIsSpd && highresFollowsMain
+          ? [makeWarning("text.highresSpdManualRequired", "tip.highresFollow")]
+          : []),
         ...(highresFollowsMain ? [] : [
           createNodeField(aioText("label.mode"), stageMode, "wide", "tip.highresBackend"),
         ]),
@@ -1404,8 +1625,6 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
           "tip.highresMaxEdge",
         ),
       );
-    } else {
-      highresBody.append(makeNote("text.highresDisabled", "tip.highresEnabled"));
     }
     highresBlock.append(highresBody);
 
@@ -1425,6 +1644,8 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       detailerEnabled,
       "tip.detailerEnabled",
       [makeIconButton("⚙", () => openDetailerSettings(node), "tip.detailerSettings")],
+      settings.detailer.enabled ? "tip.detailerEnabled" : "tip.detailerDisabled",
+      "detailer.info",
     ));
     const detailerBody = document.createElement("div");
     detailerBody.className = "easyuse-anima-aio-node-stage-body";
@@ -1479,10 +1700,13 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
             { rerender: true, focusKey: `detailer.${targetName}.inherit-sampler-settings` },
           );
           targetGrid.append(
-            createNodeField(aioText("label.followMainSampler"), followMain, "wide", "tip.detailerFollow"),
-            makeNote(
-              target.inherit_sampler_settings ? "text.inheritsMainSampler" : "text.usesStageSamplerOverride",
+            makeInfoField(
+              aioText("label.followMainSampler"),
+              followMain,
+              "wide",
               "tip.detailerFollow",
+              target.inherit_sampler_settings ? "tip.detailerFollow" : "tip.stageSamplerOverride",
+              `detailer.${targetName}.follow-main.info`,
             ),
             createNodeField(
               aioText("field.threshold"),
@@ -1549,8 +1773,6 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
         targetBlock.append(targetGrid);
         detailerBody.append(targetBlock);
       }
-    } else {
-      detailerBody.append(makeNote("text.detailerDisabled", "tip.detailerEnabled"));
     }
     detailerBlock.append(detailerBody);
 
@@ -1570,6 +1792,8 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       upscaleEnabled,
       "tip.upscaleEnabled",
       [makeIconButton("⚙", () => openUpscaleSettings(node), "tip.upscaleSettings")],
+      settings.upscale.enabled ? "tip.upscaleEnabled" : "tip.upscaleDisabled",
+      "upscale.info",
     ));
     const upscaleBody = document.createElement("div");
     upscaleBody.className = "easyuse-anima-aio-node-stage-body";
@@ -1634,7 +1858,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
             "wide",
             "tip.denoise",
           ),
-          createNodeField(
+          makeInfoField(
             aioText("field.autoTileSize"),
             createDomSettingsCheckboxControl(
               node,
@@ -1648,6 +1872,8 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
             ),
             "wide",
             "tip.usduAutoTile",
+            usdu.auto_tile_size ? "tip.usduAutoTile" : "tip.usduTile",
+            "upscale.usdu.auto-tile.info",
           ),
         );
         if (usdu.auto_tile_size) {
@@ -1667,17 +1893,9 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
             ),
           );
         }
-        upscaleBody.append(
-          makeNote(
-            usdu.auto_tile_size ? "text.usduAutoTile" : "text.usduManualTile",
-            usdu.auto_tile_size ? "tip.usduAutoTile" : "tip.usduTile",
-          ),
-        );
       } else {
         upscaleBody.append(makeNote(`ResShift ${settings.upscale.resshift?.scale || "x2"}`, "tip.resshiftScale"));
       }
-    } else {
-      upscaleBody.append(makeNote("text.upscaleDisabled", "tip.upscaleEnabled"));
     }
     upscaleBlock.append(upscaleBody);
 
@@ -1698,6 +1916,8 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       postprocessEnabled,
       "tip.postprocessEnabled",
       [makeIconButton("⚙", () => openPostprocessSettings(node), "tip.postprocessSettings")],
+      postprocess.enabled ? "tip.postprocessEnabled" : "tip.postprocessDisabled",
+      "postprocess.info",
     ));
     const postprocessBody = document.createElement("div");
     postprocessBody.className = "easyuse-anima-aio-node-stage-body";
@@ -1707,8 +1927,6 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
         ? `Fit <= ${fit.max_megapixels || 4}MP`
         : `Fit <= ${fit.max_long_edge || 2048}px`;
       postprocessBody.append(makeNote(fitText, "tip.finalFit"));
-    } else {
-      postprocessBody.append(makeNote("text.postprocessDisabled", "tip.postprocessEnabled"));
     }
     postprocessBlock.append(postprocessBody);
 

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -162,6 +162,7 @@ const AIO_TEXT = {
     "label.sampler": "Sampler",
     "label.scheduler": "Scheduler",
     "label.enabled": "Enabled",
+    "label.info": "More information",
     "label.followMainSampler": "Follow main sampler",
     "label.scaleBy": "Scale",
     "label.maxLongEdge": "Max edge",
@@ -409,15 +410,7 @@ const AIO_TEXT = {
     "text.previewDenoise": "Denoising preview",
     "text.previewGenerating": "Generating",
     "text.inputLoaderMode": "Loader mode: split diffusion model + VAE + CLIP",
-    "text.highresDisabled": "Enable Highres to expose resize and second-pass controls.",
     "text.highresSpdManualRequired": "Spectrum SPD / SPEED is not reused by Highres. Highres uses the general KSampler path.",
-    "text.detailerDisabled": "Enable Detailer to configure ordered processing blocks.",
-    "text.upscaleDisabled": "Enable Upscale to run one final USDU or ResShift pass before saving.",
-    "text.postprocessDisabled": "Enable Postprocess to cap the final image size before saving.",
-    "text.usduAutoTile": "Auto tile uses target/min/max tile sizes",
-    "text.usduManualTile": "Manual tile size",
-    "text.inheritsMainSampler": "Reuses main CFG, sampler, and scheduler. Stage Spectrum/DCW stays independent.",
-    "text.usesStageSamplerOverride": "Uses stage CFG, sampler, and scheduler with stage Spectrum/DCW.",
     "text.civitaiHashPreview": "Adds as {model}:AutoV3",
     "tip.fieldGeneric": "{label} setting. This value is saved with the node workflow.",
     "tip.additionalHashes": "Manual Image Saver additional_hashes string. Supports Name:HASH, HASH:Weight, and Name:HASH:Weight.",
@@ -438,13 +431,16 @@ const AIO_TEXT = {
     "tip.sampler": "Main ComfyUI sampler name used by the first pass.",
     "tip.scheduler": "Main ComfyUI scheduler used by the first pass.",
     "tip.highresEnabled": "Run a second pass after upscaling the first-pass image.",
-    "tip.highresFollow": "When enabled, Highres reuses the main CFG, sampler, and scheduler. Highres steps, denoise, Spectrum, and DCW remain stage-specific. SPD/SPEED falls back to general KSampler.",
+    "tip.highresDisabled": "Enable Highres to expose resize and second-pass controls.",
+    "tip.highresFollow": "When enabled, Highres reuses the main CFG, sampler, and scheduler. Highres steps, denoise, Spectrum, and DCW remain stage-specific.",
+    "tip.stageSamplerOverride": "Uses the stage CFG, sampler, scheduler, Spectrum, and DCW settings.",
     "tip.highresBackend": "Highres manual mode uses the general KSampler path to avoid second-pass model-patch conflicts.",
     "tip.highresScale": "Upscale ratio before the Highres second pass.",
     "tip.highresMaxEdge": "Maximum long edge after upscaling. Use 0 to disable this cap.",
     "tip.highresSteps": "Highres second-pass steps. This remains Highres-specific even when the main sampler is reused.",
     "tip.highresDenoise": "Highres second-pass denoise strength.",
     "tip.upscaleEnabled": "Runs one final upscale stage after Detailer and before Save.",
+    "tip.upscaleDisabled": "Enable Upscale to run one final USDU or ResShift pass before saving.",
     "tip.upscaleSettings": "Open final-stage USDU or ResShift upscale options.",
     "tip.upscaleBackend": "Selects the final upscale backend. Only one backend is used for each run.",
     "tip.upscaleScale": "USDU upscale ratio used by Ultimate SD Upscale.",
@@ -455,6 +451,7 @@ const AIO_TEXT = {
     "tip.usduAutoTile": "When enabled, tile width/height are calculated from the expected upscaled size. Target is the preferred tile size, min and max clamp the automatic result, and values align to 64 pixels.",
     "tip.usduSeam": "USDU seam-fix controls.",
     "tip.postprocessEnabled": "Runs after Upscale and before Save. Use it for final size capping only.",
+    "tip.postprocessDisabled": "Enable Postprocess to cap the final image size before saving.",
     "tip.postprocessSettings": "Open final size fit options for the Postprocess stage.",
     "tip.finalFit": "In Postprocess, downscale only when the final image exceeds the selected max long edge or megapixel limit.",
     "tip.resshiftScale": "ResShift super-resolution factor. The loader scale must match the selected student.",
@@ -462,6 +459,7 @@ const AIO_TEXT = {
     "tip.resshiftDtype": "ResShift loader precision.",
     "tip.resshiftTiling": "ResShift tiling controls for large images.",
     "tip.detailerEnabled": "Run SAM3 and Impact Detailer stages after generation.",
+    "tip.detailerDisabled": "Enable Detailer to configure ordered processing blocks.",
     "tip.detailerBlock": "Each block can be enabled, reordered, and tuned independently.",
     "tip.detailerFollow": "When enabled, this detailer block uses the main CFG, sampler, and scheduler. Spectrum/DCW remain block-specific.",
     "tip.detailerSteps": "Impact Detailer sampling steps for this block.",
@@ -497,6 +495,7 @@ const AIO_TEXT = {
     "label.sampler": "샘플러",
     "label.scheduler": "스케줄러",
     "label.enabled": "활성화",
+    "label.info": "추가 정보",
     "label.followMainSampler": "메인 샘플러 따름",
     "label.scaleBy": "확대",
     "label.maxLongEdge": "최대 긴 변",
@@ -744,15 +743,7 @@ const AIO_TEXT = {
     "text.previewDenoise": "노이즈 제거 미리보기",
     "text.previewGenerating": "생성 중",
     "text.inputLoaderMode": "로드 방식: 디퓨전 모델 + VAE + CLIP 분리 로드",
-    "text.highresDisabled": "Highres를 켜면 확대와 2차 샘플링 기본 설정이 표시됩니다.",
     "text.highresSpdManualRequired": "Spectrum SPD / SPEED는 Highres에서 재사용하지 않습니다. Highres는 일반 KSampler 경로를 사용합니다.",
-    "text.detailerDisabled": "디테일러를 켜면 순서 조정 가능한 처리 블럭이 표시됩니다.",
-    "text.upscaleDisabled": "Upscale을 켜면 저장 전에 USDU 또는 ResShift 최종 패스 하나를 실행합니다.",
-    "text.postprocessDisabled": "후보정을 켜면 저장 전 최종 이미지 크기를 제한합니다.",
-    "text.usduAutoTile": "자동 타일 target/min/max 사용",
-    "text.usduManualTile": "수동 타일 크기",
-    "text.inheritsMainSampler": "메인 CFG, 샘플러, 스케줄러를 따릅니다. Spectrum/DCW는 이 stage 설정을 사용합니다.",
-    "text.usesStageSamplerOverride": "이 stage의 CFG, 샘플러, 스케줄러와 Spectrum/DCW를 사용합니다.",
     "text.civitaiHashPreview": "{model}:AutoV3 형식으로 추가됩니다.",
     "tip.fieldGeneric": "{label} 설정입니다. 이 값은 노드 워크플로우에 저장됩니다.",
     "tip.additionalHashes": "Image Saver의 additional_hashes 수동 문자열입니다. Name:HASH, HASH:Weight, Name:HASH:Weight를 지원합니다.",
@@ -773,13 +764,16 @@ const AIO_TEXT = {
     "tip.sampler": "1차 패스에 사용할 ComfyUI 샘플러 이름입니다.",
     "tip.scheduler": "1차 패스에 사용할 ComfyUI 스케줄러입니다.",
     "tip.highresEnabled": "1차 이미지 확대 후 2차 샘플링을 실행합니다.",
-    "tip.highresFollow": "켜져 있으면 Highres가 메인 CFG, 샘플러, 스케줄러를 따릅니다. Highres 스텝, 디노이즈, Spectrum, DCW는 stage별로 적용됩니다. SPD/SPEED는 일반 KSampler로 대체됩니다.",
+    "tip.highresDisabled": "Highres를 켜면 확대와 2차 샘플링 기본 설정이 표시됩니다.",
+    "tip.highresFollow": "켜져 있으면 Highres가 메인 CFG, 샘플러, 스케줄러를 따릅니다. Highres 스텝, 디노이즈, Spectrum, DCW는 stage별로 적용됩니다.",
+    "tip.stageSamplerOverride": "이 stage의 CFG, 샘플러, 스케줄러와 Spectrum/DCW를 사용합니다.",
     "tip.highresBackend": "Highres 수동 모드는 2차 모델패치 충돌을 피하기 위해 일반 KSampler 경로를 사용합니다.",
     "tip.highresScale": "Highres 2차 패스 전에 적용할 확대 배율입니다.",
     "tip.highresMaxEdge": "확대 후 긴 변 제한입니다. 0이면 제한하지 않습니다.",
     "tip.highresSteps": "Highres 2차 패스 스텝입니다. 메인 샘플러를 재사용해도 이 값은 Highres 전용으로 적용됩니다.",
     "tip.highresDenoise": "Highres 2차 패스 디노이즈 강도입니다.",
     "tip.upscaleEnabled": "Detailer 이후 Save 전에 최종 업스케일 단계를 한 번 실행합니다.",
+    "tip.upscaleDisabled": "Upscale을 켜면 저장 전에 USDU 또는 ResShift 최종 패스 하나를 실행합니다.",
     "tip.upscaleSettings": "최종 USDU 또는 ResShift 업스케일 옵션을 엽니다.",
     "tip.upscaleBackend": "최종 업스케일 백엔드입니다. 한 번 실행할 때 하나만 사용합니다.",
     "tip.upscaleScale": "Ultimate SD Upscale에 전달할 USDU 확대 배율입니다.",
@@ -790,6 +784,7 @@ const AIO_TEXT = {
     "tip.usduAutoTile": "활성화하면 최종 업스케일 예상 크기에서 타일 너비/높이를 계산합니다. 목표값은 선호 타일 크기, 최소/최대는 자동 결과의 하한/상한이며 64px 단위로 정렬합니다.",
     "tip.usduSeam": "USDU seam-fix 설정입니다.",
     "tip.postprocessEnabled": "Upscale 이후 Save 전에 실행됩니다. 최종 크기 제한만 담당합니다.",
+    "tip.postprocessDisabled": "후보정을 켜면 저장 전 최종 이미지 크기를 제한합니다.",
     "tip.postprocessSettings": "후보정 단계의 최종 해상도 맞춤 옵션을 엽니다.",
     "tip.finalFit": "후보정 단계에서 최종 이미지가 선택한 최대 긴 변 또는 메가픽셀 수를 넘을 때만 다운스케일합니다.",
     "tip.resshiftScale": "ResShift 초해상도 배율입니다. Loader scale은 선택한 student와 일치해야 합니다.",
@@ -797,6 +792,7 @@ const AIO_TEXT = {
     "tip.resshiftDtype": "ResShift loader precision입니다.",
     "tip.resshiftTiling": "큰 이미지용 ResShift 타일링 설정입니다.",
     "tip.detailerEnabled": "생성 후 SAM3와 Impact Detailer 단계를 실행합니다.",
+    "tip.detailerDisabled": "디테일러를 켜면 순서 조정 가능한 처리 블럭이 표시됩니다.",
     "tip.detailerBlock": "각 블럭은 개별 활성화, 순서 변경, 기본 설정 조정이 가능합니다.",
     "tip.detailerFollow": "켜져 있으면 이 디테일러 블럭이 메인 CFG, 샘플러, 스케줄러를 따릅니다. Spectrum/DCW는 블럭별 설정을 사용합니다.",
     "tip.detailerSteps": "이 블럭의 Impact Detailer 샘플링 스텝입니다.",
@@ -830,6 +826,7 @@ const AIO_TEXT = {
     "label.sampler": "サンプラー",
     "label.scheduler": "スケジューラー",
     "label.enabled": "有効",
+    "label.info": "詳細情報",
     "label.followMainSampler": "メインサンプラーに追従",
     "label.scaleBy": "拡大",
     "label.maxLongEdge": "最大長辺",
@@ -856,12 +853,7 @@ const AIO_TEXT = {
     "text.previewSubtitle": "このノード出力専用のプレビュー領域です。",
     "text.previewDenoise": "デノイズプレビュー",
     "text.previewGenerating": "生成中",
-    "text.highresDisabled": "Highres を有効にすると拡大と二回目サンプリングの基本設定を表示します。",
     "text.highresSpdManualRequired": "Spectrum SPD / SPEED は Highres では再利用しません。Highres は通常 KSampler 経路を使います。",
-    "text.detailerDisabled": "Detailer を有効にすると順序変更できる処理ブロックを表示します。",
-    "text.upscaleDisabled": "Upscale を有効にすると保存前に USDU または ResShift の最終パスを一つ実行します。",
-    "text.inheritsMainSampler": "メイン CFG、サンプラー、スケジューラーに追従します。Spectrum/DCW はこの stage の設定を使います。",
-    "text.usesStageSamplerOverride": "この stage の CFG、サンプラー、スケジューラーと Spectrum/DCW を使います。",
     "text.civitaiHashPreview": "{model}:AutoV3 として追加されます。",
     "tip.fieldGeneric": "{label} の設定です。この値はノードのワークフローに保存されます。",
     "tip.additionalHashes": "Image Saver の additional_hashes 手動文字列です。Name:HASH、HASH:Weight、Name:HASH:Weight を使用できます。",
@@ -882,13 +874,22 @@ const AIO_TEXT = {
     "tip.sampler": "一回目に使う ComfyUI サンプラー名です。",
     "tip.scheduler": "一回目に使う ComfyUI スケジューラーです。",
     "tip.highresEnabled": "一回目画像を拡大して二回目サンプリングを実行します。",
-    "tip.highresFollow": "有効時、Highres はメイン CFG、サンプラー、スケジューラーに追従します。Highres ステップ、デノイズ、Spectrum、DCW は stage 別に適用されます。SPD/SPEED は通常 KSampler に置き換えます。",
+    "tip.highresDisabled": "Highres を有効にすると拡大と二回目サンプリングの基本設定を表示します。",
+    "tip.highresFollow": "有効時、Highres はメイン CFG、サンプラー、スケジューラーに追従します。Highres ステップ、デノイズ、Spectrum、DCW は stage 別に適用されます。",
+    "tip.stageSamplerOverride": "この stage の CFG、サンプラー、スケジューラーと Spectrum/DCW を使います。",
     "tip.highresBackend": "Highres 手動モードは二回目の model patch 衝突を避けるため通常 KSampler 経路を使います。",
     "tip.highresScale": "Highres 二回目パス前の拡大倍率です。",
     "tip.highresMaxEdge": "拡大後の長辺上限です。0 で上限なしです。",
     "tip.highresSteps": "Highres 二回目パスのステップです。メインサンプラーを再利用してもこの値は Highres 専用です。",
     "tip.highresDenoise": "Highres 二回目パスのデノイズ強度です。",
+    "tip.upscaleEnabled": "Detailer の後、保存前に最終 Upscale stage を一回実行します。",
+    "tip.upscaleDisabled": "Upscale を有効にすると保存前に USDU または ResShift の最終パスを一つ実行します。",
+    "tip.usduTile": "USDU の手動 tile、padding、seam 設定です。",
+    "tip.usduAutoTile": "有効にすると最終 Upscale の予想サイズから tile の幅と高さを計算します。目標値は推奨 tile サイズ、最小値と最大値は自動計算結果の下限と上限で、64px 単位に揃えます。",
+    "tip.postprocessEnabled": "Upscale の後、保存前に実行し、最終サイズの制限だけを行います。",
+    "tip.postprocessDisabled": "Postprocess を有効にすると保存前に最終画像サイズを制限します。",
     "tip.detailerEnabled": "生成後に SAM3 と Impact Detailer を実行します。",
+    "tip.detailerDisabled": "Detailer を有効にすると順序変更できる処理ブロックを表示します。",
     "tip.detailerBlock": "各ブロックは個別に有効化、並べ替え、調整できます。",
     "tip.detailerFollow": "有効時、この Detailer ブロックはメイン CFG、サンプラー、スケジューラーに追従します。Spectrum/DCW はブロック別設定を使います。",
     "tip.detailerSteps": "このブロックの Impact Detailer ステップです。",
@@ -917,6 +918,7 @@ const AIO_TEXT = {
     "label.sampler": "采样器",
     "label.scheduler": "调度器",
     "label.enabled": "启用",
+    "label.info": "更多信息",
     "label.followMainSampler": "跟随主采样器",
     "label.scaleBy": "放大",
     "label.maxLongEdge": "最长边",
@@ -943,12 +945,7 @@ const AIO_TEXT = {
     "text.previewSubtitle": "此区域专用于该节点输出预览。",
     "text.previewDenoise": "降噪预览",
     "text.previewGenerating": "生成中",
-    "text.highresDisabled": "启用 Highres 后显示放大和第二次采样基础设置。",
     "text.highresSpdManualRequired": "Spectrum SPD / SPEED 不会被 Highres 复用。Highres 使用普通 KSampler 路径。",
-    "text.detailerDisabled": "启用 Detailer 后显示可排序的处理块。",
-    "text.upscaleDisabled": "启用 Upscale 后在保存前运行一次 USDU 或 ResShift 最终处理。",
-    "text.inheritsMainSampler": "跟随主 CFG、采样器和调度器。Spectrum/DCW 使用此 stage 的设置。",
-    "text.usesStageSamplerOverride": "使用此 stage 的 CFG、采样器、调度器和 Spectrum/DCW。",
     "text.civitaiHashPreview": "将以 {model}:AutoV3 形式追加。",
     "tip.fieldGeneric": "{label} 设置。该值会随节点工作流保存。",
     "tip.additionalHashes": "Image Saver additional_hashes 手动字符串。支持 Name:HASH、HASH:Weight、Name:HASH:Weight。",
@@ -969,13 +966,22 @@ const AIO_TEXT = {
     "tip.sampler": "第一次使用的 ComfyUI 采样器名称。",
     "tip.scheduler": "第一次使用的 ComfyUI 调度器。",
     "tip.highresEnabled": "放大第一次图像后执行第二次采样。",
-    "tip.highresFollow": "启用时，Highres 跟随主 CFG、采样器和调度器。Highres 步数、降噪、Spectrum 和 DCW 按 stage 独立应用。SPD/SPEED 会回退到普通 KSampler。",
+    "tip.highresDisabled": "启用 Highres 后显示放大和第二次采样基础设置。",
+    "tip.highresFollow": "启用时，Highres 跟随主 CFG、采样器和调度器。Highres 步数、降噪、Spectrum 和 DCW 按 stage 独立应用。",
+    "tip.stageSamplerOverride": "使用此 stage 的 CFG、采样器、调度器和 Spectrum/DCW。",
     "tip.highresBackend": "Highres 手动模式使用普通 KSampler 路径，以避免第二次模型补丁冲突。",
     "tip.highresScale": "Highres 第二次采样前的放大倍率。",
     "tip.highresMaxEdge": "放大后的最长边上限。0 表示不限制。",
     "tip.highresSteps": "Highres 第二次采样步数。即使复用主采样器，此值也只用于 Highres。",
     "tip.highresDenoise": "Highres 第二次采样的降噪强度。",
+    "tip.upscaleEnabled": "在 Detailer 后、保存前运行一次最终 Upscale stage。",
+    "tip.upscaleDisabled": "启用 Upscale 后在保存前运行一次 USDU 或 ResShift 最终处理。",
+    "tip.usduTile": "USDU 手动 tile、padding 和 seam 设置。",
+    "tip.usduAutoTile": "启用后根据预计的最终 Upscale 尺寸计算 tile 宽高。目标值是首选 tile 尺寸，最小值和最大值限制自动结果，并对齐到 64px。",
+    "tip.postprocessEnabled": "在 Upscale 后、保存前运行，仅用于限制最终尺寸。",
+    "tip.postprocessDisabled": "启用 Postprocess 后在保存前限制最终图像尺寸。",
     "tip.detailerEnabled": "生成后运行 SAM3 和 Impact Detailer 阶段。",
+    "tip.detailerDisabled": "启用 Detailer 后显示可排序的处理块。",
     "tip.detailerBlock": "每个块都可单独启用、排序和调整。",
     "tip.detailerFollow": "启用时，此 Detailer 块跟随主 CFG、采样器和调度器。Spectrum/DCW 使用块级设置。",
     "tip.detailerSteps": "此块的 Impact Detailer 采样步数。",
@@ -2615,6 +2621,9 @@ function ensureStyle() {
       line-height: 1.1;
     }
     .easyuse-anima-aio-node-stage-title {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
       font-size: 11px;
     }
     .easyuse-anima-aio-node-stage-mini-title {
@@ -2644,6 +2653,11 @@ function ensureStyle() {
       font-size: 10px;
       line-height: 1.35;
     }
+    .easyuse-anima-aio-node-stage-note.warning {
+      color: #f2d5a4;
+      background: rgba(224, 157, 68, 0.1);
+      border-color: rgba(224, 157, 68, 0.32);
+    }
     .easyuse-anima-aio-node-stage-mini {
       grid-column: 1 / -1;
       padding: 7px;
@@ -2660,6 +2674,18 @@ function ensureStyle() {
       width: 22px;
       height: 20px;
       font-size: 10px;
+    }
+    .easyuse-anima-aio-node-info-field {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+    }
+    .easyuse-anima-aio-node-info-field.wide {
+      grid-column: 1 / -1;
+    }
+    .easyuse-anima-aio-node-info-field > .easyuse-anima-aio-node-field {
+      flex: 1 1 auto;
     }
     .easyuse-anima-aio-node-field {
       min-width: 0;
@@ -2817,6 +2843,47 @@ function ensureStyle() {
       width: 28px;
       padding: 0;
       flex: 0 0 auto;
+    }
+    .easyuse-anima-aio-node-info-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      min-width: 22px;
+      padding: 0;
+      color: #bcd7ca;
+      background: rgba(34, 53, 61, 0.88);
+      border: 1px solid #5f8274;
+      border-radius: 999px;
+      font: 700 10px/1 "Segoe UI", sans-serif;
+      cursor: pointer;
+    }
+    .easyuse-anima-aio-node-info-button:hover,
+    .easyuse-anima-aio-node-info-button[aria-expanded="true"] {
+      color: #f2eee5;
+      background: #315d50;
+      border-color: #82c9ad;
+    }
+    .easyuse-anima-aio-node-info-button:focus-visible {
+      outline: 2px solid #9de0c1;
+      outline-offset: 2px;
+    }
+    .easyuse-anima-aio-node-info-tooltip {
+      position: fixed;
+      z-index: 12000;
+      max-width: min(280px, calc(100vw - 16px));
+      padding: 7px 9px;
+      color: #f2eee5;
+      background: #172129;
+      border: 1px solid #638273;
+      border-radius: 6px;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.42);
+      font: 11px/1.4 "Segoe UI", sans-serif;
+      pointer-events: none;
+    }
+    .easyuse-anima-aio-node-info-tooltip[hidden] {
+      display: none;
     }
     .easyuse-anima-aio-node-icon-button.active {
       border-color: #78c8aa;


### PR DESCRIPTION
## 변경 요약

- AiO Generator의 Highres, Detailer, Upscale, Postprocess 정적 설명을 일관된 `i` 정보 툴팁으로 이동했습니다.
- Highres/Detailer sampler 상속 설명과 USDU auto/manual 도움말을 관련 field 옆 정보 버튼으로 정리했습니다.
- SPD/SPEED fallback 경고, ResShift 배율, Postprocess final-fit처럼 현재 실행에 직접 영향을 주는 동적 상태는 inline으로 유지했습니다.
- mouse hover, click/touch, keyboard focus, Enter/Space/Escape와 접근성 이름·설명 ownership을 제공합니다.
- 열린 body portal은 scroll/resize에서 위치를 갱신하며, viewport 아래 공간이 부족하면 위로 flip하고 상·하단 8px 안으로 clamp합니다.
- 닫힘·rerender·profile load·dispose에서 portal과 global listener를 정리합니다.
- en/ko/ja/zh 정적 `text.*` 중복을 `tip.*`으로 정리하면서 의미를 보존했습니다.
- 설정값, workflow serialization, backend, stage 활성 조건은 변경하지 않았습니다.

## 주요 파일

- `web/js/aio/generator_panel_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_generator_panel_runtime_smoke.mjs`

## 메인 코드 리뷰

메인 세션이 실제 diff와 주변 lifecycle·번역·DOM fixture를 검토했습니다.

- 정적 설명과 동적 경고 분리: 적합
- mouse/touch/keyboard와 aria ownership: 적합
- rerender/profile load/dispose cleanup 및 설정·serialization 불변: 적합
- 초기 리뷰에서 화면 하단 tooltip이 viewport 밖으로 잘릴 수 있는 finding 1건을 발견했습니다.
- commit `5b34b2669c8e3835014f9ad03165678d6f4ecec7`에서 tooltip 높이 기반 위쪽 flip과 수직 clamp를 추가했고, bottom-edge fixture로 해결을 확인했습니다.

## 검증

Focused 검증:

- generator panel runtime syntax·DOM smoke: 통과
- 관련 source-contract unittest 2개: 통과
- TypeScript 6.0.3: 통과
- `git diff --check`: 통과

메인 최종 검증:

- 저장소 공식 full runner: 통과
- Python unittest: 414 tests OK
- Frontend: 110 JavaScript files, TypeScript 6.0.3 통과

결정적 DOM fixture에서 확인한 표면:

- 비활성 stage inline static note 제거와 stage별 info icon
- hover, click/touch, focus, Enter/Space/Escape open/close
- `aria-label`, `aria-controls`, `aria-describedby`, `role=tooltip`
- scroll/resize 위치 갱신, bottom-edge 위쪽 flip, 상·하단 clamp
- stage on/off, rerender, profile load, dispose 후 stale portal/listener 0개
- SPD/SPEED fallback warning inline 유지
- tooltip 상호작용 전후 settings와 `widgets_values` 불변
- 기존 panel scroll/focus 복원 및 wheel forwarding 유지

## 미검증 표면과 남은 위험

- Legacy canvas 및 Node 2.0 실제 브라우저 검증은 이번 PR에서 실행하지 않았습니다.
- live browser, 실제 workflow 저장/재로드, instance sync는 실행하지 않았습니다.
- 실제 ComfyUI canvas transform/zoom 환경의 최종 시각 배치와 브라우저별 focus/touch 감각은 수동 확인 표면으로 남습니다.

Closes #171