### PR TITLE
perf: autocomplete built-in snapshot 비용 절감

### DIFF
--- a/autocomplete_dataset.py
+++ b/autocomplete_dataset.py
@@ -40,24 +40,28 @@ AUTOCOMPLETE_SOURCES = {
     "dbr_danbooru_2025_09_01": {
         "label": "Danbooru 2025-09-01 (recommended)",
         "path": DBR_DANBOORU_AUTOCOMPLETE_CSV,
+        "entry_count": 183174,
         "source": DBR_TAG_ARCHIVE_SOURCE,
         "license": DBR_TAG_ARCHIVE_LICENSE,
     },
     "dbr_e621_2025_09_01": {
         "label": "e621 2025-09-01",
         "path": DBR_E621_AUTOCOMPLETE_CSV,
+        "entry_count": 129525,
         "source": DBR_TAG_ARCHIVE_SOURCE,
         "license": DBR_TAG_ARCHIVE_LICENSE,
     },
     "dbr_danbooru_e621_merged_2025_09_01": {
         "label": "Danbooru + e621 merged 2025-09-01 (merge-risk)",
         "path": DBR_MERGED_AUTOCOMPLETE_CSV,
+        "entry_count": 295050,
         "source": DBR_TAG_ARCHIVE_SOURCE,
         "license": DBR_TAG_ARCHIVE_LICENSE,
     },
     "localsmile_kr_wiki": {
         "label": "Localsmile Danbooru KR wiki tag search (Korean)",
         "path": LOCALSMILE_AUTOCOMPLETE_CSV,
+        "entry_count": 114092,
         "source": "https://github.com/Localsmile/danbooru_KR_wiki_tag_search",
     },
 }
