### PR TITLE
[Phase 0] 공개 node/workflow contract baseline 추가

### DIFF
--- a/tests/fixtures/node_contracts_0_5_2.json
+++ b/tests/fixtures/node_contracts_0_5_2.json
@@ -1,0 +1,2345 @@
+{
+  "dynamic_inputs": {
+    "diffusion_models": [
+      "contract/diffusion_model.safetensors"
+    ],
+    "impact_schedulers": [
+      "contract_impact_scheduler"
+    ],
+    "lora_models": [
+      "None",
+      "contract/style.safetensors"
+    ],
+    "samplers": [
+      "contract_sampler_a",
+      "contract_sampler_b"
+    ],
+    "schedulers": [
+      "contract_scheduler_a",
+      "contract_scheduler_b"
+    ],
+    "text_encoders": [
+      "contract/text_encoder.safetensors"
+    ],
+    "vae_models": [
+      "contract/vae.safetensors"
+    ]
+  },
+  "is_changed": [
+    {
+      "id": "EasyUseAnimaPromptCorrector",
+      "inputs": {
+        "artist_exclusions": "",
+        "artist_overrides": "",
+        "prompt": "1girl, blue eyes"
+      },
+      "result": "{\"artist_exclusions\":\"\",\"artist_overrides\":\"\",\"mode\":\"prompt_corrector\",\"prompt\":\"1girl, blue eyes\",\"prompt_translation\":{\"enabled\":false}}"
+    },
+    {
+      "id": "EasyUseAnimaWildcard",
+      "inputs": {
+        "mode": "reproduce",
+        "populated_text": "",
+        "seed": 17,
+        "seed_after_generate": "fixed",
+        "text": "plain contract prompt"
+      },
+      "result": "{\"mode\":\"reproduce\",\"populated_text\":\"\",\"seed\":\"17\",\"seed_after_generate\":\"fixed\",\"text\":\"plain contract prompt\",\"wildcard_sources\":{\"files\":[]}}"
+    },
+    {
+      "id": "EasyUseAnimaPromptStudioAdvancedV2",
+      "inputs": {
+        "advanced_fields": "[]",
+        "artist_mix_mode": "off",
+        "use_naia": false
+      },
+      "result": "{\"artist_mix_cluster_count\":4,\"artist_mix_dominant_isolation\":true,\"artist_mix_dominant_threshold\":0.25,\"artist_mix_exact_top_k\":4,\"artist_mix_mode\":\"off\",\"artist_mix_rms_scale_cap\":2.0,\"artist_mix_start_percent\":0.5,\"artist_mix_strength_scale\":1.0,\"artist_mix_style_gain\":1.35,\"base\":\"{\\\"advanced_fields\\\":\\\"[{\\\\\\\"id\\\\\\\":\\\\\\\"positive_quality\\\\\\\",\\\\\\\"pane\\\\\\\":\\\\\\\"positive\\\\\\\",\\\\\\\"type\\\\\\\":\\\\\\\"quality\\\\\\\",\\\\\\\"label\\\\\\\":\\\\\\\"Quality Tags\\\\\\\",\\\\\\\"text\\\\\\\":\\\\\\\"newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic\\\\\\\",\\\\\\\"height\\\\\\\":72,\\\\\\\"enabled\\\\\\\":true,\\\\\\\"pin\\\\\\\":false},{\\\\\\\"id\\\\\\\":\\\\\\\"positive_artist\\\\\\\",\\\\\\\"pane\\\\\\\":\\\\\\\"positive\\\\\\\",\\\\\\\"type\\\\\\\":\\\\\\\"artist\\\\\\\",\\\\\\\"label\\\\\\\":\\\\\\\"Artist Tags\\\\\\\",\\\\\\\"text\\\\\\\":\\\\\\\"\\\\\\\",\\\\\\\"height\\\\\\\":72,\\\\\\\"enabled\\\\\\\":true,\\\\\\\"pin\\\\\\\":false},{\\\\\\\"id\\\\\\\":\\\\\\\"positive_trigger\\\\\\\",\\\\\\\"pane\\\\\\\":\\\\\\\"positive\\\\\\\",\\\\\\\"type\\\\\\\":\\\\\\\"trigger\\\\\\\",\\\\\\\"label\\\\\\\":\\\\\\\"Trigger Words\\\\\\\",\\\\\\\"text\\\\\\\":\\\\\\\"\\\\\\\",\\\\\\\"height\\\\\\\":72,\\\\\\\"enabled\\\\\\\":true,\\\\\\\"pin\\\\\\\":true},{\\\\\\\"id\\\\\\\":\\\\\\\"positive_general\\\\\\\",\\\\\\\"pane\\\\\\\":\\\\\\\"positive\\\\\\\",\\\\\\\"type\\\\\\\":\\\\\\\"general\\\\\\\",\\\\\\\"label\\\\\\\":\\\\\\\"General Tags\\\\\\\",\\\\\\\"text\\\\\\\":\\\\\\\"\\\\\\\",\\\\\\\"height\\\\\\\":150,\\\\\\\"enabled\\\\\\\":true,\\\\\\\"pin\\\\\\\":false},{\\\\\\\"id\\\\\\\":\\\\\\\"positive_trailing\\\\\\\",\\\\\\\"pane\\\\\\\":\\\\\\\"positive\\\\\\\",\\\\\\\"type\\\\\\\":\\\\\\\"general\\\\\\\",\\\\\\\"label\\\\\\\":\\\\\\\"General Tags\\\\\\\",\\\\\\\"text\\\\\\\":\\\\\\\"location, (A highly aesthetic Pixiv style illustration, clean composition, high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)\\\\\\\",\\\\\\\"height\\\\\\\":72,\\\\\\\"enabled\\\\\\\":true,\\\\\\\"pin\\\\\\\":false},{\\\\\\\"id\\\\\\\":\\\\\\\"negative_general\\\\\\\",\\\\\\\"pane\\\\\\\":\\\\\\\"negative\\\\\\\",\\\\\\\"type\\\\\\\":\\\\\\\"general\\\\\\\",\\\\\\\"label\\\\\\\":\\\\\\\"General Tags\\\\\\\",\\\\\\\"text\\\\\\\":\\\\\\\"\\\\\\\",\\\\\\\"height\\\\\\\":120,\\\\\\\"enabled\\\\\\\":true,\\\\\\\"pin\\\\\\\":false}]\\\",\\\"metadata_filter_words\\\":[\\\"contract-filter\\\"],\\\"mode\\\":\\\"prompt_studio_advanced\\\",\\\"pin_trigger_tags_to_front\\\":false,\\\"prompt_translation\\\":{\\\"enabled\\\":false},\\\"resolution\\\":[1024,1024],\\\"use_anima_mod_guidance\\\":false,\\\"use_negative_anima_mod_guidance\\\":false,\\\"wildcard_mode\\\":\\\"fixed\\\",\\\"wildcard_seed\\\":0,\\\"wildcard_seed_after_generate\\\":\\\"fixed\\\",\\\"wildcard_sources\\\":{\\\"files\\\":[]}}\"}"
+    },
+    {
+      "id": "EasyUseAnimaInput",
+      "inputs": {
+        "EASYUSE_ANIMA_PROMPT_DATA": {
+          "height": 1024,
+          "negative_prompt": "",
+          "positive_prompt": "contract prompt",
+          "width": 1024
+        },
+        "clip_name": "contract/text_encoder.safetensors",
+        "clip_type": "qwen_image",
+        "input_settings": {},
+        "unet_name": "contract/diffusion_model.safetensors",
+        "vae_name": "contract/vae.safetensors"
+      },
+      "result": "{\"clip_name\":\"contract/text_encoder.safetensors\",\"clip_type\":\"qwen_image\",\"input_settings\":{\"metadata\":{},\"resources\":{\"clip_device\":\"default\",\"clip_loader\":\"single\",\"loader_mode\":\"split\",\"unet_weight_dtype\":\"default\"},\"schema\":\"easy_use_anima_input\",\"version\":1},\"mode\":\"easy_use_anima_input\",\"prompt_data\":{\"height\":1024,\"negative_prompt\":\"\",\"positive_prompt\":\"contract prompt\",\"width\":1024},\"unet_name\":\"contract/diffusion_model.safetensors\",\"vae_name\":\"contract/vae.safetensors\"}"
+    },
+    {
+      "id": "EasyUseAnimaAIOGenerator",
+      "inputs": {
+        "easy_use_anima_input": {
+          "input_settings": {
+            "metadata": {},
+            "resources": {
+              "clip_device": "default",
+              "clip_loader": "single",
+              "loader_mode": "split",
+              "unet_weight_dtype": "default"
+            },
+            "schema": "easy_use_anima_input",
+            "version": 1
+          },
+          "prompt_data": {
+            "easy_use_anima_input": {
+              "resource_info": {
+                "clip_device": "default",
+                "clip_name": "contract/text_encoder.safetensors",
+                "clip_type": "qwen_image",
+                "loader_mode": "split",
+                "unet_name": "contract/diffusion_model.safetensors",
+                "unet_weight_dtype": "default",
+                "vae_name": "contract/vae.safetensors"
+              },
+              "schema": "easy_use_anima_input",
+              "version": 1
+            },
+            "height": 1024,
+            "negative_prompt": "",
+            "positive_prompt": "contract prompt",
+            "width": 1024
+          },
+          "resource_info": {
+            "clip_device": "default",
+            "clip_name": "contract/text_encoder.safetensors",
+            "clip_type": "qwen_image",
+            "loader_mode": "split",
+            "unet_name": "contract/diffusion_model.safetensors",
+            "unet_weight_dtype": "default",
+            "vae_name": "contract/vae.safetensors"
+          },
+          "schema": "easy_use_anima_input",
+          "version": 1
+        },
+        "generation_settings": {
+          "sampler": {
+            "seed": 17
+          }
+        },
+        "lora_stack": null
+      },
+      "result": "{\"generation_settings\":{\"artist_mix\":{\"cluster_count\":4,\"dominant_isolation\":true,\"dominant_threshold\":0.25,\"exact_top_k\":4,\"mode\":\"prompt_data\",\"rms_scale_cap\":2.0,\"start_percent\":0.5,\"strength_scale\":1.0,\"style_gain\":1.35},\"detailer\":{\"enabled\":false,\"eye\":{\"alignment\":\"32\",\"bbox_fill\":false,\"cfg\":8.0,\"combined\":false,\"contour_fill\":true,\"crop_factor\":6.0,\"cycle\":1,\"denoise\":0.29,\"detect_count\":1,\"detect_prompt\":\"eyes\",\"dit_corrections\":{\"adaptive_smc_alpha\":0.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"dcw_lambda\":0.02,\"dcw_mode\":\"off\",\"enabled\":false,\"fsg\":false,\"fsg_band_hi\":0.75,\"fsg_band_lo\":0.59,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"fsg_k\":3,\"replace_existing_cfg\":false,\"smc_cfg\":false,\"smc_cfg_lambda\":6.0},\"drop_size\":40,\"enabled\":false,\"feather\":6,\"force_inpaint\":true,\"guide_size\":1024,\"guide_size_for\":false,\"individual_masks\":true,\"inherit_sampler_settings\":true,\"inpaint_model\":false,\"label\":\"Eye Detailer\",\"max_size\":2048,\"noise_mask\":true,\"noise_mask_feather\":20,\"refine_iterations\":2,\"sampler_name\":\"contract_sampler_a\",\"scheduler\":\"contract_impact_scheduler\",\"spectrum\":{\"blend_w\":0.3,\"cheby_degree\":3,\"compat_policy\":\"conservative\",\"enabled\":true,\"flex_window\":0.15,\"history_size\":100,\"one_sampler_only\":false,\"ridge_lambda\":0.1,\"tail_actual_steps\":3,\"verbose\":false,\"warmup_steps\":6,\"window_size\":2.0},\"steps\":20,\"threshold\":0.5,\"tiled_decode\":false,\"tiled_encode\":false,\"wildcard\":\"\"},\"face\":{\"alignment\":\"32\",\"bbox_fill\":false,\"cfg\":8.0,\"combined\":false,\"contour_fill\":true,\"crop_factor\":4.0,\"cycle\":1,\"denoise\":0.33,\"detect_count\":1,\"detect_prompt\":\"face\",\"dit_corrections\":{\"adaptive_smc_alpha\":0.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"dcw_lambda\":0.02,\"dcw_mode\":\"off\",\"enabled\":false,\"fsg\":false,\"fsg_band_hi\":0.75,\"fsg_band_lo\":0.59,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"fsg_k\":3,\"replace_existing_cfg\":false,\"smc_cfg\":false,\"smc_cfg_lambda\":6.0},\"drop_size\":100,\"enabled\":false,\"feather\":5,\"force_inpaint\":true,\"guide_size\":1024,\"guide_size_for\":false,\"individual_masks\":true,\"inherit_sampler_settings\":true,\"inpaint_model\":false,\"label\":\"Face Detailer\",\"max_size\":2048,\"noise_mask\":true,\"noise_mask_feather\":10,\"refine_iterations\":2,\"sampler_name\":\"contract_sampler_a\",\"scheduler\":\"contract_impact_scheduler\",\"spectrum\":{\"blend_w\":0.3,\"cheby_degree\":3,\"compat_policy\":\"conservative\",\"enabled\":true,\"flex_window\":0.15,\"history_size\":100,\"one_sampler_only\":false,\"ridge_lambda\":0.1,\"tail_actual_steps\":3,\"verbose\":false,\"warmup_steps\":6,\"window_size\":2.0},\"steps\":20,\"threshold\":0.52,\"tiled_decode\":false,\"tiled_encode\":false,\"wildcard\":\"\"},\"order\":[\"face\",\"eye\"],\"sam3\":{\"checkpoint\":\"sam3.1_multiplex_fp16.safetensors\",\"context\":\"load_checkpoint\"}},\"highres\":{\"cfg\":8.0,\"denoise\":0.25,\"dit_corrections\":{\"adaptive_smc_alpha\":0.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"dcw_lambda\":0.02,\"dcw_mode\":\"off\",\"enabled\":false,\"fsg\":false,\"fsg_band_hi\":0.75,\"fsg_band_lo\":0.59,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"fsg_k\":3,\"replace_existing_cfg\":false,\"smc_cfg\":false,\"smc_cfg_lambda\":6.0},\"enabled\":false,\"inherit_sampler_settings\":true,\"max_long_edge\":2560,\"multiple\":\"32\",\"sampler_name\":\"contract_sampler_a\",\"scale_by\":1.5,\"scheduler\":\"contract_scheduler_a\",\"spectrum\":{\"blend_w\":0.3,\"cheby_degree\":3,\"compat_policy\":\"conservative\",\"enabled\":false,\"flex_window\":0.2,\"history_size\":100,\"one_sampler_only\":false,\"ridge_lambda\":0.1,\"tail_actual_steps\":4,\"verbose\":false,\"warmup_steps\":7,\"window_size\":2.0},\"steps\":20,\"upscale_method\":\"bicubic\"},\"mod_guidance\":{\"advanced\":{\"adapter\":\"(auto-download default)\",\"mod_end_layer\":27,\"mod_final_w\":0.0,\"mod_start_layer\":8,\"mod_taper\":0,\"mod_taper_scale\":0.25,\"mod_w\":3.0,\"quality_neg\":\"score_1, score_2, score_3, worst quality, lowres, old, bad hands, bad anatomy\",\"quality_tags\":\"highres, best quality, score_7\"},\"mode\":\"prompt_data\",\"profile\":\"step_i8_skip27\"},\"mode\":\"txt2img\",\"model_patches\":{\"aura_flow\":{\"shift\":3.0},\"dave\":{\"enabled\":false,\"mask\":\"dave_alpha.npz\",\"strength\":0.3,\"tau\":0.1},\"kj\":{\"fp16_accumulation\":false,\"sage_allow_compile\":false,\"sage_attention\":\"disabled\",\"torch_compile\":{\"backend\":\"inductor\",\"compile_transformer_blocks_only\":true,\"debug_compile_keys\":false,\"disable_dynamic_vram\":true,\"dynamic\":\"false\",\"dynamo_cache_size_limit\":64,\"enabled\":false,\"fullgraph\":false,\"mode\":\"max-autotune-no-cudagraphs\"}},\"safe_pag\":{\"block_indices\":\"18\",\"enabled\":false,\"end_percent\":0.7,\"head_indices\":\"\",\"perturbation_strength\":0.75,\"rescale\":0.2,\"rescale_mode\":\"full\",\"scale\":4.0,\"start_percent\":0.0}},\"postprocess\":{\"enabled\":false,\"fit\":{\"max_long_edge\":2048,\"max_megapixels\":4.0,\"method\":\"bicubic\",\"mode\":\"max_long_edge\"}},\"preview\":{\"compare_previous\":false,\"feed_count\":12,\"image_feed\":true,\"intermediate_images\":false},\"sampler\":{\"backend\":\"comfy_ksampler\",\"cfg\":5.0,\"denoise\":1.0,\"dit_corrections\":{\"adaptive_smc_alpha\":0.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"dcw_lambda\":0.01,\"dcw_mode\":\"off\",\"enabled\":false,\"fsg\":false,\"fsg_band_hi\":0.75,\"fsg_band_lo\":0.59,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"fsg_k\":3,\"replace_existing_cfg\":false,\"smc_cfg\":false,\"smc_cfg_lambda\":6.0},\"sampler_name\":\"contract_sampler_a\",\"scheduler\":\"contract_scheduler_a\",\"seed\":17,\"seed_after_generate\":\"fixed\",\"spd\":{\"adaptive_smc_alpha\":0.0,\"scale\":0.5,\"sigma\":0.7,\"split_mode\":\"single\"},\"spd_extra\":{},\"spectrum\":{\"blend_w\":0.3,\"cheby_degree\":3,\"compat_policy\":\"conservative\",\"enabled\":false,\"flex_window\":0.25,\"history_size\":100,\"one_sampler_only\":false,\"ridge_lambda\":0.1,\"tail_actual_steps\":3,\"verbose\":false,\"warmup_steps\":6,\"window_size\":2.0},\"spectrum_extra\":{},\"steps\":32},\"save\":{\"backend\":\"image_saver\",\"enabled\":true,\"image_saver\":{\"additional_hash_bundles\":[],\"additional_hashes\":\"\",\"civitai_hash_fetchers\":[],\"clip_skip\":0,\"counter\":0,\"custom\":\"\",\"download_civitai_data\":true,\"easy_remix\":true,\"embed_workflow\":true,\"extension\":\"webp\",\"filename\":\"%time_%basemodelname\",\"lossless_webp\":false,\"optimize_png\":true,\"path\":\"EasyUseAnima/AiO\",\"quality_jpeg_or_webp\":97,\"save_prompt_metadata\":true,\"save_workflow_as_json\":false,\"time_format\":\"%Y-%m-%d-%H%M%S\"}},\"schema\":\"easyuse_anima_aio_generation_settings\",\"upscale\":{\"backend\":\"usdu\",\"cfg\":8.0,\"denoise\":0.2,\"dit_corrections\":{\"adaptive_smc_alpha\":0.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"dcw_lambda\":0.02,\"dcw_mode\":\"off\",\"enabled\":false,\"fsg\":false,\"fsg_band_hi\":0.75,\"fsg_band_lo\":0.59,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"fsg_k\":3,\"replace_existing_cfg\":false,\"smc_cfg\":false,\"smc_cfg_lambda\":6.0},\"enabled\":false,\"inherit_sampler_settings\":true,\"resshift\":{\"chop\":512,\"dtype\":\"bf16\",\"overlap\":64,\"scale\":\"x2\",\"student_name\":\"(auto-download)\",\"tile_batch\":4},\"sampler_name\":\"contract_sampler_a\",\"scale_by\":2.0,\"scheduler\":\"contract_scheduler_a\",\"spectrum\":{\"blend_w\":0.3,\"cheby_degree\":3,\"compat_policy\":\"conservative\",\"enabled\":false,\"flex_window\":0.2,\"history_size\":100,\"one_sampler_only\":false,\"ridge_lambda\":0.1,\"tail_actual_steps\":4,\"verbose\":false,\"warmup_steps\":7,\"window_size\":2.0},\"steps\":20,\"usdu\":{\"auto_tile_max\":2048,\"auto_tile_min\":512,\"auto_tile_size\":true,\"auto_tile_target\":1024,\"batch_size\":1,\"force_uniform_tiles\":true,\"mask_blur\":8,\"mode_type\":\"Linear\",\"prompt_mode\":\"full\",\"seam_fix_denoise\":1.0,\"seam_fix_mask_blur\":8,\"seam_fix_mode\":\"None\",\"seam_fix_padding\":16,\"seam_fix_width\":64,\"tile_height\":512,\"tile_padding\":32,\"tile_width\":512,\"tiled_decode\":false,\"upscale_model_name\":\"2x-AnimeSharpV4_Fast_RCAN_PU.safetensors\"}},\"version\":1},\"input\":{\"input_settings\":{\"metadata\":{},\"resources\":{\"clip_device\":\"default\",\"clip_loader\":\"single\",\"loader_mode\":\"split\",\"unet_weight_dtype\":\"default\"},\"schema\":\"easy_use_anima_input\",\"version\":1},\"prompt_data\":{\"easy_use_anima_input\":{\"resource_info\":{\"clip_device\":\"default\",\"clip_name\":\"contract/text_encoder.safetensors\",\"clip_type\":\"qwen_image\",\"loader_mode\":\"split\",\"unet_name\":\"contract/diffusion_model.safetensors\",\"unet_weight_dtype\":\"default\",\"vae_name\":\"contract/vae.safetensors\"},\"schema\":\"easy_use_anima_input\",\"version\":1},\"height\":1024,\"negative_prompt\":\"\",\"positive_prompt\":\"contract prompt\",\"width\":1024},\"resource_info\":{\"clip_device\":\"default\",\"clip_name\":\"contract/text_encoder.safetensors\",\"clip_type\":\"qwen_image\",\"loader_mode\":\"split\",\"unet_name\":\"contract/diffusion_model.safetensors\",\"unet_weight_dtype\":\"default\",\"vae_name\":\"contract/vae.safetensors\"},\"schema\":\"easy_use_anima_input\",\"version\":1},\"lora_stack\":[],\"mode\":\"easy_use_anima_generator\"}"
+    },
+    {
+      "id": "EasyUseAnimaNAIARandomPrompt",
+      "inputs": {
+        "height": 1024,
+        "negative_prompt": "",
+        "prompt": "contract prompt",
+        "use_naia_bridge": false,
+        "width": 1024
+      },
+      "result": "{\"height\":1024,\"mode\":\"disabled\",\"negative_prompt\":\"\",\"prompt\":\"contract prompt\",\"width\":1024}"
+    }
+  ],
+  "nodes": [
+    {
+      "category": "EasyUse Anima/AiO",
+      "class_name": "EasyUseAnimaAIOGenerator",
+      "display_name": "Anima AiO Generator",
+      "function": "generate",
+      "id": "EasyUseAnimaAIOGenerator",
+      "identity": "nodes.EasyUseAnimaAIOGenerator",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "easy_use_anima_input",
+              "type": "EASY_USE_ANIMA_INPUT"
+            },
+            {
+              "config": {
+                "default": "{\"schema\":\"easyuse_anima_aio_generation_settings\",\"version\":1,\"mode\":\"txt2img\",\"sampler\":{\"backend\":\"comfy_ksampler\",\"seed\":-1,\"seed_after_generate\":\"fixed\",\"steps\":32,\"cfg\":5.0,\"sampler_name\":\"er_sde\",\"scheduler\":\"simple\",\"denoise\":1.0,\"spectrum\":{\"enabled\":false,\"window_size\":2.0,\"flex_window\":0.25,\"warmup_steps\":6,\"tail_actual_steps\":3,\"blend_w\":0.3,\"cheby_degree\":3,\"ridge_lambda\":0.1,\"history_size\":100,\"one_sampler_only\":false,\"verbose\":false,\"compat_policy\":\"conservative\"},\"spd\":{\"split_mode\":\"single\",\"scale\":0.5,\"sigma\":0.7,\"adaptive_smc_alpha\":0.0},\"spectrum_extra\":{},\"spd_extra\":{},\"dit_corrections\":{\"enabled\":false,\"dcw_mode\":\"off\",\"dcw_lambda\":0.01,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"smc_cfg\":false,\"adaptive_smc_alpha\":0.0,\"smc_cfg_lambda\":6.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"fsg\":false,\"fsg_band_lo\":0.59,\"fsg_band_hi\":0.75,\"fsg_k\":3,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"replace_existing_cfg\":false}},\"model_patches\":{\"aura_flow\":{\"shift\":3.0},\"dave\":{\"enabled\":false,\"mask\":\"dave_alpha.npz\",\"strength\":0.3,\"tau\":0.1},\"safe_pag\":{\"enabled\":false,\"scale\":4.0,\"block_indices\":\"18\",\"perturbation_strength\":0.75,\"head_indices\":\"\",\"start_percent\":0.0,\"end_percent\":0.7,\"rescale\":0.2,\"rescale_mode\":\"full\"},\"kj\":{\"fp16_accumulation\":false,\"sage_attention\":\"disabled\",\"sage_allow_compile\":false,\"torch_compile\":{\"enabled\":false,\"backend\":\"inductor\",\"fullgraph\":false,\"mode\":\"max-autotune-no-cudagraphs\",\"dynamic\":\"false\",\"compile_transformer_blocks_only\":true,\"dynamo_cache_size_limit\":64,\"debug_compile_keys\":false,\"disable_dynamic_vram\":true}}},\"mod_guidance\":{\"mode\":\"prompt_data\",\"profile\":\"step_i8_skip27\",\"advanced\":{\"adapter\":\"(auto-download default)\",\"quality_tags\":\"highres, best quality, score_7\",\"quality_neg\":\"score_1, score_2, score_3, worst quality, lowres, old, bad hands, bad anatomy\",\"mod_w\":3.0,\"mod_start_layer\":8,\"mod_end_layer\":27,\"mod_taper\":0,\"mod_taper_scale\":0.25,\"mod_final_w\":0.0}},\"artist_mix\":{\"mode\":\"prompt_data\",\"start_percent\":0.5,\"strength_scale\":1.0,\"style_gain\":1.35,\"rms_scale_cap\":2.0,\"exact_top_k\":4,\"cluster_count\":4,\"dominant_isolation\":true,\"dominant_threshold\":0.25},\"highres\":{\"enabled\":false,\"scale_by\":1.5,\"upscale_method\":\"bicubic\",\"multiple\":\"32\",\"max_long_edge\":2560,\"steps\":20,\"inherit_sampler_settings\":true,\"cfg\":8.0,\"sampler_name\":\"euler\",\"scheduler\":\"simple\",\"denoise\":0.25,\"spectrum\":{\"enabled\":false,\"window_size\":2.0,\"flex_window\":0.2,\"warmup_steps\":7,\"tail_actual_steps\":4,\"blend_w\":0.3,\"cheby_degree\":3,\"ridge_lambda\":0.1,\"history_size\":100,\"one_sampler_only\":false,\"verbose\":false,\"compat_policy\":\"conservative\"},\"dit_corrections\":{\"enabled\":false,\"dcw_mode\":\"off\",\"dcw_lambda\":0.02,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"smc_cfg\":false,\"adaptive_smc_alpha\":0.0,\"smc_cfg_lambda\":6.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"fsg\":false,\"fsg_band_lo\":0.59,\"fsg_band_hi\":0.75,\"fsg_k\":3,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"replace_existing_cfg\":false}},\"upscale\":{\"enabled\":false,\"backend\":\"usdu\",\"scale_by\":2.0,\"steps\":20,\"inherit_sampler_settings\":true,\"cfg\":8.0,\"sampler_name\":\"euler\",\"scheduler\":\"simple\",\"denoise\":0.2,\"spectrum\":{\"enabled\":false,\"window_size\":2.0,\"flex_window\":0.2,\"warmup_steps\":7,\"tail_actual_steps\":4,\"blend_w\":0.3,\"cheby_degree\":3,\"ridge_lambda\":0.1,\"history_size\":100,\"one_sampler_only\":false,\"verbose\":false,\"compat_policy\":\"conservative\"},\"dit_corrections\":{\"enabled\":false,\"dcw_mode\":\"off\",\"dcw_lambda\":0.02,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"smc_cfg\":false,\"adaptive_smc_alpha\":0.0,\"smc_cfg_lambda\":6.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"fsg\":false,\"fsg_band_lo\":0.59,\"fsg_band_hi\":0.75,\"fsg_k\":3,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"replace_existing_cfg\":false},\"usdu\":{\"upscale_model_name\":\"2x-AnimeSharpV4_Fast_RCAN_PU.safetensors\",\"auto_tile_size\":true,\"prompt_mode\":\"full\",\"mode_type\":\"Linear\",\"auto_tile_target\":1024,\"auto_tile_min\":512,\"auto_tile_max\":2048,\"tile_width\":512,\"tile_height\":512,\"mask_blur\":8,\"tile_padding\":32,\"seam_fix_mode\":\"None\",\"seam_fix_denoise\":1.0,\"seam_fix_width\":64,\"seam_fix_mask_blur\":8,\"seam_fix_padding\":16,\"force_uniform_tiles\":true,\"tiled_decode\":false,\"batch_size\":1},\"resshift\":{\"scale\":\"x2\",\"student_name\":\"(auto-download)\",\"dtype\":\"bf16\",\"chop\":512,\"overlap\":64,\"tile_batch\":4}},\"postprocess\":{\"enabled\":false,\"fit\":{\"mode\":\"max_long_edge\",\"max_long_edge\":2048,\"max_megapixels\":4.0,\"method\":\"bicubic\"}},\"detailer\":{\"enabled\":false,\"order\":[\"face\",\"eye\"],\"sam3\":{\"context\":\"load_checkpoint\",\"checkpoint\":\"sam3.1_multiplex_fp16.safetensors\"},\"face\":{\"label\":\"Face Detailer\",\"enabled\":false,\"detect_prompt\":\"face\",\"detect_count\":1,\"threshold\":0.52,\"refine_iterations\":2,\"individual_masks\":true,\"combined\":false,\"crop_factor\":4.0,\"bbox_fill\":false,\"drop_size\":100,\"contour_fill\":true,\"guide_size\":1024,\"guide_size_for\":false,\"max_size\":2048,\"steps\":20,\"inherit_sampler_settings\":true,\"cfg\":8.0,\"sampler_name\":\"euler\",\"scheduler\":\"sgm_uniform\",\"denoise\":0.33,\"feather\":5,\"noise_mask\":true,\"force_inpaint\":true,\"wildcard\":\"\",\"cycle\":1,\"alignment\":\"32\",\"inpaint_model\":false,\"noise_mask_feather\":10,\"tiled_encode\":false,\"tiled_decode\":false,\"spectrum\":{\"enabled\":true,\"window_size\":2.0,\"flex_window\":0.15,\"warmup_steps\":6,\"tail_actual_steps\":3,\"blend_w\":0.3,\"cheby_degree\":3,\"ridge_lambda\":0.1,\"history_size\":100,\"one_sampler_only\":false,\"verbose\":false,\"compat_policy\":\"conservative\"},\"dit_corrections\":{\"enabled\":false,\"dcw_mode\":\"off\",\"dcw_lambda\":0.02,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"smc_cfg\":false,\"adaptive_smc_alpha\":0.0,\"smc_cfg_lambda\":6.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"fsg\":false,\"fsg_band_lo\":0.59,\"fsg_band_hi\":0.75,\"fsg_k\":3,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"replace_existing_cfg\":false}},\"eye\":{\"label\":\"Eye Detailer\",\"enabled\":false,\"detect_prompt\":\"eyes\",\"detect_count\":1,\"threshold\":0.5,\"refine_iterations\":2,\"individual_masks\":true,\"combined\":false,\"crop_factor\":6.0,\"bbox_fill\":false,\"drop_size\":40,\"contour_fill\":true,\"guide_size\":1024,\"guide_size_for\":false,\"max_size\":2048,\"steps\":20,\"inherit_sampler_settings\":true,\"cfg\":8.0,\"sampler_name\":\"euler\",\"scheduler\":\"sgm_uniform\",\"denoise\":0.29,\"feather\":6,\"noise_mask\":true,\"force_inpaint\":true,\"wildcard\":\"\",\"cycle\":1,\"alignment\":\"32\",\"inpaint_model\":false,\"noise_mask_feather\":20,\"tiled_encode\":false,\"tiled_decode\":false,\"spectrum\":{\"enabled\":true,\"window_size\":2.0,\"flex_window\":0.15,\"warmup_steps\":6,\"tail_actual_steps\":3,\"blend_w\":0.3,\"cheby_degree\":3,\"ridge_lambda\":0.1,\"history_size\":100,\"one_sampler_only\":false,\"verbose\":false,\"compat_policy\":\"conservative\"},\"dit_corrections\":{\"enabled\":false,\"dcw_mode\":\"off\",\"dcw_lambda\":0.02,\"dcw_band_mask\":\"LL\",\"dcw_calibrator\":\"(auto-download default)\",\"smc_cfg\":false,\"adaptive_smc_alpha\":0.0,\"smc_cfg_lambda\":6.0,\"cfgpp\":false,\"cfgpp_lambda\":0.0,\"fsg\":false,\"fsg_band_lo\":0.59,\"fsg_band_hi\":0.75,\"fsg_k\":3,\"fsg_d_sigma\":0.1,\"fsg_gamma\":0.0,\"replace_existing_cfg\":false}}},\"save\":{\"enabled\":true,\"backend\":\"image_saver\",\"image_saver\":{\"filename\":\"%time_%basemodelname\",\"path\":\"EasyUseAnima/AiO\",\"extension\":\"webp\",\"lossless_webp\":false,\"quality_jpeg_or_webp\":97,\"optimize_png\":true,\"counter\":0,\"clip_skip\":0,\"time_format\":\"%Y-%m-%d-%H%M%S\",\"save_workflow_as_json\":false,\"embed_workflow\":true,\"save_prompt_metadata\":true,\"additional_hashes\":\"\",\"additional_hash_bundles\":[],\"civitai_hash_fetchers\":[],\"download_civitai_data\":true,\"easy_remix\":true,\"custom\":\"\"}},\"preview\":{\"intermediate_images\":false,\"compare_previous\":false,\"image_feed\":true,\"feed_count\":12}}",
+                "hidden": true,
+                "multiline": true
+              },
+              "name": "generation_settings",
+              "type": "STRING"
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "workflow_prompt",
+              "type": "PROMPT"
+            },
+            {
+              "config": {},
+              "name": "extra_pnginfo",
+              "type": "EXTRA_PNGINFO"
+            },
+            {
+              "config": {},
+              "name": "unique_id",
+              "type": "UNIQUE_ID"
+            }
+          ],
+          "name": "hidden"
+        },
+        {
+          "entries": [
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "lora_stack",
+              "type": "LORA_STACK"
+            }
+          ],
+          "name": "optional"
+        }
+      ],
+      "output_node": true,
+      "return_names": [
+        "image",
+        "latent",
+        "metadata_json"
+      ],
+      "return_types": [
+        "IMAGE",
+        "LATENT",
+        "STRING"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Detailer",
+      "class_name": "EasyUseAnimaDetailerAlignHook",
+      "display_name": "Anima Detailer Align Hook",
+      "function": "build",
+      "id": "EasyUseAnimaDetailerAlignHook",
+      "identity": "nodes.EasyUseAnimaDetailerAlignHook",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": "32"
+              },
+              "name": "alignment",
+              "type": [
+                "none",
+                "8",
+                "16",
+                "32",
+                "64"
+              ]
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "detailer_hook",
+              "type": "DETAILER_HOOK"
+            }
+          ],
+          "name": "optional"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "detailer_hook"
+      ],
+      "return_types": [
+        "DETAILER_HOOK"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaArtistMixConditioning",
+      "display_name": "Anima Artist Mix Conditioning",
+      "function": "encode",
+      "id": "EasyUseAnimaArtistMixConditioning",
+      "identity": "nodes.EasyUseAnimaArtistMixConditioning",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "clip",
+              "type": "CLIP"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "artist_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "correct"
+              },
+              "name": "artist_position",
+              "type": [
+                "correct",
+                "front",
+                "back"
+              ]
+            },
+            {
+              "config": {
+                "default": "prompt"
+              },
+              "name": "artist_mix_mode",
+              "type": [
+                "prompt",
+                "average",
+                "delta_rms",
+                "hybrid",
+                "clustered",
+                "exact",
+                "composite_exact",
+                "late_exact",
+                "average_late_exact",
+                "scheduled_average"
+              ]
+            },
+            {
+              "config": {
+                "default": 0.5,
+                "max": 1.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_start_percent",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 1.0,
+                "max": 5.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_strength_scale",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 1.35,
+                "max": 3.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_style_gain",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 2.0,
+                "max": 5.0,
+                "min": 1.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_rms_scale_cap",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 4,
+                "max": 64,
+                "min": 0
+              },
+              "name": "artist_mix_exact_top_k",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": 4,
+                "max": 32,
+                "min": 1
+              },
+              "name": "artist_mix_cluster_count",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "artist_mix_dominant_isolation",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": 0.25,
+                "max": 1.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_dominant_threshold",
+              "type": "FLOAT"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "positive"
+      ],
+      "return_types": [
+        "CONDITIONING"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/AiO",
+      "class_name": "EasyUseAnimaInput",
+      "display_name": "Easy Use Anima Input",
+      "function": "build",
+      "id": "EasyUseAnimaInput",
+      "identity": "nodes.EasyUseAnimaInput",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "EASYUSE_ANIMA_PROMPT_DATA",
+              "type": "EASYUSE_ANIMA_PROMPT_DATA"
+            },
+            {
+              "config": {
+                "default": "contract/diffusion_model.safetensors"
+              },
+              "name": "unet_name",
+              "type": [
+                "contract/diffusion_model.safetensors"
+              ]
+            },
+            {
+              "config": {
+                "default": "contract/vae.safetensors"
+              },
+              "name": "vae_name",
+              "type": [
+                "contract/vae.safetensors"
+              ]
+            },
+            {
+              "config": {
+                "default": "contract/text_encoder.safetensors"
+              },
+              "name": "clip_name",
+              "type": [
+                "contract/text_encoder.safetensors"
+              ]
+            },
+            {
+              "config": {
+                "default": "qwen_image"
+              },
+              "name": "clip_type",
+              "type": [
+                "qwen_image",
+                "stable_diffusion"
+              ]
+            },
+            {
+              "config": {
+                "default": "{\"schema\":\"easy_use_anima_input\",\"version\":1,\"resources\":{\"loader_mode\":\"split\",\"clip_loader\":\"single\",\"unet_weight_dtype\":\"default\",\"clip_device\":\"default\"},\"metadata\":{}}",
+                "hidden": true,
+                "multiline": true
+              },
+              "name": "input_settings",
+              "type": "STRING"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "easy use anima input"
+      ],
+      "return_types": [
+        "EASY_USE_ANIMA_INPUT"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Image",
+      "class_name": "EasyUseAnimaImageScaleByMultiple",
+      "display_name": "Anima Image Scale By Multiple",
+      "function": "upscale",
+      "id": "EasyUseAnimaImageScaleByMultiple",
+      "identity": "nodes.EasyUseAnimaImageScaleByMultiple",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "image",
+              "type": "IMAGE"
+            },
+            {
+              "config": {
+                "default": 1.5,
+                "max": 8.0,
+                "min": 0.01,
+                "step": 0.01
+              },
+              "name": "scale_by",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": "bicubic"
+              },
+              "name": "upscale_method",
+              "type": [
+                "nearest-exact",
+                "bilinear",
+                "area",
+                "bicubic",
+                "lanczos"
+              ]
+            },
+            {
+              "config": {
+                "default": "32"
+              },
+              "name": "multiple",
+              "type": [
+                "8",
+                "16",
+                "32",
+                "64"
+              ]
+            },
+            {
+              "config": {
+                "default": 0,
+                "max": 16384,
+                "min": 0,
+                "step": 32
+              },
+              "name": "max_long_edge",
+              "type": "INT"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "image",
+        "width",
+        "height",
+        "applied_scale"
+      ],
+      "return_types": [
+        "IMAGE",
+        "INT",
+        "INT",
+        "FLOAT"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/LoRA",
+      "class_name": "EasyUseAnimaLoraPreset",
+      "display_name": "Anima LoRA Preset",
+      "function": "build",
+      "id": "EasyUseAnimaLoraPreset",
+      "identity": "nodes.EasyUseAnimaLoraPreset",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "style_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": 1,
+                "max": 16,
+                "min": 1,
+                "step": 1
+              },
+              "name": "profile_index",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": "4"
+              },
+              "name": "profile_count",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "None"
+              },
+              "name": "lora_name",
+              "type": [
+                "None",
+                "contract/style.safetensors"
+              ]
+            },
+            {
+              "config": {
+                "default": "[]",
+                "multiline": true
+              },
+              "name": "loras",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "{}",
+                "multiline": true
+              },
+              "name": "profile_data",
+              "type": "STRING"
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [],
+          "name": "optional"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "style_prompt",
+        "LORA_STACK",
+        "trigger_words",
+        "active_loras",
+        "profile_index"
+      ],
+      "return_types": [
+        "STRING",
+        "LORA_STACK",
+        "STRING",
+        "STRING",
+        "INT"
+      ]
+    },
+    {
+      "category": "NAIA Bridge/API",
+      "class_name": "EasyUseAnimaNAIARandomPrompt",
+      "display_name": "Anima NAIA Random Prompt",
+      "function": "request",
+      "id": "EasyUseAnimaNAIARandomPrompt",
+      "identity": "nodes.EasyUseAnimaNAIARandomPrompt",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": true
+              },
+              "name": "use_naia_bridge",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "freeze_naia_output",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "show_preview",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "cached_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "cached_negative_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": 0,
+                "max": 8192,
+                "min": 0,
+                "step": 8
+              },
+              "name": "cached_width",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": 0,
+                "max": 8192,
+                "min": 0,
+                "step": 8
+              },
+              "name": "cached_height",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "cached_signature",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": false,
+                "placeholder": "prompt"
+              },
+              "name": "prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "override_prompt",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": false,
+                "placeholder": "negative_prompt"
+              },
+              "name": "negative_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "override_negative",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 64,
+                "step": 8
+              },
+              "name": "width",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "override_width",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 64,
+                "step": 8
+              },
+              "name": "height",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "override_height",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "use_naia_settings",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true,
+                "placeholder": "pre_prompt"
+              },
+              "name": "pre_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true,
+                "placeholder": "post_prompt"
+              },
+              "name": "post_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true,
+                "placeholder": "auto_hide"
+              },
+              "name": "auto_hide",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_author",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_work_title",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_character_name",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_character_features",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_clothes",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_color",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_location_and_background_color",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_expression",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_pose_action",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_meta_tags",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_object_tags",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": true,
+                "default": "skip",
+                "socketless": true
+              },
+              "name": "remove_noise_tags",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": false,
+                "default": "skip",
+                "socketless": false
+              },
+              "name": "e621_auto_boost",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": false,
+                "default": "skip",
+                "socketless": false
+              },
+              "name": "danbooru_auto_weight",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "advanced": false,
+                "default": "skip",
+                "socketless": false
+              },
+              "name": "tag_implication_compression",
+              "type": [
+                "skip",
+                "on",
+                "off"
+              ]
+            },
+            {
+              "config": {
+                "default": "127.0.0.1"
+              },
+              "name": "host",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": 7243,
+                "max": 65535,
+                "min": 1
+              },
+              "name": "port",
+              "type": "INT"
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "workflow_prompt",
+              "type": "PROMPT"
+            },
+            {
+              "config": {},
+              "name": "extra_pnginfo",
+              "type": "EXTRA_PNGINFO"
+            },
+            {
+              "config": {},
+              "name": "unique_id",
+              "type": "UNIQUE_ID"
+            }
+          ],
+          "name": "hidden"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "prompt",
+        "negative_prompt",
+        "width",
+        "height"
+      ],
+      "return_types": [
+        "STRING",
+        "STRING",
+        "INT",
+        "INT"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptDataConditioning",
+      "display_name": "Anima Prompt Data Conditioning",
+      "function": "apply",
+      "id": "EasyUseAnimaPromptDataConditioning",
+      "identity": "nodes.EasyUseAnimaPromptDataConditioning",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "model",
+              "type": "MODEL"
+            },
+            {
+              "config": {},
+              "name": "clip",
+              "type": "CLIP"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "EASYUSE_ANIMA_PROMPT_DATA",
+              "type": "EASYUSE_ANIMA_PROMPT_DATA"
+            },
+            {
+              "config": {
+                "default": "prompt_data"
+              },
+              "name": "mod_guidance_mode",
+              "type": [
+                "prompt_data",
+                "enabled",
+                "disabled"
+              ]
+            },
+            {
+              "config": {
+                "default": "step_i8_skip27"
+              },
+              "name": "mod_w_profile",
+              "type": [
+                "off",
+                "step_i8_skip27",
+                "step_i14",
+                "uniform_w3"
+              ]
+            },
+            {
+              "config": {
+                "default": "prompt_data"
+              },
+              "name": "artist_mix_mode",
+              "type": [
+                "prompt_data",
+                "off",
+                "prompt",
+                "average",
+                "delta_rms",
+                "hybrid",
+                "clustered",
+                "exact",
+                "composite_exact",
+                "late_exact",
+                "average_late_exact",
+                "scheduled_average"
+              ]
+            },
+            {
+              "config": {
+                "default": 0.5,
+                "max": 1.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_start_percent",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 1.0,
+                "max": 5.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_strength_scale",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 1.35,
+                "max": 3.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_style_gain",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 2.0,
+                "max": 5.0,
+                "min": 1.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_rms_scale_cap",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 4,
+                "max": 64,
+                "min": 0
+              },
+              "name": "artist_mix_exact_top_k",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": 4,
+                "max": 32,
+                "min": 1
+              },
+              "name": "artist_mix_cluster_count",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "artist_mix_dominant_isolation",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": 0.25,
+                "max": 1.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_dominant_threshold",
+              "type": "FLOAT"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "model",
+        "positive",
+        "negative",
+        "latent_image"
+      ],
+      "return_types": [
+        "MODEL",
+        "CONDITIONING",
+        "CONDITIONING",
+        "LATENT"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptDataUnpack",
+      "display_name": "EASYUSE_ANIMA_PROMPT_DATA",
+      "function": "unpack",
+      "id": "EasyUseAnimaPromptDataUnpack",
+      "identity": "nodes.EasyUseAnimaPromptDataUnpack",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "EASYUSE_ANIMA_PROMPT_DATA",
+              "type": "EASYUSE_ANIMA_PROMPT_DATA"
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "positive_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "negative_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "anima_mod_guidance_quality_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "anima_mod_guidance_negative_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "use_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "use_negative_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "metadata_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "metadata_negative_prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "width",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "height",
+              "type": "INT"
+            }
+          ],
+          "name": "optional"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "EASYUSE_ANIMA_PROMPT_DATA",
+        "positive_prompt",
+        "negative_prompt",
+        "anima_mod_guidance_quality_tags",
+        "anima_mod_guidance_negative_prompt",
+        "use_anima_mod_guidance",
+        "use_negative_anima_mod_guidance",
+        "metadata_prompt",
+        "metadata_negative_prompt",
+        "width",
+        "height"
+      ],
+      "return_types": [
+        "EASYUSE_ANIMA_PROMPT_DATA",
+        "STRING",
+        "STRING",
+        "STRING",
+        "STRING",
+        "BOOLEAN",
+        "BOOLEAN",
+        "STRING",
+        "STRING",
+        "INT",
+        "INT"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptBuilder",
+      "display_name": "Anima Prompt Builder",
+      "function": "build",
+      "id": "EasyUseAnimaPromptBuilder",
+      "identity": "nodes.EasyUseAnimaPromptBuilder",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "pin_trigger_tags_to_front",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": false
+              },
+              "name": "lora_trigger_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic",
+                "multiline": true
+              },
+              "name": "quality_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "trigger_and_artist_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "location, (A highly aesthetic Pixiv style illustration, clean composition, high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)",
+                "multiline": true
+              },
+              "name": "trailing_quality_tags",
+              "type": "STRING"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "prompt",
+        "anima_mod_guidance_quality_tags",
+        "use_anima_mod_guidance",
+        "metadata_prompt"
+      ],
+      "return_types": [
+        "STRING",
+        "STRING",
+        "BOOLEAN",
+        "STRING"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptCorrector",
+      "display_name": "Anima Prompt Corrector",
+      "function": "correct",
+      "id": "EasyUseAnimaPromptCorrector",
+      "identity": "nodes.EasyUseAnimaPromptCorrector",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "artist_overrides",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "artist_exclusions",
+              "type": "STRING"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "corrected_prompt",
+        "report"
+      ],
+      "return_types": [
+        "STRING",
+        "STRING"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptCorrectorSimple",
+      "display_name": "Anima Prompt Corrector Simple",
+      "function": "correct",
+      "id": "EasyUseAnimaPromptCorrectorSimple",
+      "identity": "nodes.EasyUseAnimaPromptCorrectorSimple",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "prompt",
+              "type": "STRING"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "prompt"
+      ],
+      "return_types": [
+        "STRING"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptStudio",
+      "display_name": "Anima Prompt Studio",
+      "function": "build",
+      "id": "EasyUseAnimaPromptStudio",
+      "identity": "nodes.EasyUseAnimaPromptStudio",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "pin_trigger_tags_to_front",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": false
+              },
+              "name": "lora_trigger_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic",
+                "multiline": true
+              },
+              "name": "quality_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "trigger_and_artist_tags",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "prompt",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "location, (A highly aesthetic Pixiv style illustration, clean composition, high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)",
+                "multiline": true
+              },
+              "name": "trailing_quality_tags",
+              "type": "STRING"
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "prompt",
+        "anima_mod_guidance_quality_tags",
+        "use_anima_mod_guidance",
+        "metadata_prompt"
+      ],
+      "return_types": [
+        "STRING",
+        "STRING",
+        "BOOLEAN",
+        "STRING"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptStudioAdvanced",
+      "display_name": "Anima Prompt Studio Advanced",
+      "function": "build",
+      "id": "EasyUseAnimaPromptStudioAdvanced",
+      "identity": "nodes.EasyUseAnimaPromptStudioAdvanced",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_naia",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "consume_naia_on_queue",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "1024"
+              },
+              "name": "resolution_bucket",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "1024 * 1024 (1:1)"
+              },
+              "name": "resolution_size",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 32,
+                "step": 32
+              },
+              "name": "resolution_custom_width",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 32,
+                "step": 32
+              },
+              "name": "resolution_custom_height",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "pin_trigger_tags_to_front",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "[{\"id\":\"positive_quality\",\"pane\":\"positive\",\"type\":\"quality\",\"label\":\"Quality Tags\",\"text\":\"newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic\",\"height\":72,\"enabled\":true},{\"id\":\"positive_artist\",\"pane\":\"positive\",\"type\":\"artist\",\"label\":\"Artist Tags\",\"text\":\"\",\"height\":72,\"enabled\":true},{\"id\":\"positive_trigger\",\"pane\":\"positive\",\"type\":\"trigger\",\"label\":\"Trigger Words\",\"text\":\"\",\"height\":72,\"enabled\":true,\"pin\":true},{\"id\":\"positive_general\",\"pane\":\"positive\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"\",\"height\":150,\"enabled\":true},{\"id\":\"positive_trailing\",\"pane\":\"positive\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"location, (A highly aesthetic Pixiv style illustration, clean composition, high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)\",\"height\":72,\"enabled\":true},{\"id\":\"negative_general\",\"pane\":\"negative\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"\",\"height\":120,\"enabled\":true}]",
+                "multiline": true
+              },
+              "name": "advanced_fields",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_negative_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "고정"
+              },
+              "name": "wildcard_mode",
+              "type": [
+                "일반 채우기",
+                "고정",
+                "순차",
+                "재현"
+              ]
+            },
+            {
+              "config": {
+                "default": 0,
+                "max": 18446744073709551615,
+                "min": 0
+              },
+              "name": "wildcard_seed",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": "fixed"
+              },
+              "name": "wildcard_seed_after_generate",
+              "type": [
+                "fixed",
+                "randomize",
+                "increment",
+                "decrement"
+              ]
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [],
+          "name": "optional"
+        },
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "workflow_prompt",
+              "type": "PROMPT"
+            },
+            {
+              "config": {},
+              "name": "extra_pnginfo",
+              "type": "EXTRA_PNGINFO"
+            },
+            {
+              "config": {},
+              "name": "unique_id",
+              "type": "UNIQUE_ID"
+            }
+          ],
+          "name": "hidden"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "positive_prompt",
+        "negative_prompt",
+        "anima_mod_guidance_quality_tags",
+        "anima_mod_guidance_negative_prompt",
+        "use_anima_mod_guidance",
+        "use_negative_anima_mod_guidance",
+        "metadata_prompt",
+        "metadata_negative_prompt",
+        "width",
+        "height"
+      ],
+      "return_types": [
+        "STRING",
+        "STRING",
+        "STRING",
+        "STRING",
+        "BOOLEAN",
+        "BOOLEAN",
+        "STRING",
+        "STRING",
+        "INT",
+        "INT"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptStudioAdvancedV2",
+      "display_name": "Anima Prompt Studio Advanced v2",
+      "function": "build",
+      "id": "EasyUseAnimaPromptStudioAdvancedV2",
+      "identity": "nodes.EasyUseAnimaPromptStudioAdvancedV2",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_naia",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "consume_naia_on_queue",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "1024"
+              },
+              "name": "resolution_bucket",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "1024 * 1024 (1:1)"
+              },
+              "name": "resolution_size",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 32,
+                "step": 32
+              },
+              "name": "resolution_custom_width",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 32,
+                "step": 32
+              },
+              "name": "resolution_custom_height",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "pin_trigger_tags_to_front",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "[{\"id\":\"positive_quality\",\"pane\":\"positive\",\"type\":\"quality\",\"label\":\"Quality Tags\",\"text\":\"newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic\",\"height\":72,\"enabled\":true},{\"id\":\"positive_artist\",\"pane\":\"positive\",\"type\":\"artist\",\"label\":\"Artist Tags\",\"text\":\"\",\"height\":72,\"enabled\":true},{\"id\":\"positive_trigger\",\"pane\":\"positive\",\"type\":\"trigger\",\"label\":\"Trigger Words\",\"text\":\"\",\"height\":72,\"enabled\":true,\"pin\":true},{\"id\":\"positive_general\",\"pane\":\"positive\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"\",\"height\":150,\"enabled\":true},{\"id\":\"positive_trailing\",\"pane\":\"positive\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"location, (A highly aesthetic Pixiv style illustration, clean composition, high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)\",\"height\":72,\"enabled\":true},{\"id\":\"negative_general\",\"pane\":\"negative\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"\",\"height\":120,\"enabled\":true}]",
+                "multiline": true
+              },
+              "name": "advanced_fields",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": false
+              },
+              "name": "use_negative_anima_mod_guidance",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": "고정"
+              },
+              "name": "wildcard_mode",
+              "type": [
+                "일반 채우기",
+                "고정",
+                "순차",
+                "재현"
+              ]
+            },
+            {
+              "config": {
+                "default": 0,
+                "max": 18446744073709551615,
+                "min": 0
+              },
+              "name": "wildcard_seed",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": "fixed"
+              },
+              "name": "wildcard_seed_after_generate",
+              "type": [
+                "fixed",
+                "randomize",
+                "increment",
+                "decrement"
+              ]
+            },
+            {
+              "config": {
+                "default": "off"
+              },
+              "name": "artist_mix_mode",
+              "type": [
+                "off",
+                "average",
+                "delta_rms",
+                "hybrid",
+                "clustered",
+                "exact",
+                "composite_exact",
+                "late_exact",
+                "average_late_exact",
+                "scheduled_average"
+              ]
+            },
+            {
+              "config": {
+                "default": 0.5,
+                "max": 1.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_start_percent",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 1.0,
+                "max": 5.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_strength_scale",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 1.35,
+                "max": 3.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_style_gain",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 2.0,
+                "max": 5.0,
+                "min": 1.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_rms_scale_cap",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": 4,
+                "max": 64,
+                "min": 0
+              },
+              "name": "artist_mix_exact_top_k",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": 4,
+                "max": 32,
+                "min": 1
+              },
+              "name": "artist_mix_cluster_count",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": true
+              },
+              "name": "artist_mix_dominant_isolation",
+              "type": "BOOLEAN"
+            },
+            {
+              "config": {
+                "default": 0.25,
+                "max": 1.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "artist_mix_dominant_threshold",
+              "type": "FLOAT"
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [],
+          "name": "optional"
+        },
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "workflow_prompt",
+              "type": "PROMPT"
+            },
+            {
+              "config": {},
+              "name": "extra_pnginfo",
+              "type": "EXTRA_PNGINFO"
+            },
+            {
+              "config": {},
+              "name": "unique_id",
+              "type": "UNIQUE_ID"
+            }
+          ],
+          "name": "hidden"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "EASYUSE_ANIMA_PROMPT_DATA"
+      ],
+      "return_types": [
+        "EASYUSE_ANIMA_PROMPT_DATA"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaPromptStudioRegional",
+      "display_name": "Anima Prompt Studio Regional",
+      "function": "build",
+      "id": "EasyUseAnimaPromptStudioRegional",
+      "identity": "nodes.EasyUseAnimaPromptStudioRegional",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": "[{\"id\":\"positive_quality\",\"pane\":\"positive\",\"type\":\"quality\",\"label\":\"Quality Tags\",\"text\":\"newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic\",\"height\":72,\"enabled\":true,\"mask_ids\":[]},{\"id\":\"positive_artist\",\"pane\":\"positive\",\"type\":\"artist\",\"label\":\"Artist Tags\",\"text\":\"\",\"height\":72,\"enabled\":true,\"mask_ids\":[]},{\"id\":\"positive_trigger\",\"pane\":\"positive\",\"type\":\"trigger\",\"label\":\"Trigger Words\",\"text\":\"\",\"height\":72,\"enabled\":true,\"pin\":true,\"mask_ids\":[]},{\"id\":\"positive_general\",\"pane\":\"positive\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"\",\"height\":150,\"enabled\":true,\"mask_ids\":[]},{\"id\":\"positive_trailing\",\"pane\":\"positive\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"location, (A highly aesthetic Pixiv style illustration, clean composition, high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)\",\"height\":72,\"enabled\":true,\"mask_ids\":[]},{\"id\":\"negative_general\",\"pane\":\"negative\",\"type\":\"general\",\"label\":\"General Tags\",\"text\":\"\",\"height\":120,\"enabled\":true,\"mask_ids\":[]}]",
+                "multiline": true
+              },
+              "name": "regional_fields",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "{\"version\":1,\"canvas\":{\"width\":1024,\"height\":1024,\"aspect_ratio\":\"1:1\",\"source\":\"resolution_fields\"},\"mask_authoring\":{\"render_space\":\"image_pixels\",\"storage_space\":\"normalized_canvas\",\"preview_enabled\":true},\"global_prompt\":\"\",\"negative_prompt\":\"\",\"next_mask_id\":1,\"masks\":[],\"regional_enabled\":false,\"mask_prompts\":[],\"assignments\":[],\"artist_mix\":{},\"conditioning_settings\":{},\"regional_settings\":{}}",
+                "multiline": true
+              },
+              "name": "regional_config",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "1024"
+              },
+              "name": "resolution_bucket",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "1024 * 1024 (1:1)"
+              },
+              "name": "resolution_size",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 32,
+                "step": 32
+              },
+              "name": "resolution_custom_width",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": 1024,
+                "max": 8192,
+                "min": 32,
+                "step": 32
+              },
+              "name": "resolution_custom_height",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": "고정"
+              },
+              "name": "wildcard_mode",
+              "type": [
+                "일반 채우기",
+                "고정",
+                "순차",
+                "재현"
+              ]
+            },
+            {
+              "config": {
+                "default": 0,
+                "max": 18446744073709551615,
+                "min": 0
+              },
+              "name": "wildcard_seed",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": "fixed"
+              },
+              "name": "wildcard_seed_after_generate",
+              "type": [
+                "fixed",
+                "randomize",
+                "increment",
+                "decrement"
+              ]
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [],
+          "name": "optional"
+        },
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "workflow_prompt",
+              "type": "PROMPT"
+            },
+            {
+              "config": {},
+              "name": "extra_pnginfo",
+              "type": "EXTRA_PNGINFO"
+            },
+            {
+              "config": {},
+              "name": "unique_id",
+              "type": "UNIQUE_ID"
+            }
+          ],
+          "name": "hidden"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "metadata_prompt",
+        "metadata_negative_prompt",
+        "width",
+        "height",
+        "regional_prompt_data"
+      ],
+      "return_types": [
+        "STRING",
+        "STRING",
+        "INT",
+        "INT",
+        "EASYUSE_ANIMA_REGIONAL_PROMPT_DATA"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaRegionalConditioning",
+      "display_name": "Anima Regional Conditioning",
+      "function": "encode",
+      "id": "EasyUseAnimaRegionalConditioning",
+      "identity": "nodes.EasyUseAnimaRegionalConditioning",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "clip",
+              "type": "CLIP"
+            },
+            {
+              "config": {
+                "forceInput": true
+              },
+              "name": "regional_prompt_data",
+              "type": "EASYUSE_ANIMA_REGIONAL_PROMPT_DATA"
+            },
+            {
+              "config": {
+                "default": 1.0,
+                "max": 10.0,
+                "min": 0.0,
+                "step": 0.01
+              },
+              "name": "mask_strength",
+              "type": "FLOAT"
+            },
+            {
+              "config": {
+                "default": "mask bounds"
+              },
+              "name": "set_cond_area",
+              "type": [
+                "mask bounds",
+                "default"
+              ]
+            }
+          ],
+          "name": "required"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "positive",
+        "negative"
+      ],
+      "return_types": [
+        "CONDITIONING",
+        "CONDITIONING"
+      ]
+    },
+    {
+      "category": "EasyUse Anima/Prompt",
+      "class_name": "EasyUseAnimaWildcard",
+      "display_name": "Anima Wildcard",
+      "function": "generate",
+      "id": "EasyUseAnimaWildcard",
+      "identity": "nodes.EasyUseAnimaWildcard",
+      "input_sections": [
+        {
+          "entries": [
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "text",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "",
+                "multiline": true
+              },
+              "name": "populated_text",
+              "type": "STRING"
+            },
+            {
+              "config": {
+                "default": "일반 채우기"
+              },
+              "name": "mode",
+              "type": [
+                "일반 채우기",
+                "고정",
+                "순차",
+                "재현"
+              ]
+            },
+            {
+              "config": {
+                "default": 0,
+                "max": 18446744073709551615,
+                "min": 0
+              },
+              "name": "seed",
+              "type": "INT"
+            },
+            {
+              "config": {
+                "default": "fixed"
+              },
+              "name": "seed_after_generate",
+              "type": [
+                "fixed",
+                "randomize",
+                "increment",
+                "decrement"
+              ]
+            }
+          ],
+          "name": "required"
+        },
+        {
+          "entries": [
+            {
+              "config": {},
+              "name": "workflow_prompt",
+              "type": "PROMPT"
+            },
+            {
+              "config": {},
+              "name": "extra_pnginfo",
+              "type": "EXTRA_PNGINFO"
+            },
+            {
+              "config": {},
+              "name": "unique_id",
+              "type": "UNIQUE_ID"
+            }
+          ],
+          "name": "hidden"
+        },
+        {
+          "entries": [],
+          "name": "optional"
+        }
+      ],
+      "output_node": false,
+      "return_names": [
+        "text",
+        "seed"
+      ],
+      "return_types": [
+        "STRING",
+        "INT"
+      ]
+    }
+  ],
+  "package_version": "0.5.2",
+  "schema_version": 1,
+  "workflow_nodes": [
+    {
+      "class_id": "EasyUseAnimaPromptDataConditioning",
+      "node_number": 24,
+      "source": "docs/example_workflows/EasyUse_Anima_artist_mix_release_ko.json",
+      "widgets_values": [
+        "prompt_data",
+        "step_i8_skip27",
+        "prompt_data",
+        0.5,
+        1,
+        1.35,
+        2,
+        4,
+        4,
+        true,
+        0.25
+      ]
+    },
+    {
+      "class_id": "EasyUseAnimaRegionalConditioning",
+      "node_number": 3,
+      "source": "docs/example_workflows/EasyUse_Anima_regional_prompt_release_ko.json",
+      "widgets_values": [
+        1,
+        "mask bounds"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/node_contracts_0_5_2.json
+++ b/tests/fixtures/node_contracts_0_5_2.json
@@ -146,7 +146,6 @@
       "display_name": "Anima AiO Generator",
       "function": "generate",
       "id": "EasyUseAnimaAIOGenerator",
-      "identity": "nodes.EasyUseAnimaAIOGenerator",
       "input_sections": [
         {
           "entries": [
@@ -220,7 +219,6 @@
       "display_name": "Anima Detailer Align Hook",
       "function": "build",
       "id": "EasyUseAnimaDetailerAlignHook",
-      "identity": "nodes.EasyUseAnimaDetailerAlignHook",
       "input_sections": [
         {
           "entries": [
@@ -265,7 +263,6 @@
       "display_name": "Anima Artist Mix Conditioning",
       "function": "encode",
       "id": "EasyUseAnimaArtistMixConditioning",
-      "identity": "nodes.EasyUseAnimaArtistMixConditioning",
       "input_sections": [
         {
           "entries": [
@@ -412,7 +409,6 @@
       "display_name": "Easy Use Anima Input",
       "function": "build",
       "id": "EasyUseAnimaInput",
-      "identity": "nodes.EasyUseAnimaInput",
       "input_sections": [
         {
           "entries": [
@@ -487,7 +483,6 @@
       "display_name": "Anima Image Scale By Multiple",
       "function": "upscale",
       "id": "EasyUseAnimaImageScaleByMultiple",
-      "identity": "nodes.EasyUseAnimaImageScaleByMultiple",
       "input_sections": [
         {
           "entries": [
@@ -565,7 +560,6 @@
       "display_name": "Anima LoRA Preset",
       "function": "build",
       "id": "EasyUseAnimaLoraPreset",
-      "identity": "nodes.EasyUseAnimaLoraPreset",
       "input_sections": [
         {
           "entries": [
@@ -650,7 +644,6 @@
       "display_name": "Anima NAIA Random Prompt",
       "function": "request",
       "id": "EasyUseAnimaNAIARandomPrompt",
-      "identity": "nodes.EasyUseAnimaNAIARandomPrompt",
       "input_sections": [
         {
           "entries": [
@@ -1074,7 +1067,6 @@
       "display_name": "Anima Prompt Data Conditioning",
       "function": "apply",
       "id": "EasyUseAnimaPromptDataConditioning",
-      "identity": "nodes.EasyUseAnimaPromptDataConditioning",
       "input_sections": [
         {
           "entries": [
@@ -1237,7 +1229,6 @@
       "display_name": "EASYUSE_ANIMA_PROMPT_DATA",
       "function": "unpack",
       "id": "EasyUseAnimaPromptDataUnpack",
-      "identity": "nodes.EasyUseAnimaPromptDataUnpack",
       "input_sections": [
         {
           "entries": [
@@ -1361,7 +1352,6 @@
       "display_name": "Anima Prompt Builder",
       "function": "build",
       "id": "EasyUseAnimaPromptBuilder",
-      "identity": "nodes.EasyUseAnimaPromptBuilder",
       "input_sections": [
         {
           "entries": [
@@ -1443,7 +1433,6 @@
       "display_name": "Anima Prompt Corrector",
       "function": "correct",
       "id": "EasyUseAnimaPromptCorrector",
-      "identity": "nodes.EasyUseAnimaPromptCorrector",
       "input_sections": [
         {
           "entries": [
@@ -1491,7 +1480,6 @@
       "display_name": "Anima Prompt Corrector Simple",
       "function": "correct",
       "id": "EasyUseAnimaPromptCorrectorSimple",
-      "identity": "nodes.EasyUseAnimaPromptCorrectorSimple",
       "input_sections": [
         {
           "entries": [
@@ -1521,7 +1509,6 @@
       "display_name": "Anima Prompt Studio",
       "function": "build",
       "id": "EasyUseAnimaPromptStudio",
-      "identity": "nodes.EasyUseAnimaPromptStudio",
       "input_sections": [
         {
           "entries": [
@@ -1603,7 +1590,6 @@
       "display_name": "Anima Prompt Studio Advanced",
       "function": "build",
       "id": "EasyUseAnimaPromptStudioAdvanced",
-      "identity": "nodes.EasyUseAnimaPromptStudioAdvanced",
       "input_sections": [
         {
           "entries": [
@@ -1777,7 +1763,6 @@
       "display_name": "Anima Prompt Studio Advanced v2",
       "function": "build",
       "id": "EasyUseAnimaPromptStudioAdvancedV2",
-      "identity": "nodes.EasyUseAnimaPromptStudioAdvancedV2",
       "input_sections": [
         {
           "entries": [
@@ -2026,7 +2011,6 @@
       "display_name": "Anima Prompt Studio Regional",
       "function": "build",
       "id": "EasyUseAnimaPromptStudioRegional",
-      "identity": "nodes.EasyUseAnimaPromptStudioRegional",
       "input_sections": [
         {
           "entries": [
@@ -2163,7 +2147,6 @@
       "display_name": "Anima Regional Conditioning",
       "function": "encode",
       "id": "EasyUseAnimaRegionalConditioning",
-      "identity": "nodes.EasyUseAnimaRegionalConditioning",
       "input_sections": [
         {
           "entries": [
@@ -2219,7 +2202,6 @@
       "display_name": "Anima Wildcard",
       "function": "generate",
       "id": "EasyUseAnimaWildcard",
-      "identity": "nodes.EasyUseAnimaWildcard",
       "input_sections": [
         {
           "entries": [

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import ast
+import importlib.util
 import json
 import math
 import re
 import sys
+import types
 import unittest
 from contextlib import contextmanager
 from pathlib import Path
@@ -18,8 +20,8 @@ import nodes
 
 
 PACKAGE_INIT = ROOT / "__init__.py"
-PACKAGE_METADATA = ROOT / "pyproject.toml"
 FIXTURE = ROOT / "tests" / "fixtures" / "node_contracts_0_5_2.json"
+FIXTURE_PROVENANCE_VERSION = "0.5.2"
 WORKFLOW_SELECTIONS = (
     (
         ROOT / "docs" / "example_workflows" / "EasyUse_Anima_artist_mix_release_ko.json",
@@ -64,16 +66,6 @@ def _root_mappings() -> tuple[list[tuple[str, str]], dict[str, str]]:
     if not isinstance(display_mappings, dict):
         raise AssertionError("NODE_DISPLAY_NAME_MAPPINGS must remain a dictionary")
     return class_mappings, display_mappings
-
-
-def _package_version() -> str:
-    match = re.search(
-        r'(?m)^version\s*=\s*"([^"]+)"\s*$',
-        PACKAGE_METADATA.read_text(encoding="utf-8"),
-    )
-    if match is None:
-        raise AssertionError("Could not read project.version from pyproject.toml")
-    return match.group(1)
 
 
 def _contains_absolute_path(value: str) -> bool:
@@ -179,6 +171,50 @@ def _deterministic_comfy_inputs():
         yield
 
 
+@contextmanager
+def _loaded_package_entrypoint():
+    package_name = "_easyuse_anima_contract_entrypoint"
+    package_prefix = f"{package_name}."
+    if any(name == package_name or name.startswith(package_prefix) for name in sys.modules):
+        raise AssertionError(f"Synthetic package namespace is already loaded: {package_name}")
+
+    package_spec = importlib.util.spec_from_file_location(
+        package_name,
+        PACKAGE_INIT,
+        submodule_search_locations=[str(ROOT)],
+    )
+    if package_spec is None or package_spec.loader is None:
+        raise AssertionError("Could not create package entrypoint spec")
+    package_module = importlib.util.module_from_spec(package_spec)
+    sys.modules[package_name] = package_module
+
+    api_stub = types.ModuleType(f"{package_name}.api")
+    sys.modules[api_stub.__name__] = api_stub
+    package_module.api = api_stub
+
+    try:
+        nodes_spec = importlib.util.spec_from_file_location(
+            f"{package_name}.nodes",
+            ROOT / "nodes.py",
+        )
+        if nodes_spec is None or nodes_spec.loader is None:
+            raise AssertionError("Could not create canonical package nodes spec")
+        package_nodes = importlib.util.module_from_spec(nodes_spec)
+        sys.modules[nodes_spec.name] = package_nodes
+        nodes_spec.loader.exec_module(package_nodes)
+
+        wildcard_module = sys.modules.get(f"{package_name}.wildcard_engine")
+        if wildcard_module is None:
+            raise AssertionError("Package nodes did not load wildcard_engine")
+        with patch.object(wildcard_module, "ensure_default_wildcard_root", return_value=None):
+            package_spec.loader.exec_module(package_module)
+            yield package_module, package_nodes
+    finally:
+        for name in list(sys.modules):
+            if name == package_name or name.startswith(package_prefix):
+                sys.modules.pop(name, None)
+
+
 def _node_contract(node_id: str, class_name: str, display_name: str) -> dict:
     node_class = getattr(nodes, class_name)
     input_types = node_class.INPUT_TYPES()
@@ -200,7 +236,6 @@ def _node_contract(node_id: str, class_name: str, display_name: str) -> dict:
     return {
         "id": node_id,
         "class_name": class_name,
-        "identity": f"nodes.{node_class.__qualname__}",
         "display_name": display_name,
         "input_sections": sections,
         "return_types": _normalize(getattr(node_class, "RETURN_TYPES")),
@@ -330,7 +365,7 @@ def build_contract_snapshot() -> dict:
     with _deterministic_comfy_inputs():
         snapshot = {
             "schema_version": 1,
-            "package_version": _package_version(),
+            "package_version": FIXTURE_PROVENANCE_VERSION,
             "dynamic_inputs": {
                 "samplers": ["contract_sampler_a", "contract_sampler_b"],
                 "schedulers": ["contract_scheduler_a", "contract_scheduler_b"],
@@ -379,18 +414,27 @@ class PublicNodeContractTests(unittest.TestCase):
 
         self.assertEqual(build_contract_snapshot(), expected)
 
-    def test_mapping_values_resolve_to_the_recorded_runtime_classes(self):
+    def test_package_mappings_use_the_canonical_runtime_class_objects(self):
         class_mappings, display_mappings = _root_mappings()
 
+        with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
+            runtime_mappings = package_entrypoint.NODE_CLASS_MAPPINGS
+            self.assertEqual(list(runtime_mappings), [node_id for node_id, _ in class_mappings])
+            self.assertEqual(package_entrypoint.NODE_DISPLAY_NAME_MAPPINGS, display_mappings)
+            for node_id, class_name in class_mappings:
+                with self.subTest(node_id=node_id):
+                    mapped_class = runtime_mappings[node_id]
+                    self.assertIs(mapped_class, getattr(package_entrypoint, class_name))
+                    self.assertIs(mapped_class, getattr(package_nodes, class_name))
+
+    def test_fixture_provenance_is_the_explicit_0_5_2_baseline(self):
+        expected = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+        self.assertEqual(expected["package_version"], FIXTURE_PROVENANCE_VERSION)
         self.assertEqual(
-            [node_id for node_id, _class_name in class_mappings],
-            list(display_mappings),
+            FIXTURE.name,
+            f"node_contracts_{FIXTURE_PROVENANCE_VERSION.replace('.', '_')}.json",
         )
-        for node_id, class_name in class_mappings:
-            with self.subTest(node_id=node_id):
-                node_class = getattr(nodes, class_name)
-                self.assertEqual(node_class.__name__, class_name)
-                self.assertTrue(callable(getattr(node_class, node_class.FUNCTION)))
 
     def test_fixture_contains_no_machine_specific_absolute_paths(self):
         _assert_no_absolute_paths(json.loads(FIXTURE.read_text(encoding="utf-8")))

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import ast
+import json
+import math
+import re
+import sys
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import nodes
+
+
+PACKAGE_INIT = ROOT / "__init__.py"
+PACKAGE_METADATA = ROOT / "pyproject.toml"
+FIXTURE = ROOT / "tests" / "fixtures" / "node_contracts_0_5_2.json"
+WORKFLOW_SELECTIONS = (
+    (
+        ROOT / "docs" / "example_workflows" / "EasyUse_Anima_artist_mix_release_ko.json",
+        24,
+        "EasyUseAnimaPromptDataConditioning",
+    ),
+    (
+        ROOT / "docs" / "example_workflows" / "EasyUse_Anima_regional_prompt_release_ko.json",
+        3,
+        "EasyUseAnimaRegionalConditioning",
+    ),
+)
+WINDOWS_DRIVE_PATH_FRAGMENT = re.compile(r"(?:^|[\"'\s])[A-Za-z]:[\\/]")
+SERIALIZATION_IRRELEVANT_CONFIG_KEYS = frozenset({"tooltip"})
+
+
+def _assignment_value(tree: ast.Module, name: str) -> ast.AST:
+    for statement in tree.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == name for target in statement.targets):
+            return statement.value
+    raise AssertionError(f"Missing top-level assignment: {name}")
+
+
+def _root_mappings() -> tuple[list[tuple[str, str]], dict[str, str]]:
+    tree = ast.parse(PACKAGE_INIT.read_text(encoding="utf-8-sig"), filename=PACKAGE_INIT.name)
+    class_mapping_node = _assignment_value(tree, "NODE_CLASS_MAPPINGS")
+    display_mapping_node = _assignment_value(tree, "NODE_DISPLAY_NAME_MAPPINGS")
+    if not isinstance(class_mapping_node, ast.Dict) or not isinstance(display_mapping_node, ast.Dict):
+        raise AssertionError("Node mappings must remain literal dictionaries")
+
+    class_mappings = []
+    for key_node, value_node in zip(class_mapping_node.keys, class_mapping_node.values):
+        if not isinstance(key_node, ast.Constant) or not isinstance(key_node.value, str):
+            raise AssertionError("NODE_CLASS_MAPPINGS keys must be string literals")
+        if not isinstance(value_node, ast.Name):
+            raise AssertionError("NODE_CLASS_MAPPINGS values must be imported class names")
+        class_mappings.append((key_node.value, value_node.id))
+
+    display_mappings = ast.literal_eval(display_mapping_node)
+    if not isinstance(display_mappings, dict):
+        raise AssertionError("NODE_DISPLAY_NAME_MAPPINGS must remain a dictionary")
+    return class_mappings, display_mappings
+
+
+def _package_version() -> str:
+    match = re.search(
+        r'(?m)^version\s*=\s*"([^"]+)"\s*$',
+        PACKAGE_METADATA.read_text(encoding="utf-8"),
+    )
+    if match is None:
+        raise AssertionError("Could not read project.version from pyproject.toml")
+    return match.group(1)
+
+
+def _contains_absolute_path(value: str) -> bool:
+    if WINDOWS_DRIVE_PATH_FRAGMENT.search(value) or "/home/" in value or value.startswith("\\\\"):
+        return True
+    stripped = value.strip()
+    if not stripped.startswith(("{", "[")):
+        return False
+    try:
+        decoded = json.loads(stripped)
+    except (TypeError, ValueError):
+        return False
+    return _value_contains_absolute_path(decoded)
+
+
+def _value_contains_absolute_path(value) -> bool:
+    if isinstance(value, dict):
+        return any(_value_contains_absolute_path(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_value_contains_absolute_path(child) for child in value)
+    return isinstance(value, str) and _contains_absolute_path(value)
+
+
+def _normalize(value):
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "Infinity" if value > 0 else "-Infinity"
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): _normalize(child)
+            for key, child in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize(child) for child in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted((_normalize(child) for child in value), key=lambda child: str(child))
+    if isinstance(value, type):
+        return f"{value.__module__}.{value.__qualname__}"
+
+    text = str(value)
+    if _contains_absolute_path(text):
+        raise AssertionError(f"Refusing to snapshot an absolute path from {type(value).__name__}")
+    return text
+
+
+def _input_spec(spec) -> dict:
+    if isinstance(spec, (tuple, list)) and spec:
+        input_type = spec[0]
+        config = spec[1] if len(spec) > 1 and isinstance(spec[1], dict) else {}
+        extra = list(spec[2:]) if len(spec) > 2 else []
+    else:
+        input_type = spec
+        config = {}
+        extra = []
+
+    contract_config = {
+        key: value
+        for key, value in config.items()
+        if key not in SERIALIZATION_IRRELEVANT_CONFIG_KEYS
+    }
+    result = {
+        "type": _normalize(input_type),
+        "config": _normalize(contract_config),
+    }
+    if extra:
+        result["extra"] = _normalize(extra)
+    return result
+
+
+@contextmanager
+def _deterministic_comfy_inputs():
+    replacements = {
+        "_comfy_max_resolution": lambda: 16384,
+        "_comfy_sampler_names": lambda: ["contract_sampler_a", "contract_sampler_b"],
+        "_comfy_scheduler_names": lambda: ["contract_scheduler_a", "contract_scheduler_b"],
+        "_comfy_checkpoint_names": lambda: ["contract/checkpoint.safetensors"],
+        "_comfy_diffusion_model_names": lambda: ["contract/diffusion_model.safetensors"],
+        "_comfy_text_encoder_names": lambda: ["contract/text_encoder.safetensors"],
+        "_comfy_vae_names": lambda: ["contract/vae.safetensors"],
+        "_comfy_clip_loader_types": lambda: ["qwen_image", "stable_diffusion"],
+        "_impact_scheduler_names": lambda: ["contract_impact_scheduler"],
+        "_lora_combo_values": lambda: ["None", "contract/style.safetensors"],
+        "resolve_metadata_filter_words": lambda: ["contract-filter"],
+        "_prompt_translation_change_key": lambda: {"enabled": False},
+        "wildcard_sources_signature": lambda: {"files": []},
+        "resolve_naia_settings": lambda: {
+            "use_naia_settings": False,
+            "pre_prompt": "",
+            "post_prompt": "",
+            "auto_hide": "",
+            "host": "127.0.0.1",
+            "port": 7243,
+            "preprocessing": {},
+            "allow_remote_api": False,
+        },
+    }
+    with patch.multiple(nodes, **replacements):
+        yield
+
+
+def _node_contract(node_id: str, class_name: str, display_name: str) -> dict:
+    node_class = getattr(nodes, class_name)
+    input_types = node_class.INPUT_TYPES()
+    sections = []
+    for section_name, entries in input_types.items():
+        sections.append(
+            {
+                "name": section_name,
+                "entries": [
+                    {
+                        "name": input_name,
+                        **_input_spec(spec),
+                    }
+                    for input_name, spec in entries.items()
+                ],
+            }
+        )
+
+    return {
+        "id": node_id,
+        "class_name": class_name,
+        "identity": f"nodes.{node_class.__qualname__}",
+        "display_name": display_name,
+        "input_sections": sections,
+        "return_types": _normalize(getattr(node_class, "RETURN_TYPES")),
+        "return_names": _normalize(getattr(node_class, "RETURN_NAMES", None)),
+        "function": getattr(node_class, "FUNCTION"),
+        "category": getattr(node_class, "CATEGORY"),
+        "output_node": bool(getattr(node_class, "OUTPUT_NODE", False)),
+    }
+
+
+def _representative_is_changed() -> list[dict]:
+    input_context = nodes.EasyUseAnimaInput().build(
+        {
+            "positive_prompt": "contract prompt",
+            "negative_prompt": "",
+            "width": 1024,
+            "height": 1024,
+        },
+        "contract/diffusion_model.safetensors",
+        "contract/vae.safetensors",
+        "contract/text_encoder.safetensors",
+        "qwen_image",
+        {},
+    )[0]
+    samples = (
+        (
+            "EasyUseAnimaPromptCorrector",
+            {
+                "prompt": "1girl, blue eyes",
+                "artist_overrides": "",
+                "artist_exclusions": "",
+            },
+        ),
+        (
+            "EasyUseAnimaWildcard",
+            {
+                "text": "plain contract prompt",
+                "populated_text": "",
+                "mode": "reproduce",
+                "seed": 17,
+                "seed_after_generate": "fixed",
+            },
+        ),
+        (
+            "EasyUseAnimaPromptStudioAdvancedV2",
+            {
+                "use_naia": False,
+                "advanced_fields": "[]",
+                "artist_mix_mode": "off",
+            },
+        ),
+        (
+            "EasyUseAnimaInput",
+            {
+                "EASYUSE_ANIMA_PROMPT_DATA": {
+                    "positive_prompt": "contract prompt",
+                    "negative_prompt": "",
+                    "width": 1024,
+                    "height": 1024,
+                },
+                "unet_name": "contract/diffusion_model.safetensors",
+                "vae_name": "contract/vae.safetensors",
+                "clip_name": "contract/text_encoder.safetensors",
+                "clip_type": "qwen_image",
+                "input_settings": {},
+            },
+        ),
+        (
+            "EasyUseAnimaAIOGenerator",
+            {
+                "easy_use_anima_input": input_context,
+                "lora_stack": None,
+                "generation_settings": {"sampler": {"seed": 17}},
+            },
+        ),
+        (
+            "EasyUseAnimaNAIARandomPrompt",
+            {
+                "use_naia_bridge": False,
+                "prompt": "contract prompt",
+                "negative_prompt": "",
+                "width": 1024,
+                "height": 1024,
+            },
+        ),
+    )
+
+    return [
+        {
+            "id": node_id,
+            "inputs": _normalize(kwargs),
+            "result": _normalize(getattr(nodes, node_id).IS_CHANGED(**kwargs)),
+        }
+        for node_id, kwargs in samples
+    ]
+
+
+def _workflow_nodes() -> list[dict]:
+    snapshots = []
+    for workflow_path, node_number, expected_type in WORKFLOW_SELECTIONS:
+        workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+        workflow_node = next(
+            node
+            for node in workflow.get("nodes", [])
+            if int(node.get("id")) == node_number
+        )
+        if workflow_node.get("type") != expected_type:
+            raise AssertionError(
+                f"{workflow_path.name}: node {node_number} changed type to {workflow_node.get('type')}"
+            )
+        snapshots.append(
+            {
+                "source": workflow_path.relative_to(ROOT).as_posix(),
+                "node_number": node_number,
+                "class_id": expected_type,
+                "widgets_values": _normalize(workflow_node.get("widgets_values", [])),
+            }
+        )
+    return snapshots
+
+
+def build_contract_snapshot() -> dict:
+    class_mappings, display_mappings = _root_mappings()
+    if list(display_mappings) != [node_id for node_id, _class_name in class_mappings]:
+        raise AssertionError("Class and display mapping order or keys diverged")
+
+    with _deterministic_comfy_inputs():
+        snapshot = {
+            "schema_version": 1,
+            "package_version": _package_version(),
+            "dynamic_inputs": {
+                "samplers": ["contract_sampler_a", "contract_sampler_b"],
+                "schedulers": ["contract_scheduler_a", "contract_scheduler_b"],
+                "impact_schedulers": ["contract_impact_scheduler"],
+                "diffusion_models": ["contract/diffusion_model.safetensors"],
+                "text_encoders": ["contract/text_encoder.safetensors"],
+                "vae_models": ["contract/vae.safetensors"],
+                "lora_models": ["None", "contract/style.safetensors"],
+            },
+            "nodes": [
+                _node_contract(node_id, class_name, display_mappings[node_id])
+                for node_id, class_name in class_mappings
+            ],
+            "is_changed": _representative_is_changed(),
+            "workflow_nodes": _workflow_nodes(),
+        }
+    _assert_no_absolute_paths(snapshot)
+    return snapshot
+
+
+def _assert_no_absolute_paths(value, path: str = "fixture") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _assert_no_absolute_paths(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _assert_no_absolute_paths(child, f"{path}[{index}]")
+    elif isinstance(value, str):
+        if _contains_absolute_path(value):
+            raise AssertionError(f"Absolute path at {path}: {value}")
+
+
+def write_fixture() -> None:
+    snapshot = build_contract_snapshot()
+    FIXTURE.parent.mkdir(parents=True, exist_ok=True)
+    FIXTURE.write_text(
+        json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+class PublicNodeContractTests(unittest.TestCase):
+    def test_generated_contract_matches_versioned_fixture(self):
+        expected = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+        self.assertEqual(build_contract_snapshot(), expected)
+
+    def test_mapping_values_resolve_to_the_recorded_runtime_classes(self):
+        class_mappings, display_mappings = _root_mappings()
+
+        self.assertEqual(
+            [node_id for node_id, _class_name in class_mappings],
+            list(display_mappings),
+        )
+        for node_id, class_name in class_mappings:
+            with self.subTest(node_id=node_id):
+                node_class = getattr(nodes, class_name)
+                self.assertEqual(node_class.__name__, class_name)
+                self.assertTrue(callable(getattr(node_class, node_class.FUNCTION)))
+
+    def test_fixture_contains_no_machine_specific_absolute_paths(self):
+        _assert_no_absolute_paths(json.loads(FIXTURE.read_text(encoding="utf-8")))
+
+    def test_absolute_path_guard_handles_nested_json_strings(self):
+        nested_contract = json.dumps({"payload": json.dumps({"text": "contract"})})
+        nested_path = json.dumps({"payload": json.dumps({"path": "Q:\\private\\file.json"})})
+
+        self.assertFalse(_contains_absolute_path(nested_contract))
+        self.assertTrue(_contains_absolute_path(nested_path))
+
+    def test_representative_workflow_class_ids_remain_public(self):
+        expected = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        public_ids = {node["id"] for node in expected["nodes"]}
+
+        for workflow_node in expected["workflow_nodes"]:
+            self.assertIn(workflow_node["class_id"], public_ids)
+            self.assertIsInstance(workflow_node["widgets_values"], list)
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--write-fixture"]:
+        write_fixture()
+    else:
+        unittest.main()

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANALYZER_PATH = ROOT / "tools" / "analyze_nodes_module.py"
+
+
+def load_analyzer():
+    spec = importlib.util.spec_from_file_location("easyuse_anima_nodes_analyzer", ANALYZER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load analyzer: {ANALYZER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+analyzer = load_analyzer()
+
+
+class NodesModuleAnalyzerTests(unittest.TestCase):
+    def test_synthetic_module_reports_definitions_locations_and_references(self):
+        source = """\
+import importlib
+from package import helper as imported_helper
+
+VALUE = 3
+
+def use_value(name):
+    return VALUE + getattr(importlib, name)
+
+class ContractNode:
+    marker = VALUE
+
+def load_dynamic():
+    return importlib.import_module("optional.module")
+"""
+
+        report = analyzer.analyze_source(source, source_label="synthetic.py")
+
+        self.assertEqual(report["top_level"]["function_count"], 2)
+        self.assertEqual(report["top_level"]["class_count"], 1)
+        self.assertEqual(
+            [item["name"] for item in report["top_level"]["globals"]],
+            ["VALUE"],
+        )
+        self.assertIn(
+            {"from": "use_value", "to": "VALUE"},
+            report["reference_edges"],
+        )
+        self.assertEqual(
+            [item["callee"] for item in report["dynamic_lookups"]],
+            ["getattr", "importlib.import_module"],
+        )
+        self.assertEqual(
+            [(item["module"], item["name"], item["scope"]) for item in report["imports"]],
+            [
+                ("importlib", None, "<module>"),
+                ("package", "helper", "<module>"),
+            ],
+        )
+
+    def test_json_and_text_rendering_are_deterministic(self):
+        first_report = analyzer.analyze_path(ROOT / "nodes.py")
+        second_report = analyzer.analyze_path(ROOT / "nodes.py")
+
+        self.assertEqual(analyzer.render_json(first_report), analyzer.render_json(second_report))
+        self.assertEqual(analyzer.render_text(first_report), analyzer.render_text(second_report))
+
+    def test_phase_zero_nodes_module_shape_matches_recorded_baseline(self):
+        report = analyzer.analyze_path(ROOT / "nodes.py")
+
+        self.assertEqual(report["git_blob_sha1"], "a09b1d76618ff46955d54d724a7b813e2a209567")
+        self.assertEqual(report["top_level"]["function_count"], 284)
+        self.assertEqual(report["top_level"]["class_count"], 25)
+        self.assertGreaterEqual(report["line_count"], 12_000)
+        class_names = {item["name"] for item in report["top_level"]["classes"]}
+        self.assertIn("EasyUseAnimaAIOGenerator", class_names)
+        self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)
+        self.assertIn("EasyUseAnimaNAIARandomPrompt", class_names)
+
+    def test_external_source_label_does_not_expose_parent_directories(self):
+        label = analyzer._source_label(Path("Z:/private/user/data/example.py"))
+
+        self.assertEqual(label, "example.py")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_import_boundaries.py
+++ b/tests/test_python_import_boundaries.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANALYZER_PATH = ROOT / "tools" / "analyze_nodes_module.py"
+INTERNAL_PACKAGE = ROOT / "easyuse_anima"
+
+
+def load_analyzer():
+    spec = importlib.util.spec_from_file_location("easyuse_anima_import_analyzer", ANALYZER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load analyzer: {ANALYZER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+analyzer = load_analyzer()
+
+
+class PythonImportBoundaryTests(unittest.TestCase):
+    def test_future_internal_package_never_imports_root_nodes(self):
+        violations = analyzer.scan_internal_package(INTERNAL_PACKAGE)
+
+        self.assertFalse(
+            [
+                violation
+                for violation in violations
+                if violation["rule"] == "internal-imports-root-nodes"
+            ]
+        )
+
+    def test_future_inner_layers_never_import_outer_layers(self):
+        violations = analyzer.scan_internal_package(INTERNAL_PACKAGE)
+
+        self.assertFalse(
+            [
+                violation
+                for violation in violations
+                if violation["rule"] == "inner-layer-imports-outer-layer"
+            ]
+        )
+
+    def test_synthetic_allowed_imports_have_no_violations(self):
+        sources = {
+            "easyuse_anima.domain.models": "from easyuse_anima.domain import values\n",
+            "easyuse_anima.services.prompt": "from easyuse_anima.domain import models\n",
+            "easyuse_anima.adapters.comfy": "from easyuse_anima.services import prompt\n",
+            "easyuse_anima.registration": "from easyuse_anima.adapters import comfy\n",
+        }
+
+        for module_name, source in sources.items():
+            with self.subTest(module=module_name):
+                self.assertEqual(
+                    analyzer.find_import_boundary_violations(source, module_name=module_name),
+                    [],
+                )
+
+    def test_synthetic_internal_import_of_root_nodes_is_rejected(self):
+        sources = (
+            "import nodes\n",
+            "from nodes import NODE_CLASS_MAPPINGS\n",
+            "import importlib\nimportlib.import_module('nodes')\n",
+        )
+
+        for source in sources:
+            with self.subTest(source=source.strip()):
+                violations = analyzer.find_import_boundary_violations(
+                    source,
+                    module_name="easyuse_anima.services.prompt",
+                )
+                self.assertIn(
+                    "internal-imports-root-nodes",
+                    {violation["rule"] for violation in violations},
+                )
+
+    def test_synthetic_inner_to_outer_back_references_are_rejected(self):
+        sources = {
+            "easyuse_anima.domain.models": (
+                "from easyuse_anima.adapters import comfy\n"
+            ),
+            "easyuse_anima.services.prompt": (
+                "from ..registration import register_nodes\n"
+            ),
+            "easyuse_anima.service.catalog": (
+                "import easyuse_anima.bootstrap.runtime\n"
+            ),
+        }
+
+        for module_name, source in sources.items():
+            with self.subTest(module=module_name):
+                violations = analyzer.find_import_boundary_violations(
+                    source,
+                    module_name=module_name,
+                )
+                self.assertIn(
+                    "inner-layer-imports-outer-layer",
+                    {violation["rule"] for violation in violations},
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_import_boundaries.py
+++ b/tests/test_python_import_boundaries.py
@@ -63,6 +63,7 @@ class PythonImportBoundaryTests(unittest.TestCase):
     def test_synthetic_internal_import_of_root_nodes_is_rejected(self):
         sources = (
             "import nodes\n",
+            "import nodes as root_nodes\n",
             "from nodes import NODE_CLASS_MAPPINGS\n",
             "import importlib\nimportlib.import_module('nodes')\n",
         )
@@ -78,6 +79,43 @@ class PythonImportBoundaryTests(unittest.TestCase):
                     {violation["rule"] for violation in violations},
                 )
 
+    def test_literal_dynamic_import_aliases_are_rejected(self):
+        sources = (
+            "import importlib as il\nil.import_module('nodes')\n",
+            "from importlib import import_module as load\nload('nodes')\n",
+        )
+
+        for source in sources:
+            with self.subTest(source=source.strip()):
+                violations = analyzer.find_import_boundary_violations(
+                    source,
+                    module_name="easyuse_anima.prompt.service",
+                )
+                self.assertIn(
+                    "internal-imports-root-nodes",
+                    {violation["rule"] for violation in violations},
+                )
+
+    def test_vertical_service_static_import_alias_is_rejected(self):
+        sources = (
+            "from .. import registration as reg\n",
+            (
+                "import importlib as il\n"
+                "il.import_module('..registration', __package__)\n"
+            ),
+        )
+
+        for source in sources:
+            with self.subTest(source=source.strip()):
+                violations = analyzer.find_import_boundary_violations(
+                    source,
+                    module_name="easyuse_anima.prompt.service",
+                )
+                self.assertIn(
+                    "inner-layer-imports-outer-layer",
+                    {violation["rule"] for violation in violations},
+                )
+
     def test_synthetic_inner_to_outer_back_references_are_rejected(self):
         sources = {
             "easyuse_anima.domain.models": (
@@ -88,6 +126,15 @@ class PythonImportBoundaryTests(unittest.TestCase):
             ),
             "easyuse_anima.service.catalog": (
                 "import easyuse_anima.bootstrap.runtime\n"
+            ),
+            "easyuse_anima.prompt.service": (
+                "from easyuse_anima import registration\n"
+            ),
+            "easyuse_anima.prompt.domain.model": (
+                "from easyuse_anima.api import routes\n"
+            ),
+            "easyuse_anima.regional.services.layout": (
+                "from easyuse_anima import nodes\n"
             ),
         }
 

--- a/tools/analyze_nodes_module.py
+++ b/tools/analyze_nodes_module.py
@@ -19,7 +19,15 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SOURCE = REPOSITORY_ROOT / "nodes.py"
 DEFAULT_INTERNAL_PACKAGE = "easyuse_anima"
 DOMAIN_LAYERS = frozenset({"domain", "service", "services"})
-OUTER_LAYERS = frozenset({"adapters", "bootstrap", "registration"})
+OUTER_LAYER_PATHS = frozenset(
+    {
+        "adapters",
+        "api.routes",
+        "bootstrap",
+        "nodes",
+        "registration",
+    }
+)
 DYNAMIC_LOOKUP_CALLEES = frozenset(
     {
         "__import__",
@@ -294,6 +302,48 @@ def _import_targets(
     module_name: str,
     is_package: bool,
 ) -> Iterable[tuple[int, str]]:
+    alias_bindings: dict[str, set[str]] = {}
+
+    def bind(name: str, target: str) -> None:
+        alias_bindings.setdefault(name, set()).add(target)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    bind(alias.asname, alias.name)
+                else:
+                    root_name = alias.name.split(".", 1)[0]
+                    bind(root_name, root_name)
+        elif isinstance(node, ast.ImportFrom):
+            base = _resolve_from_import(node, module_name=module_name, is_package=is_package)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                target = f"{base}.{alias.name}" if base else alias.name
+                bind(alias.asname or alias.name, target)
+
+    def resolve_callees(node: ast.AST) -> set[str]:
+        callee = _call_name(node)
+        resolved = {callee}
+        root_name, separator, suffix = callee.partition(".")
+        for target in alias_bindings.get(root_name, set()):
+            resolved.add(f"{target}.{suffix}" if separator else target)
+        return resolved
+
+    def resolve_dynamic_target(target: str) -> str:
+        if not target.startswith("."):
+            return target
+        level = len(target) - len(target.lstrip("."))
+        package_parts = module_name.split(".") if is_package else module_name.split(".")[:-1]
+        remove_count = max(0, level - 1)
+        if remove_count:
+            package_parts = package_parts[: max(0, len(package_parts) - remove_count)]
+        remainder = target[level:]
+        if remainder:
+            package_parts.extend(remainder.split("."))
+        return ".".join(package_parts)
+
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -305,12 +355,11 @@ def _import_targets(
             for alias in node.names:
                 if alias.name != "*":
                     yield node.lineno, f"{base}.{alias.name}" if base else alias.name
-        elif isinstance(node, ast.Call) and _call_name(node.func) in {
-            "__import__",
-            "importlib.import_module",
-        }:
+        elif isinstance(node, ast.Call):
+            if not resolve_callees(node.func).intersection({"__import__", "importlib.import_module"}):
+                continue
             if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
-                yield node.lineno, node.args[0].value
+                yield node.lineno, resolve_dynamic_target(node.args[0].value)
 
 
 def find_import_boundary_violations(
@@ -325,16 +374,17 @@ def find_import_boundary_violations(
     tree = ast.parse(source, filename=module_name)
     prefix = f"{package_name}."
     relative_name = module_name[len(prefix) :] if module_name.startswith(prefix) else ""
-    source_layer = relative_name.split(".", 1)[0] if relative_name else ""
+    source_layers = set(relative_name.split(".")) if relative_name else set()
+    is_inner_layer = bool(source_layers & DOMAIN_LAYERS)
     violations: set[tuple[str, int, str]] = set()
 
     for line, target in _import_targets(tree, module_name=module_name, is_package=is_package):
         if target == "nodes" or target.startswith("nodes."):
             violations.add(("internal-imports-root-nodes", line, target))
 
-        if source_layer in DOMAIN_LAYERS:
-            for outer_layer in OUTER_LAYERS:
-                forbidden = f"{package_name}.{outer_layer}"
+        if is_inner_layer:
+            for outer_path in OUTER_LAYER_PATHS:
+                forbidden = f"{package_name}.{outer_path}"
                 if target == forbidden or target.startswith(f"{forbidden}."):
                     violations.add(("inner-layer-imports-outer-layer", line, target))
 

--- a/tools/analyze_nodes_module.py
+++ b/tools/analyze_nodes_module.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Deterministically describe the monolithic ``nodes.py`` module.
+
+The analyzer is intentionally AST-only.  It never imports the custom node, so it
+can be used before ComfyUI, model folders, or optional node packs are available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE = REPOSITORY_ROOT / "nodes.py"
+DEFAULT_INTERNAL_PACKAGE = "easyuse_anima"
+DOMAIN_LAYERS = frozenset({"domain", "service", "services"})
+OUTER_LAYERS = frozenset({"adapters", "bootstrap", "registration"})
+DYNAMIC_LOOKUP_CALLEES = frozenset(
+    {
+        "__import__",
+        "getattr",
+        "importlib.import_module",
+        "sys.modules.get",
+    }
+)
+
+
+def _git_blob_sha1(data: bytes) -> str:
+    # The repository stores Python sources with LF even when a Windows checkout
+    # materializes CRLF.  Normalize that text boundary so the report matches the
+    # repository blob rather than the host checkout representation.
+    normalized = data.replace(b"\r\n", b"\n")
+    header = f"blob {len(normalized)}\0".encode("ascii")
+    return hashlib.sha1(header + normalized).hexdigest()
+
+
+def _source_label(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPOSITORY_ROOT).as_posix()
+    except ValueError:
+        # Reports must not disclose paths outside the repository.
+        return path.name
+
+
+def _assigned_names(node: ast.AST) -> Iterable[str]:
+    if isinstance(node, ast.Name):
+        yield node.id
+    elif isinstance(node, (ast.Tuple, ast.List)):
+        for item in node.elts:
+            yield from _assigned_names(item)
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+class _LocationVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.imports: list[dict[str, object]] = []
+        self.dynamic_lookups: list[dict[str, object]] = []
+        self._scope: list[str] = []
+
+    @property
+    def scope(self) -> str:
+        return ".".join(self._scope) if self._scope else "<module>"
+
+    def _visit_scoped(self, node: ast.AST, name: str) -> None:
+        self._scope.append(name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.imports.append(
+                {
+                    "kind": "import",
+                    "module": alias.name,
+                    "name": None,
+                    "alias": alias.asname,
+                    "line": node.lineno,
+                    "column": node.col_offset,
+                    "scope": self.scope,
+                }
+            )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = "." * node.level + (node.module or "")
+        for alias in node.names:
+            self.imports.append(
+                {
+                    "kind": "from",
+                    "module": module,
+                    "name": alias.name,
+                    "alias": alias.asname,
+                    "line": node.lineno,
+                    "column": node.col_offset,
+                    "scope": self.scope,
+                }
+            )
+
+    def visit_Call(self, node: ast.Call) -> None:
+        callee = _call_name(node.func)
+        if callee in DYNAMIC_LOOKUP_CALLEES:
+            self.dynamic_lookups.append(
+                {
+                    "callee": callee,
+                    "line": node.lineno,
+                    "column": node.col_offset,
+                    "scope": self.scope,
+                }
+            )
+        self.generic_visit(node)
+
+
+def _definition_references(node: ast.AST, known_names: set[str]) -> list[str]:
+    referenced = {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+    }
+    name = getattr(node, "name", None)
+    if isinstance(name, str):
+        referenced.discard(name)
+    return sorted(referenced & known_names)
+
+
+def analyze_source(source: str, *, source_label: str = "nodes.py", raw_bytes: bytes | None = None) -> dict:
+    raw_bytes = raw_bytes if raw_bytes is not None else source.encode("utf-8")
+    tree = ast.parse(source, filename=source_label)
+
+    functions: list[dict[str, object]] = []
+    classes: list[dict[str, object]] = []
+    globals_by_name: dict[str, int] = {}
+    definition_nodes: list[ast.AST] = []
+
+    for statement in tree.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions.append(
+                {
+                    "name": statement.name,
+                    "line": statement.lineno,
+                    "async": isinstance(statement, ast.AsyncFunctionDef),
+                }
+            )
+            definition_nodes.append(statement)
+        elif isinstance(statement, ast.ClassDef):
+            classes.append({"name": statement.name, "line": statement.lineno})
+            definition_nodes.append(statement)
+        elif isinstance(statement, ast.Assign):
+            for target in statement.targets:
+                for name in _assigned_names(target):
+                    globals_by_name.setdefault(name, statement.lineno)
+        elif isinstance(statement, (ast.AnnAssign, ast.AugAssign)):
+            for name in _assigned_names(statement.target):
+                globals_by_name.setdefault(name, statement.lineno)
+
+    globals_list = [
+        {"name": name, "line": line}
+        for name, line in sorted(globals_by_name.items())
+    ]
+    known_names = {
+        *(item["name"] for item in functions),
+        *(item["name"] for item in classes),
+        *globals_by_name,
+    }
+    reference_edges = []
+    for node in definition_nodes:
+        source_name = getattr(node, "name")
+        for target_name in _definition_references(node, known_names):
+            reference_edges.append({"from": source_name, "to": target_name})
+
+    visitor = _LocationVisitor()
+    visitor.visit(tree)
+    imports = sorted(
+        visitor.imports,
+        key=lambda item: (
+            int(item["line"]),
+            int(item["column"]),
+            str(item["module"]),
+            str(item["name"]),
+        ),
+    )
+    dynamic_lookups = sorted(
+        visitor.dynamic_lookups,
+        key=lambda item: (int(item["line"]), int(item["column"]), str(item["callee"])),
+    )
+
+    return {
+        "schema_version": 1,
+        "source": source_label,
+        "git_blob_sha1": _git_blob_sha1(raw_bytes),
+        "line_count": len(source.splitlines()),
+        "top_level": {
+            "function_count": len(functions),
+            "class_count": len(classes),
+            "global_count": len(globals_list),
+            "functions": sorted(functions, key=lambda item: (str(item["name"]), int(item["line"]))),
+            "classes": sorted(classes, key=lambda item: (str(item["name"]), int(item["line"]))),
+            "globals": globals_list,
+        },
+        "imports": imports,
+        "dynamic_lookups": dynamic_lookups,
+        "reference_edges": sorted(reference_edges, key=lambda item: (item["from"], item["to"])),
+    }
+
+
+def analyze_path(path: Path) -> dict:
+    data = path.read_bytes()
+    source = data.decode("utf-8-sig")
+    return analyze_source(source, source_label=_source_label(path), raw_bytes=data)
+
+
+def render_json(report: dict) -> str:
+    return json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def render_text(report: dict) -> str:
+    top_level = report["top_level"]
+    lines = [
+        f"source: {report['source']}",
+        f"git_blob_sha1: {report['git_blob_sha1']}",
+        f"line_count: {report['line_count']}",
+        f"top_level_functions: {top_level['function_count']}",
+        f"top_level_classes: {top_level['class_count']}",
+        f"top_level_globals: {top_level['global_count']}",
+        "",
+        "classes:",
+    ]
+    lines.extend(f"  {item['name']} @ {item['line']}" for item in top_level["classes"])
+    lines.append("")
+    lines.append("functions:")
+    lines.extend(f"  {item['name']} @ {item['line']}" for item in top_level["functions"])
+    lines.append("")
+    lines.append("globals:")
+    lines.extend(f"  {item['name']} @ {item['line']}" for item in top_level["globals"])
+    lines.append("")
+    lines.append("imports:")
+    for item in report["imports"]:
+        imported = item["module"]
+        if item["name"]:
+            imported = f"{imported}:{item['name']}"
+        lines.append(f"  {imported} @ {item['line']} ({item['scope']})")
+    lines.append("")
+    lines.append("dynamic_lookups:")
+    lines.extend(
+        f"  {item['callee']} @ {item['line']} ({item['scope']})"
+        for item in report["dynamic_lookups"]
+    )
+    lines.append("")
+    lines.append("reference_edges:")
+    lines.extend(f"  {item['from']} -> {item['to']}" for item in report["reference_edges"])
+    return "\n".join(lines) + "\n"
+
+
+def _resolve_from_import(
+    node: ast.ImportFrom,
+    *,
+    module_name: str,
+    is_package: bool,
+) -> str:
+    if node.level == 0:
+        return node.module or ""
+    package_parts = module_name.split(".") if is_package else module_name.split(".")[:-1]
+    remove_count = max(0, node.level - 1)
+    if remove_count:
+        package_parts = package_parts[: max(0, len(package_parts) - remove_count)]
+    if node.module:
+        package_parts.extend(node.module.split("."))
+    return ".".join(package_parts)
+
+
+def _import_targets(
+    tree: ast.AST,
+    *,
+    module_name: str,
+    is_package: bool,
+) -> Iterable[tuple[int, str]]:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield node.lineno, alias.name
+        elif isinstance(node, ast.ImportFrom):
+            base = _resolve_from_import(node, module_name=module_name, is_package=is_package)
+            if base:
+                yield node.lineno, base
+            for alias in node.names:
+                if alias.name != "*":
+                    yield node.lineno, f"{base}.{alias.name}" if base else alias.name
+        elif isinstance(node, ast.Call) and _call_name(node.func) in {
+            "__import__",
+            "importlib.import_module",
+        }:
+            if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+                yield node.lineno, node.args[0].value
+
+
+def find_import_boundary_violations(
+    source: str,
+    *,
+    module_name: str,
+    package_name: str = DEFAULT_INTERNAL_PACKAGE,
+    is_package: bool = False,
+) -> list[dict[str, object]]:
+    """Return stable violations for the future internal package layering rules."""
+
+    tree = ast.parse(source, filename=module_name)
+    prefix = f"{package_name}."
+    relative_name = module_name[len(prefix) :] if module_name.startswith(prefix) else ""
+    source_layer = relative_name.split(".", 1)[0] if relative_name else ""
+    violations: set[tuple[str, int, str]] = set()
+
+    for line, target in _import_targets(tree, module_name=module_name, is_package=is_package):
+        if target == "nodes" or target.startswith("nodes."):
+            violations.add(("internal-imports-root-nodes", line, target))
+
+        if source_layer in DOMAIN_LAYERS:
+            for outer_layer in OUTER_LAYERS:
+                forbidden = f"{package_name}.{outer_layer}"
+                if target == forbidden or target.startswith(f"{forbidden}."):
+                    violations.add(("inner-layer-imports-outer-layer", line, target))
+
+    return [
+        {"rule": rule, "line": line, "module": module_name, "imported": target}
+        for rule, line, target in sorted(violations, key=lambda item: (item[1], item[0], item[2]))
+    ]
+
+
+def scan_internal_package(
+    package_root: Path,
+    *,
+    package_name: str = DEFAULT_INTERNAL_PACKAGE,
+) -> list[dict[str, object]]:
+    if not package_root.is_dir():
+        return []
+
+    violations: list[dict[str, object]] = []
+    for path in sorted(package_root.rglob("*.py")):
+        relative = path.relative_to(package_root)
+        module_parts = list(relative.with_suffix("").parts)
+        is_package = bool(module_parts and module_parts[-1] == "__init__")
+        if is_package:
+            module_parts.pop()
+        module_name = ".".join((package_name, *module_parts))
+        source = path.read_text(encoding="utf-8-sig")
+        for violation in find_import_boundary_violations(
+            source,
+            module_name=module_name,
+            package_name=package_name,
+            is_package=is_package,
+        ):
+            violation["file"] = relative.as_posix()
+            violations.append(violation)
+    return sorted(
+        violations,
+        key=lambda item: (str(item["file"]), int(item["line"]), str(item["rule"])),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", nargs="?", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--format", choices=("json", "text"), default="json")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+
+    report = analyze_path(args.source)
+    rendered = render_json(report) if args.format == "json" else render_text(report)
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8", newline="\n")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 변경 요약

Issue #184의 Phase 0 공개 node/workflow contract baseline과 후속 extraction을 위한 **A-02 + A-03 seed gate**를 추가합니다.

- `nodes.py`를 import하지 않는 AST 분석기로 top-level class/function/global, import 및 dynamic lookup 위치, top-level 참조 관계를 결정적으로 보고합니다.
- 공개 node mapping 18개의 class/display mapping, `INPUT_TYPES` section 및 key 순서와 serialization 관련 config, output contract를 0.5.2 fixture로 고정합니다.
- 대표 `IS_CHANGED` 결과 6개와 기존 배포 workflow의 class ID/`widgets_values` 순서 2개를 고정합니다.
- 향후 `easyuse_anima/` 내부 package가 루트 `nodes.py`를 import하지 못하도록 하고, vertical feature의 domain/service/services가 `nodes`, `adapters`, `api.routes`, `registration`, `bootstrap`을 역참조하지 못하도록 정적 seed 규칙을 둡니다.
- literal dynamic import의 `importlib` module/function alias와 relative/static alias를 결정적으로 추적합니다.
- package entrypoint의 `NODE_CLASS_MAPPINGS`가 canonical package `nodes` class와 실제로 같은 객체인지 runtime identity로 검증합니다.
- fixture의 0.5.2는 provenance로 명시하고, 이후 `pyproject.toml` version bump는 contract parity에 섞지 않습니다.

Relates to #184
Relates to #191

## 범위

이 PR은 **Phase 0 contract baseline + A-02/A-03 seed 전용**이며, Phase A 전체 완료를 의미하지 않습니다.

- production 코드 이동 또는 동작 변경 없음
- registration/bootstrap 분리 없음
- 새 runtime module 없음
- `.comfyignore`가 `tools/`와 `tests/`를 제외하므로 Registry runtime package surface 변경 없음
- A-01 전체 inventory, SCC/순환 참조, import side-effect 보고 및 장기 architecture gate 확장은 #191 범위

다음 Move PR의 경계는 `easyuse_anima/` package skeleton과 common value/serialization/geometry 및 Comfy port 기반을 동작 보존형으로 추출하는 범위입니다. node registration/bootstrap 전환과 AiO cache/seed/async/error 정책 변경은 포함하지 않습니다.

## 주요 파일

- `tools/analyze_nodes_module.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_node_contracts.py`
- `tests/fixtures/node_contracts_0_5_2.json`
- `tests/test_python_import_boundaries.py`

## Fixture 갱신

의도된 공개 contract 변경을 검토한 뒤 다음 명령으로 fixture를 갱신합니다.

```powershell
python tests/test_node_contracts.py --write-fixture
```

갱신 후 contract parity와 실제 diff를 함께 검토해야 합니다. fixture의 `package_version: 0.5.2`는 현재 배포 version equality gate가 아니라 이 baseline의 provenance입니다.

## 검증

- `python -m unittest discover -s tests -p test_nodes_module_analyzer.py -v` — 4 passed
- `python -m unittest discover -s tests -p test_python_import_boundaries.py -v` — 7 passed
- `python -m unittest discover -s tests -p test_node_contracts.py -v` — 6 passed
- 변경 Python/test 파일 `py_compile` — passed
- analyzer JSON 출력 2회 동일성 — passed
  - blob `a09b1d76618ff46955d54d724a7b813e2a209567`
  - 12,663 lines / 284 top-level functions / 25 classes
- `git diff --check` 및 staged diff check — passed
- 공식 full runner — passed
  - Python unittest: 518 passed
  - Frontend: 110 JavaScript files, TypeScript 6.0.3
  - Python compile / git diff check: passed

## 테스트 표면과 미확인 항목

- 공개 Python node contract와 기존 workflow fixture: 검증함
- synthetic package entrypoint mapping identity: 검증함
- vertical/static/dynamic import-boundary seed: 검증함
- ComfyUI Codex test instance: 공식 full runner 검증함(518 Python tests, frontend 110 files)
- ComfyUI runtime/API/browser 및 Legacy canvas/Node 2.0 live smoke: 미실행(운영 코드 변경 없음)
- Registry package/runtime install smoke: 미실행(새 runtime module 없음)

메인 actual diff 리뷰에서 vertical/alias import 누락, 실제 mapping identity, fixture provenance를 보완한 뒤 full gate를 통과했습니다.
