### PR TITLE
번역 provider 비동기 경계와 cache 강화

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import atexit
 import asyncio
 import json
 import os
 import re
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 
 try:
@@ -32,9 +35,9 @@ from .autocomplete_dataset import (
 from .wildcard_engine import list_wildcards, resolve_wildcard_roots
 from .prompt_translation import (
     PromptTranslationError,
+    TranslationBusyError,
     TranslationCancelledError,
     TranslationTimeoutError,
-    TranslationUpstreamError,
     translate_prompt_markers,
 )
 try:
@@ -79,23 +82,77 @@ WINDOWS_RESERVED_FILE_BASENAMES = {
 PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS = 15.0
 
 
+class _PromptTranslationWorker:
+    """Own one lazy worker and never queue behind a timed-out sync call."""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._executor: ThreadPoolExecutor | None = None
+        self._in_flight: Future | None = None
+        self._closed = False
+
+    @property
+    def has_in_flight(self) -> bool:
+        with self._lock:
+            return self._in_flight is not None and not self._in_flight.done()
+
+    def submit(self, function, *args) -> Future:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Prompt translation worker is shut down.")
+            if self._in_flight is not None and not self._in_flight.done():
+                raise TranslationBusyError()
+            if self._executor is None:
+                self._executor = ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="easyuse-anima-translation",
+                )
+            future = self._executor.submit(function, *args)
+            self._in_flight = future
+        future.add_done_callback(self._release)
+        return future
+
+    def _release(self, future: Future) -> None:
+        with self._lock:
+            if self._in_flight is future:
+                self._in_flight = None
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            executor = self._executor
+            self._executor = None
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+
+
+_PROMPT_TRANSLATION_WORKER = _PromptTranslationWorker()
+atexit.register(_PROMPT_TRANSLATION_WORKER.shutdown)
+
+
 def _translate_prompt_sync(text: str) -> str:
     return translate_prompt_markers(text, resolve_prompt_translation_settings())
 
 
 async def _translate_prompt_for_route(text: str) -> str:
+    future = _PROMPT_TRANSLATION_WORKER.submit(_translate_prompt_sync, text)
+    wrapped_future = asyncio.wrap_future(future)
     try:
-        return await asyncio.wait_for(
-            asyncio.to_thread(_translate_prompt_sync, text),
+        done, _pending = await asyncio.wait(
+            (wrapped_future,),
             timeout=PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS,
         )
     except asyncio.CancelledError as exc:
-        # asyncio cannot stop a synchronous worker thread. Cancellation stops
-        # waiting immediately and is mapped by this route; the underlying sync
-        # provider call may still finish in the executor.
+        # Waiting stops immediately, while admission remains occupied until the
+        # bounded sync worker really exits.
+        wrapped_future.cancel()
         raise TranslationCancelledError() from exc
-    except asyncio.TimeoutError as exc:
-        raise TranslationTimeoutError() from exc
+    if not done:
+        wrapped_future.cancel()
+        raise TranslationTimeoutError()
+    return wrapped_future.result()
 
 
 def _prompt_translation_error_response(exc: PromptTranslationError):
@@ -723,8 +780,6 @@ if web is not None and routes is not None:
             translated = await _translate_prompt_for_route(str(data.get("text") or ""))
         except PromptTranslationError as exc:
             return _prompt_translation_error_response(exc)
-        except Exception:
-            return _prompt_translation_error_response(TranslationUpstreamError())
         return web.json_response({"status": "ok", "text": translated})
 
     @routes.get("/easyuse_anima/lora_preview")

--- a/api.py
+++ b/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
@@ -29,7 +30,13 @@ from .autocomplete_dataset import (
     search_autocomplete,
 )
 from .wildcard_engine import list_wildcards, resolve_wildcard_roots
-from .prompt_translation import translate_prompt_markers
+from .prompt_translation import (
+    PromptTranslationError,
+    TranslationCancelledError,
+    TranslationTimeoutError,
+    TranslationUpstreamError,
+    translate_prompt_markers,
+)
 try:
     from .storage import AtomicJsonStore, USER_DATA_DIR
 except ImportError:
@@ -69,6 +76,37 @@ WINDOWS_RESERVED_FILE_BASENAMES = {
     *(f"com{index}" for index in ("¹", "²", "³")),
     *(f"lpt{index}" for index in ("¹", "²", "³")),
 }
+PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS = 15.0
+
+
+def _translate_prompt_sync(text: str) -> str:
+    return translate_prompt_markers(text, resolve_prompt_translation_settings())
+
+
+async def _translate_prompt_for_route(text: str) -> str:
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(_translate_prompt_sync, text),
+            timeout=PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS,
+        )
+    except asyncio.CancelledError as exc:
+        # asyncio cannot stop a synchronous worker thread. Cancellation stops
+        # waiting immediately and is mapped by this route; the underlying sync
+        # provider call may still finish in the executor.
+        raise TranslationCancelledError() from exc
+    except asyncio.TimeoutError as exc:
+        raise TranslationTimeoutError() from exc
+
+
+def _prompt_translation_error_response(exc: PromptTranslationError):
+    return web.json_response(
+        {
+            "status": "error",
+            "code": exc.code,
+            "message": exc.message,
+        },
+        status=exc.status,
+    )
 
 
 def _parse_json_boolean(data: dict, key: str, *, default: bool = False) -> bool:
@@ -682,12 +720,11 @@ if web is not None and routes is not None:
     async def translate_prompt_handler(request):
         data = await request.json()
         try:
-            translated = translate_prompt_markers(
-                str(data.get("text") or ""),
-                resolve_prompt_translation_settings(),
-            )
-        except RuntimeError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=400)
+            translated = await _translate_prompt_for_route(str(data.get("text") or ""))
+        except PromptTranslationError as exc:
+            return _prompt_translation_error_response(exc)
+        except Exception:
+            return _prompt_translation_error_response(TranslationUpstreamError())
         return web.json_response({"status": "ok", "text": translated})
 
     @routes.get("/easyuse_anima/lora_preview")

--- a/prompt_translation.py
+++ b/prompt_translation.py
@@ -4,6 +4,7 @@ import html
 import threading
 import time
 from collections import OrderedDict
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Callable, Protocol
 
@@ -23,6 +24,7 @@ MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS = 1024
 MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS = 4096
 PROMPT_TRANSLATION_CACHE_MAX_ENTRIES = 256
 PROMPT_TRANSLATION_CACHE_TTL_SECONDS = 300.0
+PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS = 10.0
 
 
 @dataclass(frozen=True)
@@ -74,6 +76,12 @@ class TranslationCancelledError(PromptTranslationError):
     code = "translation_cancelled"
     status = 499
     default_message = "The translation request was cancelled."
+
+
+class TranslationBusyError(PromptTranslationError):
+    code = "translation_busy"
+    status = 503
+    default_message = "A prompt translation request is already in progress."
 
 
 class TranslationUpstreamError(PromptTranslationError):
@@ -144,8 +152,14 @@ def _looks_like_timeout(exc: Exception) -> bool:
 class GoogleTranslationProvider:
     """Lazy, reusable wrapper around the optional googletrans-py client."""
 
-    def __init__(self, translator_factory: Callable[[], object] | None = None):
+    def __init__(
+        self,
+        translator_factory: Callable[[], object] | None = None,
+        *,
+        timeout_seconds: float = PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
+    ):
         self._translator_factory = translator_factory
+        self._timeout_seconds = max(0.001, float(timeout_seconds))
         self._translator = None
         self._lock = threading.RLock()
 
@@ -156,7 +170,8 @@ class GoogleTranslationProvider:
             from googletrans import Translator  # type: ignore
         except ImportError as exc:
             raise TranslationProviderUnavailableError() from exc
