### PR TITLE
fix: wildcard 확장 budget과 source snapshot 정합성 강화

### DIFF
--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -123,6 +123,51 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(result.limit_reason, "cycle")
         self.assertEqual(result.replacement_count, 0)
 
+    def test_cycle_only_blocks_its_own_branch_in_either_input_order(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a.txt").write_text("__a__\n", encoding="utf-8")
+            (root / "b.txt").write_text("done\n", encoding="utf-8")
+
+            cycle_first = expand_wildcards("__a__ __b__", seed=0, roots=[root])
+            cycle_last = expand_wildcards("__b__ __a__", seed=0, roots=[root])
+
+        self.assertEqual(cycle_first.text, "__a__ done")
+        self.assertEqual(cycle_last.text, "done __a__")
+        for result in (cycle_first, cycle_last):
+            self.assertEqual(result.limit_reason, "cycle")
+            self.assertEqual(result.replacement_count, 1)
+
+    def test_cycle_does_not_stop_an_independent_later_pass(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a.txt").write_text("__a__\n", encoding="utf-8")
+            (root / "b.txt").write_text("__c__\n", encoding="utf-8")
+            (root / "c.txt").write_text("done\n", encoding="utf-8")
+
+            result = expand_wildcards("__a__ __b__", seed=0, roots=[root])
+
+        self.assertEqual(result.text, "__a__ done")
+        self.assertEqual(result.limit_reason, "cycle")
+        self.assertEqual(result.replacement_count, 2)
+
+    def test_fatal_budget_reason_takes_precedence_over_cycle_diagnostic(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a.txt").write_text("__a__\n", encoding="utf-8")
+            (root / "b.txt").write_text("done\n", encoding="utf-8")
+
+            result = expand_wildcards(
+                "__a__ __b__",
+                seed=0,
+                roots=[root],
+                budget=WildcardExpansionBudget(max_replacements=0),
+            )
+
+        self.assertEqual(result.text, "__a__ __b__")
+        self.assertEqual(result.limit_reason, "max_replacements")
+        self.assertEqual(result.replacement_count, 0)
+
     def test_indirect_cycle_reports_the_same_reason_and_count(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-import tempfile
-import unittest
 import json
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import patch
 
@@ -285,6 +287,224 @@ class WildcardEngineTests(unittest.TestCase):
 
             self.assertEqual(result.text, source)
             self.assertFalse(result.changed)
+
+    def test_deep_yaml_leaf_is_aggregated_once_per_parent_alias(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            lines = [f"{'  ' * depth}level-{depth}:" for depth in range(10)]
+            lines.append(f"{'  ' * 10}- only-leaf")
+            (root / "deep.yaml").write_text("\n".join(lines), encoding="utf-8")
+
+            mapping = wildcard_engine._load_wildcard_map([root])
+
+        for depth in range(10):
+            alias = "/".join(f"level-{index}" for index in range(depth + 1))
+            with self.subTest(alias=alias):
+                self.assertEqual([option.text for option in mapping[alias]], ["only-leaf"])
+
+    def test_yaml_parent_aggregation_preserves_siblings_and_explicit_duplicates(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "weighted.yaml").write_text(
+                "root:\n"
+                "  branch-a:\n"
+                "    leaf: [same, same]\n"
+                "  branch-b:\n"
+                "    leaf: [same]\n",
+                encoding="utf-8",
+            )
+
+            mapping = wildcard_engine._load_wildcard_map([root])
+
+        self.assertEqual(
+            [option.text for option in mapping["root/branch-a/leaf"]],
+            ["same", "same"],
+        )
+        self.assertEqual(
+            [option.text for option in mapping["root/branch-b/leaf"]],
+            ["same"],
+        )
+        self.assertEqual(
+            [option.text for option in mapping["root"]],
+            ["same", "same", "same"],
+        )
+
+    def test_unchanged_list_signature_and_expand_reuse_one_yaml_parse(self):
+        self.assertIsNotNone(wildcard_engine.yaml)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "colors.yaml").write_text("colors: [red]\n", encoding="utf-8")
+
+            with patch.object(
+                wildcard_engine.yaml,
+                "safe_load",
+                wraps=wildcard_engine.yaml.safe_load,
+            ) as safe_load:
+                first_list = list_wildcards(roots=[root])
+                first_signature = wildcard_engine.wildcard_sources_signature(roots=[root])
+                first_expansion = expand_wildcards("__colors__", seed=0, roots=[root])
+                second_list = list_wildcards(roots=[root])
+                second_signature = wildcard_engine.wildcard_sources_signature(roots=[root])
+                second_expansion = expand_wildcards("__colors__", seed=0, roots=[root])
+
+        self.assertEqual(safe_load.call_count, 1)
+        self.assertEqual(first_list, second_list)
+        self.assertEqual(first_signature, second_signature)
+        self.assertEqual(first_expansion, second_expansion)
+
+    def test_snapshot_cache_key_preserves_root_identity_and_order(self):
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            left = base / "left"
+            right = base / "right"
+            left.mkdir()
+            right.mkdir()
+            (left / "style.txt").write_text("left\n", encoding="utf-8")
+            (right / "style.txt").write_text("right\n", encoding="utf-8")
+
+            left_first = expand_wildcards("__style__", seed=0, roots=[left, right])
+            right_first = expand_wildcards("__style__", seed=0, roots=[right, left])
+            left_signature = wildcard_engine.wildcard_sources_signature(roots=[left, right])
+            right_signature = wildcard_engine.wildcard_sources_signature(roots=[right, left])
+
+        self.assertEqual(left_first.text, "left")
+        self.assertEqual(right_first.text, "right")
+        self.assertEqual(left_signature["roots"], [str(left), str(right)])
+        self.assertEqual(right_signature["roots"], [str(right), str(left)])
+
+    def test_yaml_snapshot_refreshes_after_add_modify_and_delete(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            colors = root / "colors.yaml"
+            shapes = root / "shapes.yaml"
+            colors.write_text("colors: [red]\n", encoding="utf-8")
+
+            initial_signature = wildcard_engine.wildcard_sources_signature(roots=[root])
+            initial = expand_wildcards("__colors__", seed=0, roots=[root])
+
+            colors.write_text("colors: [blue, green]\n", encoding="utf-8")
+            modified_signature = wildcard_engine.wildcard_sources_signature(roots=[root])
+            modified = expand_wildcards(
+                "__colors__",
+                seed=0,
+                mode="sequential",
+                roots=[root],
+            )
+
+            shapes.write_text("shapes: [circle]\n", encoding="utf-8")
+            after_add = list_wildcards(roots=[root])
+
+            colors.unlink()
+            after_delete = list_wildcards(roots=[root])
+            missing = expand_wildcards("__colors__", seed=0, roots=[root])
+
+        self.assertEqual(initial.text, "red")
+        self.assertNotEqual(initial_signature, modified_signature)
+        self.assertEqual(modified.text, "blue")
+        self.assertEqual(after_add, ["colors", "shapes"])
+        self.assertEqual(after_delete, ["shapes"])
+        self.assertEqual(missing.text, "__colors__")
+        self.assertEqual(missing.missing_keys, ("colors",))
+
+    def test_file_change_during_build_retries_before_publish(self):
+        build_started = threading.Event()
+        release_build = threading.Event()
+        build_calls = []
+        original_build = wildcard_engine._build_wildcard_snapshot
+
+        def blocked_first_build(source_state):
+            snapshot = original_build(source_state)
+            build_calls.append(source_state.cache_key)
+            if len(build_calls) == 1:
+                build_started.set()
+                if not release_build.wait(5):
+                    raise AssertionError("timed out waiting to mutate wildcard source")
+            return snapshot
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            colors = root / "colors.yaml"
+            colors.write_text("colors: [red]\n", encoding="utf-8")
+
+            with patch.object(
+                wildcard_engine,
+                "_build_wildcard_snapshot",
+                side_effect=blocked_first_build,
+            ), ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(
+                    expand_wildcards,
+                    "__colors__",
+                    seed=0,
+                    roots=[root],
+                )
+                try:
+                    self.assertTrue(build_started.wait(5))
+                    colors.write_text("colors: [blue-new]\n", encoding="utf-8")
+                finally:
+                    release_build.set()
+                result = future.result(timeout=5)
+
+        self.assertEqual(result.text, "blue-new")
+        self.assertEqual(len(build_calls), 2)
+
+    def test_parallel_same_key_build_is_single_flight_and_atomically_published(self):
+        build_ready = threading.Event()
+        release_build = threading.Event()
+        waiter_entered = threading.Event()
+        build_calls = []
+        original_build = wildcard_engine._build_wildcard_snapshot
+        original_wait = wildcard_engine._SNAPSHOT_CONDITION.wait
+
+        def blocked_build(source_state):
+            snapshot = original_build(source_state)
+            build_calls.append(source_state.cache_key)
+            build_ready.set()
+            if not release_build.wait(5):
+                raise AssertionError("timed out waiting for parallel wildcard request")
+            return snapshot
+
+        def observed_wait(timeout=None):
+            waiter_entered.set()
+            return original_wait(timeout)
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "library.yaml").write_text(
+                "alpha: [one]\nbeta: [two]\n",
+                encoding="utf-8",
+            )
+
+            with patch.object(
+                wildcard_engine,
+                "_build_wildcard_snapshot",
+                side_effect=blocked_build,
+            ), patch.object(
+                wildcard_engine._SNAPSHOT_CONDITION,
+                "wait",
+                side_effect=observed_wait,
+            ), ThreadPoolExecutor(max_workers=2) as executor:
+                first = executor.submit(list_wildcards, roots=[root])
+                try:
+                    self.assertTrue(build_ready.wait(5))
+                    with wildcard_engine._SNAPSHOT_CONDITION:
+                        self.assertFalse(
+                            any(
+                                snapshot.roots == (str(root),)
+                                for snapshot in wildcard_engine._SNAPSHOT_CACHE.values()
+                            )
+                        )
+                    second = executor.submit(list_wildcards, roots=[root])
+                    self.assertTrue(waiter_entered.wait(5))
+                    self.assertFalse(first.done())
+                    self.assertFalse(second.done())
+                finally:
+                    release_build.set()
+                first_result = first.result(timeout=5)
+                second_result = second.result(timeout=5)
+
+        self.assertEqual(len(build_calls), 1)
+        self.assertEqual(first_result, ["alpha", "beta"])
+        self.assertEqual(second_result, ["alpha", "beta"])
 
     def test_list_wildcards_returns_relative_keys_only(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -417,6 +417,35 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(left_signature["roots"], [str(left), str(right)])
         self.assertEqual(right_signature["roots"], [str(right), str(left)])
 
+    def test_runtime_library_reuses_snapshot_mapping_and_helper_returns_mutable_copy(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "color.txt").write_text("red\nblue\ngreen\n", encoding="utf-8")
+            snapshot = wildcard_engine._wildcard_snapshot([root])
+
+            with patch.object(
+                wildcard_engine,
+                "_load_wildcard_map",
+                side_effect=AssertionError("runtime library copied the snapshot mapping"),
+            ):
+                library = wildcard_engine._WildcardLibrary([root])
+
+            exact_options = library.options_for("color")
+            mutable_copy = wildcard_engine._load_wildcard_map([root])
+            mutable_copy["color"].append(wildcard_engine.WildcardOption("mutated"))
+            first = expand_wildcards("{2$$__color__}", seed=7, roots=[root])
+            second = expand_wildcards("{2$$__color__}", seed=7, roots=[root])
+
+        self.assertIs(library.mapping, snapshot.mapping)
+        self.assertIs(exact_options, snapshot.mapping["color"])
+        self.assertIsInstance(exact_options, tuple)
+        self.assertIsInstance(mutable_copy, dict)
+        self.assertIsInstance(mutable_copy["color"], list)
+        self.assertEqual(len(mutable_copy["color"]), 4)
+        self.assertEqual(len(snapshot.mapping["color"]), 3)
+        self.assertEqual(first, second)
+        self.assertNotIn("mutated", first.text)
+
     def test_yaml_snapshot_refreshes_after_add_modify_and_delete(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
@@ -450,6 +479,119 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(after_delete, ["shapes"])
         self.assertEqual(missing.text, "__colors__")
         self.assertEqual(missing.missing_keys, ("colors",))
+
+    def test_transient_loader_oserror_is_not_cached(self):
+        original_loader = wildcard_engine._load_wildcard_file
+        attempts = []
+
+        def flaky_loader(root, path):
+            attempts.append(path)
+            if len(attempts) == 1:
+                raise OSError("transient read failure")
+            return original_loader(root, path)
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "color.txt").write_text("red\n", encoding="utf-8")
+            cache_key = wildcard_engine._scan_wildcard_sources((root,)).cache_key
+
+            with patch.object(
+                wildcard_engine,
+                "_load_wildcard_file",
+                side_effect=flaky_loader,
+            ) as loader:
+                first = expand_wildcards("__color__", seed=0, roots=[root])
+                with wildcard_engine._SNAPSHOT_CONDITION:
+                    self.assertNotIn(cache_key, wildcard_engine._SNAPSHOT_CACHE)
+                    self.assertNotIn(cache_key, wildcard_engine._SNAPSHOT_BUILDING)
+                second = expand_wildcards("__color__", seed=0, roots=[root])
+
+        self.assertEqual(first.text, "__color__")
+        self.assertEqual(second.text, "red")
+        self.assertEqual(loader.call_count, 2)
+
+    def test_invalid_yaml_parse_remains_cacheable_as_empty(self):
+        self.assertIsNotNone(wildcard_engine.yaml)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "invalid.yaml").write_text("color: [red\n", encoding="utf-8")
+            cache_key = wildcard_engine._scan_wildcard_sources((root,)).cache_key
+
+            with patch.object(
+                wildcard_engine.yaml,
+                "safe_load",
+                wraps=wildcard_engine.yaml.safe_load,
+            ) as safe_load:
+                first = expand_wildcards("__color__", seed=0, roots=[root])
+                second = expand_wildcards("__color__", seed=0, roots=[root])
+
+            with wildcard_engine._SNAPSHOT_CONDITION:
+                self.assertIn(cache_key, wildcard_engine._SNAPSHOT_CACHE)
+
+        self.assertEqual(first.text, "__color__")
+        self.assertEqual(second.text, "__color__")
+        self.assertEqual(safe_load.call_count, 1)
+
+    def test_persistent_yaml_read_oserror_never_caches_or_leaves_building_key(self):
+        read_started = threading.Event()
+        release_read = threading.Event()
+        waiter_entered = threading.Event()
+        read_calls = []
+        original_wait = wildcard_engine._SNAPSHOT_CONDITION.wait
+
+        def unreadable_yaml(path):
+            read_calls.append(path)
+            if len(read_calls) == 1:
+                read_started.set()
+                if not release_read.wait(5):
+                    raise AssertionError("timed out waiting for parallel wildcard request")
+            raise OSError("persistent read failure")
+
+        def observed_wait(timeout=None):
+            waiter_entered.set()
+            return original_wait(timeout)
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "library.yaml").write_text("color: [red]\n", encoding="utf-8")
+            cache_key = wildcard_engine._scan_wildcard_sources((root,)).cache_key
+
+            with patch.object(
+                wildcard_engine,
+                "_read_text_file",
+                side_effect=unreadable_yaml,
+            ), patch.object(
+                wildcard_engine._SNAPSHOT_CONDITION,
+                "wait",
+                side_effect=observed_wait,
+            ), ThreadPoolExecutor(max_workers=2) as executor:
+                first = executor.submit(
+                    expand_wildcards,
+                    "__color__",
+                    seed=0,
+                    roots=[root],
+                )
+                try:
+                    self.assertTrue(read_started.wait(5))
+                    second = executor.submit(
+                        expand_wildcards,
+                        "__color__",
+                        seed=0,
+                        roots=[root],
+                    )
+                    self.assertTrue(waiter_entered.wait(5))
+                finally:
+                    release_read.set()
+                first_result = first.result(timeout=5)
+                second_result = second.result(timeout=5)
+
+            with wildcard_engine._SNAPSHOT_CONDITION:
+                self.assertNotIn(cache_key, wildcard_engine._SNAPSHOT_CACHE)
+                self.assertNotIn(cache_key, wildcard_engine._SNAPSHOT_BUILDING)
+
+        self.assertEqual(first_result.text, "__color__")
+        self.assertEqual(second_result.text, "__color__")
+        self.assertEqual(len(read_calls), 2)
 
     def test_file_change_during_build_retries_before_publish(self):
         build_started = threading.Event()

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -15,6 +15,7 @@ from settings import public_settings
 import wildcard_engine
 from wildcard_engine import (
     DEFAULT_TEST_WILDCARD_FILE,
+    WildcardExpansionBudget,
     WildcardExpansionResult,
     ensure_default_wildcard_root,
     expand_wildcards,
@@ -95,6 +96,148 @@ class WildcardEngineTests(unittest.TestCase):
         values = [part.strip() for part in result.text.split(",")]
         self.assertEqual(len(values), 2)
         self.assertEqual(len(set(values)), 2)
+
+    def test_direct_self_reference_stops_with_unresolved_token(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a.txt").write_text("__a__\n", encoding="utf-8")
+
+            first = expand_wildcards("__a__", seed=0, roots=[root])
+            second = expand_wildcards("__a__", seed=0, roots=[root])
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.text, "__a__")
+        self.assertEqual(first.limit_reason, "cycle")
+        self.assertEqual(first.replacement_count, 0)
+
+    def test_proliferating_self_reference_is_blocked_before_growth(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a.txt").write_text("__a____a__\n", encoding="utf-8")
+
+            result = expand_wildcards("__a__", seed=0, roots=[root])
+
+        self.assertEqual(result.text, "__a__")
+        self.assertEqual(result.limit_reason, "cycle")
+        self.assertEqual(result.replacement_count, 0)
+
+    def test_indirect_cycle_reports_the_same_reason_and_count(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a.txt").write_text("__b__\n", encoding="utf-8")
+            (root / "b.txt").write_text("__a__\n", encoding="utf-8")
+
+            first = expand_wildcards("__a__", seed=0, roots=[root])
+            second = expand_wildcards("__a__", seed=0, roots=[root])
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.text, "__b__")
+        self.assertEqual(first.limit_reason, "cycle")
+        self.assertEqual(first.replacement_count, 1)
+
+    def test_five_level_nested_wildcard_expands_normally(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for current, following in zip("abcde", ("b", "c", "d", "e", None)):
+                value = f"__{following}__" if following is not None else "finished"
+                (root / f"{current}.txt").write_text(f"{value}\n", encoding="utf-8")
+
+            result = expand_wildcards("__a__", seed=0, roots=[root])
+
+        self.assertEqual(result.text, "finished")
+        self.assertIsNone(result.limit_reason)
+        self.assertEqual(result.replacement_count, 5)
+
+    def test_depth_and_replacement_limits_leave_deterministic_tokens(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "a.txt").write_text("__b__ __b__\n", encoding="utf-8")
+            (root / "b.txt").write_text("__c__\n", encoding="utf-8")
+            (root / "c.txt").write_text("finished\n", encoding="utf-8")
+
+            depth_limited = expand_wildcards(
+                "__b__",
+                seed=0,
+                roots=[root],
+                budget=WildcardExpansionBudget(max_depth=1),
+            )
+            replacement_limited = expand_wildcards(
+                "__a__",
+                seed=0,
+                roots=[root],
+                budget=WildcardExpansionBudget(max_replacements=2),
+            )
+            repeated_replacement_limit = expand_wildcards(
+                "__a__",
+                seed=0,
+                roots=[root],
+                budget=WildcardExpansionBudget(max_replacements=2),
+            )
+
+        self.assertEqual(depth_limited.text, "__c__")
+        self.assertEqual(depth_limited.limit_reason, "max_depth")
+        self.assertEqual(depth_limited.replacement_count, 1)
+        self.assertEqual(replacement_limited.text, "__c__ __b__")
+        self.assertEqual(replacement_limited.limit_reason, "max_replacements")
+        self.assertEqual(replacement_limited.replacement_count, 2)
+        self.assertEqual(replacement_limited, repeated_replacement_limit)
+
+    def test_expansion_budget_clamps_callers_to_explicit_hard_caps(self):
+        budget = WildcardExpansionBudget(
+            max_depth=10**9,
+            max_replacements=10**9,
+            max_output_chars=10**9,
+            max_growth_per_pass=10**9,
+        )
+
+        self.assertEqual(budget.max_depth, wildcard_engine.MAX_EXPANSION_DEPTH)
+        self.assertEqual(budget.max_replacements, wildcard_engine.MAX_EXPANSION_REPLACEMENTS)
+        self.assertEqual(budget.max_output_chars, wildcard_engine.MAX_EXPANSION_OUTPUT_CHARS)
+        self.assertEqual(
+            budget.max_growth_per_pass,
+            wildcard_engine.MAX_EXPANSION_GROWTH_PER_PASS,
+        )
+
+    def test_output_and_growth_limits_check_candidates_before_append(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "unicode.txt").write_text(f"{'가' * 5}\n", encoding="utf-8")
+            (root / "growth.txt").write_text(f"{'x' * 21}\n", encoding="utf-8")
+
+            output_limited = expand_wildcards(
+                "__unicode__",
+                seed=0,
+                roots=[root],
+                budget=WildcardExpansionBudget(max_output_chars=12),
+            )
+            growth_limited = expand_wildcards(
+                "__growth__",
+                seed=0,
+                roots=[root],
+                budget=WildcardExpansionBudget(
+                    max_output_chars=100,
+                    max_growth_per_pass=2.0,
+                ),
+            )
+
+        self.assertEqual(output_limited.text, "__unicode__")
+        self.assertEqual(output_limited.limit_reason, "max_output_chars")
+        self.assertEqual(output_limited.replacement_count, 0)
+        self.assertLessEqual(len(output_limited.text), 12)
+        self.assertLessEqual(len(output_limited.text.encode("utf-8")), 12)
+        self.assertEqual(growth_limited.text, "__growth__")
+        self.assertEqual(growth_limited.limit_reason, "max_growth_per_pass")
+        self.assertEqual(growth_limited.replacement_count, 0)
+
+    def test_existing_seeded_expansion_result_is_preserved(self):
+        source = "{2$$red|blue|green}, {soft|hard}"
+
+        first = expand_wildcards(source, seed=7)
+        second = expand_wildcards(source, seed=7)
+
+        self.assertEqual(first.text, "blue, green, hard")
+        self.assertEqual(first, second)
+        self.assertIsNone(first.limit_reason)
 
     def test_random_multiselect_excludes_zero_weight_options_in_both_backends(self):
         numpy_module = wildcard_engine.np

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -12,7 +12,7 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Iterable, Mapping
+from typing import Iterable, Mapping, Sequence
 
 try:
     import numpy as np
@@ -146,6 +146,7 @@ class _WildcardSnapshot:
     wildcard_names: tuple[str, ...]
     roots: tuple[str, ...]
     files: tuple[_WildcardSourceFile, ...]
+    cacheable: bool
 
     def public_signature(self) -> dict:
         return {
@@ -670,8 +671,9 @@ def _yaml_entries(data, prefix: str = "") -> dict[str, list[WildcardOption]]:
 def _load_yaml_entries(path: Path) -> dict[str, list[WildcardOption]]:
     if yaml is None:
         return {}
+    text = _read_text_file(path)
     try:
-        data = yaml.safe_load(_read_text_file(path))
+        data = yaml.safe_load(text)
     except Exception:
         return {}
     return _yaml_entries(data)
@@ -738,11 +740,13 @@ def _scan_wildcard_sources(roots: tuple[Path, ...]) -> _WildcardSourceState:
 
 def _build_wildcard_snapshot(source_state: _WildcardSourceState) -> _WildcardSnapshot:
     mapping: dict[str, list[WildcardOption]] = {}
+    cacheable = True
     for source in source_state.files:
         root = source_state.roots[source.root_index]
         try:
             entries = _load_wildcard_file(root, source.path)
         except OSError:
+            cacheable = False
             continue
         for key, options in entries.items():
             if key not in mapping and options:
@@ -757,6 +761,7 @@ def _build_wildcard_snapshot(source_state: _WildcardSourceState) -> _WildcardSna
         wildcard_names=tuple(sorted(frozen_mapping)),
         roots=tuple(str(root) for root in source_state.roots),
         files=source_state.files,
+        cacheable=cacheable,
     )
 
 
@@ -787,7 +792,7 @@ def _wildcard_snapshot(roots: Iterable[Path]) -> _WildcardSnapshot:
         finally:
             with _SNAPSHOT_CONDITION:
                 _SNAPSHOT_BUILDING.discard(cache_key)
-                if snapshot is not None:
+                if snapshot is not None and snapshot.cacheable:
                     _SNAPSHOT_CACHE[cache_key] = snapshot
                     _SNAPSHOT_CACHE.move_to_end(cache_key)
                     while len(_SNAPSHOT_CACHE) > _SNAPSHOT_CACHE_LIMIT:
@@ -839,11 +844,15 @@ class _Selector:
             return int(self.rng.integers(minimum, maximum + 1))
         return self.rng.randint(minimum, maximum)
 
-    def choose_one(self, options: list[WildcardOption]) -> WildcardOption | None:
+    def choose_one(self, options: Sequence[WildcardOption]) -> WildcardOption | None:
         selected = self.choose_many(options, 1)
         return selected[0] if selected else None
 
-    def choose_many(self, options: list[WildcardOption], count: int) -> list[WildcardOption]:
+    def choose_many(
+        self,
+        options: Sequence[WildcardOption],
+        count: int,
+    ) -> list[WildcardOption]:
         if not options or count <= 0:
             return []
         if self.sequential:
@@ -887,7 +896,7 @@ class _Selector:
 
 class _WildcardLibrary:
     def __init__(self, roots: Iterable[Path]):
-        self.mapping = _load_wildcard_map(roots)
+        self.mapping = _wildcard_snapshot(roots).mapping
         self.used: list[str] = []
         self.missing: list[str] = []
 
@@ -899,7 +908,7 @@ class _WildcardLibrary:
         if key not in self.missing:
             self.missing.append(key)
 
-    def options_for(self, raw_key: str) -> list[WildcardOption]:
+    def options_for(self, raw_key: str) -> Sequence[WildcardOption]:
         key = _normalize_wildcard_key(raw_key)
         if key is None:
             return []
@@ -910,7 +919,7 @@ class _WildcardLibrary:
             self._record_missing(key)
         return options
 
-    def _options_for_normalized_key(self, key: str) -> list[WildcardOption]:
+    def _options_for_normalized_key(self, key: str) -> Sequence[WildcardOption]:
         if key in self.mapping:
             return self.mapping[key]
         if "/" not in key and "*" not in key:
@@ -984,7 +993,7 @@ def _parse_count_spec(spec: str, selector: _Selector) -> int | None:
 def _expand_multiselect_options(
     options: list[WildcardOption],
     library: _WildcardLibrary,
-) -> tuple[list[WildcardOption], str | None]:
+) -> tuple[Sequence[WildcardOption], str | None]:
     if len(options) != 1:
         return options, None
     match = WILDCARD_FULL_RE.match(options[0].text.strip())

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import bisect
 import fnmatch
+import hashlib
+import math
 import os
 import random
 import re
@@ -70,7 +73,18 @@ SEED_CONTROL_MODES = (
 
 MAX_SEED = 0xFFFFFFFFFFFFFFFF
 PUBLIC_MAX_SEED = (1 << 53) - 1
-REPLACE_DEPTH = 100
+# Defaults stop exponential inputs well before they become memory hazards while
+# leaving ample room for ordinary nested wildcard libraries.  The old depth is
+# retained as a hard ceiling for callers that provide a custom budget.
+MAX_EXPANSION_DEPTH = 100
+REPLACE_DEPTH = MAX_EXPANSION_DEPTH
+DEFAULT_MAX_EXPANSION_DEPTH = 32
+DEFAULT_MAX_EXPANSION_REPLACEMENTS = 4096
+DEFAULT_MAX_EXPANSION_OUTPUT_CHARS = 256 * 1024
+DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS = 8.0
+MAX_EXPANSION_REPLACEMENTS = 65536
+MAX_EXPANSION_OUTPUT_CHARS = 1024 * 1024
+MAX_EXPANSION_GROWTH_PER_PASS = 32.0
 WILDCARD_EXTENSIONS = {".txt", ".yaml", ".yml"}
 
 COMMENT_RE = re.compile(r"^\s*#.*(?:\n|$)", re.MULTILINE)
@@ -93,12 +107,299 @@ class WildcardOption:
     weight: float = 1.0
 
 
+def _bounded_int(value, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _bounded_float(value, default: float, minimum: float, maximum: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        parsed = default
+    if not math.isfinite(parsed):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+@dataclass(frozen=True)
+class WildcardExpansionBudget:
+    max_depth: int = DEFAULT_MAX_EXPANSION_DEPTH
+    max_replacements: int = DEFAULT_MAX_EXPANSION_REPLACEMENTS
+    max_output_chars: int = DEFAULT_MAX_EXPANSION_OUTPUT_CHARS
+    max_growth_per_pass: float = DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "max_depth",
+            _bounded_int(self.max_depth, DEFAULT_MAX_EXPANSION_DEPTH, 0, MAX_EXPANSION_DEPTH),
+        )
+        object.__setattr__(
+            self,
+            "max_replacements",
+            _bounded_int(
+                self.max_replacements,
+                DEFAULT_MAX_EXPANSION_REPLACEMENTS,
+                0,
+                MAX_EXPANSION_REPLACEMENTS,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_output_chars",
+            _bounded_int(
+                self.max_output_chars,
+                DEFAULT_MAX_EXPANSION_OUTPUT_CHARS,
+                1,
+                MAX_EXPANSION_OUTPUT_CHARS,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_growth_per_pass",
+            _bounded_float(
+                self.max_growth_per_pass,
+                DEFAULT_MAX_EXPANSION_GROWTH_PER_PASS,
+                1.0,
+                MAX_EXPANSION_GROWTH_PER_PASS,
+            ),
+        )
+
+
 @dataclass(frozen=True)
 class WildcardExpansionResult:
     text: str
     changed: bool
     used_keys: tuple[str, ...] = ()
     missing_keys: tuple[str, ...] = ()
+    replacement_count: int = 0
+    limit_reason: str | None = None
+
+
+def _utf8_width(char: str) -> int:
+    codepoint = ord(char)
+    if codepoint <= 0x7F:
+        return 1
+    if codepoint <= 0x7FF:
+        return 2
+    if codepoint <= 0xFFFF:
+        return 3
+    return 4
+
+
+def _utf8_length(value: str) -> int:
+    return sum(_utf8_width(char) for char in value)
+
+
+@dataclass(frozen=True)
+class _ExpansionSegment:
+    text: str
+    key_stack: tuple[str, ...] = ()
+
+
+class _ExpansionText:
+    def __init__(self, segments: Iterable[_ExpansionSegment]):
+        merged: list[_ExpansionSegment] = []
+        pending_parts: list[str] = []
+        pending_stack: tuple[str, ...] | None = None
+
+        def flush_pending() -> None:
+            nonlocal pending_parts, pending_stack
+            if pending_parts:
+                merged.append(_ExpansionSegment("".join(pending_parts), pending_stack or ()))
+            pending_parts = []
+            pending_stack = None
+
+        for segment in segments:
+            if not segment.text:
+                continue
+            if pending_parts and pending_stack != segment.key_stack:
+                flush_pending()
+            pending_stack = segment.key_stack
+            pending_parts.append(segment.text)
+        flush_pending()
+        self.segments = tuple(merged)
+        self.text = "".join(segment.text for segment in self.segments)
+        self.char_count = len(self.text)
+        self.byte_count = _utf8_length(self.text)
+        ends = []
+        total = 0
+        for segment in self.segments:
+            total += len(segment.text)
+            ends.append(total)
+        self._ends = tuple(ends)
+
+    @classmethod
+    def from_text(cls, text: str) -> "_ExpansionText":
+        return cls((_ExpansionSegment(text),))
+
+    def slice_segments(self, start: int, end: int) -> list[_ExpansionSegment]:
+        if start >= end or not self.segments:
+            return []
+        index = bisect.bisect_right(self._ends, start)
+        segment_start = 0 if index == 0 else self._ends[index - 1]
+        sliced = []
+        while index < len(self.segments) and segment_start < end:
+            segment = self.segments[index]
+            local_start = max(0, start - segment_start)
+            local_end = min(len(segment.text), end - segment_start)
+            if local_start < local_end:
+                sliced.append(_ExpansionSegment(segment.text[local_start:local_end], segment.key_stack))
+            segment_start = self._ends[index]
+            index += 1
+        return sliced
+
+    def key_stack_for_span(self, start: int, end: int) -> tuple[str, ...]:
+        stacks = [segment.key_stack for segment in self.slice_segments(start, end)]
+        if not stacks:
+            return ()
+        common = list(stacks[0])
+        for stack in stacks[1:]:
+            shared = 0
+            while shared < len(common) and shared < len(stack) and common[shared] == stack[shared]:
+                shared += 1
+            del common[shared:]
+            if not common:
+                break
+        return tuple(common)
+
+
+@dataclass(frozen=True)
+class _Replacement:
+    parts: tuple[str, ...]
+    separator: str
+    key_stack: tuple[str, ...]
+
+    @property
+    def char_count(self) -> int:
+        return sum(len(part) for part in self.parts) + len(self.separator) * max(0, len(self.parts) - 1)
+
+    @property
+    def byte_count(self) -> int:
+        return sum(_utf8_length(part) for part in self.parts) + _utf8_length(self.separator) * max(
+            0,
+            len(self.parts) - 1,
+        )
+
+    def materialize(self) -> str:
+        if len(self.parts) == 1:
+            return self.parts[0]
+        return self.separator.join(self.parts)
+
+
+class _ExpansionState:
+    def __init__(self, budget: WildcardExpansionBudget):
+        self.budget = budget
+        self.replacement_count = 0
+        self.limit_reason: str | None = None
+        self._pass_base_chars = 0
+        self._pass_base_bytes = 0
+
+    def begin_pass(self, current: _ExpansionText) -> None:
+        self._pass_base_chars = current.char_count
+        self._pass_base_bytes = current.byte_count
+
+    def stop(self, reason: str) -> None:
+        if self.limit_reason is None:
+            self.limit_reason = reason
+
+    def candidate(
+        self,
+        parts: Iterable[str],
+        separator: str,
+        key_stack: tuple[str, ...],
+    ) -> _Replacement | None:
+        candidate = _Replacement(tuple(parts), separator, key_stack)
+        cycle_parts = candidate.parts
+        if len(candidate.parts) > 1 and candidate.separator:
+            cycle_parts = (*candidate.parts, candidate.separator)
+        for part in cycle_parts:
+            for match in WILDCARD_RE.finditer(part):
+                key = _normalize_wildcard_key(match.group("keyword"))
+                if key is not None and key in key_stack:
+                    self.stop("cycle")
+                    return None
+        return candidate
+
+    def _replacement_limit_reason(
+        self,
+        current: _ExpansionText,
+        stage_delta_chars: int,
+        stage_delta_bytes: int,
+        matched_text: str,
+        replacement: _Replacement,
+    ) -> str | None:
+        if self.replacement_count >= self.budget.max_replacements:
+            return "max_replacements"
+        projected_chars = (
+            current.char_count
+            + stage_delta_chars
+            - len(matched_text)
+            + replacement.char_count
+        )
+        projected_bytes = (
+            current.byte_count
+            + stage_delta_bytes
+            - _utf8_length(matched_text)
+            + replacement.byte_count
+        )
+        # One conservative cap bounds both logical characters and UTF-8 bytes.
+        if projected_chars > self.budget.max_output_chars or projected_bytes > self.budget.max_output_chars:
+            return "max_output_chars"
+        growth = self.budget.max_growth_per_pass
+        if (
+            projected_chars > math.floor(max(1, self._pass_base_chars) * growth)
+            or projected_bytes > math.floor(max(1, self._pass_base_bytes) * growth)
+        ):
+            return "max_growth_per_pass"
+        return None
+
+    def replace_matches(
+        self,
+        current: _ExpansionText,
+        pattern: re.Pattern,
+        resolver,
+    ) -> _ExpansionText:
+        source = current.text
+        output: list[_ExpansionSegment] = []
+        cursor = 0
+        stage_delta_chars = 0
+        stage_delta_bytes = 0
+        for match in pattern.finditer(source):
+            output.extend(current.slice_segments(cursor, match.start()))
+            key_stack = current.key_stack_for_span(match.start(), match.end())
+            replacement = resolver(match, key_stack)
+            if self.limit_reason is not None:
+                output.extend(current.slice_segments(match.start(), len(source)))
+                return _ExpansionText(output)
+            if replacement is None:
+                output.extend(current.slice_segments(match.start(), match.end()))
+                cursor = match.end()
+                continue
+            matched_text = match.group(0)
+            reason = self._replacement_limit_reason(
+                current,
+                stage_delta_chars,
+                stage_delta_bytes,
+                matched_text,
+                replacement,
+            )
+            if reason is not None:
+                self.stop(reason)
+                output.extend(current.slice_segments(match.start(), len(source)))
+                return _ExpansionText(output)
+            replacement_text = replacement.materialize()
+            output.append(_ExpansionSegment(replacement_text, replacement.key_stack))
+            self.replacement_count += 1
+            stage_delta_chars += replacement.char_count - len(matched_text)
+            stage_delta_bytes += replacement.byte_count - _utf8_length(matched_text)
+            cursor = match.end()
+        output.extend(current.slice_segments(cursor, len(source)))
+        return _ExpansionText(output)
 
 
 def default_wildcard_root() -> Path:
@@ -540,26 +841,35 @@ def _parse_count_spec(spec: str, selector: _Selector) -> int | None:
     return selector.count_from_range(minimum, maximum)
 
 
-def _expand_multiselect_options(options: list[WildcardOption], library: _WildcardLibrary) -> list[WildcardOption]:
+def _expand_multiselect_options(
+    options: list[WildcardOption],
+    library: _WildcardLibrary,
+) -> tuple[list[WildcardOption], str | None]:
     if len(options) != 1:
-        return options
+        return options, None
     match = WILDCARD_FULL_RE.match(options[0].text.strip())
     if not match:
-        return options
-    return library.options_for(match.group("keyword"))
+        return options, None
+    raw_key = match.group("keyword")
+    return library.options_for(raw_key), _normalize_wildcard_key(raw_key)
 
 
-def _replace_dynamic(text: str, selector: _Selector, library: _WildcardLibrary) -> str:
-    def replace(match: re.Match) -> str:
+def _replace_dynamic(
+    current: _ExpansionText,
+    state: _ExpansionState,
+    selector: _Selector,
+    library: _WildcardLibrary,
+) -> _ExpansionText:
+    def replace(match: re.Match, key_stack: tuple[str, ...]) -> _Replacement | None:
         body = match.group(1)
         raw_options = _split_unescaped(body, "|")
         if not raw_options:
-            return match.group(0)
+            return None
         first_parts = raw_options[0].split("$$")
         if len(first_parts) > 1:
             count = _parse_count_spec(first_parts[0], selector)
             if count is None:
-                return match.group(0)
+                return None
             separator = ", "
             if len(first_parts) == 2:
                 first_candidate = first_parts[1]
@@ -567,34 +877,86 @@ def _replace_dynamic(text: str, selector: _Selector, library: _WildcardLibrary) 
                 separator = first_parts[1]
                 first_candidate = "$$".join(first_parts[2:])
             candidate_text = "|".join([first_candidate, *raw_options[1:]])
-            options = _expand_multiselect_options(_parse_dynamic_options(candidate_text), library)
+            options, expanded_key = _expand_multiselect_options(
+                _parse_dynamic_options(candidate_text),
+                library,
+            )
             selected = selector.choose_many(options, count)
-            return separator.join(option.text for option in selected) if selected else match.group(0)
+            if not selected:
+                return None
+            candidate_stack = key_stack + ((expanded_key,) if expanded_key is not None else ())
+            return state.candidate(
+                (option.text for option in selected),
+                separator,
+                candidate_stack,
+            )
 
         options = _parse_dynamic_options(body)
         selected = selector.choose_one(options)
-        return selected.text if selected is not None else match.group(0)
+        if selected is None:
+            return None
+        return state.candidate((selected.text,), "", key_stack)
 
-    return DYNAMIC_RE.sub(replace, text)
+    return state.replace_matches(current, DYNAMIC_RE, replace)
 
 
-def _replace_quantified_wildcards(text: str, selector: _Selector, library: _WildcardLibrary) -> str:
-    def replace(match: re.Match) -> str:
+def _replace_quantified_wildcards(
+    current: _ExpansionText,
+    state: _ExpansionState,
+    selector: _Selector,
+    library: _WildcardLibrary,
+) -> _ExpansionText:
+    def replace(match: re.Match, key_stack: tuple[str, ...]) -> _Replacement | None:
         count = max(0, int(match.group("quantifier")))
-        options = library.options_for(match.group("keyword"))
+        raw_key = match.group("keyword")
+        options = library.options_for(raw_key)
         selected = selector.choose_many(options, count)
-        return ", ".join(option.text for option in selected) if selected else match.group(0)
+        key = _normalize_wildcard_key(raw_key)
+        if not selected or key is None:
+            return None
+        return state.candidate(
+            (option.text for option in selected),
+            ", ",
+            key_stack + (key,),
+        )
 
-    return WILDCARD_QUANTIFIER_RE.sub(replace, text)
+    return state.replace_matches(current, WILDCARD_QUANTIFIER_RE, replace)
 
 
-def _replace_file_wildcards(text: str, selector: _Selector, library: _WildcardLibrary) -> str:
-    def replace(match: re.Match) -> str:
-        options = library.options_for(match.group("keyword"))
+def _replace_file_wildcards(
+    current: _ExpansionText,
+    state: _ExpansionState,
+    selector: _Selector,
+    library: _WildcardLibrary,
+) -> _ExpansionText:
+    def replace(match: re.Match, key_stack: tuple[str, ...]) -> _Replacement | None:
+        raw_key = match.group("keyword")
+        options = library.options_for(raw_key)
         selected = selector.choose_one(options)
-        return selected.text if selected is not None else match.group(0)
+        key = _normalize_wildcard_key(raw_key)
+        if selected is None or key is None:
+            return None
+        return state.candidate((selected.text,), "", key_stack + (key,))
 
-    return WILDCARD_RE.sub(replace, text)
+    return state.replace_matches(current, WILDCARD_RE, replace)
+
+
+def _bounded_output_prefix(text: str, limit: int) -> str:
+    chars = []
+    byte_count = 0
+    for char in text:
+        width = _utf8_width(char)
+        if len(chars) >= limit or byte_count + width > limit:
+            break
+        chars.append(char)
+        byte_count += width
+    return "".join(chars)
+
+
+def _expansion_state_signature(text: str) -> tuple[int, bytes]:
+    digest = hashlib.blake2b(text.encode("utf-8", errors="surrogatepass"), digest_size=16)
+    return len(text), digest.digest()
+
 
 
 def expand_wildcards(
@@ -603,22 +965,56 @@ def expand_wildcards(
     mode: str = WILDCARD_MODE_POPULATE,
     extra_paths: str | None = None,
     roots: Iterable[Path] | None = None,
+    budget: WildcardExpansionBudget | None = None,
 ) -> WildcardExpansionResult:
+    source = str(text or "")
     mode = normalize_wildcard_mode(mode)
     selector = _Selector(normalize_seed(seed), sequential=mode == WILDCARD_MODE_SEQUENTIAL)
     library = _WildcardLibrary(roots if roots is not None else resolve_wildcard_roots(extra_paths))
+    budget = budget if isinstance(budget, WildcardExpansionBudget) else WildcardExpansionBudget()
+    state = _ExpansionState(budget)
 
-    current = COMMENT_RE.sub("", str(text or ""))
-    for _ in range(REPLACE_DEPTH):
-        previous = current
-        current = _replace_dynamic(current, selector, library)
-        current = _replace_quantified_wildcards(current, selector, library)
-        current = _replace_file_wildcards(current, selector, library)
-        if current == previous:
-            break
+    cleaned = COMMENT_RE.sub("", source)
+    if len(cleaned) > budget.max_output_chars or _utf8_length(cleaned) > budget.max_output_chars:
+        cleaned = _bounded_output_prefix(cleaned, budget.max_output_chars)
+        state.stop("max_output_chars")
+    current = _ExpansionText.from_text(cleaned)
+    # Key stacks stop file recursion before append; stable pass signatures are
+    # a separate fallback for keyless fixed points and oscillating expressions.
+    seen_states = {_expansion_state_signature(current.text)}
+
+    if state.limit_reason is None:
+        for depth in range(budget.max_depth):
+            state.begin_pass(current)
+            replacements_before_pass = state.replacement_count
+            current = _replace_dynamic(current, state, selector, library)
+            if state.limit_reason is None:
+                current = _replace_quantified_wildcards(current, state, selector, library)
+            if state.limit_reason is None:
+                current = _replace_file_wildcards(current, state, selector, library)
+            if state.limit_reason is not None:
+                break
+            if state.replacement_count == replacements_before_pass:
+                break
+            if not has_wildcard_syntax(current.text):
+                break
+            signature = _expansion_state_signature(current.text)
+            if signature in seen_states:
+                state.stop("repeated_state")
+                break
+            seen_states.add(signature)
+            if depth + 1 >= budget.max_depth:
+                state.stop("max_depth")
+                break
+        else:
+            if budget.max_depth == 0 and has_wildcard_syntax(current.text):
+                state.stop("max_depth")
+
     return WildcardExpansionResult(
-        text=current,
-        changed=current != str(text or ""),
+        text=current.text,
+        changed=current.text != source,
         used_keys=tuple(library.used),
         missing_keys=tuple(library.missing),
+        replacement_count=state.replacement_count,
+        limit_reason=state.limit_reason,
     )

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import bisect
+from collections import OrderedDict
 import fnmatch
 import hashlib
 import math
 import os
 import random
 import re
+import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from types import MappingProxyType
+from typing import Iterable, Mapping
 
 try:
     import numpy as np
@@ -105,6 +108,64 @@ COUNT_SPEC_RE = re.compile(
 class WildcardOption:
     text: str
     weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class _WildcardSourceFile:
+    root_index: int
+    root: str
+    relative_path: str
+    path: Path
+    mtime_ns: int
+    size: int
+
+    @property
+    def cache_key(self) -> tuple[int, str, int, int]:
+        return (self.root_index, self.relative_path, self.mtime_ns, self.size)
+
+
+@dataclass(frozen=True)
+class _WildcardSourceState:
+    roots: tuple[Path, ...]
+    root_identities: tuple[str, ...]
+    files: tuple[_WildcardSourceFile, ...]
+
+    @property
+    def cache_key(self) -> tuple:
+        roots = tuple(
+            (identity, str(root))
+            for identity, root in zip(self.root_identities, self.roots)
+        )
+        return roots, tuple(source.cache_key for source in self.files)
+
+
+@dataclass(frozen=True)
+class _WildcardSnapshot:
+    cache_key: tuple
+    mapping: Mapping[str, tuple[WildcardOption, ...]]
+    wildcard_names: tuple[str, ...]
+    roots: tuple[str, ...]
+    files: tuple[_WildcardSourceFile, ...]
+
+    def public_signature(self) -> dict:
+        return {
+            "roots": list(self.roots),
+            "files": [
+                {
+                    "root": source.root,
+                    "path": source.relative_path,
+                    "mtime_ns": source.mtime_ns,
+                    "size": source.size,
+                }
+                for source in self.files
+            ],
+        }
+
+
+_SNAPSHOT_CACHE_LIMIT = 16
+_SNAPSHOT_CONDITION = threading.Condition()
+_SNAPSHOT_CACHE: OrderedDict[tuple, _WildcardSnapshot] = OrderedDict()
+_SNAPSHOT_BUILDING: set[tuple] = set()
 
 
 def _bounded_int(value, default: int, minimum: int, maximum: int) -> int:
@@ -571,39 +632,37 @@ def _stringify_yaml_scalar(value) -> str:
 
 def _yaml_entries(data, prefix: str = "") -> dict[str, list[WildcardOption]]:
     entries: dict[str, list[WildcardOption]] = {}
-    if isinstance(data, dict):
-        aggregate = []
-        for raw_key, value in data.items():
-            child_key = _normalize_wildcard_key(raw_key)
-            if child_key is None:
-                continue
-            path_key = f"{prefix}/{child_key}" if prefix else child_key
-            child_entries = _yaml_entries(value, path_key)
-            for key, options in child_entries.items():
-                entries.setdefault(key, []).extend(options)
-                aggregate.extend(options)
-        if prefix and aggregate:
-            entries.setdefault(prefix, []).extend(aggregate)
-        return entries
-    if isinstance(data, list):
-        options = []
-        for item in data:
-            if isinstance(item, (dict, list)):
-                child_entries = _yaml_entries(item, prefix)
-                for key, child_options in child_entries.items():
-                    entries.setdefault(key, []).extend(child_options)
-                    options.extend(child_options)
-                continue
-            option = _parse_option(_stringify_yaml_scalar(item))
+
+    def collect(value, path_prefix: str, publish_alias: bool = True) -> list[WildcardOption]:
+        aggregate: list[WildcardOption] = []
+        if isinstance(value, dict):
+            for raw_key, child_value in value.items():
+                child_key = _normalize_wildcard_key(raw_key)
+                if child_key is None:
+                    continue
+                path_key = f"{path_prefix}/{child_key}" if path_prefix else child_key
+                aggregate.extend(collect(child_value, path_key))
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, (dict, list)):
+                    # The containing list owns this alias. Nested containers still
+                    # publish their distinct child paths, but not the same prefix
+                    # again through an intermediate recursion frame.
+                    aggregate.extend(collect(item, path_prefix, publish_alias=False))
+                    continue
+                option = _parse_option(_stringify_yaml_scalar(item))
+                if option is not None:
+                    aggregate.append(option)
+        else:
+            option = _parse_option(_stringify_yaml_scalar(value))
             if option is not None:
-                options.append(option)
-        if prefix and options:
-            entries.setdefault(prefix, []).extend(options)
-        return entries
-    if prefix:
-        option = _parse_option(_stringify_yaml_scalar(data))
-        if option is not None:
-            entries[prefix] = [option]
+                aggregate.append(option)
+
+        if publish_alias and path_prefix and aggregate:
+            entries.setdefault(path_prefix, []).extend(aggregate)
+        return aggregate
+
+    collect(data, prefix)
     return entries
 
 
@@ -633,50 +692,130 @@ def _load_wildcard_file(root: Path, path: Path) -> dict[str, list[WildcardOption
     return {key: _options_from_lines(_read_text_file(path))}
 
 
-def _load_wildcard_map(roots: Iterable[Path]) -> dict[str, list[WildcardOption]]:
-    mapping: dict[str, list[WildcardOption]] = {}
-    for root in roots:
+def _wildcard_root_identity(root: Path) -> str:
+    try:
+        return os.path.normcase(os.path.abspath(os.fspath(root)))
+    except (OSError, TypeError, ValueError):
+        return os.path.normcase(str(root))
+
+
+def _scan_wildcard_sources(roots: tuple[Path, ...]) -> _WildcardSourceState:
+    files: list[_WildcardSourceFile] = []
+    for root_index, root in enumerate(roots):
         if not root.is_dir():
             continue
-        for path in sorted(root.rglob("*"), key=lambda item: item.as_posix().lower()):
-            if not path.is_file() or path.suffix.lower() not in WILDCARD_EXTENSIONS:
+        try:
+            candidates = sorted(root.rglob("*"), key=lambda item: item.as_posix().lower())
+        except OSError:
+            continue
+        for path in candidates:
+            if path.suffix.lower() not in WILDCARD_EXTENSIONS:
                 continue
             try:
-                entries = _load_wildcard_file(root, path)
-            except OSError:
+                if not path.is_file():
+                    continue
+                stat = path.stat()
+                relative = path.relative_to(root).as_posix()
+            except (OSError, ValueError):
                 continue
-            for key, options in entries.items():
-                if key not in mapping and options:
-                    mapping[key] = options
-    return mapping
+            files.append(
+                _WildcardSourceFile(
+                    root_index=root_index,
+                    root=str(root),
+                    relative_path=relative,
+                    path=path,
+                    mtime_ns=stat.st_mtime_ns,
+                    size=stat.st_size,
+                )
+            )
+    return _WildcardSourceState(
+        roots=roots,
+        root_identities=tuple(_wildcard_root_identity(root) for root in roots),
+        files=tuple(files),
+    )
+
+
+def _build_wildcard_snapshot(source_state: _WildcardSourceState) -> _WildcardSnapshot:
+    mapping: dict[str, list[WildcardOption]] = {}
+    for source in source_state.files:
+        root = source_state.roots[source.root_index]
+        try:
+            entries = _load_wildcard_file(root, source.path)
+        except OSError:
+            continue
+        for key, options in entries.items():
+            if key not in mapping and options:
+                mapping[key] = options
+
+    frozen_mapping = MappingProxyType(
+        {key: tuple(options) for key, options in mapping.items()}
+    )
+    return _WildcardSnapshot(
+        cache_key=source_state.cache_key,
+        mapping=frozen_mapping,
+        wildcard_names=tuple(sorted(frozen_mapping)),
+        roots=tuple(str(root) for root in source_state.roots),
+        files=source_state.files,
+    )
+
+
+def _wildcard_snapshot(roots: Iterable[Path]) -> _WildcardSnapshot:
+    resolved_roots = tuple(Path(root) for root in roots)
+    while True:
+        source_state = _scan_wildcard_sources(resolved_roots)
+        cache_key = source_state.cache_key
+        with _SNAPSHOT_CONDITION:
+            cached = _SNAPSHOT_CACHE.get(cache_key)
+            if cached is not None:
+                _SNAPSHOT_CACHE.move_to_end(cache_key)
+                return cached
+            if cache_key in _SNAPSHOT_BUILDING:
+                _SNAPSHOT_CONDITION.wait()
+                continue
+            _SNAPSHOT_BUILDING.add(cache_key)
+
+        snapshot = None
+        failure: BaseException | None = None
+        try:
+            candidate = _build_wildcard_snapshot(source_state)
+            verified_state = _scan_wildcard_sources(resolved_roots)
+            if verified_state.cache_key == cache_key:
+                snapshot = candidate
+        except BaseException as exc:
+            failure = exc
+        finally:
+            with _SNAPSHOT_CONDITION:
+                _SNAPSHOT_BUILDING.discard(cache_key)
+                if snapshot is not None:
+                    _SNAPSHOT_CACHE[cache_key] = snapshot
+                    _SNAPSHOT_CACHE.move_to_end(cache_key)
+                    while len(_SNAPSHOT_CACHE) > _SNAPSHOT_CACHE_LIMIT:
+                        _SNAPSHOT_CACHE.popitem(last=False)
+                _SNAPSHOT_CONDITION.notify_all()
+
+        if failure is not None:
+            raise failure
+        if snapshot is not None:
+            return snapshot
+
+
+def _load_wildcard_map(roots: Iterable[Path]) -> dict[str, list[WildcardOption]]:
+    snapshot = _wildcard_snapshot(roots)
+    return {key: list(options) for key, options in snapshot.mapping.items()}
 
 
 def list_wildcards(extra_paths: str | None = None, roots: Iterable[Path] | None = None) -> list[str]:
-    mapping = _load_wildcard_map(roots if roots is not None else resolve_wildcard_roots(extra_paths))
-    return sorted(mapping)
+    snapshot = _wildcard_snapshot(
+        roots if roots is not None else resolve_wildcard_roots(extra_paths)
+    )
+    return list(snapshot.wildcard_names)
 
 
 def wildcard_sources_signature(extra_paths: str | None = None, roots: Iterable[Path] | None = None) -> dict:
-    resolved_roots = [Path(root) for root in (roots if roots is not None else resolve_wildcard_roots(extra_paths))]
-    files = []
-    for root in resolved_roots:
-        if not root.is_dir():
-            continue
-        for path in sorted(root.rglob("*"), key=lambda item: item.as_posix().lower()):
-            if not path.is_file() or path.suffix.lower() not in WILDCARD_EXTENSIONS:
-                continue
-            try:
-                stat = path.stat()
-                relative = path.relative_to(root).as_posix()
-            except OSError:
-                continue
-            files.append({
-                "root": str(root),
-                "path": relative,
-                "mtime_ns": stat.st_mtime_ns,
-                "size": stat.st_size,
-            })
-    return {"roots": [str(root) for root in resolved_roots], "files": files}
+    snapshot = _wildcard_snapshot(
+        roots if roots is not None else resolve_wildcard_roots(extra_paths)
+    )
+    return snapshot.public_signature()
 
 
 class _Selector:

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -357,6 +357,7 @@ class _ExpansionState:
         self.budget = budget
         self.replacement_count = 0
         self.limit_reason: str | None = None
+        self.cycle_detected = False
         self._pass_base_chars = 0
         self._pass_base_bytes = 0
 
@@ -382,7 +383,7 @@ class _ExpansionState:
             for match in WILDCARD_RE.finditer(part):
                 key = _normalize_wildcard_key(match.group("keyword"))
                 if key is not None and key in key_stack:
-                    self.stop("cycle")
+                    self.cycle_detected = True
                     return None
         return candidate
 
@@ -1155,5 +1156,5 @@ def expand_wildcards(
         used_keys=tuple(library.used),
         missing_keys=tuple(library.missing),
         replacement_count=state.replacement_count,
-        limit_reason=state.limit_reason,
+        limit_reason=state.limit_reason or ("cycle" if state.cycle_detected else None),
     )


### PR DESCRIPTION
## 변경 요약

- 재귀 wildcard 확장에 깊이, 치환 수, 출력 크기, pass 성장률 제한을 적용하고 결과 진단을 노출합니다.
- 직접·간접 순환은 해당 분기만 보류하며, 독립 분기의 확장을 계속합니다.
- TXT/YAML wildcard 소스를 불변 snapshot으로 캐시하고 동일 키 동시 빌드를 단일화합니다.
- 파일 변경 중 빌드와 일시적 읽기 오류에서 불완전 snapshot이 캐시에 게시되지 않도록 보장합니다.
- YAML 상위 별칭 집계 중복을 제거하고 런타임 조회는 불변 mapping을 직접 재사용합니다.

Closes #159
Closes #160

## 주요 파일

- `wildcard_engine.py`
- `tests/test_wildcards.py`

## 메인 검토에서 보완한 항목

- 순환 감지가 전체 확장을 중단하던 동작을 분기 단위 진단으로 수정
- 일시적 `OSError`로 만들어진 불완전 snapshot의 영구 캐시 방지
- 매 확장 호출마다 snapshot mapping 전체를 복사하던 비용 제거

## 검증

```powershell
powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <target-worktree> -Profile full
```

- Python compile: 통과
- Python unittest: 466 tests 통과
- Frontend: 110 JavaScript files 통과, TypeScript 6.0.3
- `git diff --check`: 통과

## 테스트 표면

- ComfyUI Codex test instance: 프로젝트 full suite
- Live ComfyUI smoke: 실행하지 않음 (backend wildcard 경계와 deterministic regression으로 검증)

## 남은 위험 / 미확인

- source signature는 경로, `mtime_ns`, 크기를 사용합니다. 내용이 바뀌면서 두 metadata가 모두 완전히 보존되는 비정상적 외부 수정은 다음 signature 변화 전까지 감지되지 않을 수 있습니다.
- 공개 node input schema와 기존 seed 동작은 유지하며 회귀 테스트로 확인했습니다.