### PR TITLE
fix: AiO info tooltip 단일 owner 및 outside dismiss

### DIFF
--- a/tests/frontend_aio_generator_panel_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_panel_runtime_smoke.mjs
@@ -224,6 +224,21 @@ function createFixture() {
     }
   }
 
+  function dispatchDocument(type, event = {}) {
+    const nextEvent = {
+      target: document.body,
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+      ...event,
+    };
+    for (const entry of [...(document.listeners.get(type) || [])]) {
+      entry.handler(nextEvent);
+    }
+    return nextEvent;
+  }
+
   function runStaleAnimationFrames() {
     for (const callback of staleAnimationFrames.splice(0)) {
       callback();
@@ -519,10 +534,223 @@ function createFixture() {
     runStaleAnimationFrames,
     windowListenerCount,
     dispatchWindow,
+    dispatchDocument,
     actionCalls,
     defaultSettings,
     dependencyCalls: () => dependencyCalls,
   };
+}
+
+function createOwnerTestNode(fixture, settings) {
+  const nodeSettings = clone(settings);
+  return {
+    settings: nodeSettings,
+    widgets: [],
+    widgets_values: ["owner-test-widget-state"],
+    widgetValues: {
+      seed: nodeSettings.sampler.seed,
+      steps: nodeSettings.sampler.steps,
+      cfg: nodeSettings.sampler.cfg,
+      denoise: nodeSettings.sampler.denoise,
+      sampler_name: nodeSettings.sampler.sampler_name,
+      scheduler: nodeSettings.sampler.scheduler,
+    },
+    profileValue: "custom",
+    size: [620, 700],
+    minWidth: 560,
+    __easyuseAnimaGeneratorPreviewImages: [],
+    __easyuseAnimaSelectedPreviewIndex: 0,
+    addDOMWidget(name, type, element, options) {
+      const widget = {
+        name,
+        type,
+        element,
+        options,
+        onRemoveCalls: 0,
+        onRemove() {
+          this.onRemoveCalls += 1;
+          fixture.domWidgetStore.delete(this);
+        },
+      };
+      this.widgets.push(widget);
+      fixture.domWidgetStore.add(widget);
+      fixture.document.body.append(element);
+      return widget;
+    },
+  };
+}
+
+function infoTooltipFor(fixture, button) {
+  return findByAttribute(
+    fixture.document.body,
+    "id",
+    button.getAttribute("aria-describedby"),
+  );
+}
+
+function visibleInfoTooltips(fixture) {
+  return fixture.document
+    .querySelectorAll("[data-aio-info-tooltip]")
+    .filter((tooltip) => !tooltip.hidden);
+}
+
+function clickInfoTrigger(fixture, button) {
+  fixture.dispatchDocument("pointerdown", { target: button });
+  fixture.dispatchDocument("click", { target: button });
+  button.emit("click");
+}
+
+const OWNER_DOCUMENT_EVENT_NAMES = ["pointerdown", "click", "touchstart", "keydown"];
+
+function assertOwnerDocumentListenerCount(fixture, expected, message) {
+  for (const eventName of OWNER_DOCUMENT_EVENT_NAMES) {
+    assert.equal(
+      fixture.document.listenerCount(eventName, true),
+      expected,
+      message + ": " + eventName,
+    );
+  }
+}
+
+{
+  const ownerFixture = createFixture();
+  const ownerSettings = clone(ownerFixture.defaultSettings);
+  ownerSettings.highres.enabled = true;
+  ownerSettings.highres.inherit_sampler_settings = false;
+  ownerSettings.detailer.enabled = true;
+  ownerSettings.detailer.face.enabled = true;
+  const firstNode = createOwnerTestNode(ownerFixture, ownerSettings);
+  const secondNode = createOwnerTestNode(ownerFixture, ownerSettings);
+  ownerFixture.runtime.ensurePanel(firstNode);
+  ownerFixture.runtime.ensurePanel(secondNode);
+  const firstPanel = firstNode.__easyuseAnimaGeneratorPanelEl;
+  const secondPanel = secondNode.__easyuseAnimaGeneratorPanelEl;
+  const firstHighres = findByAttribute(firstPanel, "data-aio-focus-key", "highres.info");
+  const firstDetailer = findByAttribute(
+    firstPanel,
+    "data-aio-focus-key",
+    "detailer.face.follow-main.info",
+  );
+  const secondDetailer = findByAttribute(
+    secondPanel,
+    "data-aio-focus-key",
+    "detailer.face.follow-main.info",
+  );
+  assert.ok(firstHighres && firstDetailer && secondDetailer);
+  const firstHighresTooltip = infoTooltipFor(ownerFixture, firstHighres);
+  const firstDetailerTooltip = infoTooltipFor(ownerFixture, firstDetailer);
+  const secondDetailerTooltip = infoTooltipFor(ownerFixture, secondDetailer);
+  assert.ok(firstHighresTooltip && firstDetailerTooltip && secondDetailerTooltip);
+  assertOwnerDocumentListenerCount(ownerFixture, 0, "closed tooltips must not own document listeners");
+
+  clickInfoTrigger(ownerFixture, firstHighres);
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 1);
+  assert.equal(firstHighres.getAttribute("aria-expanded"), "true");
+  clickInfoTrigger(ownerFixture, firstDetailer);
+  assert.equal(
+    visibleInfoTooltips(ownerFixture).length,
+    1,
+    "opening Detailer after Highres must leave exactly one visible portal",
+  );
+  assert.equal(firstHighresTooltip.hidden, true);
+  assert.equal(firstHighres.getAttribute("aria-expanded"), "false");
+  assert.equal(firstDetailerTooltip.hidden, false);
+  assert.equal(firstDetailer.getAttribute("aria-expanded"), "true");
+  assertOwnerDocumentListenerCount(ownerFixture, 1, "the current owner must bind once");
+
+  clickInfoTrigger(ownerFixture, firstDetailer);
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 0, "trigger click must toggle closed");
+  clickInfoTrigger(ownerFixture, firstDetailer);
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 1, "trigger click must toggle open");
+  ownerFixture.dispatchDocument("pointerdown", { target: firstDetailerTooltip });
+  ownerFixture.dispatchDocument("click", { target: firstDetailerTooltip });
+  ownerFixture.dispatchDocument("touchstart", { target: firstDetailerTooltip });
+  assert.equal(
+    firstDetailerTooltip.hidden,
+    false,
+    "tooltip-contained interaction must preserve the current owner",
+  );
+
+  const outside = ownerFixture.document.createElement("div");
+  ownerFixture.document.body.append(outside);
+  ownerFixture.dispatchDocument("pointerdown", { target: outside });
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 0);
+  assert.equal(firstDetailer.getAttribute("aria-expanded"), "false");
+  clickInfoTrigger(ownerFixture, firstDetailer);
+  ownerFixture.dispatchDocument("click", { target: outside });
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 0);
+  clickInfoTrigger(ownerFixture, firstDetailer);
+  ownerFixture.dispatchDocument("touchstart", { target: outside });
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 0);
+  assertOwnerDocumentListenerCount(ownerFixture, 0, "outside close must release document listeners");
+
+  clickInfoTrigger(ownerFixture, firstHighres);
+  clickInfoTrigger(ownerFixture, firstDetailer);
+  const escapeEvent = ownerFixture.dispatchDocument("keydown", {
+    key: "Escape",
+    target: outside,
+  });
+  assert.equal(escapeEvent.defaultPrevented, true);
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 0, "Escape must close the global owner");
+  assert.equal(firstHighres.getAttribute("aria-expanded"), "false");
+  assert.equal(firstDetailer.getAttribute("aria-expanded"), "false");
+
+  clickInfoTrigger(ownerFixture, firstHighres);
+  const staleOutsideHandler = ownerFixture.document.listeners.get("click")[0].handler;
+  clickInfoTrigger(ownerFixture, secondDetailer);
+  assert.equal(firstHighresTooltip.hidden, true);
+  assert.equal(secondDetailerTooltip.hidden, false);
+  staleOutsideHandler({ target: outside });
+  assert.equal(
+    secondDetailerTooltip.hidden,
+    false,
+    "a stale owner close callback must not close the newer owner",
+  );
+  ownerFixture.runtime.disposePanel(firstNode);
+  assert.equal(
+    secondDetailerTooltip.hidden,
+    false,
+    "stale panel dispose must not close the newer owner",
+  );
+  assertOwnerDocumentListenerCount(ownerFixture, 1, "stale cleanup must preserve the newer listener owner");
+  ownerFixture.runtime.ensurePanel(firstNode);
+
+  const otherFixture = createFixture();
+  const otherNode = createOwnerTestNode(otherFixture, ownerSettings);
+  otherFixture.runtime.ensurePanel(otherNode);
+  const otherHighres = findByAttribute(
+    otherNode.__easyuseAnimaGeneratorPanelEl,
+    "data-aio-focus-key",
+    "highres.info",
+  );
+  const otherHighresTooltip = infoTooltipFor(otherFixture, otherHighres);
+  assert.ok(otherHighres && otherHighresTooltip);
+  clickInfoTrigger(otherFixture, otherHighres);
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 1);
+  assert.equal(visibleInfoTooltips(otherFixture).length, 1);
+  assert.equal(secondDetailerTooltip.hidden, false);
+  assert.equal(otherHighresTooltip.hidden, false, "different documents must retain independent owners");
+
+  const rerenderedFirstHighres = findByAttribute(
+    firstNode.__easyuseAnimaGeneratorPanelEl,
+    "data-aio-focus-key",
+    "highres.info",
+  );
+  clickInfoTrigger(ownerFixture, rerenderedFirstHighres);
+  assert.equal(secondDetailerTooltip.hidden, true);
+  assert.equal(otherHighresTooltip.hidden, false);
+  ownerFixture.runtime.disposePanel(firstNode);
+  assert.equal(visibleInfoTooltips(ownerFixture).length, 0);
+  assert.equal(otherHighresTooltip.hidden, false, "disposing another document must not close its owner");
+  assertOwnerDocumentListenerCount(ownerFixture, 0, "current panel dispose must restore baseline");
+  ownerFixture.runtime.disposePanel(secondNode);
+  assert.equal(ownerFixture.document.querySelectorAll("[data-aio-info-tooltip]").length, 0);
+
+  otherFixture.runtime.renderPanel(otherNode);
+  assert.equal(otherHighresTooltip.parentElement, null, "rerender must remove the owned portal");
+  assertOwnerDocumentListenerCount(otherFixture, 0, "current panel rerender must restore baseline");
+  otherFixture.runtime.disposePanel(otherNode);
+  assert.equal(otherFixture.document.querySelectorAll("[data-aio-info-tooltip]").length, 0);
 }
 
 const fixture = createFixture();