-        return Translator()
+        # googletrans-py forwards this value to its httpx.Client transport.
+        return Translator(timeout=self._timeout_seconds)
 
     def translate(self, text: str, source: str, target: str) -> str:
         value = str(text or "")
@@ -235,6 +250,12 @@ _CACHE_MISS = object()
 TranslationCacheKey = tuple[str, str, str, str]
 
 
+@dataclass
+class _TranslationFlight:
+    lock: threading.Lock
+    users: int = 0
+
+
 class BoundedTranslationCache:
     def __init__(
         self,
@@ -291,7 +312,25 @@ class PromptTranslationService:
         self.max_markers = max(1, int(max_markers))
         self.max_marker_characters = max(1, int(max_marker_characters))
         self.max_total_characters = max(1, int(max_total_characters))
-        self._translation_lock = threading.RLock()
+        self._flights: dict[TranslationCacheKey, _TranslationFlight] = {}
+        self._flights_lock = threading.RLock()
+
+    @contextmanager
+    def _single_flight(self, key: TranslationCacheKey):
+        with self._flights_lock:
+            flight = self._flights.get(key)
+            if flight is None:
+                flight = _TranslationFlight(lock=threading.Lock())
+                self._flights[key] = flight
+            flight.users += 1
+        try:
+            with flight.lock:
+                yield
+        finally:
+            with self._flights_lock:
+                flight.users -= 1
+                if flight.users == 0 and self._flights.get(key) is flight:
+                    self._flights.pop(key, None)
 
     def _validate_markers(self, markers: list[tuple[int, int, str]]) -> None:
         if len(markers) > self.max_markers:
@@ -313,7 +352,10 @@ class PromptTranslationService:
 
     def _translate_cached(self, text: str, settings: PromptTranslationSettings) -> str:
         key = (settings.provider, settings.source, settings.target, text)
-        with self._translation_lock:
+        cached = self.cache.get(key)
+        if cached is not _CACHE_MISS:
+            return str(cached)
+        with self._single_flight(key):
             cached = self.cache.get(key)
             if cached is not _CACHE_MISS:
                 return str(cached)

--- a/prompt_translation.py
+++ b/prompt_translation.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import html
+import threading
+import time
+from collections import OrderedDict
 from dataclasses import dataclass
+from typing import Callable, Protocol
 
 
 PROMPT_TRANSLATION_PROVIDER_OFF = "off"
@@ -14,6 +18,12 @@ DEFAULT_PROMPT_TRANSLATION_SOURCE = "auto"
 DEFAULT_PROMPT_TRANSLATION_TARGET = "en"
 PROMPT_TRANSLATION_MARKER_LABEL = "translation"
 
+MAX_PROMPT_TRANSLATION_MARKERS = 64
+MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS = 1024
+MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS = 4096
+PROMPT_TRANSLATION_CACHE_MAX_ENTRIES = 256
+PROMPT_TRANSLATION_CACHE_TTL_SECONDS = 300.0
+
 
 @dataclass(frozen=True)
 class PromptTranslationSettings:
@@ -22,9 +32,59 @@ class PromptTranslationSettings:
     target: str = DEFAULT_PROMPT_TRANSLATION_TARGET
 
 
-class _TranslationResult:
-    def __init__(self, text: str = ""):
-        self.text = text
+class PromptTranslationError(RuntimeError):
+    code = "translation_error"
+    status = 500
+    default_message = "Prompt translation failed."
+
+    def __init__(self, message: str | None = None):
+        super().__init__(message or self.default_message)
+        self.message = message or self.default_message
+
+
+class PromptTranslationLimitError(PromptTranslationError):
+    status = 413
+
+
+class TranslationMarkerCountError(PromptTranslationLimitError):
+    code = "translation_marker_count_exceeded"
+
+
+class TranslationMarkerSizeError(PromptTranslationLimitError):
+    code = "translation_marker_too_long"
+
+
+class TranslationTotalSizeError(PromptTranslationLimitError):
+    code = "translation_marker_characters_exceeded"
+
+
+class TranslationProviderUnavailableError(PromptTranslationError):
+    code = "translation_provider_unavailable"
+    status = 503
+    default_message = "The selected translation provider is unavailable."
+
+
+class TranslationTimeoutError(PromptTranslationError):
+    code = "translation_timeout"
+    status = 504
+    default_message = "The translation provider timed out."
+
+
+class TranslationCancelledError(PromptTranslationError):
+    code = "translation_cancelled"
+    status = 499
+    default_message = "The translation request was cancelled."
+
+
+class TranslationUpstreamError(PromptTranslationError):
+    code = "translation_upstream_error"
+    status = 502
+    default_message = "The translation provider request failed."
+
+
+class TranslationProvider(Protocol):
+    def translate(self, text: str, source: str, target: str) -> str:
+        """Translate one marker value and return plain text."""
 
 
 def normalize_prompt_translation_provider(value) -> str:
@@ -75,22 +135,77 @@ def has_prompt_translation_markers(text: str) -> bool:
     return next(iter_prompt_translation_markers(text), None) is not None
 
 
-def strip_prompt_translation_markers(text: str) -> str:
-    return translate_prompt_markers(
-        text,
-        PromptTranslationSettings(provider=PROMPT_TRANSLATION_PROVIDER_OFF),
-    )
+def _looks_like_timeout(exc: Exception) -> bool:
+    if isinstance(exc, TimeoutError):
+        return True
+    return any("timeout" in cls.__name__.lower() for cls in type(exc).__mro__)
 
 
-def _google_translate_with_googletrans(text: str, source: str, target: str) -> _TranslationResult:
-    try:
-        from googletrans import Translator  # type: ignore
-    except ImportError as exc:
-        raise RuntimeError(
-            "Google prompt translation requires googletrans-py and explicit Google provider selection."
-        ) from exc
-    translated = Translator().translate(text, src=source or "auto", dest=target or "en")
-    return _TranslationResult(html.unescape(str(getattr(translated, "text", "") or "")))
+class GoogleTranslationProvider:
+    """Lazy, reusable wrapper around the optional googletrans-py client."""
+
+    def __init__(self, translator_factory: Callable[[], object] | None = None):
+        self._translator_factory = translator_factory
+        self._translator = None
+        self._lock = threading.RLock()
+
+    def _create_translator(self):
+        if self._translator_factory is not None:
+            return self._translator_factory()
+        try:
+            from googletrans import Translator  # type: ignore
+        except ImportError as exc:
+            raise TranslationProviderUnavailableError() from exc
+        return Translator()
+
+    def translate(self, text: str, source: str, target: str) -> str:
+        value = str(text or "")
+        if not value.strip():
+            return value
+        try:
+            with self._lock:
+                if self._translator is None:
+                    self._translator = self._create_translator()
+                translated = self._translator.translate(
+                    value,
+                    src=source or DEFAULT_PROMPT_TRANSLATION_SOURCE,
+                    dest=target or DEFAULT_PROMPT_TRANSLATION_TARGET,
+                )
+        except PromptTranslationError:
+            raise
+        except ImportError as exc:
+            raise TranslationProviderUnavailableError() from exc
+        except Exception as exc:
+            if _looks_like_timeout(exc):
+                raise TranslationTimeoutError() from exc
+            raise TranslationUpstreamError() from exc
+        return html.unescape(str(getattr(translated, "text", "") or ""))
+
+
+_TRANSLATION_PROVIDER_FACTORIES: dict[str, Callable[[], TranslationProvider]] = {
+    PROMPT_TRANSLATION_PROVIDER_GOOGLE: GoogleTranslationProvider,
+}
+_TRANSLATION_PROVIDER_INSTANCES: dict[str, TranslationProvider] = {}
+_TRANSLATION_PROVIDER_LOCK = threading.RLock()
+
+
+def get_translation_provider(provider: str) -> TranslationProvider:
+    name = str(provider or "").strip().lower()
+    with _TRANSLATION_PROVIDER_LOCK:
+        instance = _TRANSLATION_PROVIDER_INSTANCES.get(name)
+        if instance is not None:
+            return instance
+        factory = _TRANSLATION_PROVIDER_FACTORIES.get(name)
+        if factory is None:
+            raise TranslationProviderUnavailableError()
+        try:
+            instance = factory()
+        except PromptTranslationError:
+            raise
+        except Exception as exc:
+            raise TranslationProviderUnavailableError() from exc
+        _TRANSLATION_PROVIDER_INSTANCES[name] = instance
+        return instance
 
 
 def google_translate_text(text: str, source: str = "auto", target: str = "en") -> str:
@@ -99,11 +214,13 @@ def google_translate_text(text: str, source: str = "auto", target: str = "en") -
         return value
     source = normalize_prompt_translation_language(source, DEFAULT_PROMPT_TRANSLATION_SOURCE)
     target = normalize_prompt_translation_language(target, DEFAULT_PROMPT_TRANSLATION_TARGET)
-    # External translation is opt-in through the prompt translation provider
-    # setting. No API keys are read from environment variables and no response is
-    # executed as code.
-    result = _google_translate_with_googletrans(value, source, target)
-    return result.text
+    # External translation is opt-in through the provider setting. The optional
+    # dependency is imported only after this function is reached.
+    return get_translation_provider(PROMPT_TRANSLATION_PROVIDER_GOOGLE).translate(
+        value,
+        source,
+        target,
+    )
 
 
 def _translate_segment(segment: str, settings: PromptTranslationSettings) -> str:
@@ -114,23 +231,151 @@ def _translate_segment(segment: str, settings: PromptTranslationSettings) -> str
     return str(segment or "")
 
 
-def translate_prompt_markers(text: str, settings: PromptTranslationSettings | None = None) -> str:
-    value = str(text or "")
-    markers = list(iter_prompt_translation_markers(value))
-    if not markers:
-        return value
-    settings = settings or PromptTranslationSettings()
-    settings = PromptTranslationSettings(
-        provider=normalize_prompt_translation_provider(settings.provider),
-        source=normalize_prompt_translation_language(settings.source, DEFAULT_PROMPT_TRANSLATION_SOURCE),
-        target=normalize_prompt_translation_language(settings.target, DEFAULT_PROMPT_TRANSLATION_TARGET),
+_CACHE_MISS = object()
+TranslationCacheKey = tuple[str, str, str, str]
+
+
+class BoundedTranslationCache:
+    def __init__(
+        self,
+        max_entries: int = PROMPT_TRANSLATION_CACHE_MAX_ENTRIES,
+        ttl_seconds: float = PROMPT_TRANSLATION_CACHE_TTL_SECONDS,
+        time_func: Callable[[], float] = time.monotonic,
+    ):
+        self.max_entries = max(0, int(max_entries))
+        self.ttl_seconds = max(0.0, float(ttl_seconds))
+        self._time_func = time_func
+        self._entries: OrderedDict[TranslationCacheKey, tuple[float, str]] = OrderedDict()
+        self._lock = threading.RLock()
+
+    def get(self, key: TranslationCacheKey):
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return _CACHE_MISS
+            expires_at, value = entry
+            if expires_at <= self._time_func():
+                self._entries.pop(key, None)
+                return _CACHE_MISS
+            self._entries.move_to_end(key)
+            return value
+
+    def put(self, key: TranslationCacheKey, value: str) -> None:
+        if self.max_entries == 0 or self.ttl_seconds == 0:
+            return
+        with self._lock:
+            self._entries[key] = (self._time_func() + self.ttl_seconds, str(value))
+            self._entries.move_to_end(key)
+            while len(self._entries) > self.max_entries:
+                self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+class PromptTranslationService:
+    def __init__(
+        self,
+        *,
+        cache: BoundedTranslationCache | None = None,
+        max_markers: int = MAX_PROMPT_TRANSLATION_MARKERS,
+        max_marker_characters: int = MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS,
+        max_total_characters: int = MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS,
+    ):
+        self.cache = cache if cache is not None else BoundedTranslationCache()
+        self.max_markers = max(1, int(max_markers))
+        self.max_marker_characters = max(1, int(max_marker_characters))
+        self.max_total_characters = max(1, int(max_total_characters))
+        self._translation_lock = threading.RLock()
+
+    def _validate_markers(self, markers: list[tuple[int, int, str]]) -> None:
+        if len(markers) > self.max_markers:
+            raise TranslationMarkerCountError(
+                f"Prompt translation supports at most {self.max_markers} markers per request."
+            )
+        for _start, _end, segment in markers:
+            if len(segment) > self.max_marker_characters:
+                raise TranslationMarkerSizeError(
+                    "Prompt translation supports at most "
+                    f"{self.max_marker_characters} characters in one marker."
+                )
+        total_characters = sum(len(segment) for _start, _end, segment in markers)
+        if total_characters > self.max_total_characters:
+            raise TranslationTotalSizeError(
+                "Prompt translation supports at most "
+                f"{self.max_total_characters} marker characters per request."
+            )
+
+    def _translate_cached(self, text: str, settings: PromptTranslationSettings) -> str:
+        key = (settings.provider, settings.source, settings.target, text)
+        with self._translation_lock:
+            cached = self.cache.get(key)
+            if cached is not _CACHE_MISS:
+                return str(cached)
+            translated = _translate_segment(text, settings)
+            self.cache.put(key, translated)
+            return translated
+
+    def translate_prompt(
+        self,
+        text: str,
+        settings: PromptTranslationSettings | None = None,
+    ) -> str:
+        value = str(text or "")
+        markers = list(iter_prompt_translation_markers(value))
+        if not markers:
+            return value
+        settings = settings or PromptTranslationSettings()
+        settings = PromptTranslationSettings(
+            provider=normalize_prompt_translation_provider(settings.provider),
+            source=normalize_prompt_translation_language(
+                settings.source,
+                DEFAULT_PROMPT_TRANSLATION_SOURCE,
+            ),
+            target=normalize_prompt_translation_language(
+                settings.target,
+                DEFAULT_PROMPT_TRANSLATION_TARGET,
+            ),
+        )
+
+        if settings.provider == PROMPT_TRANSLATION_PROVIDER_OFF:
+            translated_segments = {segment.strip(): segment.strip() for _, _, segment in markers}
+        else:
+            self._validate_markers(markers)
+            translated_segments: dict[str, str] = {}
+            for _start, _end, segment in markers:
+                marker_text = segment.strip()
+                if marker_text not in translated_segments:
+                    translated_segments[marker_text] = (
+                        self._translate_cached(marker_text, settings) if marker_text else ""
+                    )
+
+        output: list[str] = []
+        cursor = 0
+        for start, end, segment in markers:
+            output.append(value[cursor:start])
+            output.append(translated_segments[segment.strip()])
+            cursor = end
+        output.append(value[cursor:])
+        return "".join(output)
+
+
+_DEFAULT_TRANSLATION_SERVICE = PromptTranslationService()
+
+
+def strip_prompt_translation_markers(text: str) -> str:
+    return translate_prompt_markers(
+        text,
+        PromptTranslationSettings(provider=PROMPT_TRANSLATION_PROVIDER_OFF),
     )
 
-    output: list[str] = []
-    cursor = 0
-    for start, end, segment in markers:
-        output.append(value[cursor:start])
-        output.append(_translate_segment(segment.strip(), settings))
-        cursor = end
-    output.append(value[cursor:])
-    return "".join(output)
+
+def translate_prompt_markers(text: str, settings: PromptTranslationSettings | None = None) -> str:
+    """Compatibility facade used by synchronous ComfyUI node execution."""
+
+    return _DEFAULT_TRANSLATION_SERVICE.translate_prompt(text, settings)

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -52,6 +52,27 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class SettingsFrontendTests(unittest.TestCase):
+    def test_prompt_translation_setting_discloses_external_marker_text_transfer(self):
+        entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
+        definitions_source = SETTINGS_DEFINITIONS.read_text(encoding="utf-8")
+
+        for notice in (
+            "the text inside each %{...} marker is sent to Google's external translation service",
+            "각 %{...} 마커 안의 텍스트가 Google 외부 번역 서비스로 전송됩니다",
+            "各 %{...} マーカー内のテキストが Google の外部翻訳サービスへ送信されます",
+            "每个 %{...} 标记内的文本都会发送到 Google 外部翻译服务",
+        ):
+            with self.subTest(notice=notice):
+                self.assertIn(notice, entry_source)
+
+        provider_start = definitions_source.index(
+            'id: "EasyUseAnima.Prompt.TranslationProvider"'
+        )
+        provider_end = definitions_source.index("}),", provider_start)
+        provider_definition = definitions_source[provider_start:provider_end]
+        self.assertIn('defaultValue: "off"', provider_definition)
+        self.assertIn('options: ["off", "google"]', provider_definition)
+
     def test_editor_smokes_share_fake_dom_harness(self):
         harness_source = SETTINGS_FAKE_DOM_HARNESS.read_text(encoding="utf-8")
 

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -142,6 +142,46 @@ class PromptCorrectorTests(unittest.TestCase):
         self.assertNotIn("GOOGLE_TRANSLATION_API_KEY", source)
         self.assertNotIn("requests.post", source)
 
+    def test_sync_node_output_and_translation_change_key_contracts_are_preserved(self):
+        off_settings = PromptTranslationSettings(
+            provider=PROMPT_TRANSLATION_PROVIDER_OFF,
+            source="auto",
+            target="en",
+        )
+        google_settings = PromptTranslationSettings(
+            provider=PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+            source="ko",
+            target="ja",
+        )
+
+        with patch("nodes.resolve_prompt_translation_settings", return_value=off_settings):
+            result = EasyUseAnimaPromptCorrectorSimple().correct("%{long_hair, 1girl}")
+            off_key = EasyUseAnimaPromptCorrectorSimple.IS_CHANGED(
+                prompt="%{long_hair, 1girl}"
+            )
+            repeated_off_key = EasyUseAnimaPromptCorrectorSimple.IS_CHANGED(
+                prompt="%{long_hair, 1girl}"
+            )
+
+        with patch("nodes.resolve_prompt_translation_settings", return_value=google_settings):
+            google_key = EasyUseAnimaPromptCorrectorSimple.IS_CHANGED(
+                prompt="%{long_hair, 1girl}"
+            )
+
+        self.assertEqual(result, ("1girl, long hair",))
+        self.assertEqual(EasyUseAnimaPromptCorrectorSimple.RETURN_TYPES, ("STRING",))
+        self.assertEqual(EasyUseAnimaPromptCorrectorSimple.RETURN_NAMES, ("prompt",))
+        self.assertEqual(off_key, repeated_off_key)
+        self.assertNotEqual(off_key, google_key)
+        self.assertEqual(
+            json.loads(off_key)["prompt_translation"],
+            {"provider": "off", "source": "auto", "target": "en"},
+        )
+        self.assertEqual(
+            json.loads(google_key)["prompt_translation"],
+            {"provider": "google", "source": "ko", "target": "ja"},
+        )
+
     def test_prompt_correctors_translate_marked_text_before_correction(self):
         with (
             patch(

--- a/tests/test_prompt_translation.py
+++ b/tests/test_prompt_translation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import builtins
+import sys
+import threading
 import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
@@ -9,6 +11,7 @@ from unittest.mock import patch
 
 from prompt_translation import (
     PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+    PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS,
     BoundedTranslationCache,
     GoogleTranslationProvider,
     PromptTranslationService,
@@ -98,6 +101,25 @@ class PromptTranslationServiceTests(unittest.TestCase):
             translate_calls,
             [("하나", "ko", "en"), ("둘", "ko", "ja")],
         )
+
+    def test_google_provider_passes_timeout_to_real_client_constructor(self):
+        received_timeouts = []
+
+        class Translator:
+            def __init__(self, *, timeout):
+                received_timeouts.append(timeout)
+
+            def translate(self, text, *, src, dest):
+                return SimpleNamespace(text=f"{src}:{dest}:{text}")
+
+        fake_googletrans = SimpleNamespace(Translator=Translator)
+        with patch.dict(sys.modules, {"googletrans": fake_googletrans}):
+            provider = GoogleTranslationProvider(timeout_seconds=2.5)
+            result = provider.translate("text", "auto", "en")
+
+        self.assertEqual(result, "auto:en:text")
+        self.assertEqual(received_timeouts, [2.5])
+        self.assertGreater(PROMPT_TRANSLATION_PROVIDER_TIMEOUT_SECONDS, 0)
 
     def test_provider_factory_reuses_one_provider_instance(self):
         provider = GoogleTranslationProvider(translator_factory=lambda: object())
@@ -206,6 +228,30 @@ class PromptTranslationServiceTests(unittest.TestCase):
         self.assertEqual(results, ["shared"] * 16)
         provider.assert_called_once_with("same", "ko", "en")
 
+    def test_different_cache_keys_do_not_share_a_service_wide_cache_lock(self):
+        service = PromptTranslationService(
+            cache=BoundedTranslationCache(max_entries=8, ttl_seconds=60)
+        )
+        both_providers_started = threading.Barrier(2)
+
+        def translate(text, source, target):
+            both_providers_started.wait(timeout=1)
+            return text.upper()
+
+        with patch(
+            "prompt_translation.google_translate_text",
+            side_effect=translate,
+        ):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(
+                    executor.map(
+                        lambda text: service.translate_prompt(f"%{{{text}}}", GOOGLE_SETTINGS),
+                        ("first", "second"),
+                    )
+                )
+
+        self.assertEqual(results, ["FIRST", "SECOND"])
+
     def test_all_marker_budgets_fail_before_provider_call(self):
         service = PromptTranslationService(
             max_markers=2,
@@ -236,7 +282,7 @@ class GoogleTranslationProviderErrorTests(unittest.TestCase):
             provider.translate("text", "auto", "en")
         self.assertEqual(raised.exception.code, "translation_provider_unavailable")
 
-    def test_timeout_and_arbitrary_upstream_errors_are_normalized(self):
+    def test_provider_boundary_normalizes_timeout_and_arbitrary_upstream_errors(self):
         class TimeoutTranslator:
             def translate(self, *_args, **_kwargs):
                 raise TimeoutError("slow")

--- a/tests/test_prompt_translation.py
+++ b/tests/test_prompt_translation.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import builtins
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from prompt_translation import (
+    PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+    BoundedTranslationCache,
+    GoogleTranslationProvider,
+    PromptTranslationService,
+    PromptTranslationSettings,
+    TranslationMarkerCountError,
+    TranslationMarkerSizeError,
+    TranslationProviderUnavailableError,
+    TranslationTimeoutError,
+    TranslationTotalSizeError,
+    TranslationUpstreamError,
+    _TRANSLATION_PROVIDER_FACTORIES,
+    _TRANSLATION_PROVIDER_INSTANCES,
+    get_translation_provider,
+)
+
+
+GOOGLE_SETTINGS = PromptTranslationSettings(
+    provider=PROMPT_TRANSLATION_PROVIDER_GOOGLE,
+    source="ko",
+    target="en",
+)
+
+
+class PromptTranslationServiceTests(unittest.TestCase):
+    def test_repeated_identical_markers_call_provider_once_and_replace_every_position(self):
+        service = PromptTranslationService(
+            cache=BoundedTranslationCache(max_entries=8, ttl_seconds=60)
+        )
+
+        with patch(
+            "prompt_translation.google_translate_text",
+            return_value="girl with red hair",
+        ) as provider:
+            translated = service.translate_prompt(
+                "%{빨간 머리의 소녀}, %{빨간 머리의 소녀}, %{ 빨간 머리의 소녀 }",
+                GOOGLE_SETTINGS,
+            )
+
+        self.assertEqual(
+            translated,
+            "girl with red hair, girl with red hair, girl with red hair",
+        )
+        provider.assert_called_once_with("빨간 머리의 소녀", "ko", "en")
+
+    def test_off_mode_preserves_unwrap_and_literal_marker_without_import_or_provider(self):
+        service = PromptTranslationService()
+        real_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name == "googletrans" or name.startswith("googletrans."):
+                self.fail("off mode must not import googletrans")
+            return real_import(name, *args, **kwargs)
+
+        with (
+            patch("builtins.__import__", side_effect=guarded_import),
+            patch("prompt_translation.get_translation_provider") as provider_factory,
+        ):
+            translated = service.translate_prompt(
+                r"1girl, %{검은 드레스}, \%{literal}",
+                PromptTranslationSettings(),
+            )
+
+        self.assertEqual(translated, r"1girl, 검은 드레스, \%{literal}")
+        provider_factory.assert_not_called()
+
+    def test_google_provider_lazily_creates_and_reuses_one_client(self):
+        factory_calls = []
+        translate_calls = []
+
+        class Translator:
+            def translate(self, text, *, src, dest):
+                translate_calls.append((text, src, dest))
+                return SimpleNamespace(text=f"{text}:{dest}")
+
+        def factory():
+            factory_calls.append(True)
+            return Translator()
+
+        provider = GoogleTranslationProvider(translator_factory=factory)
+        self.assertEqual(factory_calls, [])
+
+        self.assertEqual(provider.translate("하나", "ko", "en"), "하나:en")
+        self.assertEqual(provider.translate("둘", "ko", "ja"), "둘:ja")
+
+        self.assertEqual(len(factory_calls), 1)
+        self.assertEqual(
+            translate_calls,
+            [("하나", "ko", "en"), ("둘", "ko", "ja")],
+        )
+
+    def test_provider_factory_reuses_one_provider_instance(self):
+        provider = GoogleTranslationProvider(translator_factory=lambda: object())
+        factory_calls = []
+
+        def factory():
+            factory_calls.append(True)
+            return provider
+
+        with (
+            patch.dict(_TRANSLATION_PROVIDER_INSTANCES, {}, clear=True),
+            patch.dict(
+                _TRANSLATION_PROVIDER_FACTORIES,
+                {PROMPT_TRANSLATION_PROVIDER_GOOGLE: factory},
+                clear=True,
+            ),
+        ):
+            first = get_translation_provider(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
+            second = get_translation_provider(PROMPT_TRANSLATION_PROVIDER_GOOGLE)
+
+        self.assertIs(first, provider)
+        self.assertIs(second, provider)
+        self.assertEqual(len(factory_calls), 1)
+
+    def test_cache_hit_ttl_expiry_and_lru_bound_are_deterministic(self):
+        now = [0.0]
+        lru_cache = BoundedTranslationCache(
+            max_entries=2,
+            ttl_seconds=10,
+            time_func=lambda: now[0],
+        )
+        lru_service = PromptTranslationService(cache=lru_cache)
+
+        with patch(
+            "prompt_translation.google_translate_text",
+            side_effect=lambda text, source, target: text.upper(),
+        ) as provider:
+            self.assertEqual(lru_service.translate_prompt("%{a}", GOOGLE_SETTINGS), "A")
+            self.assertEqual(lru_service.translate_prompt("%{b}", GOOGLE_SETTINGS), "B")
+            self.assertEqual(lru_service.translate_prompt("%{a}", GOOGLE_SETTINGS), "A")
+            self.assertEqual(lru_service.translate_prompt("%{c}", GOOGLE_SETTINGS), "C")
+            self.assertEqual(len(lru_cache), 2)
+            self.assertEqual(lru_service.translate_prompt("%{b}", GOOGLE_SETTINGS), "B")
+            self.assertEqual(provider.call_count, 4)
+
+        ttl_cache = BoundedTranslationCache(
+            max_entries=2,
+            ttl_seconds=5,
+            time_func=lambda: now[0],
+        )
+        ttl_service = PromptTranslationService(cache=ttl_cache)
+        now[0] = 0.0
+        with patch(
+            "prompt_translation.google_translate_text",
+            return_value="cached",
+        ) as provider:
+            ttl_service.translate_prompt("%{ttl}", GOOGLE_SETTINGS)
+            now[0] = 4.0
+            ttl_service.translate_prompt("%{ttl}", GOOGLE_SETTINGS)
+            now[0] = 5.0
+            ttl_service.translate_prompt("%{ttl}", GOOGLE_SETTINGS)
+            self.assertEqual(provider.call_count, 2)
+
+    def test_cache_key_partitions_source_target_and_text(self):
+        service = PromptTranslationService(
+            cache=BoundedTranslationCache(max_entries=8, ttl_seconds=60)
+        )
+        settings = (
+            GOOGLE_SETTINGS,
+            PromptTranslationSettings(provider="google", source="auto", target="en"),
+            PromptTranslationSettings(provider="google", source="ko", target="ja"),
+        )
+
+        with patch(
+            "prompt_translation.google_translate_text",
+            side_effect=lambda text, source, target: f"{source}:{target}:{text}",
+        ) as provider:
+            for item in settings:
+                service.translate_prompt("%{same}", item)
+            service.translate_prompt("%{different}", GOOGLE_SETTINGS)
+            service.translate_prompt("%{same}", GOOGLE_SETTINGS)
+
+        self.assertEqual(provider.call_count, 4)
+
+    def test_cache_and_request_dedup_are_thread_safe(self):
+        service = PromptTranslationService(
+            cache=BoundedTranslationCache(max_entries=8, ttl_seconds=60)
+        )
+
+        def translate(text, source, target):
+            time.sleep(0.01)
+            return "shared"
+
+        with patch(
+            "prompt_translation.google_translate_text",
+            side_effect=translate,
+        ) as provider:
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                results = list(
+                    executor.map(
+                        lambda _index: service.translate_prompt("%{same}", GOOGLE_SETTINGS),
+                        range(16),
+                    )
+                )
+
+        self.assertEqual(results, ["shared"] * 16)
+        provider.assert_called_once_with("same", "ko", "en")
+
+    def test_all_marker_budgets_fail_before_provider_call(self):
+        service = PromptTranslationService(
+            max_markers=2,
+            max_marker_characters=4,
+            max_total_characters=6,
+        )
+        cases = (
+            ("%{a}%{b}%{c}", TranslationMarkerCountError),
+            ("%{abcde}", TranslationMarkerSizeError),
+            ("%{abcd}%{abc}", TranslationTotalSizeError),
+        )
+
+        with patch("prompt_translation.google_translate_text") as provider:
+            for text, error_type in cases:
+                with self.subTest(error=error_type.__name__):
+                    with self.assertRaises(error_type):
+                        service.translate_prompt(text, GOOGLE_SETTINGS)
+            provider.assert_not_called()
+
+
+class GoogleTranslationProviderErrorTests(unittest.TestCase):
+    def test_missing_optional_dependency_has_stable_unavailable_error(self):
+        def unavailable():
+            raise ImportError("googletrans is not installed")
+
+        provider = GoogleTranslationProvider(translator_factory=unavailable)
+        with self.assertRaises(TranslationProviderUnavailableError) as raised:
+            provider.translate("text", "auto", "en")
+        self.assertEqual(raised.exception.code, "translation_provider_unavailable")
+
+    def test_timeout_and_arbitrary_upstream_errors_are_normalized(self):
+        class TimeoutTranslator:
+            def translate(self, *_args, **_kwargs):
+                raise TimeoutError("slow")
+
+        class FailedTranslator:
+            def translate(self, *_args, **_kwargs):
+                raise ValueError("provider internals must not leak")
+
+        with self.assertRaises(TranslationTimeoutError) as timeout:
+            GoogleTranslationProvider(lambda: TimeoutTranslator()).translate(
+                "text", "auto", "en"
+            )
+        self.assertEqual(timeout.exception.message, "The translation provider timed out.")
+
+        with self.assertRaises(TranslationUpstreamError) as upstream:
+            GoogleTranslationProvider(lambda: FailedTranslator()).translate(
+                "text", "auto", "en"
+            )
+        self.assertEqual(
+            upstream.exception.message,
+            "The translation provider request failed.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -69,8 +69,13 @@ def load_api_routes():
 
 
 class PromptTranslationApiTests(unittest.TestCase):
-    def test_route_runs_sync_translation_off_event_loop(self):
+    def load_routes(self):
         api, routes, translation = load_api_routes()
+        self.addCleanup(api._PROMPT_TRANSLATION_WORKER.shutdown)
+        return api, routes, translation
+
+    def test_route_runs_sync_translation_off_event_loop(self):
+        api, routes, translation = self.load_routes()
         handler = routes.handlers[ROUTE]
         worker_started = threading.Event()
 
@@ -102,9 +107,49 @@ class PromptTranslationApiTests(unittest.TestCase):
         self.assertEqual(response, {"payload": {"status": "ok", "text": "translated"}, "status": 200})
         self.assertGreaterEqual(heartbeat, 3)
 
-    def test_route_timeout_has_stable_504_json(self):
-        api, routes, translation = load_api_routes()
+    def test_timeout_keeps_bounded_admission_without_using_shared_executor(self):
+        api, routes, translation = self.load_routes()
         handler = routes.handlers[ROUTE]
+        worker_started = threading.Event()
+        release_worker = threading.Event()
+
+        def blocking_translation(*_args):
+            worker_started.set()
+            release_worker.wait(timeout=1)
+            return "late"
+
+        async def exercise():
+            heartbeat = 0
+            stop_heartbeat = False
+
+            async def beat():
+                nonlocal heartbeat
+                while not stop_heartbeat:
+                    heartbeat += 1
+                    await asyncio.sleep(0.001)
+
+            heartbeat_task = asyncio.create_task(beat())
+            try:
+                first_response = await handler(JsonRequest({"text": "%{first}"}))
+                self.assertTrue(worker_started.is_set())
+                self.assertTrue(api._PROMPT_TRANSLATION_WORKER.has_in_flight)
+                repeated_responses = await asyncio.gather(
+                    *(
+                        handler(JsonRequest({"text": f"%{{later-{index}}}"}))
+                        for index in range(20)
+                    )
+                )
+            finally:
+                release_worker.set()
+                deadline = asyncio.get_running_loop().time() + 1
+                while (
+                    api._PROMPT_TRANSLATION_WORKER.has_in_flight
+                    and asyncio.get_running_loop().time() < deadline
+                ):
+                    await asyncio.sleep(0.001)
+                stop_heartbeat = True
+                await heartbeat_task
+            return first_response, repeated_responses, heartbeat
 
         with (
             patch.object(
@@ -116,10 +161,11 @@ class PromptTranslationApiTests(unittest.TestCase):
             patch.object(
                 api,
                 "translate_prompt_markers",
-                side_effect=lambda *_args: (time.sleep(0.05), "late")[1],
-            ),
+                side_effect=blocking_translation,
+            ) as worker,
+            patch.object(api.asyncio, "to_thread") as shared_executor_submit,
         ):
-            response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+            response, repeated_responses, heartbeat = asyncio.run(exercise())
 
         self.assertEqual(
             response,
@@ -132,9 +178,27 @@ class PromptTranslationApiTests(unittest.TestCase):
                 "status": 504,
             },
         )
+        self.assertEqual(worker.call_count, 1)
+        shared_executor_submit.assert_not_called()
+        self.assertGreaterEqual(heartbeat, 3)
+        self.assertFalse(api._PROMPT_TRANSLATION_WORKER.has_in_flight)
+        self.assertEqual(
+            repeated_responses,
+            [
+                {
+                    "payload": {
+                        "status": "error",
+                        "code": "translation_busy",
+                        "message": "A prompt translation request is already in progress.",
+                    },
+                    "status": 503,
+                }
+            ]
+            * 20,
+        )
 
     def test_route_cancellation_stops_waiting_with_stable_499_json(self):
-        api, routes, translation = load_api_routes()
+        api, routes, translation = self.load_routes()
         handler = routes.handlers[ROUTE]
         worker_started = threading.Event()
         release_worker = threading.Event()
@@ -149,9 +213,19 @@ class PromptTranslationApiTests(unittest.TestCase):
             while not worker_started.is_set():
                 await asyncio.sleep(0)
             task.cancel()
-            response = await task
-            release_worker.set()
-            return response
+            try:
+                response = await task
+                self.assertTrue(api._PROMPT_TRANSLATION_WORKER.has_in_flight)
+                busy_response = await handler(JsonRequest({"text": "%{later}"}))
+            finally:
+                release_worker.set()
+                deadline = asyncio.get_running_loop().time() + 1
+                while (
+                    api._PROMPT_TRANSLATION_WORKER.has_in_flight
+                    and asyncio.get_running_loop().time() < deadline
+                ):
+                    await asyncio.sleep(0.001)
+            return response, busy_response
 
         with (
             patch.object(
@@ -161,7 +235,7 @@ class PromptTranslationApiTests(unittest.TestCase):
             ),
             patch.object(api, "translate_prompt_markers", side_effect=blocking_translation),
         ):
-            response = asyncio.run(exercise())
+            response, busy_response = asyncio.run(exercise())
 
         self.assertEqual(
             response,
@@ -174,52 +248,58 @@ class PromptTranslationApiTests(unittest.TestCase):
                 "status": 499,
             },
         )
+        self.assertEqual(busy_response["status"], 503)
+        self.assertEqual(busy_response["payload"]["code"], "translation_busy")
+        self.assertFalse(api._PROMPT_TRANSLATION_WORKER.has_in_flight)
 
-    def test_route_maps_unavailable_and_arbitrary_upstream_failures(self):
-        api, routes, translation = load_api_routes()
+    def test_route_maps_only_prompt_translation_errors(self):
+        api, routes, translation = self.load_routes()
         handler = routes.handlers[ROUTE]
         settings = translation.PromptTranslationSettings(provider="google")
-        cases = (
-            (
-                translation.TranslationProviderUnavailableError(),
-                503,
-                "translation_provider_unavailable",
-                "The selected translation provider is unavailable.",
+        with (
+            patch.object(api, "resolve_prompt_translation_settings", return_value=settings),
+            patch.object(
+                api,
+                "translate_prompt_markers",
+                side_effect=translation.TranslationProviderUnavailableError(),
             ),
-            (
-                ValueError("provider internals must not leak"),
-                502,
-                "translation_upstream_error",
-                "The translation provider request failed.",
-            ),
+        ):
+            response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+
+        self.assertEqual(
+            response,
+            {
+                "payload": {
+                    "status": "error",
+                    "code": "translation_provider_unavailable",
+                    "message": "The selected translation provider is unavailable.",
+                },
+                "status": 503,
+            },
         )
 
-        for error, status, code, message in cases:
-            with self.subTest(code=code):
-                with (
-                    patch.object(
-                        api,
-                        "resolve_prompt_translation_settings",
-                        return_value=settings,
-                    ),
-                    patch.object(api, "translate_prompt_markers", side_effect=error),
-                ):
-                    response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+    def test_route_does_not_mask_settings_or_payload_programming_errors_as_upstream(self):
+        api, routes, _translation = self.load_routes()
+        handler = routes.handlers[ROUTE]
 
-                self.assertEqual(
-                    response,
-                    {
-                        "payload": {
-                            "status": "error",
-                            "code": code,
-                            "message": message,
-                        },
-                        "status": status,
-                    },
-                )
+        for error in (
+            RuntimeError("settings storage failed"),
+            TimeoutError("settings storage timeout"),
+        ):
+            with self.subTest(error=type(error).__name__):
+                with patch.object(
+                    api,
+                    "resolve_prompt_translation_settings",
+                    side_effect=error,
+                ):
+                    with self.assertRaisesRegex(type(error), str(error)):
+                        asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+
+        with self.assertRaises(AttributeError):
+            asyncio.run(handler(JsonRequest([])))
 
     def test_all_marker_budgets_return_413_before_provider_resolution(self):
-        api, routes, translation = load_api_routes()
+        api, routes, translation = self.load_routes()
         handler = routes.handlers[ROUTE]
         settings = translation.PromptTranslationSettings(provider="google")
         cases = (

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_NAME = "easyuse_anima_translation_api_test_package"
+ROUTE = "/easyuse_anima/translate_prompt"
+
+
+class RouteRegistry:
+    def __init__(self):
+        self.handlers = {}
+
+    def get(self, path):
+        def register(handler):
+            self.handlers[path] = handler
+            return handler
+
+        return register
+
+    def post(self, path):
+        return self.get(path)
+
+
+class JsonRequest:
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def json(self):
+        return self.payload
+
+
+def load_api_routes():
+    package = types.ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE_NAME] = package
+
+    routes = RouteRegistry()
+    fake_server = types.ModuleType("server")
+    fake_server.PromptServer = type(
+        "PromptServer",
+        (),
+        {"instance": types.SimpleNamespace(routes=routes)},
+    )
+    fake_aiohttp = types.ModuleType("aiohttp")
+    fake_aiohttp.web = types.SimpleNamespace(
+        json_response=lambda payload, status=200: {"payload": payload, "status": status},
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        f"{PACKAGE_NAME}.api",
+        ROOT / "api.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with patch.dict(sys.modules, {"server": fake_server, "aiohttp": fake_aiohttp}):
+        spec.loader.exec_module(module)
+        translation = sys.modules[module.translate_prompt_markers.__module__]
+    return module, routes, translation
+
+
+class PromptTranslationApiTests(unittest.TestCase):
+    def test_route_runs_sync_translation_off_event_loop(self):
+        api, routes, translation = load_api_routes()
+        handler = routes.handlers[ROUTE]
+        worker_started = threading.Event()
+
+        def slow_translation(text, settings):
+            worker_started.set()
+            time.sleep(0.05)
+            return "translated"
+
+        async def exercise():
+            heartbeat = 0
+            task = asyncio.create_task(handler(JsonRequest({"text": "%{text}"})))
+            while not worker_started.is_set():
+                await asyncio.sleep(0)
+            while not task.done():
+                heartbeat += 1
+                await asyncio.sleep(0.002)
+            return await task, heartbeat
+
+        with (
+            patch.object(
+                api,
+                "resolve_prompt_translation_settings",
+                return_value=translation.PromptTranslationSettings(provider="google"),
+            ),
+            patch.object(api, "translate_prompt_markers", side_effect=slow_translation),
+        ):
+            response, heartbeat = asyncio.run(exercise())
+
+        self.assertEqual(response, {"payload": {"status": "ok", "text": "translated"}, "status": 200})
+        self.assertGreaterEqual(heartbeat, 3)
+
+    def test_route_timeout_has_stable_504_json(self):
+        api, routes, translation = load_api_routes()
+        handler = routes.handlers[ROUTE]
+
+        with (
+            patch.object(
+                api,
+                "resolve_prompt_translation_settings",
+                return_value=translation.PromptTranslationSettings(provider="google"),
+            ),
+            patch.object(api, "PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS", 0.01),
+            patch.object(
+                api,
+                "translate_prompt_markers",
+                side_effect=lambda *_args: (time.sleep(0.05), "late")[1],
+            ),
+        ):
+            response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+
+        self.assertEqual(
+            response,
+            {
+                "payload": {
+                    "status": "error",
+                    "code": "translation_timeout",
+                    "message": "The translation provider timed out.",
+                },
+                "status": 504,
+            },
+        )
+
+    def test_route_cancellation_stops_waiting_with_stable_499_json(self):
+        api, routes, translation = load_api_routes()
+        handler = routes.handlers[ROUTE]
+        worker_started = threading.Event()
+        release_worker = threading.Event()
+
+        def blocking_translation(*_args):
+            worker_started.set()
+            release_worker.wait(timeout=1)
+            return "late"
+
+        async def exercise():
+            task = asyncio.create_task(handler(JsonRequest({"text": "%{text}"})))
+            while not worker_started.is_set():
+                await asyncio.sleep(0)
+            task.cancel()
+            response = await task
+            release_worker.set()
+            return response
+
+        with (
+            patch.object(
+                api,
+                "resolve_prompt_translation_settings",
+                return_value=translation.PromptTranslationSettings(provider="google"),
+            ),
+            patch.object(api, "translate_prompt_markers", side_effect=blocking_translation),
+        ):
+            response = asyncio.run(exercise())
+
+        self.assertEqual(
+            response,
+            {
+                "payload": {
+                    "status": "error",
+                    "code": "translation_cancelled",
+                    "message": "The translation request was cancelled.",
+                },
+                "status": 499,
+            },
+        )
+
+    def test_route_maps_unavailable_and_arbitrary_upstream_failures(self):
+        api, routes, translation = load_api_routes()
+        handler = routes.handlers[ROUTE]
+        settings = translation.PromptTranslationSettings(provider="google")
+        cases = (
+            (
+                translation.TranslationProviderUnavailableError(),
+                503,
+                "translation_provider_unavailable",
+                "The selected translation provider is unavailable.",
+            ),
+            (
+                ValueError("provider internals must not leak"),
+                502,
+                "translation_upstream_error",
+                "The translation provider request failed.",
+            ),
+        )
+
+        for error, status, code, message in cases:
+            with self.subTest(code=code):
+                with (
+                    patch.object(
+                        api,
+                        "resolve_prompt_translation_settings",
+                        return_value=settings,
+                    ),
+                    patch.object(api, "translate_prompt_markers", side_effect=error),
+                ):
+                    response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+
+                self.assertEqual(
+                    response,
+                    {
+                        "payload": {
+                            "status": "error",
+                            "code": code,
+                            "message": message,
+                        },
+                        "status": status,
+                    },
+                )
+
+    def test_all_marker_budgets_return_413_before_provider_resolution(self):
+        api, routes, translation = load_api_routes()
+        handler = routes.handlers[ROUTE]
+        settings = translation.PromptTranslationSettings(provider="google")
+        cases = (
+            (
+                "%{a}" * (translation.MAX_PROMPT_TRANSLATION_MARKERS + 1),
+                "translation_marker_count_exceeded",
+            ),
+            (
+                "%{" + "a" * (translation.MAX_PROMPT_TRANSLATION_MARKER_CHARACTERS + 1) + "}",
+                "translation_marker_too_long",
+            ),
+            (
+                "".join(
+                    "%{" + "a" * 1000 + "}"
+                    for _index in range(
+                        translation.MAX_PROMPT_TRANSLATION_TOTAL_CHARACTERS // 1000 + 1
+                    )
+                ),
+                "translation_marker_characters_exceeded",
+            ),
+        )
+
+        with (
+            patch.object(api, "resolve_prompt_translation_settings", return_value=settings),
+            patch.object(translation, "get_translation_provider") as provider_factory,
+        ):
+            for text, code in cases:
+                with self.subTest(code=code):
+                    response = asyncio.run(handler(JsonRequest({"text": text})))
+                    self.assertEqual(response["status"], 413)
+                    self.assertEqual(response["payload"]["status"], "error")
+                    self.assertEqual(response["payload"]["code"], code)
+            provider_factory.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -68,7 +68,7 @@ const TEXT = {
     promptTranslation: "Prompt translation",
     promptTranslationProvider: "Translation method",
     promptTranslationProviderTip:
-      "Default is OFF. Select Google Translate only when you explicitly want external translation for text wrapped as %{...}.",
+      "Default is OFF. When Google Translate is selected, the text inside each %{...} marker is sent to Google's external translation service.",
     promptTranslationProviderGoogle: "Google Translate",
     promptTranslationProviderOff: "No translation, unwrap only",
     promptTranslationSource: "Source language",
@@ -190,7 +190,7 @@ const TEXT = {
     promptTranslation: "프롬프트 번역",
     promptTranslationProvider: "번역 방식",
     promptTranslationProviderTip:
-      "기본값은 OFF입니다. %{...}로 감싼 텍스트를 외부 번역으로 보낼 때만 Google 번역을 명시적으로 선택하세요.",
+      "기본값은 OFF입니다. Google 번역을 선택하면 각 %{...} 마커 안의 텍스트가 Google 외부 번역 서비스로 전송됩니다.",
     promptTranslationProviderGoogle: "Google 번역",
     promptTranslationProviderOff: "번역 안 함, 구문만 제거",
     promptTranslationSource: "원본 언어",
@@ -312,7 +312,7 @@ const TEXT = {
     promptTranslation: "プロンプト翻訳",
     promptTranslationProvider: "翻訳方式",
     promptTranslationProviderTip:
-      "既定値は OFF です。%{...} で囲んだテキストを外部翻訳へ送る場合だけ Google 翻訳を明示的に選択してください。",
+      "既定値は OFF です。Google 翻訳を選ぶと、各 %{...} マーカー内のテキストが Google の外部翻訳サービスへ送信されます。",
     promptTranslationProviderGoogle: "Google 翻訳",
     promptTranslationProviderOff: "翻訳しない、構文だけ外す",
     promptTranslationSource: "元言語",
@@ -434,7 +434,7 @@ const TEXT = {
     promptTranslation: "提示词翻译",
     promptTranslationProvider: "翻译方式",
     promptTranslationProviderTip:
-      "默认值为 OFF。只有在明确希望把 %{...} 包裹的文本发送到外部翻译时，才选择 Google 翻译。",
+      "默认值为 OFF。选择 Google 翻译后，每个 %{...} 标记内的文本都会发送到 Google 外部翻译服务。",
     promptTranslationProviderGoogle: "Google 翻译",
     promptTranslationProviderOff: "不翻译，仅去除语法",
     promptTranslationSource: "源语言",


### PR DESCRIPTION
## 변경 요약

- `TranslationProvider` interface와 lazy/reusable Google client를 추가했습니다.
- `googletrans-py` client 생성 시 10초 transport timeout을 전달합니다.
- translate route는 shared default executor를 사용하지 않고 큐가 없는 전용 단일 worker를 사용합니다.
- route timeout/cancel 뒤에도 실제 sync future가 끝날 때까지 admission을 유지하며, 후속 요청은 503 / `translation_busy`로 즉시 반환합니다.
- 동일 marker dedup, provider/source/target/text 기준 bounded LRU+TTL cache, 동일 cache key별 single-flight를 적용했습니다.
- marker 수·단일 marker 문자 수·요청당 총 marker 문자 수 상한을 provider 호출 전에 검증합니다.
- 기존 sync node의 `translate_prompt_markers(...)` facade와 output/`IS_CHANGED` 계약을 유지했습니다.
- route는 `PromptTranslationError`만 국소 JSON 계약으로 매핑하며 settings/storage/payload/programming 오류를 502/504로 위장하지 않습니다.
- Google provider 선택 시 `%{...}` 내부 텍스트가 Google 외부 번역 서비스로 전송됨을 settings UI 4개 언어에서 명시했습니다.

Relates to #164

## 주요 파일

- `prompt_translation.py`: provider, transport timeout, lazy client, budget, key별 single-flight, bounded cache
- `api.py`: 전용 bounded worker, timeout/cancellation/admission, route-local 오류 계약
- `web/js/easyuse_anima_settings.js`: 외부 전송 경계 안내
- `tests/test_prompt_translation.py`, `tests/test_prompt_translation_api.py`: provider/cache/budget/비차단/bounded admission/error 회귀
- `tests/test_prompt_corrector.py`, `tests/test_frontend_settings.py`: sync node와 UI 계약 회귀

## 검증

통합 HEAD `455e6f7b561933b13408f2efc340834ccc6259ae`에서 실행했습니다.

- 집중 unittest: translation/API/node/settings/Registry 176 tests, OK
- Python compile: 통과
- `node --check web/js/easyuse_anima_settings.js`: 통과
- 공식 `full` project check:
  - Python unittest 538 tests, OK
  - frontend 110 JavaScript files, TypeScript 6.0.3, 통과
  - Python compile 및 git diff check, 통과
- GitHub checks: 보고된 check 없음

검증 표면: ComfyUI Codex test environment의 module/API mock/frontend semantic smoke. Live ComfyUI API/browser smoke와 실제 Google 외부 호출은 실행하지 않았습니다.

## Packaging 판단

현재 Registry 유지관리 계약은 install dependency를 `pyproject.toml`과 `requirements.txt`에 함께 유지하지만, optional extra가 Registry/Manager 설치에서 보장된다는 근거는 확인되지 않았습니다. 따라서 dependency metadata는 변경하지 않았고 `googletrans-py==4.0.0`은 packaging상 필수 dependency로 유지했습니다. 런타임은 lazy import와 명시적 `translation_provider_unavailable` 경계를 사용합니다.

## 오류 및 취소 계약

- budget 초과: 413 + 세부 code, provider 호출 0회
- active worker admission 거부: 503 / `translation_busy`
- provider unavailable: 503 / `translation_provider_unavailable`
- provider wrapper가 정규화한 upstream failure: 502 / `translation_upstream_error`
- provider/route timeout: 504 / `translation_timeout`
- route waiting cancellation: 499 / `translation_cancelled`
- 그 외 내부 오류: route에서 위장하지 않고 상위 처리 경계로 전파

## 남은 위험 / 미확인

- 실행 중인 sync thread는 강제 종료할 수 없습니다. timeout/cancel 뒤 worker는 실제 sync 요청이 반환될 때까지 최대 1개만 남고, 그동안 후속 route는 `translation_busy`입니다.
- Google transport timeout은 HTTP 작업당 10초입니다. 서로 다른 marker를 순차 처리하는 한 요청은 route의 15초 waiting timeout보다 오래 background에서 실행될 수 있습니다.
- 실제 Google 외부 호출과 live browser/API 검증은 실행하지 않았습니다.
- Registry optional dependency 분리는 별도 정책 확인이 필요합니다.