@@ -105,7 +109,7 @@ _DYNAMIC_PROMPT_SYNTAX_RE = re.compile(r"(?<!\\)\{(?:[^{}]|(?<=\\)[{}])*?(?<!\\)
 _DESCRIPTION_PREFIX_RE = re.compile(r"^\[([^\]]+)\]")
 _COMMENT_RE = re.compile(r"^[ \t]*#[^\n]*", re.MULTILINE)
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AutocompleteEntry:
     tag: str
     tag_key: str
@@ -115,7 +119,7 @@ class AutocompleteEntry:
     search: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _AutocompleteCacheKey:
     resolved_path: str
     mtime_ns: int
@@ -123,7 +127,7 @@ class _AutocompleteCacheKey:
     schema_version: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _AutocompleteSnapshot:
     key: _AutocompleteCacheKey
     entries: tuple[AutocompleteEntry, ...]
@@ -400,14 +404,43 @@ def _entry_map(path: Path = AUTOCOMPLETE_CSV) -> Mapping[str, AutocompleteEntry]
     return _snapshot(path).entry_map
 
 
-def _snapshot_status(snapshot: _AutocompleteSnapshot, path: Path) -> dict:
-    exists = snapshot.key.mtime_ns != _MISSING_FILE_STAT
+def _status_from_key(key: _AutocompleteCacheKey, path: Path, count: int) -> dict:
+    exists = key.mtime_ns != _MISSING_FILE_STAT
     return {
         "path": str(path),
         "exists": exists,
-        "count": len(snapshot.entries),
-        "mtime": snapshot.key.mtime_ns / 1_000_000_000 if exists else 0,
+        "count": count,
+        "mtime": key.mtime_ns / 1_000_000_000 if exists else 0,
     }
+
+
+def _snapshot_status(snapshot: _AutocompleteSnapshot, path: Path) -> dict:
+    return _status_from_key(snapshot.key, path, len(snapshot.entries))
+
+
+def _cached_snapshot_for_key(
+    key: _AutocompleteCacheKey,
+) -> _AutocompleteSnapshot | None:
+    with _CACHE_LOCK:
+        snapshot = _CACHE.get(key.resolved_path)
+        if snapshot is not None and snapshot.key == key:
+            return snapshot
+    return None
+
+
+def _builtin_manifest_entry_count(key: _AutocompleteCacheKey) -> int | None:
+    resolved_path = Path(key.resolved_path)
+    for source in AUTOCOMPLETE_SOURCES.values():
+        if Path(source["path"]).resolve(strict=False) != resolved_path:
+            continue
+        # Built-in paths identify release-owned assets. Do not bind the fast
+        # path to byte size because Git EOL conversion can vary by checkout;
+        # tools/benchmark_autocomplete.py verifies parser counts before release.
+        entry_count = source.get("entry_count")
+        if type(entry_count) is int and entry_count >= 0:
+            return entry_count
+        return None
+    return None
 
 
 def _token_base(token: str) -> str:
@@ -726,6 +759,20 @@ def classify_prompt_text(text: str, limit: int = 240, path: Path = AUTOCOMPLETE_
 
 
 def autocomplete_status(path: Path = AUTOCOMPLETE_CSV) -> dict:
+    key = _cache_key(path)
+    if key.mtime_ns == _MISSING_FILE_STAT:
+        return _status_from_key(key, path, 0)
+
+    cached = _cached_snapshot_for_key(key)
+    if cached is not None:
+        return _snapshot_status(cached, path)
+
+    manifest_count = _builtin_manifest_entry_count(key)
+    if manifest_count is not None:
+        return _status_from_key(key, path, manifest_count)
+
+    # Public helper callers may provide arbitrary paths. Preserve their exact
+    # count semantics when no verified built-in manifest applies.
     return _snapshot_status(_snapshot(path), path)
 
 

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -3279,6 +3279,157 @@ class AutocompleteDatasetTests(unittest.TestCase):
         self.assertEqual(korean["results"][0]["category"], "character")
         self.assertEqual(status["count"], 2)
 
+    def test_autocomplete_status_uses_builtin_manifest_without_loading_dataset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "built-in.csv"
+            path.write_text(
+                'first tag,0,100,"[일반] first"\nsecond tag,0,90,"[일반] second"\n',
+                encoding="utf-8",
+            )
+            expected_mtime = path.stat().st_mtime_ns / 1_000_000_000
+            sources = {
+                "fixture": {
+                    "label": "Fixture",
+                    "path": path,
+                    "entry_count": 2,
+                }
+            }
+
+            with (
+                patch.object(autocomplete_dataset, "AUTOCOMPLETE_SOURCES", sources),
+                patch.object(
+                    autocomplete_dataset,
+                    "_snapshot",
+                    side_effect=AssertionError("status must not load a snapshot"),
+                ) as snapshot,
+                patch.object(
+                    autocomplete_dataset,
+                    "_load_entries",
+                    side_effect=AssertionError("status must not load entries"),
+                ) as load_entries,
+            ):
+                status = autocomplete_status(path)
+
+        self.assertEqual(set(status), {"path", "exists", "count", "mtime"})
+        self.assertEqual(status["path"], str(path))
+        self.assertTrue(status["exists"])
+        self.assertEqual(status["count"], 2)
+        self.assertEqual(status["mtime"], expected_mtime)
+        snapshot.assert_not_called()
+        load_entries.assert_not_called()
+
+    def test_autocomplete_status_builtin_missing_and_non_file_preserve_policy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            targets = (root / "missing.csv", root)
+            for target in targets:
+                with self.subTest(target=target):
+                    sources = {
+                        "fixture": {
+                            "label": "Fixture",
+                            "path": target,
+                            "entry_count": 99,
+                        }
+                    }
+                    with (
+                        patch.object(
+                            autocomplete_dataset,
+                            "AUTOCOMPLETE_SOURCES",
+                            sources,
+                        ),
+                        patch.object(
+                            autocomplete_dataset,
+                            "_snapshot",
+                            side_effect=AssertionError("missing status must stay metadata-only"),
+                        ) as snapshot,
+                        patch.object(
+                            autocomplete_dataset,
+                            "_load_entries",
+                            side_effect=AssertionError("missing status must not load entries"),
+                        ) as load_entries,
+                    ):
+                        status = autocomplete_status(target)
+
+                    self.assertEqual(
+                        status,
+                        {
+                            "path": str(target),
+                            "exists": False,
+                            "count": 0,
+                            "mtime": 0,
+                        },
+                    )
+                    snapshot.assert_not_called()
+                    load_entries.assert_not_called()
+
+    def test_autocomplete_status_custom_path_preserves_exact_snapshot_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "custom.csv"
+            path.write_text('first tag,0,100,"[일반] first"\n', encoding="utf-8")
+            original_load = autocomplete_dataset._load_entries
+
+            with (
+                patch.object(autocomplete_dataset, "AUTOCOMPLETE_SOURCES", {}),
+                patch.object(
+                    autocomplete_dataset,
+                    "_load_entries",
+                    wraps=original_load,
+                ) as load_entries,
+            ):
+                first = autocomplete_status(path)
+                first_stat = path.stat()
+                path.write_text(
+                    'second tag,0,100,"[일반] second"\n'
+                    'third longer tag,0,90,"[일반] third"\n',
+                    encoding="utf-8",
+                )
+                next_mtime = first_stat.st_mtime_ns + 1_000_000_000
+                os.utime(path, ns=(next_mtime, next_mtime))
+                second = autocomplete_status(path)
+
+        self.assertEqual(first["count"], 1)
+        self.assertEqual(second["count"], 2)
+        self.assertEqual(load_entries.call_count, 2)
+
+    def test_search_classify_and_status_report_the_same_snapshot_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "built-in.csv"
+            path.write_text(
+                'shared tag,0,100,"[일반] shared"\n'
+                'other tag,0,90,"[일반] other"\n',
+                encoding="utf-8",
+            )
+            sources = {
+                "fixture": {
+                    "label": "Fixture",
+                    "path": path,
+                    "entry_count": 2,
+                }
+            }
+
+            with patch.object(
+                autocomplete_dataset,
+                "AUTOCOMPLETE_SOURCES",
+                sources,
+            ):
+                searched = search_autocomplete("shared", path=path)
+                classified = classify_prompt_text("shared tag", path=path)
+                status = autocomplete_status(path)
+
+        self.assertEqual(searched["status"], classified["status"])
+        self.assertEqual(searched["status"], status)
+        self.assertEqual(status["count"], 2)
+
+    def test_autocomplete_snapshot_records_use_slots(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "slots.csv"
+            path.write_text('slotted tag,0,100,"[일반] slotted"\n', encoding="utf-8")
+            snapshot = autocomplete_dataset._snapshot(path)
+
+        self.assertFalse(hasattr(snapshot, "__dict__"))
+        self.assertFalse(hasattr(snapshot.key, "__dict__"))
+        self.assertFalse(hasattr(snapshot.entries[0], "__dict__"))
+
     def test_searches_escaped_literal_parentheses(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tags.csv"

--- a/tools/benchmark_autocomplete.py
+++ b/tools/benchmark_autocomplete.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Measure autocomplete cold/warm latency and Python heap usage.
+
+Examples:
+  python tools/benchmark_autocomplete.py
+  python tools/benchmark_autocomplete.py --fixture-entries 1000 --warm-runs 3
+  python tools/benchmark_autocomplete.py --verify-manifest
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import platform
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+import autocomplete_dataset as dataset
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be at least 1")
+    return parsed
+
+
+def _write_fixture(path: Path, entry_count: int) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        for index in range(entry_count):
+            tag = "1girl" if index == 0 else f"benchmark tag {index:06d}"
+            count = entry_count - index
+            handle.write(f'{tag},0,{count},"[general] benchmark fixture {index}"\n')
+
+
+def _clear_cached_source(path: Path) -> None:
+    key = dataset._cache_key(path)
+    with dataset._CACHE_LOCK:
+        if any(
+            inflight_key.resolved_path == key.resolved_path
+            for inflight_key in dataset._INFLIGHT
+        ):
+            raise RuntimeError(f"autocomplete load already in flight: {key.resolved_path}")
+        dataset._CACHE.pop(key.resolved_path, None)
+
+
+def _benchmark(path: Path, query: str, warm_runs: int) -> dict:
+    resolved_path = path.resolve(strict=False)
+    _clear_cached_source(resolved_path)
+    gc.collect()
+
+    tracemalloc.start()
+    try:
+        baseline_heap, _ = tracemalloc.get_traced_memory()
+        cold_started = time.perf_counter()
+        cold_result = dataset.search_autocomplete(query, path=resolved_path)
+        cold_ms = (time.perf_counter() - cold_started) * 1000
+        cold_heap_current, cold_heap_peak = tracemalloc.get_traced_memory()
+
+        warm_times = []
+        warm_result = None
+        for _ in range(warm_runs):
+            warm_started = time.perf_counter()
+            warm_result = dataset.search_autocomplete(query, path=resolved_path)
+            warm_times.append((time.perf_counter() - warm_started) * 1000)
+
+        heap_current, heap_peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    if warm_result is None or warm_result["status"] != cold_result["status"]:
+        raise RuntimeError("cold and warm searches did not use the same snapshot status")
+
+    return {
+        "source_path": str(resolved_path),
+        "source_exists": cold_result["status"]["exists"],
+        "entry_count": cold_result["status"]["count"],
+        "query": query,
+        "cold_ms": round(cold_ms, 3),
+        "warm_ms_median": round(statistics.median(warm_times), 3),
+        "warm_ms_min": round(min(warm_times), 3),
+        "warm_runs": warm_runs,
+        "memory_metric": "tracemalloc_python_heap",
+        "cold_heap_retained_bytes": max(0, cold_heap_current - baseline_heap),
+        "cold_heap_peak_bytes": max(0, cold_heap_peak - baseline_heap),
+        "overall_heap_retained_bytes": max(0, heap_current - baseline_heap),
+        "overall_heap_peak_bytes": max(0, heap_peak - baseline_heap),
+        "python": sys.version.replace("\n", " "),
+        "platform": platform.platform(),
+    }
+
+
+def _verify_manifest() -> int:
+    checks = []
+    has_drift = False
+    for source_key, source in dataset.AUTOCOMPLETE_SOURCES.items():
+        path = Path(source["path"]).resolve(strict=False)
+        expected_count = source.get("entry_count")
+        started = time.perf_counter()
+        entries = dataset._load_entries(path)
+        actual_count = len(entries)
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        matches = (
+            path.is_file()
+            and type(expected_count) is int
+            and expected_count == actual_count
+        )
+        has_drift = has_drift or not matches
+        checks.append(
+            {
+                "source": source_key,
+                "source_path": str(path),
+                "source_exists": path.is_file(),
+                "manifest_entry_count": expected_count,
+                "parser_entry_count": actual_count,
+                "file_size_bytes": path.stat().st_size if path.is_file() else None,
+                "elapsed_ms": round(elapsed_ms, 3),
+                "matches": matches,
+            }
+        )
+        del entries
+        gc.collect()
+
+    print(
+        json.dumps(
+            {
+                "manifest_drift": has_drift,
+                "checks": checks,
+                "python": sys.version.replace("\n", " "),
+                "platform": platform.platform(),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 1 if has_drift else 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source_group = parser.add_mutually_exclusive_group()
+    source_group.add_argument(
+        "--source-key",
+        choices=tuple(dataset.AUTOCOMPLETE_SOURCES),
+        help="benchmark a configured built-in source",
+    )
+    source_group.add_argument("--source", type=Path, help="benchmark an arbitrary CSV path")
+    source_group.add_argument(
+        "--fixture-entries",
+        type=_positive_int,
+        help="generate and benchmark a temporary CSV with this many entries",
+    )
+    parser.add_argument("--query", default="1girl", help="autocomplete query")
+    parser.add_argument("--warm-runs", type=_positive_int, default=5)
+    parser.add_argument(
+        "--verify-manifest",
+        action="store_true",
+        help="verify all built-in manifest counts and exit without benchmarking",
+    )
+    args = parser.parse_args()
+    if args.verify_manifest and (
+        args.source_key is not None
+        or args.source is not None
+        or args.fixture_entries is not None
+    ):
+        parser.error("--verify-manifest cannot be combined with a source option")
+    if not str(args.query).strip():
+        parser.error("--query must not be empty")
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.verify_manifest:
+        return _verify_manifest()
+
+    if args.fixture_entries is not None:
+        with tempfile.TemporaryDirectory(prefix="easyuse-anima-autocomplete-") as tmp:
+            path = Path(tmp) / "fixture.csv"
+            _write_fixture(path, args.fixture_entries)
+            result = _benchmark(path, args.query, args.warm_runs)
+            result["fixture_entries"] = args.fixture_entries
+    elif args.source is not None:
+        result = _benchmark(args.source, args.query, args.warm_runs)
+    else:
+        _, path = dataset.resolve_autocomplete_source(args.source_key)
+        result = _benchmark(path, args.query, args.warm_runs)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 변경 요약

- 내장 autocomplete 소스의 엔트리 수를 manifest로 관리해 status 조회 시 대형 TXT snapshot을 로드하지 않도록 했습니다.
- 내장 소스 status는 파일 metadata와 manifest를 사용하고, 사용자 지정 경로는 기존 정확한 snapshot fallback을 유지합니다.
- dataset record를 `slots=True`로 축소했습니다.
- cold/warm 시간과 `tracemalloc` peak를 측정하고 manifest 정합성을 검증하는 `tools/benchmark_autocomplete.py`를 추가했습니다.

## 배경과 영향

Issue #162의 Phase 1A입니다. 대형 내장 TXT 데이터셋의 상태 조회와 Python object overhead를 줄이는 안전한 기반 작업이며, API `to_thread` 분리와 검색 index 도입은 후속 Phase 1B 범위로 남깁니다.

- 내장 소스: manifest 기반 빠른 status
- 사용자 지정 소스: 기존 정확성 우선 동작 유지
- 공개 응답 형식과 workflow 호환성 변경 없음

Relates to #162

## 검증

- `python -m unittest` focused `AutocompleteDatasetTests`: 36 passed
- Python compile 및 manifest verification benchmark: passed
- 공식 full project check: Python 435 tests passed
- Frontend checks: 110 JavaScript files, TypeScript 6.0.3 passed
- `git diff --check`: passed

## 테스트 표면

- ComfyUI Codex test environment: Python/frontend project validation
- Live ComfyUI smoke: not run (backend dataset/status 최적화로 브라우저 동작 변경 없음)

## 남은 범위

- Issue #162 Phase 1B: API blocking I/O 분리와 prefix index/benchmark 기준 확정
- manifest count 변경 시 benchmark의 `--verify-manifest` 검증 필요