--- a/web/js/aio/generator_panel_runtime.js
+++ b/web/js/aio/generator_panel_runtime.js
@@ -4,6 +4,28 @@ const GENERATOR_DOM_WIDGET = "easyuse_anima_generator_panel";
 const GENERATOR_NODE_MIN_WIDTH = 560;
 const GENERATOR_NODE_DEFAULT_WIDTH = 620;
 const GENERATOR_PANEL_CONTROL_SELECTOR = "input, select, textarea, button";
+const generatorInfoTooltipOwners = new WeakMap();
+
+function claimGeneratorInfoTooltipOwner(document, owner) {
+  const currentOwner = generatorInfoTooltipOwners.get(document);
+  if (currentOwner === owner) {
+    return;
+  }
+  currentOwner?.close?.();
+  generatorInfoTooltipOwners.set(document, owner);
+  owner.connect?.();
+}
+
+function releaseGeneratorInfoTooltipOwner(document, owner) {
+  if (generatorInfoTooltipOwners.get(document) === owner) {
+    generatorInfoTooltipOwners.delete(document);
+  }
+  owner.disconnect?.();
+}
+
+function closeGeneratorInfoTooltipOwner(document) {
+  generatorInfoTooltipOwners.get(document)?.close?.();
+}
 
 /**
  * @typedef {object} AioGeneratorPanelControls
@@ -1174,6 +1196,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
       let hovered = false;
       let pinned = false;
       let trackingPosition = false;
+      let trackingDocument = false;
 
       const positionTooltip = () => {
         const rect = button.getBoundingClientRect?.() || {};
@@ -1210,11 +1233,64 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
           window.removeEventListener("scroll", positionTooltip, true);
         }
       };
+      const closeTooltip = () => {
+        if (disposed) {
+          return;
+        }
+        pinned = false;
+        dismissed = true;
+        syncVisibility();
+      };
+      const onDocumentOutside = (event) => {
+        const target = event?.target;
+        if (button.contains?.(target) || tooltip.contains?.(target)) {
+          return;
+        }
+        closeTooltip();
+      };
+      const onDocumentKeyDown = (event) => {
+        if (event?.key !== "Escape") {
+          return;
+        }
+        event.preventDefault?.();
+        closeGeneratorInfoTooltipOwner(document);
+      };
+      const documentListeners = [
+        ["pointerdown", onDocumentOutside],
+        ["click", onDocumentOutside],
+        ["touchstart", onDocumentOutside],
+        ["keydown", onDocumentKeyDown],
+      ];
+      const updateDocumentTracking = (enabled) => {
+        if (trackingDocument === enabled) {
+          return;
+        }
+        trackingDocument = enabled;
+        for (const [eventName, listener] of documentListeners) {
+          if (enabled) {
+            document.addEventListener(eventName, listener, true);
+          } else {
+            document.removeEventListener(eventName, listener, true);
+          }
+        }
+      };
+      const owner = {
+        trigger: button,
+        tooltip,
+        close: closeTooltip,
+        connect: () => updateDocumentTracking(true),
+        disconnect: () => updateDocumentTracking(false),
+      };
       const syncVisibility = () => {
         if (disposed) {
           return;
         }
         const visible = !dismissed && (hovered || focused || pinned);
+        if (visible) {
+          claimGeneratorInfoTooltipOwner(document, owner);
+        } else {
+          releaseGeneratorInfoTooltipOwner(document, owner);
+        }
         tooltip.hidden = !visible;
         button.setAttribute("aria-expanded", visible ? "true" : "false");
         updatePositionTracking(visible);
@@ -1274,9 +1350,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
         } else if (event.key === "Escape") {
           event.preventDefault?.();
           event.stopPropagation?.();
-          pinned = false;
-          dismissed = true;
-          syncVisibility();
+          closeGeneratorInfoTooltipOwner(document);
         }
       };
       const listeners = [
@@ -1296,6 +1370,7 @@ export function aioCreateGeneratorPanelRuntime(dependencies) {
           return;
         }
         disposed = true;
+        releaseGeneratorInfoTooltipOwner(document, owner);
         updatePositionTracking(false);
         for (const [eventName, listener] of listeners) {
           button.removeEventListener(eventName, listener);


### PR DESCRIPTION
## 변경 요약

- AiO info tooltip의 현재 owner를 document 단위 `WeakMap`으로 관리합니다.
- 새 tooltip이 열리기 전에 이전 owner를 닫고 이전 trigger의 `aria-expanded`를 `false`로 동기화합니다.
- trigger/tooltip 외부의 pointer, click, touch와 document 전역 Escape로 현재 owner를 닫습니다.
- owner identity guard와 panel lifecycle cleanup으로 stale close/rerender/dispose가 새 owner를 닫지 않도록 했습니다.

## 원인

기존 info tooltip은 각 버튼이 portal과 visibility를 독립 소유했으며 document 단위의 현재 owner와 outside-dismiss 계약이 없었습니다. 그 결과 Highres tooltip을 연 뒤 Detailer tooltip을 열어도 첫 portal과 `aria-expanded=true`가 남았습니다.

## 주요 파일

- `web/js/aio/generator_panel_runtime.js`
- `tests/frontend_aio_generator_panel_runtime_smoke.mjs`

## 검증

- `node tests\frontend_aio_generator_panel_runtime_smoke.mjs` — 통과
- `node --check web\js\aio\generator_panel_runtime.js` — 통과
- `npx --yes --package "typescript@6.0.3" -- tsc -p jsconfig.json` — 통과
- `python -m unittest discover -s tests -p test_aio_frontend.py` — 35 tests, 통과
- 공식 full profile — Python unittest 466 tests 통과
- 공식 full profile — Frontend 110 JavaScript files 통과, TypeScript 6.0.3
- `git diff --check` — 통과

## 테스트 표면

- fake document/event target 기반 deterministic AiO generator panel runtime smoke
- 같은 document의 다중 panel owner 전환과 서로 다른 document 격리
- Highres → Detailer 단일 portal, outside dismiss, trigger/portal containment, global Escape
- stale close/dispose identity guard, rerender/dispose listener baseline
- ComfyUI Codex test instance Node 2.0 property panel live browser:
  - Highres → Detailer 전환 후 visible tooltip 1개, 이전 trigger `aria-expanded=false`
  - canvas 외부 클릭 및 Escape 후 visible tooltip 0개
  - 동일 trigger 재클릭 닫기
  - `role=tooltip`, `aria-describedby`, fixed placement, z-index 12000
  - 1280×720 viewport 내부 배치 유지

## 남은 위험 / 미확인

- Legacy canvas live browser는 별도로 실행하지 않았습니다. 공통 DOM runtime의 deterministic test와 Node 2.0 live surface에서 검증했습니다.
- Shadow DOM retargeting/composed path는 현재 ComfyUI 표면에서 사용하지 않으며 fake DOM smoke가 이를 재현하지는 않습니다.

Closes #180