### PR TITLE
fix: settings/profile JSON 저장 원자화

### DIFF
--- a/api.py
+++ b/api.py
@@ -519,14 +519,14 @@ def _rename_aio_profile(old_name: str, new_name: str, *, overwrite: bool = False
         raise FileExistsError("Profile already exists")
 
     target_path = target or _aio_profile_path(safe_new_name)
-    data = AtomicJsonStore(target_path).replace_from(
+    return AtomicJsonStore(target_path).replace_from(
         AtomicJsonStore(source),
         overwrite=overwrite,
         backup_target=True,
-    )
-    return _normalize_aio_profile_payload(
-        target_path.stem,
-        data if isinstance(data, dict) else {},
+        transform=lambda data: _normalize_aio_profile_payload(
+            target_path.stem,
+            data if isinstance(data, dict) else {},
+        ),
     )
 
 

--- a/api.py
+++ b/api.py
@@ -499,7 +499,10 @@ def _delete_aio_profile(name: str) -> dict:
     if path is None or not path.is_file():
         raise FileNotFoundError("Profile not found")
     deleted_name = path.stem
-    path.unlink()
+    try:
+        AtomicJsonStore(path).delete()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError("Profile not found") from exc
     return {"name": deleted_name}
 
 
@@ -516,12 +519,15 @@ def _rename_aio_profile(old_name: str, new_name: str, *, overwrite: bool = False
         raise FileExistsError("Profile already exists")
 
     target_path = target or _aio_profile_path(safe_new_name)
-    AtomicJsonStore(target_path).replace_from(
+    data = AtomicJsonStore(target_path).replace_from(
         AtomicJsonStore(source),
         overwrite=overwrite,
         backup_target=True,
     )
-    return _load_aio_profile(target_path.stem)
+    return _normalize_aio_profile_payload(
+        target_path.stem,
+        data if isinstance(data, dict) else {},
+    )
 
 
 def _resolve_lora_preview_path(lora_name: str):

--- a/api.py
+++ b/api.py
@@ -31,9 +31,9 @@ from .autocomplete_dataset import (
 from .wildcard_engine import list_wildcards, resolve_wildcard_roots
 from .prompt_translation import translate_prompt_markers
 try:
-    from .storage import USER_DATA_DIR
+    from .storage import AtomicJsonStore, USER_DATA_DIR
 except ImportError:
-    from storage import USER_DATA_DIR
+    from storage import AtomicJsonStore, USER_DATA_DIR
 
 
 LORA_PREVIEW_EXTENSIONS = (".webp", ".png", ".jpg", ".jpeg")
@@ -368,16 +368,29 @@ def _fix_lora_profile_payload(data: dict) -> dict:
     return payload
 
 
+def _read_profile_json(path: Path):
+    store = AtomicJsonStore(path)
+    with store.locked():
+        try:
+            return store.read()
+        except json.JSONDecodeError:
+            if path.read_text(encoding="utf-8") == "":
+                return {}
+            raise
+
+
 def _save_lora_profile(name: str, data: dict, *, overwrite: bool = False) -> dict:
     safe_name = _sanitize_lora_profile_name(name)
     payload = _normalize_lora_profile_payload(data)
     LORA_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
-    existing = _find_lora_profile_path(safe_name)
-    if existing is not None and not overwrite:
-        raise FileExistsError("Profile already exists")
-    path = existing or _lora_profile_path(safe_name)
-    payload["name"] = path.stem
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    requested_path = _lora_profile_path(safe_name)
+    with AtomicJsonStore(requested_path).locked():
+        existing = _find_lora_profile_path(safe_name)
+        if existing is not None and not overwrite:
+            raise FileExistsError("Profile already exists")
+        path = existing or requested_path
+        payload["name"] = path.stem
+        AtomicJsonStore(path).write(payload)
     return payload
 
 
@@ -385,7 +398,7 @@ def _load_lora_profile(name: str) -> dict:
     path = _find_lora_profile_path(name)
     if path is None or not path.is_file():
         raise FileNotFoundError("Profile not found")
-    data = json.loads(path.read_text(encoding="utf-8") or "{}")
+    data = _read_profile_json(path)
     if not isinstance(data, dict):
         data = {}
     payload = _normalize_lora_profile_payload(data)
@@ -457,14 +470,16 @@ def _list_aio_profiles(profile_dir: Path | None = None) -> list[dict]:
 def _save_aio_profile(name: str, data: dict, *, overwrite: bool = False) -> dict:
     payload = _normalize_aio_profile_payload(name, data)
     AIO_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
-    existing = _find_aio_profile_path(payload["name"])
-    if existing is not None and not overwrite:
-        raise FileExistsError("Profile already exists")
-    if existing is None and len(_list_aio_profiles()) >= MAX_AIO_PROFILES:
-        raise ValueError(f"A maximum of {MAX_AIO_PROFILES} profiles can be saved")
-    path = existing or _aio_profile_path(payload["name"])
-    payload["name"] = path.stem
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    requested_path = _aio_profile_path(payload["name"])
+    with AtomicJsonStore(requested_path).locked():
+        existing = _find_aio_profile_path(payload["name"])
+        if existing is not None and not overwrite:
+            raise FileExistsError("Profile already exists")
+        if existing is None and len(_list_aio_profiles()) >= MAX_AIO_PROFILES:
+            raise ValueError(f"A maximum of {MAX_AIO_PROFILES} profiles can be saved")
+        path = existing or requested_path
+        payload["name"] = path.stem
+        AtomicJsonStore(path).write(payload)
     return payload
 
 
@@ -473,7 +488,7 @@ def _load_aio_profile(name: str) -> dict:
     if path is None or not path.is_file():
         raise FileNotFoundError("Profile not found")
     try:
-        data = json.loads(path.read_text(encoding="utf-8") or "{}")
+        data = _read_profile_json(path)
     except json.JSONDecodeError as exc:
         raise ValueError("Profile data is invalid") from exc
     return _normalize_aio_profile_payload(path.stem, data if isinstance(data, dict) else {})
@@ -500,13 +515,13 @@ def _rename_aio_profile(old_name: str, new_name: str, *, overwrite: bool = False
     if target is not None and not overwrite:
         raise FileExistsError("Profile already exists")
 
-    payload = _load_aio_profile(source.stem)
-    payload["name"] = safe_new_name
     target_path = target or _aio_profile_path(safe_new_name)
-    target_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    source.unlink()
-    payload["name"] = target_path.stem
-    return payload
+    AtomicJsonStore(target_path).replace_from(
+        AtomicJsonStore(source),
+        overwrite=overwrite,
+        backup_target=True,
+    )
+    return _load_aio_profile(target_path.stem)
 
 
 def _resolve_lora_preview_path(lora_name: str):

--- a/settings.py
+++ b/settings.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 try:
-    from .storage import USER_DATA_DIR
+    from .storage import AtomicJsonStore, USER_DATA_DIR
     from .prompt_translation import (
         DEFAULT_PROMPT_TRANSLATION_SOURCE,
         DEFAULT_PROMPT_TRANSLATION_TARGET,
@@ -14,7 +14,7 @@ try:
         normalize_prompt_translation_provider,
     )
 except ImportError:
-    from storage import USER_DATA_DIR
+    from storage import AtomicJsonStore, USER_DATA_DIR
     from prompt_translation import (
         DEFAULT_PROMPT_TRANSLATION_SOURCE,
         DEFAULT_PROMPT_TRANSLATION_TARGET,
@@ -220,10 +220,8 @@ LONG_TEXT_SETTING_ALIASES = {
 
 
 def _read_json_file(path: Path) -> dict:
-    if not path.is_file():
-        return {}
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = AtomicJsonStore(path).read(default={})
     except (OSError, json.JSONDecodeError):
         return {}
     return data if isinstance(data, dict) else {}
@@ -248,22 +246,24 @@ def load_long_text_settings() -> dict:
 def save_long_text_settings(values: dict) -> dict:
     if not isinstance(values, dict):
         values = {}
-    settings = load_long_text_settings()
-    settings.update(_normalize_long_text_settings(values))
-    LONG_TEXT_SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    LONG_TEXT_SETTINGS_FILE.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "values": {key: settings.get(key, "") for key in sorted(LONG_TEXT_SETTING_KEYS)},
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    updates = _normalize_long_text_settings(values)
+    saved: dict = {}
+
+    def merge(current) -> dict:
+        settings = _normalize_long_text_settings(current if isinstance(current, dict) else {})
+        settings.update(updates)
+        saved.update(settings)
+        return {
+            "version": 1,
+            "values": {key: settings.get(key, "") for key in sorted(LONG_TEXT_SETTING_KEYS)},
+        }
+
+    AtomicJsonStore(LONG_TEXT_SETTINGS_FILE).update(
+        merge,
+        default={},
+        trailing_newline=True,
     )
-    return settings
+    return saved
 
 
 def _comfy_settings_candidates() -> list[Path]:
@@ -356,13 +356,11 @@ def get_settings() -> dict:
 def save_setting(key: str, value) -> dict:
     if key not in DEFAULT_SETTINGS:
         raise KeyError(f"Unknown setting: {key}")
-    settings = get_settings()
-    settings[key] = _stringify_setting_value(value)
-    SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SETTINGS_FILE.write_text(
-        json.dumps(settings, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    store = AtomicJsonStore(SETTINGS_FILE)
+    with store.locked():
+        settings = get_settings()
+        settings[key] = _stringify_setting_value(value)
+        store.write(settings, trailing_newline=True)
     return settings
 
 

--- a/storage.py
+++ b/storage.py
@@ -254,19 +254,43 @@ class AtomicJsonStore:
             self._write_bytes_unlocked(encoded)
             return value
 
+    def delete(self) -> None:
+        """Delete the primary and backup under the shared primary-path lock.
+
+        The backup is removed and its directory entry is synced before the
+        primary is touched. Therefore a backup deletion failure preserves the
+        primary. Any primary unlink or directory fsync failure is propagated;
+        callers can inspect the files to determine the completed boundary.
+        """
+
+        with self.locked():
+            if not self.path.is_file():
+                raise FileNotFoundError(self.path)
+
+            if self.backup_path is not None:
+                try:
+                    self.backup_path.unlink()
+                except FileNotFoundError:
+                    pass
+                else:
+                    _fsync_directory(self.path.parent)
+
+            self.path.unlink()
+            _fsync_directory(self.path.parent)
+
     def replace_from(
         self,
         source: "AtomicJsonStore",
         *,
         overwrite: bool = True,
         backup_target: bool = True,
-    ) -> None:
-        """Atomically move a valid same-directory primary into this store."""
+    ):
+        """Atomically move a valid same-directory primary and return its JSON."""
 
         if source.path.parent != self.path.parent:
             raise ValueError("Atomic JSON moves require the same directory")
         with _locked_paths(source.path, self.path):
-            source._read_path(source.path)
+            value = source._read_path(source.path)
             self.path.parent.mkdir(parents=True, exist_ok=True)
             if self.path.exists() and not overwrite:
                 raise FileExistsError("Profile already exists")
@@ -274,3 +298,4 @@ class AtomicJsonStore:
                 self._backup_primary_unlocked()
             os.replace(source.path, self.path)
             _fsync_directory(self.path.parent)
+            return value

--- a/storage.py
+++ b/storage.py
@@ -284,16 +284,19 @@ class AtomicJsonStore:
         *,
         overwrite: bool = True,
         backup_target: bool = True,
-    ):
-        """Atomically move a valid same-directory primary and return its JSON."""
+        transform: Callable[[object], _T] | None = None,
+    ) -> object | _T:
+        """Validate/transform under both locks, then atomically move the primary."""
 
         if source.path.parent != self.path.parent:
             raise ValueError("Atomic JSON moves require the same directory")
         with _locked_paths(source.path, self.path):
             value = source._read_path(source.path)
-            self.path.parent.mkdir(parents=True, exist_ok=True)
             if self.path.exists() and not overwrite:
                 raise FileExistsError("Profile already exists")
+            if transform is not None:
+                value = transform(value)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
             if backup_target and self.path.is_file():
                 self._backup_primary_unlocked()
             os.replace(source.path, self.path)

--- a/storage.py
+++ b/storage.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import errno
+import json
+import os
+import tempfile
+import threading
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Callable, Iterator, TypeVar
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parent
@@ -25,3 +32,245 @@ def _resolve_user_data_dir() -> Path:
 
 
 USER_DATA_DIR = _resolve_user_data_dir()
+
+
+_T = TypeVar("_T")
+_MISSING = object()
+_PATH_LOCKS: dict[str, threading.RLock] = {}
+_PATH_LOCKS_GUARD = threading.Lock()
+_RECOVERABLE_READ_ERRORS = (FileNotFoundError, json.JSONDecodeError, UnicodeError)
+_UNSUPPORTED_DIRECTORY_FSYNC_ERRORS = {
+    errno.EACCES,
+    errno.EBADF,
+    errno.EINVAL,
+    errno.ENOTSUP,
+    errno.EPERM,
+}
+
+
+def _resolved_path(path: str | os.PathLike[str]) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
+
+
+def _path_lock_key(path: Path) -> str:
+    return os.path.normcase(str(path))
+
+
+def _path_lock(path: Path) -> threading.RLock:
+    key = _path_lock_key(path)
+    with _PATH_LOCKS_GUARD:
+        lock = _PATH_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _PATH_LOCKS[key] = lock
+        return lock
+
+
+@contextmanager
+def _locked_paths(*paths: Path) -> Iterator[None]:
+    locks = {
+        _path_lock_key(path): _path_lock(path)
+        for path in paths
+    }
+    ordered = [locks[key] for key in sorted(locks)]
+    for lock in ordered:
+        lock.acquire()
+    try:
+        yield
+    finally:
+        for lock in reversed(ordered):
+            lock.release()
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        if os.name == "nt" or exc.errno in _UNSUPPORTED_DIRECTORY_FSYNC_ERRORS:
+            return
+        raise
+    try:
+        try:
+            os.fsync(descriptor)
+        except OSError as exc:
+            if os.name != "nt" and exc.errno not in _UNSUPPORTED_DIRECTORY_FSYNC_ERRORS:
+                raise
+    finally:
+        os.close(descriptor)
+
+
+def _unlink_if_present(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+class AtomicJsonStore:
+    """Durable JSON storage with atomic publication and backup recovery.
+
+    Reads return the primary JSON document when it is valid. A missing, invalid
+    UTF-8, or invalid JSON primary falls back to a valid backup without mutating
+    either file. If neither document is usable, ``default`` is returned when it
+    was supplied; otherwise the primary error is raised (or the backup parse
+    error when the primary is missing).
+
+    Writes publish a fully flushed and fsynced same-directory temporary file
+    with ``os.replace``. When backups are enabled, a valid existing primary is
+    copied to a durable backup temp and atomically published before the new
+    primary. Invalid primaries never replace an existing valid backup.
+    """
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        backup: bool | str | os.PathLike[str] = True,
+    ) -> None:
+        self.path = _resolved_path(path)
+        if backup is True:
+            backup_path = self.path.with_name(f"{self.path.name}.bak")
+        elif backup is False:
+            backup_path = None
+        else:
+            backup_path = _resolved_path(backup)
+            if backup_path.parent != self.path.parent:
+                raise ValueError("Backup must be in the same directory as the primary")
+        self.backup_path = backup_path
+
+    @contextmanager
+    def locked(self) -> Iterator[None]:
+        """Hold the process-wide lock shared by all stores for this path."""
+
+        with _locked_paths(self.path):
+            yield
+
+    def _read_path(self, path: Path):
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _read_unlocked(self, default=_MISSING):
+        try:
+            return self._read_path(self.path)
+        except _RECOVERABLE_READ_ERRORS as primary_error:
+            backup_error = None
+            if self.backup_path is not None:
+                try:
+                    return self._read_path(self.backup_path)
+                except _RECOVERABLE_READ_ERRORS as exc:
+                    backup_error = exc
+
+            if default is not _MISSING:
+                return default
+            if isinstance(primary_error, FileNotFoundError) and backup_error is not None:
+                if not isinstance(backup_error, FileNotFoundError):
+                    raise backup_error from primary_error
+            raise primary_error
+
+    def read(self, *, default=_MISSING):
+        with self.locked():
+            return self._read_unlocked(default)
+
+    def _write_temp(self, target: Path, data: bytes) -> Path:
+        descriptor, temp_name = tempfile.mkstemp(
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+        )
+        temp_path = Path(temp_name)
+        try:
+            try:
+                with os.fdopen(descriptor, "wb") as handle:
+                    descriptor = -1
+                    handle.write(data)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+        except BaseException:
+            _unlink_if_present(temp_path)
+            raise
+        return temp_path
+
+    def _backup_primary_unlocked(self) -> bool:
+        if self.backup_path is None or not self.path.is_file():
+            return False
+        try:
+            raw = self.path.read_bytes()
+            json.loads(raw.decode("utf-8"))
+        except _RECOVERABLE_READ_ERRORS:
+            return False
+
+        backup_temp = self._write_temp(self.backup_path, raw)
+        try:
+            os.replace(backup_temp, self.backup_path)
+            _fsync_directory(self.path.parent)
+        finally:
+            _unlink_if_present(backup_temp)
+        return True
+
+    def _write_bytes_unlocked(self, encoded: bytes) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        primary_temp = self._write_temp(self.path, encoded)
+        try:
+            self._backup_primary_unlocked()
+            os.replace(primary_temp, self.path)
+            _fsync_directory(self.path.parent)
+        finally:
+            _unlink_if_present(primary_temp)
+
+    @staticmethod
+    def _encode(value, *, indent: int | None, trailing_newline: bool) -> bytes:
+        encoded = json.dumps(value, ensure_ascii=False, indent=indent)
+        if trailing_newline:
+            encoded += "\n"
+        return encoded.encode("utf-8")
+
+    def write(
+        self,
+        value,
+        *,
+        indent: int | None = 2,
+        trailing_newline: bool = False,
+    ) -> None:
+        encoded = self._encode(value, indent=indent, trailing_newline=trailing_newline)
+        with self.locked():
+            self._write_bytes_unlocked(encoded)
+
+    def update(
+        self,
+        transform: Callable[[object], _T],
+        *,
+        default=_MISSING,
+        indent: int | None = 2,
+        trailing_newline: bool = False,
+    ) -> _T:
+        """Run a read-modify-write callback while holding the path lock."""
+
+        with self.locked():
+            value = transform(self._read_unlocked(default))
+            encoded = self._encode(value, indent=indent, trailing_newline=trailing_newline)
+            self._write_bytes_unlocked(encoded)
+            return value
+
+    def replace_from(
+        self,
+        source: "AtomicJsonStore",
+        *,
+        overwrite: bool = True,
+        backup_target: bool = True,
+    ) -> None:
+        """Atomically move a valid same-directory primary into this store."""
+
+        if source.path.parent != self.path.parent:
+            raise ValueError("Atomic JSON moves require the same directory")
+        with _locked_paths(source.path, self.path):
+            source._read_path(source.path)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            if self.path.exists() and not overwrite:
+                raise FileExistsError("Profile already exists")
+            if backup_target and self.path.is_file():
+                self._backup_primary_unlocked()
+            os.replace(source.path, self.path)
+            _fsync_directory(self.path.parent)

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -449,6 +449,63 @@ class AIOProfileStorageTests(unittest.TestCase):
                 self.assertEqual(errors, [])
                 self.assertEqual(api._load_aio_profile("Concurrent")["settings"]["value"], "new")
 
+    def test_rename_rejects_invalid_source_schema_before_publish(self):
+        api = load_api_module()
+        invalid_payloads = (
+            ("array", []),
+            ("empty object", {}),
+            ("non-object settings", {"settings": []}),
+        )
+
+        for label, invalid_payload in invalid_payloads:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                source = root / "Source.json"
+                target = root / "Target.json"
+                source.write_text(
+                    json.dumps(invalid_payload, ensure_ascii=False),
+                    encoding="utf-8",
+                )
+                source_bytes = source.read_bytes()
+
+                with patch.object(api, "AIO_PROFILE_DIR", root):
+                    with self.assertRaisesRegex(ValueError, "Profile settings must be an object"):
+                        api._rename_aio_profile("Source", "Target")
+
+                self.assertEqual(source.read_bytes(), source_bytes)
+                self.assertFalse(target.exists())
+                self.assertFalse((root / "Target.json.bak").exists())
+
+    def test_rename_invalid_schema_preserves_overwrite_target_and_existing_backup(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Target", {"settings": {"value": "old target"}})
+                api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "current target"}},
+                    overwrite=True,
+                )
+                source = root / "Source.json"
+                target = root / "Target.json"
+                backup = root / "Target.json.bak"
+                source.write_text('{"settings": []}', encoding="utf-8")
+                source_bytes = source.read_bytes()
+                target_bytes = target.read_bytes()
+                backup_bytes = backup.read_bytes()
+
+                with self.assertRaisesRegex(ValueError, "Profile settings must be an object"):
+                    api._rename_aio_profile("Source", "Target", overwrite=True)
+
+                self.assertEqual(source.read_bytes(), source_bytes)
+                self.assertEqual(target.read_bytes(), target_bytes)
+                self.assertEqual(backup.read_bytes(), backup_bytes)
+                self.assertEqual(
+                    [path for path in root.iterdir() if path.name.endswith(".tmp")],
+                    [],
+                )
+
     def test_rename_overwrite_atomically_moves_source_and_keeps_target_backup(self):
         api = load_api_module()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -108,6 +108,199 @@ class AIOProfileStorageTests(unittest.TestCase):
                 self.assertEqual(deleted["name"], "Production")
                 self.assertEqual(api._list_aio_profiles(), [])
 
+    def test_delete_removes_profile_primary_and_backup(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Delete Me", {"settings": {"value": "old"}})
+                api._save_aio_profile(
+                    "Delete Me",
+                    {"settings": {"value": "current"}},
+                    overwrite=True,
+                )
+                primary = root / "Delete Me.json"
+                backup = root / "Delete Me.json.bak"
+                self.assertTrue(primary.is_file())
+                self.assertTrue(backup.is_file())
+
+                deleted = api._delete_aio_profile("delete me")
+
+                self.assertEqual(deleted["name"], "Delete Me")
+                self.assertFalse(primary.exists())
+                self.assertFalse(backup.exists())
+
+    def test_delete_backup_failure_preserves_profile_primary(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Preserved", {"settings": {"value": "old"}})
+                api._save_aio_profile(
+                    "Preserved",
+                    {"settings": {"value": "current"}},
+                    overwrite=True,
+                )
+                primary = (root / "Preserved.json").resolve()
+                backup = (root / "Preserved.json.bak").resolve()
+                real_unlink = Path.unlink
+
+                def fail_backup_unlink(path, *args, **kwargs):
+                    if Path(path) == backup:
+                        raise OSError("backup unlink failed")
+                    return real_unlink(path, *args, **kwargs)
+
+                with patch.object(Path, "unlink", autospec=True, side_effect=fail_backup_unlink):
+                    with self.assertRaisesRegex(OSError, "backup unlink failed"):
+                        api._delete_aio_profile("Preserved")
+
+                self.assertEqual(api._load_aio_profile("Preserved")["settings"]["value"], "current")
+                self.assertTrue(primary.is_file())
+                self.assertTrue(backup.is_file())
+
+    def test_deleted_backup_cannot_recover_after_same_name_recreation(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Recreated", {"settings": {"value": "old"}})
+                api._save_aio_profile(
+                    "Recreated",
+                    {"settings": {"value": "current"}},
+                    overwrite=True,
+                )
+                api._delete_aio_profile("Recreated")
+
+                api._save_aio_profile("Recreated", {"settings": {"value": "recreated"}})
+                primary = root / "Recreated.json"
+                backup = root / "Recreated.json.bak"
+                self.assertFalse(backup.exists())
+                primary.write_text("{", encoding="utf-8")
+
+                with self.assertRaisesRegex(ValueError, "Profile data is invalid"):
+                    api._load_aio_profile("Recreated")
+
+    def test_delete_waits_for_in_progress_write_on_same_profile_path(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_path = (root / "Concurrent Delete.json").resolve()
+            publish_ready = threading.Event()
+            release_publish = threading.Event()
+            delete_started = threading.Event()
+            delete_done = threading.Event()
+            errors: list[BaseException] = []
+            deleted: list[dict] = []
+            real_replace = profile_storage.os.replace
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Concurrent Delete", {"settings": {"value": "old"}})
+
+                def block_primary_publish(source, target):
+                    if Path(target) == profile_path:
+                        publish_ready.set()
+                        if not release_publish.wait(2):
+                            raise AssertionError("profile publish was not released")
+                    return real_replace(source, target)
+
+                def overwrite_profile():
+                    try:
+                        api._save_aio_profile(
+                            "Concurrent Delete",
+                            {"settings": {"value": "new"}},
+                            overwrite=True,
+                        )
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                def delete_profile():
+                    delete_started.set()
+                    try:
+                        deleted.append(api._delete_aio_profile("Concurrent Delete"))
+                    except BaseException as exc:
+                        errors.append(exc)
+                    finally:
+                        delete_done.set()
+
+                with patch.object(profile_storage.os, "replace", side_effect=block_primary_publish):
+                    writer = threading.Thread(target=overwrite_profile)
+                    deleter = threading.Thread(target=delete_profile)
+                    writer.start()
+                    self.assertTrue(publish_ready.wait(2))
+                    deleter.start()
+                    self.assertTrue(delete_started.wait(2))
+                    self.assertFalse(delete_done.wait(0.05))
+                    release_publish.set()
+                    writer.join(2)
+                    deleter.join(2)
+
+                self.assertFalse(writer.is_alive())
+                self.assertFalse(deleter.is_alive())
+                self.assertEqual(errors, [])
+                self.assertEqual(deleted, [{"name": "Concurrent Delete"}])
+                self.assertFalse(profile_path.exists())
+                self.assertFalse((root / "Concurrent Delete.json.bak").exists())
+
+    def test_delete_waits_for_in_progress_rename_on_target_profile_path(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = (root / "Source.json").resolve()
+            target = (root / "Target.json").resolve()
+            move_ready = threading.Event()
+            release_move = threading.Event()
+            delete_started = threading.Event()
+            delete_done = threading.Event()
+            errors: list[BaseException] = []
+            real_replace = profile_storage.os.replace
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+
+                def block_profile_move(current, destination):
+                    if Path(current) == source and Path(destination) == target:
+                        move_ready.set()
+                        if not release_move.wait(2):
+                            raise AssertionError("profile move was not released")
+                    return real_replace(current, destination)
+
+                def rename_profile():
+                    try:
+                        api._rename_aio_profile("Source", "Target", overwrite=True)
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                def delete_target():
+                    delete_started.set()
+                    try:
+                        api._delete_aio_profile("Target")
+                    except BaseException as exc:
+                        errors.append(exc)
+                    finally:
+                        delete_done.set()
+
+                with patch.object(profile_storage.os, "replace", side_effect=block_profile_move):
+                    renamer = threading.Thread(target=rename_profile)
+                    deleter = threading.Thread(target=delete_target)
+                    renamer.start()
+                    self.assertTrue(move_ready.wait(2))
+                    deleter.start()
+                    self.assertTrue(delete_started.wait(2))
+                    self.assertFalse(delete_done.wait(0.05))
+                    release_move.set()
+                    renamer.join(2)
+                    deleter.join(2)
+
+                self.assertFalse(renamer.is_alive())
+                self.assertFalse(deleter.is_alive())
+                self.assertEqual(errors, [])
+                self.assertFalse(source.exists())
+                self.assertFalse(target.exists())
+                self.assertFalse((root / "Target.json.bak").exists())
+
     def test_filename_identity_collisions_require_explicit_overwrite(self):
         api = load_api_module()
         collision_cases = (
@@ -412,6 +605,23 @@ class AIOProfileApiRouteTests(unittest.TestCase):
                     response["payload"],
                     {"status": "error", "message": "Profile already exists"},
                 )
+
+    def test_delete_missing_profile_preserves_404_response_contract(self):
+        api, routes = load_api_routes()
+        handler = routes.handlers["/easyuse_anima/aio_profiles/delete"]
+
+        with patch.object(
+            api,
+            "_delete_aio_profile",
+            side_effect=FileNotFoundError("Profile not found"),
+        ):
+            response = asyncio.run(handler(JsonRequest({"name": "Missing"})))
+
+        self.assertEqual(response["status"], 404)
+        self.assertEqual(
+            response["payload"],
+            {"status": "error", "message": "Profile not found"},
+        )
 
 
 class AIOBuiltinProfileTests(unittest.TestCase):

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import json
 import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
 import types
 import unittest
 from pathlib import Path
@@ -181,6 +183,161 @@ class AIOProfileStorageTests(unittest.TestCase):
                 (Path(tmp) / "Broken.json").write_text("{", encoding="utf-8")
                 with self.assertRaisesRegex(ValueError, "Profile data is invalid"):
                     api._load_aio_profile("Broken")
+
+    def test_empty_profile_preserves_legacy_payload_validation_contract(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                (root / "Empty.json").write_text("", encoding="utf-8")
+
+                with self.assertRaisesRegex(ValueError, "Profile settings must be an object"):
+                    api._load_aio_profile("Empty")
+
+    def test_invalid_primary_recovers_last_valid_backup(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Recoverable", {"settings": {"value": "first"}})
+                api._save_aio_profile(
+                    "Recoverable",
+                    {"settings": {"value": "second"}},
+                    overwrite=True,
+                )
+                (root / "Recoverable.json").write_text("{", encoding="utf-8")
+
+                recovered = api._load_aio_profile("Recoverable")
+
+        self.assertEqual(recovered["name"], "Recoverable")
+        self.assertEqual(recovered["settings"]["value"], "first")
+
+    def test_concurrent_profile_publish_never_exposes_partial_json(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_path = (root / "Concurrent.json").resolve()
+            publish_ready = threading.Event()
+            release_publish = threading.Event()
+            errors: list[BaseException] = []
+            real_replace = profile_storage.os.replace
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Concurrent", {"settings": {"value": "old"}})
+
+                def block_primary_publish(source, target):
+                    if Path(target) == profile_path:
+                        publish_ready.set()
+                        if not release_publish.wait(2):
+                            raise AssertionError("profile publish was not released")
+                    return real_replace(source, target)
+
+                def overwrite_profile():
+                    try:
+                        api._save_aio_profile(
+                            "Concurrent",
+                            {"settings": {"value": "new", "items": list(range(1000))}},
+                            overwrite=True,
+                        )
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                with patch.object(profile_storage.os, "replace", side_effect=block_primary_publish):
+                    writer = threading.Thread(target=overwrite_profile)
+                    writer.start()
+                    self.assertTrue(publish_ready.wait(2))
+                    visible = json.loads(profile_path.read_text(encoding="utf-8"))
+                    self.assertEqual(visible["settings"]["value"], "old")
+                    release_publish.set()
+                    writer.join(2)
+
+                self.assertFalse(writer.is_alive())
+                self.assertEqual(errors, [])
+                self.assertEqual(api._load_aio_profile("Concurrent")["settings"]["value"], "new")
+
+    def test_rename_overwrite_atomically_moves_source_and_keeps_target_backup(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+
+                renamed = api._rename_aio_profile("Source", "Target", overwrite=True)
+
+                backup = json.loads((root / "Target.json.bak").read_text(encoding="utf-8"))
+                self.assertEqual(renamed["name"], "Target")
+                self.assertEqual(renamed["settings"]["value"], "source")
+                self.assertEqual(backup["settings"]["value"], "target")
+                self.assertFalse((root / "Source.json").exists())
+
+    def test_rename_move_failure_preserves_source_target_and_backup(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = (root / "Source.json").resolve()
+            target = (root / "Target.json").resolve()
+            real_replace = profile_storage.os.replace
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+
+                def fail_move(current, destination):
+                    if Path(current) == source and Path(destination) == target:
+                        raise OSError("rename move failed")
+                    return real_replace(current, destination)
+
+                with patch.object(profile_storage.os, "replace", side_effect=fail_move):
+                    with self.assertRaisesRegex(OSError, "rename move failed"):
+                        api._rename_aio_profile("Source", "Target", overwrite=True)
+
+                self.assertEqual(api._load_aio_profile("Source")["settings"]["value"], "source")
+                self.assertEqual(api._load_aio_profile("Target")["settings"]["value"], "target")
+                backup = json.loads((root / "Target.json.bak").read_text(encoding="utf-8"))
+                self.assertEqual(backup["settings"]["value"], "target")
+                self.assertEqual([path for path in root.iterdir() if path.name.endswith(".tmp")], [])
+
+    def test_rename_target_backup_failure_preserves_source_and_target(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backup_path = (root / "Target.json.bak").resolve()
+            real_replace = profile_storage.os.replace
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+
+                def fail_backup(current, destination):
+                    if Path(destination) == backup_path:
+                        raise OSError("target backup failed")
+                    return real_replace(current, destination)
+
+                with patch.object(profile_storage.os, "replace", side_effect=fail_backup):
+                    with self.assertRaisesRegex(OSError, "target backup failed"):
+                        api._rename_aio_profile("Source", "Target", overwrite=True)
+
+                self.assertEqual(api._load_aio_profile("Source")["settings"]["value"], "source")
+                self.assertEqual(api._load_aio_profile("Target")["settings"]["value"], "target")
+                self.assertEqual([path for path in root.iterdir() if path.name.endswith(".tmp")], [])
+
+    def test_rename_does_not_depend_on_a_separate_unlink(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+
+                with patch.object(Path, "unlink", side_effect=OSError("unlink failed")):
+                    renamed = api._rename_aio_profile("Source", "Renamed")
+
+                self.assertEqual(renamed["name"], "Renamed")
+                self.assertFalse((root / "Source.json").exists())
+                self.assertTrue((root / "Renamed.json").is_file())
 
 
 class AIOProfileApiRouteTests(unittest.TestCase):

--- a/tests/test_lora_profiles.py
+++ b/tests/test_lora_profiles.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import json
 import sys
 import tempfile
 import types
@@ -110,6 +111,51 @@ class LoraProfileStorageTests(unittest.TestCase):
                 loaded = api._load_lora_profile("style_preset")
                 self.assertEqual(loaded["profile_data"]["2"]["style_prompt"], "@b")
                 self.assertEqual(loaded["profile_data"]["2"]["loras"][0]["name"], "foo.safetensors")
+
+    def test_invalid_primary_recovers_last_valid_backup(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                api._save_lora_profile(
+                    "Recoverable",
+                    {"profile_data": {"1": {"style_prompt": "first"}}},
+                )
+                api._save_lora_profile(
+                    "Recoverable",
+                    {"profile_data": {"1": {"style_prompt": "second"}}},
+                    overwrite=True,
+                )
+                (root / "Recoverable.json").write_text("{", encoding="utf-8")
+
+                recovered = api._load_lora_profile("Recoverable")
+
+        self.assertEqual(recovered["name"], "Recoverable")
+        self.assertEqual(recovered["profile_data"]["1"]["style_prompt"], "first")
+
+    def test_invalid_primary_and_backup_preserve_json_error_contract(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                (root / "Broken.json").write_text("{", encoding="utf-8")
+                (root / "Broken.json.bak").write_text("[", encoding="utf-8")
+
+                with self.assertRaises(json.JSONDecodeError):
+                    api._load_lora_profile("Broken")
+
+    def test_empty_profile_preserves_legacy_default_payload_contract(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                (root / "Empty.json").write_text("", encoding="utf-8")
+
+                loaded = api._load_lora_profile("Empty")
+
+        self.assertEqual(loaded["name"], "Empty")
+        self.assertEqual(loaded["profile_count"], 1)
+        self.assertEqual(loaded["profile_data"], {})
 
     def test_filename_identity_collisions_require_explicit_overwrite(self):
         api = load_api_module()

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -2714,6 +2714,150 @@ class SettingsTests(unittest.TestCase):
                         self.assertEqual(persisted[key], expected)
                         self.assertEqual(reloaded[key], expected)
 
+    def test_parallel_save_setting_updates_do_not_lose_different_keys(self):
+        root = Path(__file__).resolve().parents[1] / "__pycache__" / "parallel_settings_test"
+        shutil.rmtree(root, ignore_errors=True)
+        root.mkdir(parents=True, exist_ok=True)
+        settings_file = root / "settings.json"
+        long_text_settings_file = root / "long_text_settings.json"
+        first_read = threading.Event()
+        release_first = threading.Event()
+        second_started = threading.Event()
+        second_done = threading.Event()
+        errors: list[BaseException] = []
+        original_read = easyuse_settings._read_json_file
+
+        def coordinated_read(path: Path) -> dict:
+            data = original_read(path)
+            if Path(path) == settings_file and threading.current_thread().name == "first-setting":
+                first_read.set()
+                if not release_first.wait(2):
+                    raise AssertionError("first settings read was not released")
+            return data
+
+        def save_first():
+            try:
+                easyuse_settings.save_setting("autocomplete.limit", 33)
+            except BaseException as exc:
+                errors.append(exc)
+
+        def save_second():
+            second_started.set()
+            try:
+                easyuse_settings.save_setting("prompt_studio.font_family", "Inter")
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                second_done.set()
+
+        try:
+            with (
+                patch.object(easyuse_settings, "SETTINGS_FILE", settings_file),
+                patch.object(easyuse_settings, "LONG_TEXT_SETTINGS_FILE", long_text_settings_file),
+                patch.object(easyuse_settings, "_load_comfy_settings", return_value={}),
+                patch.object(easyuse_settings, "_read_json_file", side_effect=coordinated_read),
+            ):
+                first = threading.Thread(target=save_first, name="first-setting")
+                second = threading.Thread(target=save_second, name="second-setting")
+                first.start()
+                self.assertTrue(first_read.wait(2))
+                second.start()
+                self.assertTrue(second_started.wait(2))
+                self.assertFalse(second_done.wait(0.05))
+                release_first.set()
+                first.join(2)
+                second.join(2)
+
+            self.assertFalse(first.is_alive())
+            self.assertFalse(second.is_alive())
+            self.assertEqual(errors, [])
+            persisted = json.loads(settings_file.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["autocomplete.limit"], "33")
+            self.assertEqual(persisted["prompt_studio.font_family"], "Inter")
+        finally:
+            release_first.set()
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_parallel_long_text_updates_do_not_lose_different_keys(self):
+        root = Path(__file__).resolve().parents[1] / "__pycache__" / "parallel_long_text_test"
+        shutil.rmtree(root, ignore_errors=True)
+        root.mkdir(parents=True, exist_ok=True)
+        long_text_settings_file = root / "long_text_settings.json"
+        first_read = threading.Event()
+        release_first = threading.Event()
+        second_started = threading.Event()
+        second_done = threading.Event()
+        errors: list[BaseException] = []
+        store_class = easyuse_settings.AtomicJsonStore
+        original_read = store_class._read_unlocked
+
+        def coordinated_read(store, *args, **kwargs):
+            data = original_read(store, *args, **kwargs)
+            if (
+                store.path == long_text_settings_file.resolve()
+                and threading.current_thread().name == "first-long-text"
+            ):
+                first_read.set()
+                if not release_first.wait(2):
+                    raise AssertionError("first long-text read was not released")
+            return data
+
+        def save_first():
+            try:
+                easyuse_settings.save_long_text_settings(
+                    {"prompt.metadata_filter_words": "metadata"}
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        def save_second():
+            second_started.set()
+            try:
+                easyuse_settings.save_long_text_settings({"naia.pre_prompt": "prefix"})
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                second_done.set()
+
+        try:
+            with (
+                patch.object(
+                    easyuse_settings,
+                    "LONG_TEXT_SETTINGS_FILE",
+                    long_text_settings_file,
+                ),
+                patch.object(
+                    store_class,
+                    "_read_unlocked",
+                    autospec=True,
+                    side_effect=coordinated_read,
+                ),
+            ):
+                first = threading.Thread(target=save_first, name="first-long-text")
+                second = threading.Thread(target=save_second, name="second-long-text")
+                first.start()
+                self.assertTrue(first_read.wait(2))
+                second.start()
+                self.assertTrue(second_started.wait(2))
+                self.assertFalse(second_done.wait(0.05))
+                release_first.set()
+                first.join(2)
+                second.join(2)
+
+            self.assertFalse(first.is_alive())
+            self.assertFalse(second.is_alive())
+            self.assertEqual(errors, [])
+            persisted = json.loads(long_text_settings_file.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["values"]["prompt.metadata_filter_words"], "metadata")
+            self.assertEqual(persisted["values"]["naia.pre_prompt"], "prefix")
+        finally:
+            release_first.set()
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_save_setting_preserves_unknown_key_rejection_contract(self):
+        with self.assertRaisesRegex(KeyError, "Unknown setting"):
+            easyuse_settings.save_setting("future.unknown", "value")
+
     def test_public_settings_does_not_expose_token_file(self):
         settings = public_settings()
         self.assertEqual(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
 import importlib.util
+import json
+import shutil
 import sys
 import tempfile
+import threading
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
+
+import storage
+from storage import AtomicJsonStore
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -44,14 +53,193 @@ class StoragePathTests(unittest.TestCase):
             fake_folder_paths = types.SimpleNamespace(
                 get_system_user_directory=lambda name: str(root / f"__{name}")
             )
-            storage = load_storage_module(fake_folder_paths)
+            loaded_storage = load_storage_module(fake_folder_paths)
 
-            self.assertEqual(storage.USER_DATA_DIR, root / "__easyuse_anima")
+            self.assertEqual(loaded_storage.USER_DATA_DIR, root / "__easyuse_anima")
 
     def test_falls_back_to_package_data_dir_without_comfyui_folder_paths(self):
-        storage = load_storage_module()
+        loaded_storage = load_storage_module()
 
-        self.assertEqual(storage.USER_DATA_DIR, storage.PACKAGE_DATA_DIR)
+        self.assertEqual(loaded_storage.USER_DATA_DIR, loaded_storage.PACKAGE_DATA_DIR)
+
+
+class AtomicJsonStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.root = ROOT / "__pycache__" / "atomic_json_store_tests" / self._testMethodName
+        shutil.rmtree(self.root, ignore_errors=True)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _store(self) -> AtomicJsonStore:
+        return AtomicJsonStore(self.root / "state.json")
+
+    def _temp_files(self) -> list[Path]:
+        return [path for path in self.root.iterdir() if path.name.endswith(".tmp")]
+
+    def test_replace_failure_preserves_primary_bytes_and_cleans_temps(self):
+        store = self._store()
+        store.write({"value": "old"}, trailing_newline=True)
+        original = store.path.read_bytes()
+        real_replace = storage.os.replace
+        primary_temp_paths: list[Path] = []
+
+        def fail_primary_publish(source, target):
+            if Path(target) == store.path:
+                primary_temp_paths.append(Path(source))
+                raise OSError("primary publish failed")
+            return real_replace(source, target)
+
+        with patch.object(storage.os, "replace", side_effect=fail_primary_publish):
+            with self.assertRaisesRegex(OSError, "primary publish failed"):
+                store.write({"value": "new"}, trailing_newline=True)
+
+        self.assertEqual(store.path.read_bytes(), original)
+        self.assertEqual(store.read(), {"value": "old"})
+        self.assertEqual(json.loads(store.backup_path.read_text(encoding="utf-8")), {"value": "old"})
+        self.assertEqual([path.parent for path in primary_temp_paths], [store.path.parent])
+        self.assertEqual(self._temp_files(), [])
+
+    def test_temp_fsync_failure_preserves_primary_and_cleans_temp(self):
+        store = self._store()
+        store.write({"value": "old"})
+        original = store.path.read_bytes()
+
+        with patch.object(storage.os, "fsync", side_effect=OSError("data fsync failed")):
+            with self.assertRaisesRegex(OSError, "data fsync failed"):
+                store.write({"value": "new"})
+
+        self.assertEqual(store.path.read_bytes(), original)
+        self.assertEqual(self._temp_files(), [])
+
+    def test_temp_creation_failure_preserves_primary(self):
+        store = self._store()
+        store.write({"value": "old"})
+        original = store.path.read_bytes()
+
+        with patch.object(storage.tempfile, "mkstemp", side_effect=OSError("temp create failed")):
+            with self.assertRaisesRegex(OSError, "temp create failed"):
+                store.write({"value": "new"})
+
+        self.assertEqual(store.path.read_bytes(), original)
+        self.assertEqual(self._temp_files(), [])
+
+    def test_backup_publish_failure_preserves_primary_and_previous_backup(self):
+        store = self._store()
+        store.write({"value": "first"})
+        store.write({"value": "second"})
+        primary = store.path.read_bytes()
+        backup = store.backup_path.read_bytes()
+        real_replace = storage.os.replace
+
+        def fail_backup_publish(source, target):
+            if Path(target) == store.backup_path:
+                raise OSError("backup publish failed")
+            return real_replace(source, target)
+
+        with patch.object(storage.os, "replace", side_effect=fail_backup_publish):
+            with self.assertRaisesRegex(OSError, "backup publish failed"):
+                store.write({"value": "third"})
+
+        self.assertEqual(store.path.read_bytes(), primary)
+        self.assertEqual(store.backup_path.read_bytes(), backup)
+        self.assertEqual(self._temp_files(), [])
+
+    def test_invalid_or_missing_primary_reads_valid_backup_without_repair(self):
+        store = self._store()
+        store.path.write_text("{", encoding="utf-8")
+        store.backup_path.write_text('{"value": "backup"}', encoding="utf-8")
+
+        self.assertEqual(store.read(), {"value": "backup"})
+        self.assertEqual(store.path.read_text(encoding="utf-8"), "{")
+
+        store.path.unlink()
+        self.assertEqual(store.read(), {"value": "backup"})
+        self.assertFalse(store.path.exists())
+
+    def test_invalid_backup_uses_explicit_error_or_default_contract(self):
+        store = self._store()
+        store.path.write_text("{", encoding="utf-8")
+        store.backup_path.write_text("[", encoding="utf-8")
+
+        with self.assertRaises(json.JSONDecodeError):
+            store.read()
+        self.assertEqual(store.read(default={"fallback": True}), {"fallback": True})
+
+        store.path.unlink()
+        with self.assertRaises(json.JSONDecodeError):
+            store.read()
+
+    def test_store_instances_share_the_same_resolved_path_lock(self):
+        first_store = AtomicJsonStore(self.root / "nested" / ".." / "state.json")
+        second_store = self._store()
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_attempted = threading.Event()
+        second_entered = threading.Event()
+
+        def hold_first_lock():
+            with first_store.locked():
+                first_entered.set()
+                self.assertTrue(release_first.wait(2))
+
+        def enter_second_lock():
+            self.assertTrue(first_entered.wait(2))
+            second_attempted.set()
+            with second_store.locked():
+                second_entered.set()
+
+        first = threading.Thread(target=hold_first_lock)
+        second = threading.Thread(target=enter_second_lock)
+        first.start()
+        second.start()
+        self.assertTrue(first_entered.wait(2))
+        self.assertTrue(second_attempted.wait(2))
+        self.assertFalse(second_entered.wait(0.05))
+        release_first.set()
+        first.join(2)
+        second.join(2)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertTrue(second_entered.is_set())
+
+    def test_reader_sees_complete_primary_while_publish_is_blocked(self):
+        writer_store = self._store()
+        reader_store = AtomicJsonStore(self.root / "." / "state.json")
+        writer_store.write({"value": "old", "items": list(range(100))})
+        publish_ready = threading.Event()
+        release_publish = threading.Event()
+        errors: list[BaseException] = []
+        real_replace = storage.os.replace
+
+        def block_primary_publish(source, target):
+            if Path(target) == writer_store.path:
+                publish_ready.set()
+                if not release_publish.wait(2):
+                    raise AssertionError("publish release was not signaled")
+            return real_replace(source, target)
+
+        def write_new_value():
+            try:
+                writer_store.write({"value": "new", "items": list(range(1000))})
+            except BaseException as exc:
+                errors.append(exc)
+
+        with patch.object(storage.os, "replace", side_effect=block_primary_publish):
+            writer = threading.Thread(target=write_new_value)
+            writer.start()
+            self.assertTrue(publish_ready.wait(2))
+            visible = json.loads(writer_store.path.read_text(encoding="utf-8"))
+            self.assertEqual(visible["value"], "old")
+            release_publish.set()
+            writer.join(2)
+
+        self.assertFalse(writer.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(reader_store.read()["value"], "new")
+        self.assertEqual(self._temp_files(), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -146,6 +146,89 @@ class AtomicJsonStoreTests(unittest.TestCase):
         self.assertEqual(store.backup_path.read_bytes(), backup)
         self.assertEqual(self._temp_files(), [])
 
+    def test_delete_removes_primary_and_backup(self):
+        store = self._store()
+        store.write({"value": "old"})
+        store.write({"value": "current"})
+        self.assertTrue(store.path.is_file())
+        self.assertTrue(store.backup_path.is_file())
+
+        store.delete()
+
+        self.assertFalse(store.path.exists())
+        self.assertFalse(store.backup_path.exists())
+
+    def test_backup_unlink_failure_preserves_primary(self):
+        store = self._store()
+        store.write({"value": "old"})
+        store.write({"value": "current"})
+        primary = store.path.read_bytes()
+        backup = store.backup_path.read_bytes()
+        real_unlink = Path.unlink
+
+        def fail_backup_unlink(path, *args, **kwargs):
+            if Path(path) == store.backup_path:
+                raise OSError("backup unlink failed")
+            return real_unlink(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", autospec=True, side_effect=fail_backup_unlink):
+            with self.assertRaisesRegex(OSError, "backup unlink failed"):
+                store.delete()
+
+        self.assertEqual(store.path.read_bytes(), primary)
+        self.assertEqual(store.backup_path.read_bytes(), backup)
+
+    def test_primary_unlink_failure_is_propagated_after_backup_removal(self):
+        store = self._store()
+        store.write({"value": "old"})
+        store.write({"value": "current"})
+        primary = store.path.read_bytes()
+        real_unlink = Path.unlink
+
+        def fail_primary_unlink(path, *args, **kwargs):
+            if Path(path) == store.path:
+                raise OSError("primary unlink failed")
+            return real_unlink(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", autospec=True, side_effect=fail_primary_unlink):
+            with self.assertRaisesRegex(OSError, "primary unlink failed"):
+                store.delete()
+
+        self.assertEqual(store.path.read_bytes(), primary)
+        self.assertFalse(store.backup_path.exists())
+
+    def test_backup_directory_fsync_failure_preserves_primary_and_reports_state(self):
+        store = self._store()
+        store.write({"value": "old"})
+        store.write({"value": "current"})
+        primary = store.path.read_bytes()
+
+        with patch.object(
+            storage,
+            "_fsync_directory",
+            side_effect=OSError("directory fsync failed"),
+        ):
+            with self.assertRaisesRegex(OSError, "directory fsync failed"):
+                store.delete()
+
+        self.assertEqual(store.path.read_bytes(), primary)
+        self.assertFalse(store.backup_path.exists())
+
+    def test_primary_directory_fsync_failure_reports_deleted_primary(self):
+        store = self._store()
+        store.write({"value": "current"})
+        self.assertFalse(store.backup_path.exists())
+
+        with patch.object(
+            storage,
+            "_fsync_directory",
+            side_effect=OSError("directory fsync failed"),
+        ):
+            with self.assertRaisesRegex(OSError, "directory fsync failed"):
+                store.delete()
+
+        self.assertFalse(store.path.exists())
+
     def test_invalid_or_missing_primary_reads_valid_backup_without_repair(self):
         store = self._store()
         store.path.write_text("{", encoding="utf-8")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -229,6 +229,28 @@ class AtomicJsonStoreTests(unittest.TestCase):
 
         self.assertFalse(store.path.exists())
 
+    def test_replace_transform_failure_preserves_source_target_and_backup(self):
+        source = AtomicJsonStore(self.root / "source.json")
+        target = AtomicJsonStore(self.root / "target.json")
+        source.write({"settings": {"value": "source"}})
+        target.write({"settings": {"value": "old target"}})
+        target.write({"settings": {"value": "current target"}})
+        source_bytes = source.path.read_bytes()
+        target_bytes = target.path.read_bytes()
+        backup_bytes = target.backup_path.read_bytes()
+
+        def reject_source(value):
+            self.assertEqual(value, {"settings": {"value": "source"}})
+            raise ValueError("source schema is invalid")
+
+        with self.assertRaisesRegex(ValueError, "source schema is invalid"):
+            target.replace_from(source, transform=reject_source)
+
+        self.assertEqual(source.path.read_bytes(), source_bytes)
+        self.assertEqual(target.path.read_bytes(), target_bytes)
+        self.assertEqual(target.backup_path.read_bytes(), backup_bytes)
+        self.assertEqual(self._temp_files(), [])
+
     def test_invalid_or_missing_primary_reads_valid_backup_without_repair(self):
         store = self._store()
         store.path.write_text("{", encoding="utf-8")


### PR DESCRIPTION
## 변경 요약

- `storage.py`에 resolved-path 기준 process-wide `RLock`을 공유하는 `AtomicJsonStore`를 추가했습니다.
- JSON을 same-directory temp에 UTF-8로 기록하고 flush + data fsync 후 `os.replace`로 publish합니다.
- 유효한 primary의 `.bak`도 temp + replace로 원자 게시하고 invalid/missing primary는 valid backup으로 fallback합니다.
- `settings.json`과 `long_text_settings.json` read-modify-write를 같은 path lock 안에서 처리해 병렬 업데이트 유실을 막습니다.
- LoRA/AiO profile save/load를 atomic store에 적용하고 AiO rename을 same-directory `os.replace` move로 전환합니다.
- AiO delete가 동일 primary-path lock 아래 primary와 backup 수명주기를 함께 처리합니다.
- rename은 source/target lock 안에서 profile schema를 backup/publish 전에 검증하고 검증된 target-name payload를 반환합니다.
- Part 1의 collision/overwrite/409/name 정규화 계약을 유지합니다.

## 주요 파일

- `storage.py`
- `settings.py`
- `api.py`
- `tests/test_storage.py`
- `tests/test_prompt_corrector.py`
- `tests/test_aio_profiles.py`
- `tests/test_lora_profiles.py`

## 메인 리뷰에서 보완한 차단점

1. primary만 삭제해 남은 `.bak`이 동일 이름 재생성 후 삭제된 옛 profile을 복구하던 수명주기 결함
2. valid JSON이지만 invalid profile schema인 source를 target으로 이동한 뒤 예외가 발생하던 rename publish 순서
3. concurrent rename/delete에서 move 후 lock 밖 재-load가 target 삭제와 경합하던 반환 race

각 경계는 source/target/backup byte 보존, failure ordering, 동일 path 동시성 회귀로 고정했습니다.

## 검증

### Worker focused

- 변경 파일 Python compile — 통과
- storage/AiO/LoRA/settings focused — 66 tests, OK
- delete lifecycle affected — 38 tests, OK
- pre-publish schema validation affected — 41 tests, OK
- `git diff --check` / staged diff check — 통과

### Main full/integration

```powershell
powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <target-worktree> -Profile full
```

- 최신 `dev` 결합 head `f27ad401d5051da0517df4b152edca473cd448d9`
- Python compile — 통과
- Python unittest — 501 tests, OK
- Frontend — 110 JavaScript files, TypeScript 6.0.3, 통과
- `git diff --check` — 통과

### Failure injection / concurrency 표면

- primary replace, data fsync/temp 생성, backup publish 실패
- delete backup unlink, primary unlink, directory fsync 실패
- AiO rename move/target backup/validator 실패
- settings/long-text lost-update 방지
- profile publish 중 partial JSON 비노출
- write/delete 및 rename/delete 동일 target-path 직렬화
- invalid schema에서 source/target/기존 backup byte-for-byte 보존

## 테스트 표면

- ComfyUI Codex test instance: backend storage/settings/profile focused + project full suite
- Live ComfyUI smoke: 미실행 (backend durable storage와 deterministic failure/concurrency 경계로 검증)

## 남은 범위와 위험

- stable profile ID, revision, migration, optimistic concurrency는 Part 3로 남깁니다.
- lock은 process-wide이며 여러 ComfyUI process 사이의 RMW 직렬화는 제공하지 않습니다. 파일 publish 자체는 atomic replace입니다.
- Windows에서 지원되지 않는 directory fsync는 건너뛰지만 data fsync와 지원되는 directory fsync 실패는 전파합니다.
- 이 PR은 Issue #163을 닫지 않습니다.

Relates to #163