### PR TITLE
[Maintenance] PR A-01 Python backend inventory baseline

### DIFF
--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -7336,10 +7336,19 @@
     ],
     "module_graph_policy": {
       "duplicate_policy": "collapse by source and target path",
+      "excluded_branch_contexts": [
+        {
+          "branch": "body",
+          "kind": "if",
+          "type_checking": true
+        }
+      ],
       "included_classifications": [
         "compatibility_fallback",
         "internal"
-      ]
+      ],
+      "scc_node_scope": "runtime_import_closure",
+      "type_checking_policy": "exclude edges nested in if TYPE_CHECKING body from runtime graph, SCC, public surface, and Registry runtime taxonomies"
     },
     "sccs": [
       {

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -1267,6 +1267,23 @@
       },
       {
         "alias": null,
+        "bound_name": "weakref",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "weakref",
+        "kind": "static_import",
+        "line": 9,
+        "name": null,
+        "optional": false,
+        "requested": "weakref",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Future",
         "branch_context": [],
         "classification": "external",
@@ -1274,7 +1291,7 @@
         "conditional": false,
         "imported": "concurrent.futures:Future",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "Future",
         "optional": false,
         "requested": "concurrent.futures",
@@ -1291,7 +1308,7 @@
         "conditional": false,
         "imported": "concurrent.futures:ThreadPoolExecutor",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "ThreadPoolExecutor",
         "optional": false,
         "requested": "concurrent.futures",
@@ -1308,7 +1325,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
@@ -1325,7 +1342,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 12
+            "line": 13
           }
         ],
         "classification": "external",
@@ -1333,7 +1350,7 @@
         "conditional": true,
         "imported": "server",
         "kind": "static_import",
-        "line": 13,
+        "line": 14,
         "name": null,
         "optional": true,
         "requested": "server",
@@ -1350,7 +1367,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 12
+            "line": 13
           }
         ],
         "classification": "external",
@@ -1358,7 +1375,7 @@
         "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "web",
         "optional": true,
         "requested": "aiohttp",
@@ -1375,7 +1392,7 @@
         "conditional": false,
         "imported": ".settings:load_long_text_settings",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "load_long_text_settings",
         "optional": false,
         "requested": ".settings",
@@ -1393,7 +1410,7 @@
         "conditional": false,
         "imported": ".settings:public_settings",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "public_settings",
         "optional": false,
         "requested": ".settings",
@@ -1411,7 +1428,7 @@
         "conditional": false,
         "imported": ".settings:resolve_autocomplete_limit",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "resolve_autocomplete_limit",
         "optional": false,
         "requested": ".settings",
@@ -1429,7 +1446,7 @@
         "conditional": false,
         "imported": ".settings:resolve_autocomplete_source",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": ".settings",
@@ -1447,7 +1464,7 @@
         "conditional": false,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -1465,7 +1482,7 @@
         "conditional": false,
         "imported": ".settings:save_long_text_settings",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "save_long_text_settings",
         "optional": false,
         "requested": ".settings",
@@ -1483,7 +1500,7 @@
         "conditional": false,
         "imported": ".settings:save_setting",
         "kind": "static_from",
-        "line": 19,
+        "line": 20,
         "name": "save_setting",
         "optional": false,
         "requested": ".settings",
@@ -1501,7 +1518,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:autocomplete_status",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "autocomplete_status",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1519,7 +1536,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:available_autocomplete_sources",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "available_autocomplete_sources",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1537,7 +1554,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:classify_prompt_text",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "classify_prompt_text",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1555,7 +1572,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:resolve_autocomplete_source",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1573,7 +1590,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:search_autocomplete",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "search_autocomplete",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1591,7 +1608,7 @@
         "conditional": false,
         "imported": ".wildcard_engine:list_wildcards",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "list_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -1609,7 +1626,7 @@
         "conditional": false,
         "imported": ".wildcard_engine:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 35,
+        "line": 36,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -1627,7 +1644,7 @@
         "conditional": false,
         "imported": ".prompt_translation:PromptTranslationError",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "PromptTranslationError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1645,7 +1662,7 @@
         "conditional": false,
         "imported": ".prompt_translation:TranslationBusyError",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "TranslationBusyError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1663,7 +1680,7 @@
         "conditional": false,
         "imported": ".prompt_translation:TranslationCancelledError",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "TranslationCancelledError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1681,7 +1698,7 @@
         "conditional": false,
         "imported": ".prompt_translation:TranslationTimeoutError",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "TranslationTimeoutError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1699,7 +1716,7 @@
         "conditional": false,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 36,
+        "line": 37,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1710,6 +1727,132 @@
       },
       {
         "alias": null,
+        "bound_name": "ApiContractError",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:ApiContractError",
+        "kind": "static_from",
+        "line": 44,
+        "name": "ApiContractError",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "error_payload",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:error_payload",
+        "kind": "static_from",
+        "line": 44,
+        "name": "error_payload",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_boolean",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:json_boolean",
+        "kind": "static_from",
+        "line": 44,
+        "name": "json_boolean",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_integer",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:json_integer",
+        "kind": "static_from",
+        "line": 44,
+        "name": "json_integer",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_object",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:json_object",
+        "kind": "static_from",
+        "line": 44,
+        "name": "json_object",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json_string",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:json_string",
+        "kind": "static_from",
+        "line": 44,
+        "name": "json_string",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "parse_json_object",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:parse_json_object",
+        "kind": "static_from",
+        "line": 44,
+        "name": "parse_json_object",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
         "bound_name": "AtomicJsonStore",
         "branch_context": [
           {
@@ -1717,7 +1860,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 43
+            "line": 53
           }
         ],
         "classification": "internal",
@@ -1725,12 +1868,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 43
+          "try_line": 53
         },
         "conditional": true,
         "imported": ".storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 44,
+        "line": 54,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": ".storage",
@@ -1748,7 +1891,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 43
+            "line": 53
           }
         ],
         "classification": "internal",
@@ -1756,12 +1899,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 43
+          "try_line": 53
         },
         "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 44,
+        "line": 54,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -1780,9 +1923,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 45,
+            "handler_line": 55,
             "kind": "try",
-            "line": 43
+            "line": 53
           }
         ],
         "classification": "compatibility_fallback",
@@ -1790,12 +1933,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 43
+          "try_line": 53
         },
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 46,
+        "line": 56,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "storage",
@@ -1814,9 +1957,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 45,
+            "handler_line": 55,
             "kind": "try",
-            "line": 43
+            "line": 53
           }
         ],
         "classification": "compatibility_fallback",
@@ -1824,12 +1967,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 43
+          "try_line": 53
         },
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 46,
+        "line": 56,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -1847,7 +1990,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 302
+            "line": 371
           }
         ],
         "classification": "external",
@@ -1855,7 +1998,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 303,
+        "line": 372,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -1872,7 +2015,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 328
+            "line": 397
           }
         ],
         "classification": "external",
@@ -1880,7 +2023,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 329,
+        "line": 398,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -1897,7 +2040,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 629
+            "line": 717
           }
         ],
         "classification": "external",
@@ -1905,13 +2048,81 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 630,
+        "line": 718,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
         "role": "optional_dependency",
         "scope": "_resolve_lora_preview_path",
         "source": "api.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 4,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 4,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api_contract.py"
       },
       {
         "alias": null,
@@ -7044,6 +7255,10 @@
       },
       {
         "from": "api.py",
+        "to": "api_contract.py"
+      },
+      {
+        "from": "api.py",
         "to": "autocomplete_dataset.py"
       },
       {
@@ -7184,6 +7399,12 @@
       {
         "cyclic": false,
         "modules": [
+          "api_contract.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "autocomplete_dataset.py"
         ]
       },
@@ -7220,7 +7441,7 @@
     ]
   },
   "inventory": {
-    "module_count": 15,
+    "module_count": 16,
     "modules": [
       {
         "is_package": true,
@@ -7320,14 +7541,26 @@
       },
       {
         "is_package": false,
-        "loc": 892,
+        "loc": 1130,
         "module": "api",
-        "normalized_git_blob_sha1": "1a2bc89917efb74c89e2bde079b24e0ea9e86be1",
+        "normalized_git_blob_sha1": "ee5bf095b79089fc5f7ec9306df3e906d312abab",
         "path": "api.py",
         "top_level": {
+          "class_count": 2,
+          "function_count": 55,
+          "global_count": 18
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 138,
+        "module": "api_contract",
+        "normalized_git_blob_sha1": "51acfd3601fe1ab671b5ddf3e7694cc2ba05c394",
+        "path": "api_contract.py",
+        "top_level": {
           "class_count": 1,
-          "function_count": 39,
-          "global_count": 14
+          "function_count": 7,
+          "global_count": 0
         }
       },
       {
@@ -7596,16 +7829,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 45,
+            "handler_line": 55,
             "kind": "try",
-            "line": 43
+            "line": 53
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 46,
+        "line": 56,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -7619,16 +7852,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 45,
+            "handler_line": 55,
             "kind": "try",
-            "line": 43
+            "line": 53
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 46,
+        "line": 56,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -8856,9 +9089,20 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "weakref",
+        "kind": "static_import",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "concurrent.futures:Future",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "optional": false,
         "role": "ordinary",
         "source": "api.py"
@@ -8869,7 +9113,7 @@
         "conditional": false,
         "imported": "concurrent.futures:ThreadPoolExecutor",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "optional": false,
         "role": "ordinary",
         "source": "api.py"
@@ -8880,7 +9124,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "api.py"
@@ -8892,14 +9136,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 12
+            "line": 13
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server",
         "kind": "static_import",
-        "line": 13,
+        "line": 14,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -8911,14 +9155,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 12
+            "line": 13
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -8930,14 +9174,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 302
+            "line": 371
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 303,
+        "line": 372,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -8949,14 +9193,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 328
+            "line": 397
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 329,
+        "line": 398,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -8968,17 +9212,61 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 629
+            "line": 717
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 630,
+        "line": 718,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api_contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api_contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api_contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api_contract.py"
       },
       {
         "branch_context": [],
@@ -10672,14 +10960,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 12
+            "line": 13
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server",
         "kind": "static_import",
-        "line": 13,
+        "line": 14,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -10691,14 +10979,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 12
+            "line": 13
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -10710,14 +10998,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 302
+            "line": 371
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 303,
+        "line": 372,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -10729,14 +11017,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 328
+            "line": 397
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 329,
+        "line": 398,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -10748,14 +11036,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 629
+            "line": 717
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 630,
+        "line": 718,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -11671,6 +11959,7 @@
       "anima_prompt/ordering.py",
       "anima_prompt/parser.py",
       "api.py",
+      "api_contract.py",
       "autocomplete_dataset.py",
       "nodes.py",
       "prompt_translation.py",
@@ -11688,6 +11977,7 @@
       "anima_prompt/ordering.py",
       "anima_prompt/parser.py",
       "api.py",
+      "api_contract.py",
       "autocomplete_dataset.py",
       "nodes.py",
       "prompt_translation.py",
@@ -11894,7 +12184,7 @@
         "column": 29,
         "context": "assign:INVALID_PROFILE_NAME_CHARS",
         "kind": "import_time_call",
-        "line": 52,
+        "line": 62,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11903,7 +12193,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 77,
+        "line": 87,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11912,7 +12202,25 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 78,
+        "line": 88,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.Lock",
+        "column": 25,
+        "context": "assign:_FILE_IO_LIMITERS_LOCK",
+        "kind": "import_time_call",
+        "line": 100,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "weakref.WeakKeyDictionary",
+        "column": 47,
+        "context": "assign:_FILE_IO_LIMITERS",
+        "kind": "import_time_call",
+        "line": 101,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11921,7 +12229,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 131,
+        "line": 150,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11930,7 +12238,16 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 132,
+        "line": 151,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 36,
+        "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
+        "kind": "import_time_call",
+        "line": 744,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11939,7 +12256,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 663,
+        "line": 894,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11948,7 +12265,7 @@
         "column": 5,
         "context": "decorator:get_settings_handler",
         "kind": "route_registration",
-        "line": 668,
+        "line": 899,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11957,7 +12274,7 @@
         "column": 5,
         "context": "decorator:set_setting_handler",
         "kind": "route_registration",
-        "line": 672,
+        "line": 903,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11966,7 +12283,7 @@
         "column": 5,
         "context": "decorator:get_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 690,
+        "line": 920,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11975,7 +12292,7 @@
         "column": 5,
         "context": "decorator:get_wildcards_handler",
         "kind": "route_registration",
-        "line": 700,
+        "line": 926,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11984,7 +12301,7 @@
         "column": 5,
         "context": "decorator:save_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 712,
+        "line": 930,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -11993,7 +12310,7 @@
         "column": 5,
         "context": "decorator:autocomplete_status_handler",
         "kind": "route_registration",
-        "line": 730,
+        "line": 941,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12002,7 +12319,7 @@
         "column": 5,
         "context": "decorator:autocomplete_handler",
         "kind": "route_registration",
-        "line": 742,
+        "line": 945,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12011,7 +12328,7 @@
         "column": 5,
         "context": "decorator:classify_prompt_handler",
         "kind": "route_registration",
-        "line": 764,
+        "line": 962,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12020,7 +12337,7 @@
         "column": 5,
         "context": "decorator:translate_prompt_handler",
         "kind": "route_registration",
-        "line": 776,
+        "line": 980,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12029,7 +12346,7 @@
         "column": 5,
         "context": "decorator:lora_preview_handler",
         "kind": "route_registration",
-        "line": 785,
+        "line": 993,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12038,7 +12355,7 @@
         "column": 5,
         "context": "decorator:loras_handler",
         "kind": "route_registration",
-        "line": 795,
+        "line": 1006,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12047,7 +12364,7 @@
         "column": 5,
         "context": "decorator:lora_profiles_handler",
         "kind": "route_registration",
-        "line": 799,
+        "line": 1010,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12056,7 +12373,7 @@
         "column": 5,
         "context": "decorator:save_lora_profile_handler",
         "kind": "route_registration",
-        "line": 803,
+        "line": 1014,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12065,7 +12382,7 @@
         "column": 5,
         "context": "decorator:load_lora_profile_handler",
         "kind": "route_registration",
-        "line": 819,
+        "line": 1035,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12074,7 +12391,7 @@
         "column": 5,
         "context": "decorator:aio_profiles_handler",
         "kind": "route_registration",
-        "line": 829,
+        "line": 1051,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12083,7 +12400,7 @@
         "column": 5,
         "context": "decorator:save_aio_profile_handler",
         "kind": "route_registration",
-        "line": 833,
+        "line": 1057,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12092,7 +12409,7 @@
         "column": 5,
         "context": "decorator:load_aio_profile_handler",
         "kind": "route_registration",
-        "line": 849,
+        "line": 1077,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12101,7 +12418,7 @@
         "column": 5,
         "context": "decorator:delete_aio_profile_handler",
         "kind": "route_registration",
-        "line": 859,
+        "line": 1088,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12110,7 +12427,7 @@
         "column": 5,
         "context": "decorator:rename_aio_profile_handler",
         "kind": "route_registration",
-        "line": 870,
+        "line": 1101,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12119,7 +12436,7 @@
         "column": 5,
         "context": "decorator:fix_lora_profile_handler",
         "kind": "route_registration",
-        "line": 888,
+        "line": 1121,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -12660,13 +12977,13 @@
       },
       {
         "kind": "set",
-        "line": 56,
+        "line": 66,
         "module": "api.py",
         "name": "AIO_RESERVED_PROFILE_NAMES"
       },
       {
         "kind": "set",
-        "line": 72,
+        "line": 82,
         "module": "api.py",
         "name": "WINDOWS_RESERVED_FILE_BASENAMES"
       },
@@ -12944,10 +13261,19 @@
     "owner_candidates": [
       {
         "categories": [
+          "lock"
+        ],
+        "initializer": "threading.Lock",
+        "line": 100,
+        "module": "api.py",
+        "name": "_FILE_IO_LIMITERS_LOCK"
+      },
+      {
+        "categories": [
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 131,
+        "line": 150,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -1,0 +1,8291 @@
+{
+  "determinism": {
+    "encoding": "utf-8-sig",
+    "newline_normalization": "CRLF and CR become LF before parsing and hashing",
+    "ordering": "paths, modules, edges, candidates, SCCs, and JSON keys are sorted",
+    "path_format": "repository-relative POSIX"
+  },
+  "imports": {
+    "edges": [
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 2,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "scope": "<module>",
+        "source": "__init__.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaAIOGenerator",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaAIOGenerator",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaArtistMixConditioning",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaArtistMixConditioning",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaDetailerAlignHook",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaDetailerAlignHook",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaImageScaleByMultiple",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaImageScaleByMultiple",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaInput",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaInput",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaLoraPreset",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaLoraPreset",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaNAIARandomPrompt",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaNAIARandomPrompt",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptBuilder",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptBuilder",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptCorrector",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptCorrector",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptCorrectorSimple",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptCorrectorSimple",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptDataConditioning",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptDataConditioning",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptDataUnpack",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptDataUnpack",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudio",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudio",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudioAdvanced",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudioAdvanced",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudioAdvancedV2",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudioAdvancedV2",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudioRegional",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudioRegional",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaRegionalConditioning",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaRegionalConditioning",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".nodes:EasyUseAnimaWildcard",
+        "kind": "static_from",
+        "line": 4,
+        "name": "EasyUseAnimaWildcard",
+        "optional": false,
+        "requested": ".nodes",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".:api",
+        "kind": "static_from",
+        "line": 24,
+        "name": "api",
+        "optional": false,
+        "requested": ".",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".wildcard_engine:ensure_default_wildcard_root",
+        "kind": "static_from",
+        "line": 25,
+        "name": "ensure_default_wildcard_root",
+        "optional": false,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "__init__.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".correction:correct_prompt",
+        "kind": "static_from",
+        "line": 8,
+        "name": "correct_prompt",
+        "optional": false,
+        "requested": ".correction",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".correction:inspect_prompt",
+        "kind": "static_from",
+        "line": 8,
+        "name": "inspect_prompt",
+        "optional": false,
+        "requested": ".correction",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".knowledge:KnowledgeBaseNotFound",
+        "kind": "static_from",
+        "line": 9,
+        "name": "KnowledgeBaseNotFound",
+        "optional": false,
+        "requested": ".knowledge",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".knowledge:PromptKnowledgeBase",
+        "kind": "static_from",
+        "line": 9,
+        "name": "PromptKnowledgeBase",
+        "optional": false,
+        "requested": ".knowledge",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".knowledge:load_knowledge_base",
+        "kind": "static_from",
+        "line": 9,
+        "name": "load_knowledge_base",
+        "optional": false,
+        "requested": ".knowledge",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:CorrectionResult",
+        "kind": "static_from",
+        "line": 14,
+        "name": "CorrectionResult",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:ParsedPrompt",
+        "kind": "static_from",
+        "line": 14,
+        "name": "ParsedPrompt",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:TagInfo",
+        "kind": "static_from",
+        "line": 14,
+        "name": "TagInfo",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:TagToken",
+        "kind": "static_from",
+        "line": 14,
+        "name": "TagToken",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/__init__.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 6,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".knowledge:PromptKnowledgeBase",
+        "kind": "static_from",
+        "line": 8,
+        "name": "PromptKnowledgeBase",
+        "optional": false,
+        "requested": ".knowledge",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:CorrectionResult",
+        "kind": "static_from",
+        "line": 9,
+        "name": "CorrectionResult",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:TagToken",
+        "kind": "static_from",
+        "line": 9,
+        "name": "TagToken",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".normalize:lookup_key",
+        "kind": "static_from",
+        "line": 10,
+        "name": "lookup_key",
+        "optional": false,
+        "requested": ".normalize",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/normalize.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".normalize:normalize_tag",
+        "kind": "static_from",
+        "line": 10,
+        "name": "normalize_tag",
+        "optional": false,
+        "requested": ".normalize",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/normalize.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".normalize:render_artist_tag",
+        "kind": "static_from",
+        "line": 10,
+        "name": "render_artist_tag",
+        "optional": false,
+        "requested": ".normalize",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/normalize.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".ordering:classify_tag",
+        "kind": "static_from",
+        "line": 11,
+        "name": "classify_tag",
+        "optional": false,
+        "requested": ".ordering",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/ordering.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".ordering:section_sort_key",
+        "kind": "static_from",
+        "line": 11,
+        "name": "section_sort_key",
+        "optional": false,
+        "requested": ".ordering",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/ordering.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".parser:parse_prompt",
+        "kind": "static_from",
+        "line": 12,
+        "name": "parse_prompt",
+        "optional": false,
+        "requested": ".parser",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".parser:render_tags",
+        "kind": "static_from",
+        "line": 12,
+        "name": "render_tags",
+        "optional": false,
+        "requested": ".parser",
+        "scope": "<module>",
+        "source": "anima_prompt/correction.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "scope": "<module>",
+        "source": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "scope": "<module>",
+        "source": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:TagInfo",
+        "kind": "static_from",
+        "line": 8,
+        "name": "TagInfo",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/knowledge.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".normalize:lookup_key",
+        "kind": "static_from",
+        "line": 9,
+        "name": "lookup_key",
+        "optional": false,
+        "requested": ".normalize",
+        "scope": "<module>",
+        "source": "anima_prompt/knowledge.py",
+        "target": "anima_prompt/normalize.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".ordering:TagSection",
+        "kind": "static_from",
+        "line": 10,
+        "name": "TagSection",
+        "optional": false,
+        "requested": ".ordering",
+        "scope": "<module>",
+        "source": "anima_prompt/knowledge.py",
+        "target": "anima_prompt/ordering.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".ordering:builtin_tag_section",
+        "kind": "static_from",
+        "line": 10,
+        "name": "builtin_tag_section",
+        "optional": false,
+        "requested": ".ordering",
+        "scope": "<module>",
+        "source": "anima_prompt/knowledge.py",
+        "target": "anima_prompt/ordering.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "scope": "<module>",
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:field",
+        "kind": "static_from",
+        "line": 5,
+        "name": "field",
+        "optional": false,
+        "requested": "dataclasses",
+        "scope": "<module>",
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "enum:Enum",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Enum",
+        "optional": false,
+        "requested": "enum",
+        "scope": "<module>",
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "anima_prompt/normalize.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "anima_prompt/normalize.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "anima_prompt/ordering.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "anima_prompt/ordering.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:TagInfo",
+        "kind": "static_from",
+        "line": 7,
+        "name": "TagInfo",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/ordering.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:TagSection",
+        "kind": "static_from",
+        "line": 7,
+        "name": "TagSection",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/ordering.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".normalize:lookup_key",
+        "kind": "static_from",
+        "line": 8,
+        "name": "lookup_key",
+        "optional": false,
+        "requested": ".normalize",
+        "scope": "<module>",
+        "source": "anima_prompt/ordering.py",
+        "target": "anima_prompt/normalize.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".models:ParsedPrompt",
+        "kind": "static_from",
+        "line": 7,
+        "name": "ParsedPrompt",
+        "optional": false,
+        "requested": ".models",
+        "scope": "<module>",
+        "source": "anima_prompt/parser.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "atexit",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "atexit",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "asyncio",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "asyncio",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "concurrent.futures:Future",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Future",
+        "optional": false,
+        "requested": "concurrent.futures",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "concurrent.futures:ThreadPoolExecutor",
+        "kind": "static_from",
+        "line": 9,
+        "name": "ThreadPoolExecutor",
+        "optional": false,
+        "requested": "concurrent.futures",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 10,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "server",
+        "kind": "static_import",
+        "line": 13,
+        "name": null,
+        "optional": true,
+        "requested": "server",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "aiohttp:web",
+        "kind": "static_from",
+        "line": 14,
+        "name": "web",
+        "optional": true,
+        "requested": "aiohttp",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".settings:load_long_text_settings",
+        "kind": "static_from",
+        "line": 19,
+        "name": "load_long_text_settings",
+        "optional": false,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".settings:public_settings",
+        "kind": "static_from",
+        "line": 19,
+        "name": "public_settings",
+        "optional": false,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".settings:resolve_autocomplete_limit",
+        "kind": "static_from",
+        "line": 19,
+        "name": "resolve_autocomplete_limit",
+        "optional": false,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".settings:resolve_autocomplete_source",
+        "kind": "static_from",
+        "line": 19,
+        "name": "resolve_autocomplete_source",
+        "optional": false,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 19,
+        "name": "resolve_prompt_translation_settings",
+        "optional": false,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".settings:save_long_text_settings",
+        "kind": "static_from",
+        "line": 19,
+        "name": "save_long_text_settings",
+        "optional": false,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".settings:save_setting",
+        "kind": "static_from",
+        "line": 19,
+        "name": "save_setting",
+        "optional": false,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".autocomplete_dataset:autocomplete_status",
+        "kind": "static_from",
+        "line": 28,
+        "name": "autocomplete_status",
+        "optional": false,
+        "requested": ".autocomplete_dataset",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".autocomplete_dataset:available_autocomplete_sources",
+        "kind": "static_from",
+        "line": 28,
+        "name": "available_autocomplete_sources",
+        "optional": false,
+        "requested": ".autocomplete_dataset",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".autocomplete_dataset:classify_prompt_text",
+        "kind": "static_from",
+        "line": 28,
+        "name": "classify_prompt_text",
+        "optional": false,
+        "requested": ".autocomplete_dataset",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "autocomplete_dataset.py"
+      },
+      {
+        "alias": "resolve_autocomplete_source_path",
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".autocomplete_dataset:resolve_autocomplete_source",
+        "kind": "static_from",
+        "line": 28,
+        "name": "resolve_autocomplete_source",
+        "optional": false,
+        "requested": ".autocomplete_dataset",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".autocomplete_dataset:search_autocomplete",
+        "kind": "static_from",
+        "line": 28,
+        "name": "search_autocomplete",
+        "optional": false,
+        "requested": ".autocomplete_dataset",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".wildcard_engine:list_wildcards",
+        "kind": "static_from",
+        "line": 35,
+        "name": "list_wildcards",
+        "optional": false,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".wildcard_engine:resolve_wildcard_roots",
+        "kind": "static_from",
+        "line": 35,
+        "name": "resolve_wildcard_roots",
+        "optional": false,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".prompt_translation:PromptTranslationError",
+        "kind": "static_from",
+        "line": 36,
+        "name": "PromptTranslationError",
+        "optional": false,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".prompt_translation:TranslationBusyError",
+        "kind": "static_from",
+        "line": 36,
+        "name": "TranslationBusyError",
+        "optional": false,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".prompt_translation:TranslationCancelledError",
+        "kind": "static_from",
+        "line": 36,
+        "name": "TranslationCancelledError",
+        "optional": false,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".prompt_translation:TranslationTimeoutError",
+        "kind": "static_from",
+        "line": 36,
+        "name": "TranslationTimeoutError",
+        "optional": false,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 36,
+        "name": "translate_prompt_markers",
+        "optional": false,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 44,
+        "name": "AtomicJsonStore",
+        "optional": true,
+        "requested": ".storage",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 44,
+        "name": "USER_DATA_DIR",
+        "optional": true,
+        "requested": ".storage",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 46,
+        "name": "AtomicJsonStore",
+        "optional": false,
+        "requested": "storage",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 46,
+        "name": "USER_DATA_DIR",
+        "optional": false,
+        "requested": "storage",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 303,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_list_loras",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 329,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_lora_full_path",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 630,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_resolve_lora_preview_path",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "csv",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "csv",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "heapq",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "heapq",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "itertools",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "itertools",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "stat",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "stat",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "time",
+        "kind": "static_import",
+        "line": 9,
+        "name": null,
+        "optional": false,
+        "requested": "time",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "unicodedata",
+        "kind": "static_import",
+        "line": 10,
+        "name": null,
+        "optional": false,
+        "requested": "unicodedata",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "concurrent.futures:Future",
+        "kind": "static_from",
+        "line": 11,
+        "name": "Future",
+        "optional": false,
+        "requested": "concurrent.futures",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 12,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 13,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "types:MappingProxyType",
+        "kind": "static_from",
+        "line": 14,
+        "name": "MappingProxyType",
+        "optional": false,
+        "requested": "types",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 15,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".anima_prompt.knowledge:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 18,
+        "name": "PACKAGE_DATA_DIR",
+        "optional": true,
+        "requested": ".anima_prompt.knowledge",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/knowledge.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".anima_prompt.models:TagSection",
+        "kind": "static_from",
+        "line": 19,
+        "name": "TagSection",
+        "optional": true,
+        "requested": ".anima_prompt.models",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".anima_prompt.ordering:builtin_tag_section",
+        "kind": "static_from",
+        "line": 20,
+        "name": "builtin_tag_section",
+        "optional": true,
+        "requested": ".anima_prompt.ordering",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/ordering.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 21,
+        "name": "parse_prompt",
+        "optional": true,
+        "requested": ".anima_prompt.parser",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 22,
+        "name": "iter_prompt_translation_markers",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 24,
+        "name": "PACKAGE_DATA_DIR",
+        "optional": false,
+        "requested": "anima_prompt.knowledge",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "anima_prompt.models:TagSection",
+        "kind": "static_from",
+        "line": 25,
+        "name": "TagSection",
+        "optional": false,
+        "requested": "anima_prompt.models",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "anima_prompt.ordering:builtin_tag_section",
+        "kind": "static_from",
+        "line": 26,
+        "name": "builtin_tag_section",
+        "optional": false,
+        "requested": "anima_prompt.ordering",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 27,
+        "name": "parse_prompt",
+        "optional": false,
+        "requested": "anima_prompt.parser",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 28,
+        "name": "iter_prompt_translation_markers",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 2,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "inspect",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "inspect",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "random",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "random",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 9,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "sys",
+        "kind": "static_import",
+        "line": 10,
+        "name": null,
+        "optional": false,
+        "requested": "sys",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:ceil",
+        "kind": "static_from",
+        "line": 11,
+        "name": "ceil",
+        "optional": false,
+        "requested": "math",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:gcd",
+        "kind": "static_from",
+        "line": 11,
+        "name": "gcd",
+        "optional": false,
+        "requested": "math",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:isfinite",
+        "kind": "static_from",
+        "line": 11,
+        "name": "isfinite",
+        "optional": false,
+        "requested": "math",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:lcm",
+        "kind": "static_from",
+        "line": 11,
+        "name": "lcm",
+        "optional": false,
+        "requested": "math",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:log",
+        "kind": "static_from",
+        "line": 11,
+        "name": "log",
+        "optional": false,
+        "requested": "math",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:sqrt",
+        "kind": "static_from",
+        "line": 11,
+        "name": "sqrt",
+        "optional": false,
+        "requested": "math",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 12,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Optional",
+        "kind": "static_from",
+        "line": 12,
+        "name": "Optional",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 15,
+        "name": "correct_prompt",
+        "optional": true,
+        "requested": ".anima_prompt",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 15,
+        "name": "load_knowledge_base",
+        "optional": true,
+        "requested": ".anima_prompt",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 16,
+        "name": "parse_prompt",
+        "optional": true,
+        "requested": ".anima_prompt.parser",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 17,
+        "name": "resolve_metadata_filter_words",
+        "optional": true,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 17,
+        "name": "resolve_naia_settings",
+        "optional": true,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 17,
+        "name": "resolve_prompt_translation_settings",
+        "optional": true,
+        "requested": ".settings",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 22,
+        "name": "has_prompt_translation_markers",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 22,
+        "name": "translate_prompt_markers",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 23,
+        "name": "MAX_SEED",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 23,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 23,
+        "name": "SEED_CONTROL_DECREMENT",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 23,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 23,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 23,
+        "name": "SEED_CONTROL_MODES",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 23,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 23,
+        "name": "WILDCARD_MODE_FIXED",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 23,
+        "name": "WILDCARD_MODE_LABELS",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 23,
+        "name": "WILDCARD_MODE_POPULATE",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 23,
+        "name": "WILDCARD_MODE_REPRODUCE",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 23,
+        "name": "WILDCARD_MODE_SEQUENTIAL",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 23,
+        "name": "expand_wildcards",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 23,
+        "name": "has_wildcard_syntax",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 23,
+        "name": "next_seed",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 23,
+        "name": "normalize_seed",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 23,
+        "name": "normalize_wildcard_mode",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 23,
+        "name": "wildcard_sources_signature",
+        "optional": true,
+        "requested": ".wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 44,
+        "name": "correct_prompt",
+        "optional": false,
+        "requested": "anima_prompt",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 44,
+        "name": "load_knowledge_base",
+        "optional": false,
+        "requested": "anima_prompt",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 45,
+        "name": "parse_prompt",
+        "optional": false,
+        "requested": "anima_prompt.parser",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 46,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "settings",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 46,
+        "name": "resolve_naia_settings",
+        "optional": false,
+        "requested": "settings",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 46,
+        "name": "resolve_prompt_translation_settings",
+        "optional": false,
+        "requested": "settings",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 51,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 51,
+        "name": "translate_prompt_markers",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 52,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 52,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 52,
+        "name": "SEED_CONTROL_DECREMENT",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 52,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 52,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 52,
+        "name": "SEED_CONTROL_MODES",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 52,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 52,
+        "name": "WILDCARD_MODE_FIXED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 52,
+        "name": "WILDCARD_MODE_LABELS",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 52,
+        "name": "WILDCARD_MODE_POPULATE",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 52,
+        "name": "WILDCARD_MODE_REPRODUCE",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 52,
+        "name": "WILDCARD_MODE_SEQUENTIAL",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 52,
+        "name": "expand_wildcards",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 52,
+        "name": "has_wildcard_syntax",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 52,
+        "name": "next_seed",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 52,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 52,
+        "name": "normalize_wildcard_mode",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 52,
+        "name": "wildcard_sources_signature",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "scope": "<module>",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2044,
+        "name": null,
+        "optional": false,
+        "requested": "nodes",
+        "scope": "_comfy_max_resolution",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2053,
+        "name": null,
+        "optional": false,
+        "requested": "comfy.samplers",
+        "scope": "_comfy_sampler_names",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2072,
+        "name": null,
+        "optional": false,
+        "requested": "comfy.samplers",
+        "scope": "_comfy_scheduler_names",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2099,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_comfy_checkpoint_names",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2111,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_folder_path_names",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "core",
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "impact.core",
+        "kind": "static_import",
+        "line": 2185,
+        "name": null,
+        "optional": false,
+        "requested": "impact.core",
+        "scope": "_impact_core_module",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2191,
+        "name": "core",
+        "optional": false,
+        "requested": "modules.impact",
+        "scope": "_impact_core_module",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2207,
+        "name": null,
+        "optional": false,
+        "requested": "comfy.samplers",
+        "scope": "_impact_scheduler_names",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2216,
+        "name": null,
+        "optional": false,
+        "requested": "nodes",
+        "scope": "_find_impact_detailer_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2232,
+        "name": "DetailerForEach",
+        "optional": false,
+        "requested": "impact.impact_pack",
+        "scope": "_find_impact_detailer_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2238,
+        "name": "DetailerForEach",
+        "optional": false,
+        "requested": "modules.impact.impact_pack",
+        "scope": "_find_impact_detailer_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2252,
+        "name": null,
+        "optional": false,
+        "requested": "nodes",
+        "scope": "_find_comfy_node_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
+        "kind": "static_from",
+        "line": 2369,
+        "name": "SAM3_Detect",
+        "optional": false,
+        "requested": "comfy_extras.nodes_sam3",
+        "scope": "_find_sam3_detect_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "impact.segs_nodes:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2393,
+        "name": "MaskToSEGS",
+        "optional": false,
+        "requested": "impact.segs_nodes",
+        "scope": "_find_impact_mask_to_segs_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "modules.impact.segs_nodes:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2399,
+        "name": "MaskToSEGS",
+        "optional": false,
+        "requested": "modules.impact.segs_nodes",
+        "scope": "_find_impact_mask_to_segs_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2405,
+        "name": "MaskToSEGS",
+        "optional": false,
+        "requested": "impact.impact_pack",
+        "scope": "_find_impact_mask_to_segs_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2411,
+        "name": "MaskToSEGS",
+        "optional": false,
+        "requested": "modules.impact.impact_pack",
+        "scope": "_find_impact_mask_to_segs_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2867,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_aio_lora_metadata_name",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "model_management",
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "comfy.model_management",
+        "kind": "static_import",
+        "line": 2907,
+        "name": null,
+        "optional": false,
+        "requested": "comfy.model_management",
+        "scope": "_cleanup_aio_ephemeral_model",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 12,
+        "conditional": true,
+        "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
+        "kind": "static_from",
+        "line": 3370,
+        "name": "UpscaleModelLoader",
+        "optional": false,
+        "requested": "comfy_extras.nodes_upscale_model",
+        "scope": "_load_upscale_model_with_comfy",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 4170,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_aio_preview_base_directory",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "server:PromptServer",
+        "kind": "static_from",
+        "line": 4232,
+        "name": "PromptServer",
+        "optional": false,
+        "requested": "server",
+        "scope": "_send_aio_preview_event",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 4259,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_save_aio_temp_preview_image",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "np",
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "numpy",
+        "kind": "static_import",
+        "line": 4260,
+        "name": null,
+        "optional": false,
+        "requested": "numpy",
+        "scope": "_save_aio_temp_preview_image",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "PIL:Image",
+        "kind": "static_from",
+        "line": 4261,
+        "name": "Image",
+        "optional": false,
+        "requested": "PIL",
+        "scope": "_save_aio_temp_preview_image",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 4453,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_empty_mask_for_image",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "comfy.utils",
+        "kind": "static_import",
+        "line": 4706,
+        "name": null,
+        "optional": false,
+        "requested": "comfy.utils",
+        "scope": "_common_upscale_image",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "F",
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch.nn.functional",
+        "kind": "static_import",
+        "line": 4710,
+        "name": null,
+        "optional": false,
+        "requested": "torch.nn.functional",
+        "scope": "_common_upscale_image",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5622,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_copy_conditioning_metadata",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5639,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_pad_conditioning_tensor",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5660,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_blend_conditionings",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5737,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_artist_delta_rms_from_encoded",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 6536,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_encode_artist_clustered",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 7561,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_regional_union_mask_for_ids",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 7595,
+        "name": null,
+        "optional": false,
+        "requested": "torch",
+        "scope": "_regional_mask_bounds_area",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "requests",
+        "kind": "static_import",
+        "line": 7671,
+        "name": null,
+        "optional": true,
+        "requested": "requests",
+        "scope": "_post_random",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "py.nodes.utils:apply_lora_syntax_format",
+        "kind": "static_from",
+        "line": 7887,
+        "name": "apply_lora_syntax_format",
+        "optional": false,
+        "requested": "py.nodes.utils",
+        "scope": "_apply_lora_syntax_format",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 7897,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_fallback_lora_path",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 7919,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_lora_stack_name",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "py.utils.utils:get_lora_info",
+        "kind": "static_from",
+        "line": 8024,
+        "name": "get_lora_info",
+        "optional": false,
+        "requested": "py.utils.utils",
+        "scope": "_get_lora_info",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 8068,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_lora_combo_values",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 8093,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_lora_model_exists",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "html",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "html",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "time",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "time",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections:OrderedDict",
+        "kind": "static_from",
+        "line": 6,
+        "name": "OrderedDict",
+        "optional": false,
+        "requested": "collections",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 7,
+        "name": "contextmanager",
+        "optional": false,
+        "requested": "contextlib",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 8,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Callable",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Callable",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 12,
+        "conditional": false,
+        "imported": "googletrans:Translator",
+        "kind": "static_from",
+        "line": 170,
+        "name": "Translator",
+        "optional": true,
+        "requested": "googletrans",
+        "scope": "GoogleTranslationProvider._create_translator",
+        "source": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 4,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 7,
+        "name": "AtomicJsonStore",
+        "optional": true,
+        "requested": ".storage",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 7,
+        "name": "USER_DATA_DIR",
+        "optional": true,
+        "requested": ".storage",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 8,
+        "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 8,
+        "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 8,
+        "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 8,
+        "name": "PromptTranslationSettings",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 8,
+        "name": "normalize_prompt_translation_language",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".prompt_translation:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 8,
+        "name": "normalize_prompt_translation_provider",
+        "optional": true,
+        "requested": ".prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 17,
+        "name": "AtomicJsonStore",
+        "optional": false,
+        "requested": "storage",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 17,
+        "name": "USER_DATA_DIR",
+        "optional": false,
+        "requested": "storage",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 18,
+        "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 18,
+        "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 18,
+        "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 18,
+        "name": "PromptTranslationSettings",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 18,
+        "name": "normalize_prompt_translation_language",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "prompt_translation:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 18,
+        "name": "normalize_prompt_translation_provider",
+        "optional": false,
+        "requested": "prompt_translation",
+        "scope": "<module>",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 272,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_comfy_settings_candidates",
+        "source": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "errno",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "errno",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "tempfile",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "tempfile",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 8,
+        "name": "contextmanager",
+        "optional": false,
+        "requested": "contextlib",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Callable",
+        "kind": "static_from",
+        "line": 10,
+        "name": "Callable",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Iterator",
+        "kind": "static_from",
+        "line": 10,
+        "name": "Iterator",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeVar",
+        "kind": "static_from",
+        "line": 10,
+        "name": "TypeVar",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 20,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_resolve_user_data_dir",
+        "source": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "bisect",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "bisect",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections:OrderedDict",
+        "kind": "static_from",
+        "line": 4,
+        "name": "OrderedDict",
+        "optional": false,
+        "requested": "collections",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "fnmatch",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "fnmatch",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "hashlib",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "hashlib",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "math",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 8,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "random",
+        "kind": "static_import",
+        "line": 9,
+        "name": null,
+        "optional": false,
+        "requested": "random",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 10,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 11,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 12,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 13,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "types:MappingProxyType",
+        "kind": "static_from",
+        "line": 14,
+        "name": "MappingProxyType",
+        "optional": false,
+        "requested": "types",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Iterable",
+        "kind": "static_from",
+        "line": 15,
+        "name": "Iterable",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 15,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Sequence",
+        "kind": "static_from",
+        "line": 15,
+        "name": "Sequence",
+        "optional": false,
+        "requested": "typing",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": "np",
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "numpy",
+        "kind": "static_import",
+        "line": 18,
+        "name": null,
+        "optional": false,
+        "requested": "numpy",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "yaml",
+        "kind": "static_import",
+        "line": 23,
+        "name": null,
+        "optional": false,
+        "requested": "yaml",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 28,
+        "name": "USER_DATA_DIR",
+        "optional": true,
+        "requested": ".storage",
+        "scope": "<module>",
+        "source": "wildcard_engine.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 4,
+        "conditional": false,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 30,
+        "name": "USER_DATA_DIR",
+        "optional": false,
+        "requested": "storage",
+        "scope": "<module>",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 8,
+        "conditional": false,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 534,
+        "name": null,
+        "optional": false,
+        "requested": "folder_paths",
+        "scope": "_comfy_base_path",
+        "source": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "classification": "internal",
+        "column": 12,
+        "conditional": true,
+        "imported": ".settings:get_settings",
+        "kind": "static_from",
+        "line": 555,
+        "name": "get_settings",
+        "optional": true,
+        "requested": ".settings",
+        "scope": "resolve_wildcard_roots",
+        "source": "wildcard_engine.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "classification": "external",
+        "column": 12,
+        "conditional": true,
+        "imported": "settings:get_settings",
+        "kind": "static_from",
+        "line": 557,
+        "name": "get_settings",
+        "optional": false,
+        "requested": "settings",
+        "scope": "resolve_wildcard_roots",
+        "source": "wildcard_engine.py"
+      }
+    ],
+    "module_graph": [
+      {
+        "from": "__init__.py",
+        "to": "api.py"
+      },
+      {
+        "from": "__init__.py",
+        "to": "nodes.py"
+      },
+      {
+        "from": "__init__.py",
+        "to": "wildcard_engine.py"
+      },
+      {
+        "from": "anima_prompt/__init__.py",
+        "to": "anima_prompt/correction.py"
+      },
+      {
+        "from": "anima_prompt/__init__.py",
+        "to": "anima_prompt/knowledge.py"
+      },
+      {
+        "from": "anima_prompt/__init__.py",
+        "to": "anima_prompt/models.py"
+      },
+      {
+        "from": "anima_prompt/correction.py",
+        "to": "anima_prompt/knowledge.py"
+      },
+      {
+        "from": "anima_prompt/correction.py",
+        "to": "anima_prompt/models.py"
+      },
+      {
+        "from": "anima_prompt/correction.py",
+        "to": "anima_prompt/normalize.py"
+      },
+      {
+        "from": "anima_prompt/correction.py",
+        "to": "anima_prompt/ordering.py"
+      },
+      {
+        "from": "anima_prompt/correction.py",
+        "to": "anima_prompt/parser.py"
+      },
+      {
+        "from": "anima_prompt/knowledge.py",
+        "to": "anima_prompt/models.py"
+      },
+      {
+        "from": "anima_prompt/knowledge.py",
+        "to": "anima_prompt/normalize.py"
+      },
+      {
+        "from": "anima_prompt/knowledge.py",
+        "to": "anima_prompt/ordering.py"
+      },
+      {
+        "from": "anima_prompt/ordering.py",
+        "to": "anima_prompt/models.py"
+      },
+      {
+        "from": "anima_prompt/ordering.py",
+        "to": "anima_prompt/normalize.py"
+      },
+      {
+        "from": "anima_prompt/parser.py",
+        "to": "anima_prompt/models.py"
+      },
+      {
+        "from": "api.py",
+        "to": "autocomplete_dataset.py"
+      },
+      {
+        "from": "api.py",
+        "to": "prompt_translation.py"
+      },
+      {
+        "from": "api.py",
+        "to": "settings.py"
+      },
+      {
+        "from": "api.py",
+        "to": "storage.py"
+      },
+      {
+        "from": "api.py",
+        "to": "wildcard_engine.py"
+      },
+      {
+        "from": "autocomplete_dataset.py",
+        "to": "anima_prompt/knowledge.py"
+      },
+      {
+        "from": "autocomplete_dataset.py",
+        "to": "anima_prompt/models.py"
+      },
+      {
+        "from": "autocomplete_dataset.py",
+        "to": "anima_prompt/ordering.py"
+      },
+      {
+        "from": "autocomplete_dataset.py",
+        "to": "anima_prompt/parser.py"
+      },
+      {
+        "from": "autocomplete_dataset.py",
+        "to": "prompt_translation.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "anima_prompt/__init__.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "anima_prompt/parser.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "prompt_translation.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "settings.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "wildcard_engine.py"
+      },
+      {
+        "from": "settings.py",
+        "to": "prompt_translation.py"
+      },
+      {
+        "from": "settings.py",
+        "to": "storage.py"
+      },
+      {
+        "from": "wildcard_engine.py",
+        "to": "settings.py"
+      },
+      {
+        "from": "wildcard_engine.py",
+        "to": "storage.py"
+      }
+    ],
+    "sccs": [
+      {
+        "cyclic": false,
+        "modules": [
+          "__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "anima_prompt/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "anima_prompt/correction.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "anima_prompt/knowledge.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "anima_prompt/models.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "anima_prompt/normalize.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "anima_prompt/ordering.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "anima_prompt/parser.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "api.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "autocomplete_dataset.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "nodes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "prompt_translation.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "settings.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "storage.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "wildcard_engine.py"
+        ]
+      }
+    ]
+  },
+  "inventory": {
+    "module_count": 15,
+    "modules": [
+      {
+        "is_package": true,
+        "loc": 82,
+        "module": "__root__",
+        "normalized_git_blob_sha1": "bc6892b27aceb8392dcf53828c80e1a69f640e2f",
+        "path": "__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 5
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 26,
+        "module": "anima_prompt",
+        "normalized_git_blob_sha1": "1387f35f1c8d0c639a24d16257ca562b64cad8d0",
+        "path": "anima_prompt/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 275,
+        "module": "anima_prompt.correction",
+        "normalized_git_blob_sha1": "8423904dbfed4d46030a689f0db9f54912976682",
+        "path": "anima_prompt/correction.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 12,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 48,
+        "module": "anima_prompt.knowledge",
+        "normalized_git_blob_sha1": "6a36369906080a0496aa33bf42c199f1203acda3",
+        "path": "anima_prompt/knowledge.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 59,
+        "module": "anima_prompt.models",
+        "normalized_git_blob_sha1": "5caf1b54fc33ebcc9f19f96d9204e5fceec7d3ff",
+        "path": "anima_prompt/models.py",
+        "top_level": {
+          "class_count": 5,
+          "function_count": 0,
+          "global_count": 0
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 48,
+        "module": "anima_prompt.normalize",
+        "normalized_git_blob_sha1": "2500d513c43695fac44b354f32b51a3c8f07d4f7",
+        "path": "anima_prompt/normalize.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 4,
+          "global_count": 2
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 158,
+        "module": "anima_prompt.ordering",
+        "normalized_git_blob_sha1": "06ed5bfccd1b48526037a4c4cdd17c4ab805ab23",
+        "path": "anima_prompt/ordering.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 3,
+          "global_count": 8
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 73,
+        "module": "anima_prompt.parser",
+        "normalized_git_blob_sha1": "3b7bf04cbd8fcf0c0645962c655972f392d5bd62",
+        "path": "anima_prompt/parser.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 5,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 892,
+        "module": "api",
+        "normalized_git_blob_sha1": "1a2bc89917efb74c89e2bde079b24e0ea9e86be1",
+        "path": "api.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 39,
+          "global_count": 12
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 855,
+        "module": "autocomplete_dataset",
+        "normalized_git_blob_sha1": "a705fa5d5838bd6427aaa65da12fba0ad6eeb3f2",
+        "path": "autocomplete_dataset.py",
+        "top_level": {
+          "class_count": 4,
+          "function_count": 43,
+          "global_count": 28
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 12663,
+        "module": "nodes",
+        "normalized_git_blob_sha1": "a09b1d76618ff46955d54d724a7b813e2a209567",
+        "path": "nodes.py",
+        "top_level": {
+          "class_count": 25,
+          "function_count": 284,
+          "global_count": 126
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 423,
+        "module": "prompt_translation",
+        "normalized_git_blob_sha1": "efd8064a08414064071990575cc6a9631c829c23",
+        "path": "prompt_translation.py",
+        "top_level": {
+          "class_count": 16,
+          "function_count": 11,
+          "global_count": 18
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 700,
+        "module": "settings",
+        "normalized_git_blob_sha1": "681fe2bc4edb324c04ed7f4405dfa84d6412a1dc",
+        "path": "settings.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 36,
+          "global_count": 13
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 304,
+        "module": "storage",
+        "normalized_git_blob_sha1": "7dc248b4665db14cbd907cede619e8e8d5ff2eb6",
+        "path": "storage.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 7,
+          "global_count": 10
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 1169,
+        "module": "wildcard_engine",
+        "normalized_git_blob_sha1": "a015c07bedfd6e630e1cd90899734b6d85304b57",
+        "path": "wildcard_engine.py",
+        "top_level": {
+          "class_count": 12,
+          "function_count": 39,
+          "global_count": 38
+        }
+      }
+    ]
+  },
+  "public_surface": {
+    "compatibility_names": [
+      "EasyUseAnimaAIOGenerator",
+      "EasyUseAnimaArtistMixConditioning",
+      "EasyUseAnimaDetailerAlignHook",
+      "EasyUseAnimaImageScaleByMultiple",
+      "EasyUseAnimaInput",
+      "EasyUseAnimaLoraPreset",
+      "EasyUseAnimaNAIARandomPrompt",
+      "EasyUseAnimaPromptBuilder",
+      "EasyUseAnimaPromptCorrector",
+      "EasyUseAnimaPromptCorrectorSimple",
+      "EasyUseAnimaPromptDataConditioning",
+      "EasyUseAnimaPromptDataUnpack",
+      "EasyUseAnimaPromptStudio",
+      "EasyUseAnimaPromptStudioAdvanced",
+      "EasyUseAnimaPromptStudioAdvancedV2",
+      "EasyUseAnimaPromptStudioRegional",
+      "EasyUseAnimaRegionalConditioning",
+      "EasyUseAnimaWildcard",
+      "NODE_CLASS_MAPPINGS",
+      "NODE_DISPLAY_NAME_MAPPINGS",
+      "WEB_DIRECTORY",
+      "api",
+      "ensure_default_wildcard_root",
+      "logger"
+    ],
+    "declared_all": [
+      "NODE_CLASS_MAPPINGS",
+      "NODE_DISPLAY_NAME_MAPPINGS",
+      "WEB_DIRECTORY"
+    ],
+    "public_globals": [
+      "NODE_CLASS_MAPPINGS",
+      "NODE_DISPLAY_NAME_MAPPINGS",
+      "WEB_DIRECTORY",
+      "logger"
+    ],
+    "reexports": [
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaAIOGenerator",
+        "line": 4,
+        "name": "EasyUseAnimaAIOGenerator",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaArtistMixConditioning",
+        "line": 4,
+        "name": "EasyUseAnimaArtistMixConditioning",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaDetailerAlignHook",
+        "line": 4,
+        "name": "EasyUseAnimaDetailerAlignHook",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaImageScaleByMultiple",
+        "line": 4,
+        "name": "EasyUseAnimaImageScaleByMultiple",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaInput",
+        "line": 4,
+        "name": "EasyUseAnimaInput",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaLoraPreset",
+        "line": 4,
+        "name": "EasyUseAnimaLoraPreset",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaNAIARandomPrompt",
+        "line": 4,
+        "name": "EasyUseAnimaNAIARandomPrompt",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptBuilder",
+        "line": 4,
+        "name": "EasyUseAnimaPromptBuilder",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptCorrector",
+        "line": 4,
+        "name": "EasyUseAnimaPromptCorrector",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptCorrectorSimple",
+        "line": 4,
+        "name": "EasyUseAnimaPromptCorrectorSimple",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptDataConditioning",
+        "line": 4,
+        "name": "EasyUseAnimaPromptDataConditioning",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptDataUnpack",
+        "line": 4,
+        "name": "EasyUseAnimaPromptDataUnpack",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudio",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudio",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudioAdvanced",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudioAdvanced",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudioAdvancedV2",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudioAdvancedV2",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaPromptStudioRegional",
+        "line": 4,
+        "name": "EasyUseAnimaPromptStudioRegional",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaRegionalConditioning",
+        "line": 4,
+        "name": "EasyUseAnimaRegionalConditioning",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".nodes:EasyUseAnimaWildcard",
+        "line": 4,
+        "name": "EasyUseAnimaWildcard",
+        "source": "nodes.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".:api",
+        "line": 24,
+        "name": "api",
+        "source": "api.py"
+      },
+      {
+        "declared_in_all": false,
+        "imported": ".wildcard_engine:ensure_default_wildcard_root",
+        "line": 25,
+        "name": "ensure_default_wildcard_root",
+        "source": "wildcard_engine.py"
+      }
+    ],
+    "root": "__init__.py"
+  },
+  "registry": {
+    "entry_modules": [
+      "__init__.py"
+    ],
+    "external_imports": [
+      {
+        "classification": "external",
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 2,
+        "optional": false,
+        "source": "__init__.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "source": "anima_prompt/correction.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "anima_prompt/correction.py"
+      },
+      {
+        "classification": "external",
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "source": "anima_prompt/correction.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "source": "anima_prompt/knowledge.py"
+      },
+      {
+        "classification": "external",
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "source": "anima_prompt/knowledge.py"
+      },
+      {
+        "classification": "external",
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "source": "anima_prompt/knowledge.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "classification": "external",
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "classification": "external",
+        "imported": "dataclasses:field",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "classification": "external",
+        "imported": "enum:Enum",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "source": "anima_prompt/models.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "source": "anima_prompt/normalize.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "anima_prompt/normalize.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "source": "anima_prompt/ordering.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "anima_prompt/ordering.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "source": "anima_prompt/parser.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "anima_prompt/parser.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "atexit",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "asyncio",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "os",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 8,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "concurrent.futures:Future",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "concurrent.futures:ThreadPoolExecutor",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "server",
+        "kind": "static_import",
+        "line": 13,
+        "optional": true,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "aiohttp:web",
+        "kind": "static_from",
+        "line": 14,
+        "optional": true,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 303,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 329,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 630,
+        "optional": false,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "csv",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "heapq",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "itertools",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "stat",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 8,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "time",
+        "kind": "static_import",
+        "line": 9,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "unicodedata",
+        "kind": "static_import",
+        "line": 10,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "concurrent.futures:Future",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 12,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 13,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "types:MappingProxyType",
+        "kind": "static_from",
+        "line": 14,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 15,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "anima_prompt.models:TagSection",
+        "kind": "static_from",
+        "line": 25,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "anima_prompt.ordering:builtin_tag_section",
+        "kind": "static_from",
+        "line": 26,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 27,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 28,
+        "optional": false,
+        "source": "autocomplete_dataset.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 2,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "inspect",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "os",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "random",
+        "kind": "static_import",
+        "line": 8,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 9,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "sys",
+        "kind": "static_import",
+        "line": 10,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "math:ceil",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "math:gcd",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "math:isfinite",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "math:lcm",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "math:log",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "math:sqrt",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 12,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Optional",
+        "kind": "static_from",
+        "line": 12,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 44,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 44,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 45,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2044,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2053,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2072,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2099,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2111,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "impact.core",
+        "kind": "static_import",
+        "line": 2185,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2191,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2207,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2216,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2232,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2238,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2252,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
+        "kind": "static_from",
+        "line": 2369,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "impact.segs_nodes:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2393,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "modules.impact.segs_nodes:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2399,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2405,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2411,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2867,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "comfy.model_management",
+        "kind": "static_import",
+        "line": 2907,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
+        "kind": "static_from",
+        "line": 3370,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 4170,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "server:PromptServer",
+        "kind": "static_from",
+        "line": 4232,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 4259,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "numpy",
+        "kind": "static_import",
+        "line": 4260,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "PIL:Image",
+        "kind": "static_from",
+        "line": 4261,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 4453,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "comfy.utils",
+        "kind": "static_import",
+        "line": 4706,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch.nn.functional",
+        "kind": "static_import",
+        "line": 4710,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5622,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5639,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5660,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5737,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 6536,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 7561,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 7595,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "requests",
+        "kind": "static_import",
+        "line": 7671,
+        "optional": true,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "py.nodes.utils:apply_lora_syntax_format",
+        "kind": "static_from",
+        "line": 7887,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 7897,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 7919,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "py.utils.utils:get_lora_info",
+        "kind": "static_from",
+        "line": 8024,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 8068,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 8093,
+        "optional": false,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "html",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "time",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "collections:OrderedDict",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Callable",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "googletrans:Translator",
+        "kind": "static_from",
+        "line": 170,
+        "optional": true,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "json",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 17,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 17,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "prompt_translation:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 272,
+        "optional": false,
+        "source": "settings.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "errno",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "json",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "os",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "tempfile",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Callable",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Iterator",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:TypeVar",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 20,
+        "optional": false,
+        "source": "storage.py"
+      },
+      {
+        "classification": "external",
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "bisect",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "collections:OrderedDict",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "fnmatch",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "hashlib",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "math",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "os",
+        "kind": "static_import",
+        "line": 8,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "random",
+        "kind": "static_import",
+        "line": 9,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "re",
+        "kind": "static_import",
+        "line": 10,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 11,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 12,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 13,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "types:MappingProxyType",
+        "kind": "static_from",
+        "line": 14,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Iterable",
+        "kind": "static_from",
+        "line": 15,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Mapping",
+        "kind": "static_from",
+        "line": 15,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "typing:Sequence",
+        "kind": "static_from",
+        "line": 15,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "numpy",
+        "kind": "static_import",
+        "line": 18,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "yaml",
+        "kind": "static_import",
+        "line": 23,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 30,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 534,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "settings:get_settings",
+        "kind": "static_from",
+        "line": 557,
+        "optional": false,
+        "source": "wildcard_engine.py"
+      }
+    ],
+    "ignore_file": ".comfyignore",
+    "ignore_file_normalized_git_blob_sha1": "eb21e90ae0cf04f8a0763090ec8ca3301fd8cffa",
+    "missing_internal_imports": [],
+    "optional_imports": [
+      {
+        "classification": "external",
+        "imported": "server",
+        "kind": "static_import",
+        "line": 13,
+        "optional": true,
+        "source": "api.py"
+      },
+      {
+        "classification": "external",
+        "imported": "aiohttp:web",
+        "kind": "static_from",
+        "line": 14,
+        "optional": true,
+        "source": "api.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 44,
+        "optional": true,
+        "source": "api.py",
+        "target": "storage.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 44,
+        "optional": true,
+        "source": "api.py",
+        "target": "storage.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".anima_prompt.knowledge:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 18,
+        "optional": true,
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/knowledge.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".anima_prompt.models:TagSection",
+        "kind": "static_from",
+        "line": 19,
+        "optional": true,
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".anima_prompt.ordering:builtin_tag_section",
+        "kind": "static_from",
+        "line": 20,
+        "optional": true,
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/ordering.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 21,
+        "optional": true,
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 22,
+        "optional": true,
+        "source": "autocomplete_dataset.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 15,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 15,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 16,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 17,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 17,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 17,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 22,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 22,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 23,
+        "optional": true,
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "classification": "external",
+        "imported": "requests",
+        "kind": "static_import",
+        "line": 7671,
+        "optional": true,
+        "source": "nodes.py"
+      },
+      {
+        "classification": "external",
+        "imported": "googletrans:Translator",
+        "kind": "static_from",
+        "line": 170,
+        "optional": true,
+        "source": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 7,
+        "optional": true,
+        "source": "settings.py",
+        "target": "storage.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 7,
+        "optional": true,
+        "source": "settings.py",
+        "target": "storage.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 8,
+        "optional": true,
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 8,
+        "optional": true,
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 8,
+        "optional": true,
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 8,
+        "optional": true,
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 8,
+        "optional": true,
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".prompt_translation:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 8,
+        "optional": true,
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 28,
+        "optional": true,
+        "source": "wildcard_engine.py",
+        "target": "storage.py"
+      },
+      {
+        "classification": "internal",
+        "imported": ".settings:get_settings",
+        "kind": "static_from",
+        "line": 555,
+        "optional": true,
+        "source": "wildcard_engine.py",
+        "target": "settings.py"
+      }
+    ],
+    "package_root": ".",
+    "runtime_import_closure": [
+      "__init__.py",
+      "anima_prompt/__init__.py",
+      "anima_prompt/correction.py",
+      "anima_prompt/knowledge.py",
+      "anima_prompt/models.py",
+      "anima_prompt/normalize.py",
+      "anima_prompt/ordering.py",
+      "anima_prompt/parser.py",
+      "api.py",
+      "autocomplete_dataset.py",
+      "nodes.py",
+      "prompt_translation.py",
+      "settings.py",
+      "storage.py",
+      "wildcard_engine.py"
+    ],
+    "shipped_python_modules": [
+      "__init__.py",
+      "anima_prompt/__init__.py",
+      "anima_prompt/correction.py",
+      "anima_prompt/knowledge.py",
+      "anima_prompt/models.py",
+      "anima_prompt/normalize.py",
+      "anima_prompt/ordering.py",
+      "anima_prompt/parser.py",
+      "api.py",
+      "autocomplete_dataset.py",
+      "nodes.py",
+      "prompt_translation.py",
+      "settings.py",
+      "storage.py",
+      "wildcard_engine.py"
+    ],
+    "unreachable_shipped_python_modules": []
+  },
+  "schema_version": 1,
+  "side_effects": {
+    "candidates": [
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 27,
+        "module": "__init__.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "ensure_default_wildcard_root",
+        "column": 4,
+        "context": "expression",
+        "kind": "directory_creation",
+        "line": 30,
+        "module": "__init__.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logger.warning",
+        "column": 4,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 32,
+        "module": "__init__.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 11,
+        "context": "assign:_WORD_RE",
+        "kind": "import_time_call",
+        "line": 14,
+        "module": "anima_prompt/correction.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:PromptSyntax",
+        "kind": "import_time_call",
+        "line": 17,
+        "module": "anima_prompt/correction.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "Path",
+        "column": 19,
+        "context": "assign:PACKAGE_DATA_DIR",
+        "kind": "import_time_call",
+        "line": 12,
+        "module": "anima_prompt/knowledge.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "resolve",
+        "column": 19,
+        "context": "assign:PACKAGE_DATA_DIR",
+        "kind": "import_time_call",
+        "line": 12,
+        "module": "anima_prompt/knowledge.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:TagInfo",
+        "kind": "import_time_call",
+        "line": 22,
+        "module": "anima_prompt/models.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:TagToken",
+        "kind": "import_time_call",
+        "line": 30,
+        "module": "anima_prompt/models.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:ParsedPrompt",
+        "kind": "import_time_call",
+        "line": 42,
+        "module": "anima_prompt/models.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:CorrectionResult",
+        "kind": "import_time_call",
+        "line": 50,
+        "module": "anima_prompt/models.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "field",
+        "column": 32,
+        "context": "assign:report",
+        "kind": "import_time_call",
+        "line": 59,
+        "module": "anima_prompt/models.py",
+        "scope": "CorrectionResult"
+      },
+      {
+        "callee": "re.compile",
+        "column": 12,
+        "context": "assign:_SPACE_RE",
+        "kind": "import_time_call",
+        "line": 7,
+        "module": "anima_prompt/normalize.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 17,
+        "context": "assign:_PONY_SCORE_RE",
+        "kind": "import_time_call",
+        "line": 8,
+        "module": "anima_prompt/normalize.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 15,
+        "context": "assign:QUALITY_TAGS",
+        "kind": "import_time_call",
+        "line": 10,
+        "module": "anima_prompt/ordering.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 12,
+        "context": "assign:META_TAGS",
+        "kind": "import_time_call",
+        "line": 41,
+        "module": "anima_prompt/ordering.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 12,
+        "context": "assign:YEAR_TAGS",
+        "kind": "import_time_call",
+        "line": 54,
+        "module": "anima_prompt/ordering.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 14,
+        "context": "assign:SAFETY_TAGS",
+        "kind": "import_time_call",
+        "line": 64,
+        "module": "anima_prompt/ordering.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:YEAR_TAG_PATTERN",
+        "kind": "import_time_call",
+        "line": 76,
+        "module": "anima_prompt/ordering.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 26,
+        "context": "assign:ANIMA_PERSON_COUNT_TAGS",
+        "kind": "import_time_call",
+        "line": 78,
+        "module": "anima_prompt/ordering.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 27,
+        "context": "assign:_SENTENCE_COUNT_SPLIT_RE",
+        "kind": "import_time_call",
+        "line": 9,
+        "module": "anima_prompt/parser.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 29,
+        "context": "assign:INVALID_PROFILE_NAME_CHARS",
+        "kind": "import_time_call",
+        "line": 52,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "range",
+        "column": 33,
+        "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
+        "kind": "import_time_call",
+        "line": 77,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "range",
+        "column": 33,
+        "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
+        "kind": "import_time_call",
+        "line": 78,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_PromptTranslationWorker",
+        "column": 29,
+        "context": "assign:_PROMPT_TRANSLATION_WORKER",
+        "kind": "import_time_call",
+        "line": 131,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "atexit.register",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 132,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_get_prompt_routes",
+        "column": 9,
+        "context": "assign:routes",
+        "kind": "route_registry_creation",
+        "line": 663,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:get_settings_handler",
+        "kind": "route_registration",
+        "line": 668,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:set_setting_handler",
+        "kind": "route_registration",
+        "line": 672,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:get_long_text_settings_handler",
+        "kind": "route_registration",
+        "line": 690,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:get_wildcards_handler",
+        "kind": "route_registration",
+        "line": 700,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:save_long_text_settings_handler",
+        "kind": "route_registration",
+        "line": 712,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:autocomplete_status_handler",
+        "kind": "route_registration",
+        "line": 730,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:autocomplete_handler",
+        "kind": "route_registration",
+        "line": 742,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:classify_prompt_handler",
+        "kind": "route_registration",
+        "line": 764,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:translate_prompt_handler",
+        "kind": "route_registration",
+        "line": 776,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:lora_preview_handler",
+        "kind": "route_registration",
+        "line": 785,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:loras_handler",
+        "kind": "route_registration",
+        "line": 795,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:lora_profiles_handler",
+        "kind": "route_registration",
+        "line": 799,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:save_lora_profile_handler",
+        "kind": "route_registration",
+        "line": 803,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:load_lora_profile_handler",
+        "kind": "route_registration",
+        "line": 819,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:aio_profiles_handler",
+        "kind": "route_registration",
+        "line": 829,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:save_aio_profile_handler",
+        "kind": "route_registration",
+        "line": 833,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.get",
+        "column": 5,
+        "context": "decorator:load_aio_profile_handler",
+        "kind": "route_registration",
+        "line": 849,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:delete_aio_profile_handler",
+        "kind": "route_registration",
+        "line": 859,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:rename_aio_profile_handler",
+        "kind": "route_registration",
+        "line": 870,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "routes.post",
+        "column": 5,
+        "context": "decorator:fix_lora_profile_handler",
+        "kind": "route_registration",
+        "line": 888,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:_INLINE_SPACE_RE",
+        "kind": "import_time_call",
+        "line": 69,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 12,
+        "context": "assign:_COUNT_RE",
+        "kind": "import_time_call",
+        "line": 98,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 20,
+        "context": "assign:_WEIGHT_NUMBER_RE",
+        "kind": "import_time_call",
+        "line": 103,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 21,
+        "context": "assign:_WEIGHTED_TOKEN_RE",
+        "kind": "import_time_call",
+        "line": 104,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 21,
+        "context": "assign:_WILDCARD_TOKEN_RE",
+        "kind": "import_time_call",
+        "line": 105,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 22,
+        "context": "assign:_WILDCARD_SYNTAX_RE",
+        "kind": "import_time_call",
+        "line": 106,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 27,
+        "context": "assign:_DYNAMIC_PROMPT_TOKEN_RE",
+        "kind": "import_time_call",
+        "line": 107,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 28,
+        "context": "assign:_DYNAMIC_PROMPT_SYNTAX_RE",
+        "kind": "import_time_call",
+        "line": 108,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 25,
+        "context": "assign:_DESCRIPTION_PREFIX_RE",
+        "kind": "import_time_call",
+        "line": 109,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 14,
+        "context": "assign:_COMMENT_RE",
+        "kind": "import_time_call",
+        "line": 110,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:AutocompleteEntry",
+        "kind": "import_time_call",
+        "line": 112,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_AutocompleteCacheKey",
+        "kind": "import_time_call",
+        "line": 122,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_AutocompleteSnapshot",
+        "kind": "import_time_call",
+        "line": 130,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.Lock",
+        "column": 14,
+        "context": "assign:_CACHE_LOCK",
+        "kind": "import_time_call",
+        "line": 141,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 73,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "set",
+        "column": 62,
+        "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
+        "kind": "import_time_call",
+        "line": 227,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:_HASH_COMMENT_RE",
+        "kind": "import_time_call",
+        "line": 817,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 18,
+        "context": "assign:_MULTI_COMMA_RE",
+        "kind": "import_time_call",
+        "line": 818,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:_INLINE_SPACE_RE",
+        "kind": "import_time_call",
+        "line": 819,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 21,
+        "context": "assign:_WEIGHTED_TOKEN_RE",
+        "kind": "import_time_call",
+        "line": 820,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 22,
+        "context": "assign:_WEIGHTED_ARTIST_RE",
+        "kind": "import_time_call",
+        "line": 821,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:_ARTIST_GROUP_RE",
+        "kind": "import_time_call",
+        "line": 824,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 24,
+        "context": "assign:_SECTION_SEPARATOR_RE",
+        "kind": "import_time_call",
+        "line": 828,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 23,
+        "context": "assign:_RESOLUTION_LABEL_RE",
+        "kind": "import_time_call",
+        "line": 829,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 28,
+        "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
+        "kind": "import_time_call",
+        "line": 832,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_AnyType",
+        "column": 12,
+        "context": "assign:_ANY_TYPE",
+        "kind": "import_time_call",
+        "line": 851,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 26,
+        "context": "assign:_AIO_DETAILER_CUSTOM_RE",
+        "kind": "import_time_call",
+        "line": 1243,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:PromptTranslationSettings",
+        "kind": "import_time_call",
+        "line": 30,
+        "module": "prompt_translation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.RLock",
+        "column": 29,
+        "context": "assign:_TRANSLATION_PROVIDER_LOCK",
+        "kind": "import_time_call",
+        "line": 204,
+        "module": "prompt_translation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "object",
+        "column": 14,
+        "context": "assign:_CACHE_MISS",
+        "kind": "import_time_call",
+        "line": 249,
+        "module": "prompt_translation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "PromptTranslationService",
+        "column": 31,
+        "context": "assign:_DEFAULT_TRANSLATION_SERVICE",
+        "kind": "import_time_call",
+        "line": 410,
+        "module": "prompt_translation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "Path",
+        "column": 15,
+        "context": "assign:PACKAGE_ROOT",
+        "kind": "import_time_call",
+        "line": 13,
+        "module": "storage.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "resolve",
+        "column": 15,
+        "context": "assign:PACKAGE_ROOT",
+        "kind": "import_time_call",
+        "line": 13,
+        "module": "storage.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_resolve_user_data_dir",
+        "column": 16,
+        "context": "assign:USER_DATA_DIR",
+        "kind": "import_time_call",
+        "line": 34,
+        "module": "storage.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "TypeVar",
+        "column": 5,
+        "context": "assign:_T",
+        "kind": "import_time_call",
+        "line": 37,
+        "module": "storage.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "object",
+        "column": 11,
+        "context": "assign:_MISSING",
+        "kind": "import_time_call",
+        "line": 38,
+        "module": "storage.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.Lock",
+        "column": 20,
+        "context": "assign:_PATH_LOCKS_GUARD",
+        "kind": "import_time_call",
+        "line": 40,
+        "module": "storage.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 13,
+        "context": "assign:COMMENT_RE",
+        "kind": "import_time_call",
+        "line": 93,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 13,
+        "context": "assign:DYNAMIC_RE",
+        "kind": "import_time_call",
+        "line": 94,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 14,
+        "context": "assign:WILDCARD_RE",
+        "kind": "import_time_call",
+        "line": 95,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:WILDCARD_FULL_RE",
+        "kind": "import_time_call",
+        "line": 96,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 25,
+        "context": "assign:WILDCARD_QUANTIFIER_RE",
+        "kind": "import_time_call",
+        "line": 97,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:WEIGHT_PREFIX_RE",
+        "kind": "import_time_call",
+        "line": 101,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 16,
+        "context": "assign:COUNT_SPEC_RE",
+        "kind": "import_time_call",
+        "line": 102,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:WildcardOption",
+        "kind": "import_time_call",
+        "line": 107,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_WildcardSourceFile",
+        "kind": "import_time_call",
+        "line": 113,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_WildcardSourceState",
+        "kind": "import_time_call",
+        "line": 127,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_WildcardSnapshot",
+        "kind": "import_time_call",
+        "line": 142,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.Condition",
+        "column": 22,
+        "context": "assign:_SNAPSHOT_CONDITION",
+        "kind": "import_time_call",
+        "line": 167,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "OrderedDict",
+        "column": 57,
+        "context": "assign:_SNAPSHOT_CACHE",
+        "kind": "import_time_call",
+        "line": 168,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "set",
+        "column": 33,
+        "context": "assign:_SNAPSHOT_BUILDING",
+        "kind": "import_time_call",
+        "line": 169,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:WildcardExpansionBudget",
+        "kind": "import_time_call",
+        "line": 190,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:WildcardExpansionResult",
+        "kind": "import_time_call",
+        "line": 235,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_ExpansionSegment",
+        "kind": "import_time_call",
+        "line": 260,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:_Replacement",
+        "kind": "import_time_call",
+        "line": 333,
+        "module": "wildcard_engine.py",
+        "scope": "<module>"
+      }
+    ]
+  },
+  "state": {
+    "mutable_globals": [
+      {
+        "kind": "dict",
+        "line": 34,
+        "module": "__init__.py",
+        "name": "NODE_CLASS_MAPPINGS"
+      },
+      {
+        "kind": "dict",
+        "line": 55,
+        "module": "__init__.py",
+        "name": "NODE_DISPLAY_NAME_MAPPINGS"
+      },
+      {
+        "kind": "list",
+        "line": 78,
+        "module": "__init__.py",
+        "name": "__all__"
+      },
+      {
+        "kind": "list",
+        "line": 16,
+        "module": "anima_prompt/__init__.py",
+        "name": "__all__"
+      },
+      {
+        "kind": "dict",
+        "line": 119,
+        "module": "anima_prompt/ordering.py",
+        "name": "BUILTIN_TAG_SECTIONS"
+      },
+      {
+        "kind": "dict",
+        "line": 106,
+        "module": "anima_prompt/ordering.py",
+        "name": "SECTION_ORDER"
+      },
+      {
+        "kind": "set",
+        "line": 56,
+        "module": "api.py",
+        "name": "AIO_RESERVED_PROFILE_NAMES"
+      },
+      {
+        "kind": "set",
+        "line": 72,
+        "module": "api.py",
+        "name": "WINDOWS_RESERVED_FILE_BASENAMES"
+      },
+      {
+        "kind": "dict",
+        "line": 39,
+        "module": "autocomplete_dataset.py",
+        "name": "AUTOCOMPLETE_SOURCES"
+      },
+      {
+        "kind": "dict",
+        "line": 142,
+        "module": "autocomplete_dataset.py",
+        "name": "_CACHE"
+      },
+      {
+        "kind": "dict",
+        "line": 70,
+        "module": "autocomplete_dataset.py",
+        "name": "_DANBOORU_CATEGORY_NAMES"
+      },
+      {
+        "kind": "dict",
+        "line": 77,
+        "module": "autocomplete_dataset.py",
+        "name": "_E621_CATEGORY_NAMES"
+      },
+      {
+        "kind": "dict",
+        "line": 143,
+        "module": "autocomplete_dataset.py",
+        "name": "_INFLIGHT"
+      },
+      {
+        "kind": "dict",
+        "line": 86,
+        "module": "autocomplete_dataset.py",
+        "name": "_MERGED_E621_CATEGORY_NAMES"
+      },
+      {
+        "kind": "dict",
+        "line": 87,
+        "module": "nodes.py",
+        "name": "ADVANCED_FIELD_LABELS"
+      },
+      {
+        "kind": "set",
+        "line": 86,
+        "module": "nodes.py",
+        "name": "ADVANCED_FIELD_PANES"
+      },
+      {
+        "kind": "set",
+        "line": 85,
+        "module": "nodes.py",
+        "name": "ADVANCED_FIELD_TYPES"
+      },
+      {
+        "kind": "dict",
+        "line": 738,
+        "module": "nodes.py",
+        "name": "ADVANCED_RESOLUTION_BUCKETS"
+      },
+      {
+        "kind": "dict",
+        "line": 247,
+        "module": "nodes.py",
+        "name": "AIO_GENERATION_DEFAULT_SETTINGS"
+      },
+      {
+        "kind": "dict",
+        "line": 236,
+        "module": "nodes.py",
+        "name": "AIO_INPUT_DEFAULT_SETTINGS"
+      },
+      {
+        "kind": "dict",
+        "line": 4141,
+        "module": "nodes.py",
+        "name": "AIO_PREVIEW_STAGE_LABELS"
+      },
+      {
+        "kind": "set",
+        "line": 231,
+        "module": "nodes.py",
+        "name": "AIO_SPECIAL_SEEDS"
+      },
+      {
+        "kind": "dict",
+        "line": 673,
+        "module": "nodes.py",
+        "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
+      },
+      {
+        "kind": "list",
+        "line": 704,
+        "module": "nodes.py",
+        "name": "EXTEND_PROMPT_SLOT_SPECS"
+      },
+      {
+        "kind": "list",
+        "line": 728,
+        "module": "nodes.py",
+        "name": "IMAGE_SCALE_MULTIPLES"
+      },
+      {
+        "kind": "list",
+        "line": 727,
+        "module": "nodes.py",
+        "name": "IMAGE_UPSCALE_METHODS"
+      },
+      {
+        "kind": "set",
+        "line": 77,
+        "module": "nodes.py",
+        "name": "NAIA_LOCAL_HOSTS"
+      },
+      {
+        "kind": "list",
+        "line": 815,
+        "module": "nodes.py",
+        "name": "PP_STATE_CHOICES"
+      },
+      {
+        "kind": "list",
+        "line": 798,
+        "module": "nodes.py",
+        "name": "PREPROCESSING_KEYS"
+      },
+      {
+        "kind": "set",
+        "line": 107,
+        "module": "nodes.py",
+        "name": "REGIONAL_FIELD_TYPES"
+      },
+      {
+        "kind": "set",
+        "line": 1242,
+        "module": "nodes.py",
+        "name": "_AIO_DETAILER_RESERVED_KEYS"
+      },
+      {
+        "kind": "dict",
+        "line": 4154,
+        "module": "nodes.py",
+        "name": "_AIO_FIRST_PASS_CACHE"
+      },
+      {
+        "kind": "list",
+        "line": 4155,
+        "module": "nodes.py",
+        "name": "_AIO_FIRST_PASS_CACHE_ORDER"
+      },
+      {
+        "kind": "set",
+        "line": 227,
+        "module": "nodes.py",
+        "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
+      },
+      {
+        "kind": "set",
+        "line": 14,
+        "module": "prompt_translation.py",
+        "name": "PROMPT_TRANSLATION_PROVIDERS"
+      },
+      {
+        "kind": "dict",
+        "line": 200,
+        "module": "prompt_translation.py",
+        "name": "_TRANSLATION_PROVIDER_FACTORIES"
+      },
+      {
+        "kind": "dict",
+        "line": 203,
+        "module": "prompt_translation.py",
+        "name": "_TRANSLATION_PROVIDER_INSTANCES"
+      },
+      {
+        "kind": "set",
+        "line": 93,
+        "module": "settings.py",
+        "name": "AUTOCOMPLETE_COMMIT_KEYS"
+      },
+      {
+        "kind": "set",
+        "line": 87,
+        "module": "settings.py",
+        "name": "AUTOCOMPLETE_MODES"
+      },
+      {
+        "kind": "dict",
+        "line": 148,
+        "module": "settings.py",
+        "name": "COMFY_SETTING_KEYS"
+      },
+      {
+        "kind": "dict",
+        "line": 30,
+        "module": "settings.py",
+        "name": "DEFAULT_SETTINGS"
+      },
+      {
+        "kind": "dict",
+        "line": 206,
+        "module": "settings.py",
+        "name": "LONG_TEXT_SETTING_ALIASES"
+      },
+      {
+        "kind": "set",
+        "line": 199,
+        "module": "settings.py",
+        "name": "LONG_TEXT_SETTING_KEYS"
+      },
+      {
+        "kind": "list",
+        "line": 112,
+        "module": "settings.py",
+        "name": "NAIA_PREPROCESSING_KEYS"
+      },
+      {
+        "kind": "set",
+        "line": 103,
+        "module": "settings.py",
+        "name": "NAIA_RESOLUTION_BUCKETS"
+      },
+      {
+        "kind": "set",
+        "line": 98,
+        "module": "settings.py",
+        "name": "NAIA_RESOLUTION_MODES"
+      },
+      {
+        "kind": "list",
+        "line": 130,
+        "module": "settings.py",
+        "name": "PROMPT_STUDIO_COLOR_KEYS"
+      },
+      {
+        "kind": "dict",
+        "line": 39,
+        "module": "storage.py",
+        "name": "_PATH_LOCKS"
+      },
+      {
+        "kind": "set",
+        "line": 42,
+        "module": "storage.py",
+        "name": "_UNSUPPORTED_DIRECTORY_FSYNC_ERRORS"
+      },
+      {
+        "kind": "set",
+        "line": 91,
+        "module": "wildcard_engine.py",
+        "name": "WILDCARD_EXTENSIONS"
+      },
+      {
+        "kind": "dict",
+        "line": 52,
+        "module": "wildcard_engine.py",
+        "name": "WILDCARD_MODE_ALIASES"
+      },
+      {
+        "kind": "set",
+        "line": 169,
+        "module": "wildcard_engine.py",
+        "name": "_SNAPSHOT_BUILDING"
+      }
+    ],
+    "owner_candidates": [
+      {
+        "categories": [
+          "executor"
+        ],
+        "initializer": "_PromptTranslationWorker",
+        "line": 131,
+        "module": "api.py",
+        "name": "_PROMPT_TRANSLATION_WORKER"
+      },
+      {
+        "categories": [
+          "cache",
+          "mutable_container"
+        ],
+        "initializer": "Dict",
+        "line": 142,
+        "module": "autocomplete_dataset.py",
+        "name": "_CACHE"
+      },
+      {
+        "categories": [
+          "lock"
+        ],
+        "initializer": "threading.Lock",
+        "line": 141,
+        "module": "autocomplete_dataset.py",
+        "name": "_CACHE_LOCK"
+      },
+      {
+        "categories": [
+          "future",
+          "mutable_container",
+          "single_flight"
+        ],
+        "initializer": "Dict",
+        "line": 143,
+        "module": "autocomplete_dataset.py",
+        "name": "_INFLIGHT"
+      },
+      {
+        "categories": [
+          "cache",
+          "mutable_container"
+        ],
+        "initializer": "Dict",
+        "line": 4154,
+        "module": "nodes.py",
+        "name": "_AIO_FIRST_PASS_CACHE"
+      },
+      {
+        "categories": [
+          "cache",
+          "mutable_container"
+        ],
+        "initializer": "List",
+        "line": 4155,
+        "module": "nodes.py",
+        "name": "_AIO_FIRST_PASS_CACHE_ORDER"
+      },
+      {
+        "categories": [
+          "client",
+          "mutable_container"
+        ],
+        "initializer": "Dict",
+        "line": 203,
+        "module": "prompt_translation.py",
+        "name": "_TRANSLATION_PROVIDER_INSTANCES"
+      },
+      {
+        "categories": [
+          "lock"
+        ],
+        "initializer": "threading.RLock",
+        "line": 204,
+        "module": "prompt_translation.py",
+        "name": "_TRANSLATION_PROVIDER_LOCK"
+      },
+      {
+        "categories": [
+          "lock",
+          "mutable_container"
+        ],
+        "initializer": "Dict",
+        "line": 39,
+        "module": "storage.py",
+        "name": "_PATH_LOCKS"
+      },
+      {
+        "categories": [
+          "lock"
+        ],
+        "initializer": "threading.Lock",
+        "line": 40,
+        "module": "storage.py",
+        "name": "_PATH_LOCKS_GUARD"
+      },
+      {
+        "categories": [
+          "mutable_container",
+          "single_flight"
+        ],
+        "initializer": "set",
+        "line": 169,
+        "module": "wildcard_engine.py",
+        "name": "_SNAPSHOT_BUILDING"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -9,6 +9,8 @@
     "edges": [
       {
         "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -18,11 +20,14 @@
         "name": null,
         "optional": false,
         "requested": "logging",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaAIOGenerator",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -32,12 +37,15 @@
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaArtistMixConditioning",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -47,12 +55,15 @@
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaDetailerAlignHook",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -62,12 +73,15 @@
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaImageScaleByMultiple",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -77,12 +91,15 @@
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaInput",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -92,12 +109,15 @@
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaLoraPreset",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -107,12 +127,15 @@
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaNAIARandomPrompt",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -122,12 +145,15 @@
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptBuilder",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -137,12 +163,15 @@
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptCorrector",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -152,12 +181,15 @@
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptCorrectorSimple",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -167,12 +199,15 @@
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptDataConditioning",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -182,12 +217,15 @@
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptDataUnpack",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -197,12 +235,15 @@
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptStudio",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -212,12 +253,15 @@
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptStudioAdvanced",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -227,12 +271,15 @@
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -242,12 +289,15 @@
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaPromptStudioRegional",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -257,12 +307,15 @@
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaRegionalConditioning",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -272,12 +325,15 @@
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "EasyUseAnimaWildcard",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -287,12 +343,15 @@
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".nodes",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "api",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -302,12 +361,15 @@
         "name": "api",
         "optional": false,
         "requested": ".",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "ensure_default_wildcard_root",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -317,12 +379,15 @@
         "name": "ensure_default_wildcard_root",
         "optional": false,
         "requested": ".wildcard_engine",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "__init__.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "correct_prompt",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -332,12 +397,15 @@
         "name": "correct_prompt",
         "optional": false,
         "requested": ".correction",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/correction.py"
       },
       {
         "alias": null,
+        "bound_name": "inspect_prompt",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -347,12 +415,15 @@
         "name": "inspect_prompt",
         "optional": false,
         "requested": ".correction",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/correction.py"
       },
       {
         "alias": null,
+        "bound_name": "KnowledgeBaseNotFound",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -362,12 +433,15 @@
         "name": "KnowledgeBaseNotFound",
         "optional": false,
         "requested": ".knowledge",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "PromptKnowledgeBase",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -377,12 +451,15 @@
         "name": "PromptKnowledgeBase",
         "optional": false,
         "requested": ".knowledge",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "load_knowledge_base",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -392,12 +469,15 @@
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".knowledge",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "CorrectionResult",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -407,12 +487,15 @@
         "name": "CorrectionResult",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "ParsedPrompt",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -422,12 +505,15 @@
         "name": "ParsedPrompt",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "TagInfo",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -437,12 +523,15 @@
         "name": "TagInfo",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "TagToken",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -452,12 +541,15 @@
         "name": "TagToken",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/__init__.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -467,11 +559,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -481,11 +576,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py"
       },
       {
         "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -495,11 +593,14 @@
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py"
       },
       {
         "alias": null,
+        "bound_name": "PromptKnowledgeBase",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -509,12 +610,15 @@
         "name": "PromptKnowledgeBase",
         "optional": false,
         "requested": ".knowledge",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "CorrectionResult",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -524,12 +628,15 @@
         "name": "CorrectionResult",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "TagToken",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -539,12 +646,15 @@
         "name": "TagToken",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "lookup_key",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -554,12 +664,15 @@
         "name": "lookup_key",
         "optional": false,
         "requested": ".normalize",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/normalize.py"
       },
       {
         "alias": null,
+        "bound_name": "normalize_tag",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -569,12 +682,15 @@
         "name": "normalize_tag",
         "optional": false,
         "requested": ".normalize",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/normalize.py"
       },
       {
         "alias": null,
+        "bound_name": "render_artist_tag",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -584,12 +700,15 @@
         "name": "render_artist_tag",
         "optional": false,
         "requested": ".normalize",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/normalize.py"
       },
       {
         "alias": null,
+        "bound_name": "classify_tag",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -599,12 +718,15 @@
         "name": "classify_tag",
         "optional": false,
         "requested": ".ordering",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
+        "bound_name": "section_sort_key",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -614,12 +736,15 @@
         "name": "section_sort_key",
         "optional": false,
         "requested": ".ordering",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
+        "bound_name": "parse_prompt",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -629,12 +754,15 @@
         "name": "parse_prompt",
         "optional": false,
         "requested": ".parser",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/parser.py"
       },
       {
         "alias": null,
+        "bound_name": "render_tags",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -644,12 +772,15 @@
         "name": "render_tags",
         "optional": false,
         "requested": ".parser",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/correction.py",
         "target": "anima_prompt/parser.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -659,11 +790,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -673,11 +807,14 @@
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -687,11 +824,14 @@
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "TagInfo",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -701,12 +841,15 @@
         "name": "TagInfo",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/knowledge.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "lookup_key",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -716,12 +859,15 @@
         "name": "lookup_key",
         "optional": false,
         "requested": ".normalize",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/knowledge.py",
         "target": "anima_prompt/normalize.py"
       },
       {
         "alias": null,
+        "bound_name": "TagSection",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -731,12 +877,15 @@
         "name": "TagSection",
         "optional": false,
         "requested": ".ordering",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/knowledge.py",
         "target": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
+        "bound_name": "builtin_tag_section",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -746,12 +895,15 @@
         "name": "builtin_tag_section",
         "optional": false,
         "requested": ".ordering",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/knowledge.py",
         "target": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -761,11 +913,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -775,11 +930,14 @@
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "field",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -789,11 +947,14 @@
         "name": "field",
         "optional": false,
         "requested": "dataclasses",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "Enum",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -803,11 +964,14 @@
         "name": "Enum",
         "optional": false,
         "requested": "enum",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -817,11 +981,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/normalize.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -831,11 +998,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/normalize.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -845,11 +1015,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -859,11 +1032,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
+        "bound_name": "TagInfo",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -873,12 +1049,15 @@
         "name": "TagInfo",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/ordering.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "TagSection",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -888,12 +1067,15 @@
         "name": "TagSection",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/ordering.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "lookup_key",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -903,12 +1085,15 @@
         "name": "lookup_key",
         "optional": false,
         "requested": ".normalize",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/ordering.py",
         "target": "anima_prompt/normalize.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -918,11 +1103,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/parser.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -932,11 +1120,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/parser.py"
       },
       {
         "alias": null,
+        "bound_name": "ParsedPrompt",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -946,12 +1137,15 @@
         "name": "ParsedPrompt",
         "optional": false,
         "requested": ".models",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "anima_prompt/parser.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -961,11 +1155,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "atexit",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -975,11 +1172,14 @@
         "name": null,
         "optional": false,
         "requested": "atexit",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "asyncio",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -989,11 +1189,14 @@
         "name": null,
         "optional": false,
         "requested": "asyncio",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1003,11 +1206,14 @@
         "name": null,
         "optional": false,
         "requested": "json",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1017,11 +1223,14 @@
         "name": null,
         "optional": false,
         "requested": "os",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1031,11 +1240,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1045,11 +1257,14 @@
         "name": null,
         "optional": false,
         "requested": "threading",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "Future",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1059,11 +1274,14 @@
         "name": "Future",
         "optional": false,
         "requested": "concurrent.futures",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "ThreadPoolExecutor",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1073,11 +1291,14 @@
         "name": "ThreadPoolExecutor",
         "optional": false,
         "requested": "concurrent.futures",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1087,39 +1308,64 @@
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "server",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
         "classification": "external",
         "column": 4,
-        "conditional": false,
+        "conditional": true,
         "imported": "server",
         "kind": "static_import",
         "line": 13,
         "name": null,
         "optional": true,
         "requested": "server",
+        "role": "optional_dependency",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "web",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
         "classification": "external",
         "column": 4,
-        "conditional": false,
+        "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
         "line": 14,
         "name": "web",
         "optional": true,
         "requested": "aiohttp",
+        "role": "optional_dependency",
         "scope": "<module>",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "load_long_text_settings",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1129,12 +1375,15 @@
         "name": "load_long_text_settings",
         "optional": false,
         "requested": ".settings",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "public_settings",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1144,12 +1393,15 @@
         "name": "public_settings",
         "optional": false,
         "requested": ".settings",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "resolve_autocomplete_limit",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1159,12 +1411,15 @@
         "name": "resolve_autocomplete_limit",
         "optional": false,
         "requested": ".settings",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "resolve_autocomplete_source",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1174,12 +1429,15 @@
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": ".settings",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "resolve_prompt_translation_settings",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1189,12 +1447,15 @@
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "save_long_text_settings",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1204,12 +1465,15 @@
         "name": "save_long_text_settings",
         "optional": false,
         "requested": ".settings",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "save_setting",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1219,12 +1483,15 @@
         "name": "save_setting",
         "optional": false,
         "requested": ".settings",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "autocomplete_status",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1234,12 +1501,15 @@
         "name": "autocomplete_status",
         "optional": false,
         "requested": ".autocomplete_dataset",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "available_autocomplete_sources",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1249,12 +1519,15 @@
         "name": "available_autocomplete_sources",
         "optional": false,
         "requested": ".autocomplete_dataset",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "classify_prompt_text",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1264,12 +1537,15 @@
         "name": "classify_prompt_text",
         "optional": false,
         "requested": ".autocomplete_dataset",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "autocomplete_dataset.py"
       },
       {
         "alias": "resolve_autocomplete_source_path",
+        "bound_name": "resolve_autocomplete_source_path",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1279,12 +1555,15 @@
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": ".autocomplete_dataset",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "search_autocomplete",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1294,12 +1573,15 @@
         "name": "search_autocomplete",
         "optional": false,
         "requested": ".autocomplete_dataset",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "list_wildcards",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1309,12 +1591,15 @@
         "name": "list_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "resolve_wildcard_roots",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1324,12 +1609,15 @@
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".wildcard_engine",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "PromptTranslationError",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1339,12 +1627,15 @@
         "name": "PromptTranslationError",
         "optional": false,
         "requested": ".prompt_translation",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "TranslationBusyError",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1354,12 +1645,15 @@
         "name": "TranslationBusyError",
         "optional": false,
         "requested": ".prompt_translation",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "TranslationCancelledError",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1369,12 +1663,15 @@
         "name": "TranslationCancelledError",
         "optional": false,
         "requested": ".prompt_translation",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "TranslationTimeoutError",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1384,12 +1681,15 @@
         "name": "TranslationTimeoutError",
         "optional": false,
         "requested": ".prompt_translation",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "translate_prompt_markers",
+        "branch_context": [],
         "classification": "internal",
         "column": 0,
         "conditional": false,
@@ -1399,112 +1699,220 @@
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "api.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "AtomicJsonStore",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 43
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "AtomicJsonStore",
+          "target": "storage.py",
+          "try_line": 43
+        },
+        "conditional": true,
         "imported": ".storage:AtomicJsonStore",
         "kind": "static_from",
         "line": 44,
         "name": "AtomicJsonStore",
-        "optional": true,
+        "optional": false,
         "requested": ".storage",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "api.py",
         "target": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 43
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 43
+        },
+        "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
         "line": 44,
         "name": "USER_DATA_DIR",
-        "optional": true,
+        "optional": false,
         "requested": ".storage",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "api.py",
         "target": "storage.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "AtomicJsonStore",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 45,
+            "kind": "try",
+            "line": 43
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "AtomicJsonStore",
+          "target": "storage.py",
+          "try_line": 43
+        },
+        "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
         "line": 46,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "storage",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "api.py"
+        "source": "api.py",
+        "target": "storage.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 45,
+            "kind": "try",
+            "line": 43
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 43
+        },
+        "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
         "line": 46,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "api.py"
+        "source": "api.py",
+        "target": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 302
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 303,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_list_loras",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 328
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 329,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_lora_full_path",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 629
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 630,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_resolve_lora_preview_path",
         "source": "api.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1514,11 +1922,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "csv",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1528,11 +1939,14 @@
         "name": null,
         "optional": false,
         "requested": "csv",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "heapq",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1542,11 +1956,14 @@
         "name": null,
         "optional": false,
         "requested": "heapq",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "itertools",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1556,11 +1973,14 @@
         "name": null,
         "optional": false,
         "requested": "itertools",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1570,11 +1990,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "stat",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1584,11 +2007,14 @@
         "name": null,
         "optional": false,
         "requested": "stat",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1598,11 +2024,14 @@
         "name": null,
         "optional": false,
         "requested": "threading",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "time",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1612,11 +2041,14 @@
         "name": null,
         "optional": false,
         "requested": "time",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "unicodedata",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1626,11 +2058,14 @@
         "name": null,
         "optional": false,
         "requested": "unicodedata",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "Future",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1640,11 +2075,14 @@
         "name": "Future",
         "optional": false,
         "requested": "concurrent.futures",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1654,11 +2092,14 @@
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1668,11 +2109,14 @@
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "MappingProxyType",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1682,11 +2126,14 @@
         "name": "MappingProxyType",
         "optional": false,
         "requested": "types",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1696,156 +2143,339 @@
         "name": "Mapping",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py"
       },
       {
         "alias": null,
+        "bound_name": "PACKAGE_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PACKAGE_DATA_DIR",
+          "target": "anima_prompt/knowledge.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": ".anima_prompt.knowledge:PACKAGE_DATA_DIR",
         "kind": "static_from",
         "line": 18,
         "name": "PACKAGE_DATA_DIR",
-        "optional": true,
+        "optional": false,
         "requested": ".anima_prompt.knowledge",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
         "target": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
+        "bound_name": "TagSection",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "TagSection",
+          "target": "anima_prompt/models.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": ".anima_prompt.models:TagSection",
         "kind": "static_from",
         "line": 19,
         "name": "TagSection",
-        "optional": true,
+        "optional": false,
         "requested": ".anima_prompt.models",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
         "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
+        "bound_name": "builtin_tag_section",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "builtin_tag_section",
+          "target": "anima_prompt/ordering.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": ".anima_prompt.ordering:builtin_tag_section",
         "kind": "static_from",
         "line": 20,
         "name": "builtin_tag_section",
-        "optional": true,
+        "optional": false,
         "requested": ".anima_prompt.ordering",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
         "target": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
+        "bound_name": "parse_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "parse_prompt",
+          "target": "anima_prompt/parser.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
         "line": 21,
         "name": "parse_prompt",
-        "optional": true,
+        "optional": false,
         "requested": ".anima_prompt.parser",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
         "target": "anima_prompt/parser.py"
       },
       {
         "alias": null,
+        "bound_name": "iter_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "iter_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": ".prompt_translation:iter_prompt_translation_markers",
         "kind": "static_from",
         "line": 22,
         "name": "iter_prompt_translation_markers",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "PACKAGE_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PACKAGE_DATA_DIR",
+          "target": "anima_prompt/knowledge.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
         "kind": "static_from",
         "line": 24,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": "anima_prompt.knowledge",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "autocomplete_dataset.py"
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/knowledge.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "TagSection",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "TagSection",
+          "target": "anima_prompt/models.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": "anima_prompt.models:TagSection",
         "kind": "static_from",
         "line": 25,
         "name": "TagSection",
         "optional": false,
         "requested": "anima_prompt.models",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "autocomplete_dataset.py"
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/models.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "builtin_tag_section",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "builtin_tag_section",
+          "target": "anima_prompt/ordering.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": "anima_prompt.ordering:builtin_tag_section",
         "kind": "static_from",
         "line": 26,
         "name": "builtin_tag_section",
         "optional": false,
         "requested": "anima_prompt.ordering",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "autocomplete_dataset.py"
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/ordering.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "parse_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "parse_prompt",
+          "target": "anima_prompt/parser.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
         "line": 27,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "autocomplete_dataset.py"
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/parser.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "iter_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "iter_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 17
+        },
+        "conditional": true,
         "imported": "prompt_translation:iter_prompt_translation_markers",
         "kind": "static_from",
         "line": 28,
         "name": "iter_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "autocomplete_dataset.py"
+        "source": "autocomplete_dataset.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1855,11 +2485,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "inspect",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1869,11 +2502,14 @@
         "name": null,
         "optional": false,
         "requested": "inspect",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1883,11 +2519,14 @@
         "name": null,
         "optional": false,
         "requested": "json",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1897,11 +2536,14 @@
         "name": null,
         "optional": false,
         "requested": "logging",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1911,11 +2553,14 @@
         "name": null,
         "optional": false,
         "requested": "os",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "random",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1925,11 +2570,14 @@
         "name": null,
         "optional": false,
         "requested": "random",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1939,11 +2587,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "sys",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1953,11 +2604,14 @@
         "name": null,
         "optional": false,
         "requested": "sys",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "ceil",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1967,11 +2621,14 @@
         "name": "ceil",
         "optional": false,
         "requested": "math",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "gcd",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1981,11 +2638,14 @@
         "name": "gcd",
         "optional": false,
         "requested": "math",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "isfinite",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -1995,11 +2655,14 @@
         "name": "isfinite",
         "optional": false,
         "requested": "math",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "lcm",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -2009,11 +2672,14 @@
         "name": "lcm",
         "optional": false,
         "requested": "math",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "log",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -2023,11 +2689,14 @@
         "name": "log",
         "optional": false,
         "requested": "math",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "sqrt",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -2037,11 +2706,14 @@
         "name": "sqrt",
         "optional": false,
         "requested": "math",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -2051,11 +2723,14 @@
         "name": "Any",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "Optional",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -2065,1031 +2740,2193 @@
         "name": "Optional",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "correct_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "correct_prompt",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
         "line": 15,
         "name": "correct_prompt",
-        "optional": true,
+        "optional": false,
         "requested": ".anima_prompt",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "anima_prompt/__init__.py"
       },
       {
         "alias": null,
+        "bound_name": "load_knowledge_base",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "load_knowledge_base",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
         "line": 15,
         "name": "load_knowledge_base",
-        "optional": true,
+        "optional": false,
         "requested": ".anima_prompt",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "anima_prompt/__init__.py"
       },
       {
         "alias": null,
+        "bound_name": "parse_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "parse_prompt",
+          "target": "anima_prompt/parser.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
         "line": 16,
         "name": "parse_prompt",
-        "optional": true,
+        "optional": false,
         "requested": ".anima_prompt.parser",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "anima_prompt/parser.py"
       },
       {
         "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
         "line": 17,
         "name": "resolve_metadata_filter_words",
-        "optional": true,
+        "optional": false,
         "requested": ".settings",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "resolve_naia_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "resolve_naia_settings",
+          "target": "settings.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
         "line": 17,
         "name": "resolve_naia_settings",
-        "optional": true,
+        "optional": false,
         "requested": ".settings",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "resolve_prompt_translation_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "resolve_prompt_translation_settings",
+          "target": "settings.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
         "line": 17,
         "name": "resolve_prompt_translation_settings",
-        "optional": true,
+        "optional": false,
         "requested": ".settings",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
         "line": 22,
         "name": "has_prompt_translation_markers",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "translate_prompt_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "translate_prompt_markers",
+          "target": "prompt_translation.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
         "line": 22,
         "name": "translate_prompt_markers",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
         "line": 23,
         "name": "MAX_SEED",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
         "line": 23,
         "name": "PUBLIC_MAX_SEED",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "SEED_CONTROL_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_DECREMENT",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
         "line": 23,
         "name": "SEED_CONTROL_DECREMENT",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
         "line": 23,
         "name": "SEED_CONTROL_FIXED",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
         "line": 23,
         "name": "SEED_CONTROL_INCREMENT",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
         "line": 23,
         "name": "SEED_CONTROL_MODES",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
         "line": 23,
         "name": "SEED_CONTROL_RANDOMIZE",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "WILDCARD_MODE_FIXED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
         "line": 23,
         "name": "WILDCARD_MODE_FIXED",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "WILDCARD_MODE_LABELS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_LABELS",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
         "line": 23,
         "name": "WILDCARD_MODE_LABELS",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "WILDCARD_MODE_POPULATE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_POPULATE",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
         "line": 23,
         "name": "WILDCARD_MODE_POPULATE",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "WILDCARD_MODE_REPRODUCE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_REPRODUCE",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
         "line": 23,
         "name": "WILDCARD_MODE_REPRODUCE",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
         "line": 23,
         "name": "WILDCARD_MODE_SEQUENTIAL",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
         "line": 23,
         "name": "expand_wildcards",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "has_wildcard_syntax",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "has_wildcard_syntax",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
         "line": 23,
         "name": "has_wildcard_syntax",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
         "line": 23,
         "name": "next_seed",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
         "line": 23,
         "name": "normalize_seed",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "normalize_wildcard_mode",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_wildcard_mode",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
         "line": 23,
         "name": "normalize_wildcard_mode",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "wildcard_sources_signature",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "wildcard_sources_signature",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
         "line": 23,
         "name": "wildcard_sources_signature",
-        "optional": true,
+        "optional": false,
         "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "correct_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "correct_prompt",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
         "line": 44,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "load_knowledge_base",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "load_knowledge_base",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
         "line": 44,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "parse_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "parse_prompt",
+          "target": "anima_prompt/parser.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
         "line": 45,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "anima_prompt/parser.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
         "line": 46,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "settings.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "resolve_naia_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "resolve_naia_settings",
+          "target": "settings.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
         "line": 46,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "settings.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "resolve_prompt_translation_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "resolve_prompt_translation_settings",
+          "target": "settings.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
         "line": 46,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "settings.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
         "line": 51,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "translate_prompt_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "translate_prompt_markers",
+          "target": "prompt_translation.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
         "line": 51,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
         "line": 52,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
         "line": 52,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "SEED_CONTROL_DECREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_DECREMENT",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
         "line": 52,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
         "line": 52,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
         "line": 52,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
         "line": 52,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
         "line": 52,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "WILDCARD_MODE_FIXED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
         "line": 52,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "WILDCARD_MODE_LABELS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_LABELS",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
         "line": 52,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "WILDCARD_MODE_POPULATE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_POPULATE",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
         "line": 52,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "WILDCARD_MODE_REPRODUCE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_REPRODUCE",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
         "line": 52,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
         "line": 52,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
         "line": 52,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "has_wildcard_syntax",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "has_wildcard_syntax",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
         "line": 52,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
         "line": 52,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
         "line": 52,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "normalize_wildcard_mode",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_wildcard_mode",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
         "line": 52,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "wildcard_sources_signature",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "wildcard_sources_signature",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
         "line": 52,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "nodes.py"
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2043
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
         "line": 2044,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "nodes",
+        "role": "optional_dependency",
         "scope": "_comfy_max_resolution",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "comfy",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2052
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
         "line": 2053,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "comfy.samplers",
+        "role": "optional_dependency",
         "scope": "_comfy_sampler_names",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "comfy",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2071
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
         "line": 2072,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "comfy.samplers",
+        "role": "optional_dependency",
         "scope": "_comfy_scheduler_names",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2098
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 2099,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_comfy_checkpoint_names",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2110
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 2111,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_folder_path_names",
         "source": "nodes.py"
       },
       {
         "alias": "core",
+        "bound_name": "core",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2184
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
         "line": 2185,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "impact.core",
+        "role": "optional_dependency",
         "scope": "_impact_core_module",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "core",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2190
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
         "line": 2191,
         "name": "core",
-        "optional": false,
+        "optional": true,
         "requested": "modules.impact",
+        "role": "optional_dependency",
         "scope": "_impact_core_module",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "comfy",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2206
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
         "line": 2207,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "comfy.samplers",
+        "role": "optional_dependency",
         "scope": "_impact_scheduler_names",
         "source": "nodes.py"
       },
       {
         "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2215
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
         "line": 2216,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "nodes",
+        "role": "optional_dependency",
         "scope": "_find_impact_detailer_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "DetailerForEach",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2231
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
         "line": 2232,
         "name": "DetailerForEach",
-        "optional": false,
+        "optional": true,
         "requested": "impact.impact_pack",
+        "role": "optional_dependency",
         "scope": "_find_impact_detailer_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "DetailerForEach",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2237
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
         "line": 2238,
         "name": "DetailerForEach",
-        "optional": false,
+        "optional": true,
         "requested": "modules.impact.impact_pack",
+        "role": "optional_dependency",
         "scope": "_find_impact_detailer_class",
         "source": "nodes.py"
       },
       {
         "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2251
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
         "line": 2252,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "nodes",
+        "role": "optional_dependency",
         "scope": "_find_comfy_node_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "SAM3_Detect",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2368
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
         "line": 2369,
         "name": "SAM3_Detect",
-        "optional": false,
+        "optional": true,
         "requested": "comfy_extras.nodes_sam3",
+        "role": "optional_dependency",
         "scope": "_find_sam3_detect_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "MaskToSEGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2392
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 2393,
         "name": "MaskToSEGS",
-        "optional": false,
+        "optional": true,
         "requested": "impact.segs_nodes",
+        "role": "optional_dependency",
         "scope": "_find_impact_mask_to_segs_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "MaskToSEGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2398
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 2399,
         "name": "MaskToSEGS",
-        "optional": false,
+        "optional": true,
         "requested": "modules.impact.segs_nodes",
+        "role": "optional_dependency",
         "scope": "_find_impact_mask_to_segs_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "MaskToSEGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2404
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
         "line": 2405,
         "name": "MaskToSEGS",
-        "optional": false,
+        "optional": true,
         "requested": "impact.impact_pack",
+        "role": "optional_dependency",
         "scope": "_find_impact_mask_to_segs_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "MaskToSEGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2410
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
         "line": 2411,
         "name": "MaskToSEGS",
-        "optional": false,
+        "optional": true,
         "requested": "modules.impact.impact_pack",
+        "role": "optional_dependency",
         "scope": "_find_impact_mask_to_segs_class",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2866
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 2867,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_aio_lora_metadata_name",
         "source": "nodes.py"
       },
       {
         "alias": "model_management",
+        "bound_name": "model_management",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2906
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
         "line": 2907,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "comfy.model_management",
+        "role": "optional_dependency",
         "scope": "_cleanup_aio_ephemeral_model",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "UpscaleModelLoader",
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 3368,
+            "type_checking": false
+          },
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 3369
+          }
+        ],
         "classification": "external",
         "column": 12,
         "conditional": true,
@@ -3097,321 +4934,569 @@
         "kind": "static_from",
         "line": 3370,
         "name": "UpscaleModelLoader",
-        "optional": false,
+        "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
+        "role": "optional_dependency",
         "scope": "_load_upscale_model_with_comfy",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4169
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 4170,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_aio_preview_base_directory",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "PromptServer",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4231
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
         "line": 4232,
         "name": "PromptServer",
-        "optional": false,
+        "optional": true,
         "requested": "server",
+        "role": "optional_dependency",
         "scope": "_send_aio_preview_event",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 4259,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_save_aio_temp_preview_image",
         "source": "nodes.py"
       },
       {
         "alias": "np",
+        "bound_name": "np",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
         "line": 4260,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "numpy",
+        "role": "optional_dependency",
         "scope": "_save_aio_temp_preview_image",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "Image",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
         "line": 4261,
         "name": "Image",
-        "optional": false,
+        "optional": true,
         "requested": "PIL",
+        "role": "optional_dependency",
         "scope": "_save_aio_temp_preview_image",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4452
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 4453,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_empty_mask_for_image",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "comfy",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4705
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "comfy.utils",
         "kind": "static_import",
         "line": 4706,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "comfy.utils",
+        "role": "optional_dependency",
         "scope": "_common_upscale_image",
         "source": "nodes.py"
       },
       {
         "alias": "F",
+        "bound_name": "F",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": false,
+            "exceptions": [
+              "Exception"
+            ],
+            "handler_line": 4709,
+            "kind": "try",
+            "line": 4705
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch.nn.functional",
         "kind": "static_import",
         "line": 4710,
         "name": null,
         "optional": false,
         "requested": "torch.nn.functional",
+        "role": "ordinary",
         "scope": "_common_upscale_image",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5621
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5622,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_copy_conditioning_metadata",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5638
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5639,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_pad_conditioning_tensor",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5659
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5660,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_blend_conditionings",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5736
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5737,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_artist_delta_rms_from_encoded",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 6535
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 6536,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_encode_artist_clustered",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7560
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 7561,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_regional_union_mask_for_ids",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7594
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 7595,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "torch",
+        "role": "optional_dependency",
         "scope": "_regional_mask_bounds_area",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "requests",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 7670
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "requests",
         "kind": "static_import",
         "line": 7671,
         "name": null,
         "optional": true,
         "requested": "requests",
+        "role": "optional_dependency",
         "scope": "_post_random",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "apply_lora_syntax_format",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7886
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
         "line": 7887,
         "name": "apply_lora_syntax_format",
-        "optional": false,
+        "optional": true,
         "requested": "py.nodes.utils",
+        "role": "optional_dependency",
         "scope": "_apply_lora_syntax_format",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7896
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 7897,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_fallback_lora_path",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7918
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 7919,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_lora_stack_name",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "get_lora_info",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8023
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
         "line": 8024,
         "name": "get_lora_info",
-        "optional": false,
+        "optional": true,
         "requested": "py.utils.utils",
+        "role": "optional_dependency",
         "scope": "_get_lora_info",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8067
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 8068,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_lora_combo_values",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8092
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 8093,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_lora_model_exists",
         "source": "nodes.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3421,11 +5506,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "html",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3435,11 +5523,14 @@
         "name": null,
         "optional": false,
         "requested": "html",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3449,11 +5540,14 @@
         "name": null,
         "optional": false,
         "requested": "threading",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "time",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3463,11 +5557,14 @@
         "name": null,
         "optional": false,
         "requested": "time",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "OrderedDict",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3477,11 +5574,14 @@
         "name": "OrderedDict",
         "optional": false,
         "requested": "collections",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "contextmanager",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3491,11 +5591,14 @@
         "name": "contextmanager",
         "optional": false,
         "requested": "contextlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3505,11 +5608,14 @@
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3519,11 +5625,14 @@
         "name": "Callable",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3533,25 +5642,39 @@
         "name": "Protocol",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "Translator",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 169
+          }
+        ],
         "classification": "external",
         "column": 12,
-        "conditional": false,
+        "conditional": true,
         "imported": "googletrans:Translator",
         "kind": "static_from",
         "line": 170,
         "name": "Translator",
         "optional": true,
         "requested": "googletrans",
+        "role": "optional_dependency",
         "scope": "GoogleTranslationProvider._create_translator",
         "source": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3561,11 +5684,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3575,11 +5701,14 @@
         "name": null,
         "optional": false,
         "requested": "json",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3589,257 +5718,559 @@
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "AtomicJsonStore",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "AtomicJsonStore",
+          "target": "storage.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".storage:AtomicJsonStore",
         "kind": "static_from",
         "line": 7,
         "name": "AtomicJsonStore",
-        "optional": true,
+        "optional": false,
         "requested": ".storage",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
         "line": 7,
         "name": "USER_DATA_DIR",
-        "optional": true,
+        "optional": false,
         "requested": ".storage",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "kind": "static_from",
         "line": 8,
         "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
         "kind": "static_from",
         "line": 8,
         "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
         "kind": "static_from",
         "line": 8,
         "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "PromptTranslationSettings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationSettings",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".prompt_translation:PromptTranslationSettings",
         "kind": "static_from",
         "line": 8,
         "name": "PromptTranslationSettings",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "normalize_prompt_translation_language",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_language",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".prompt_translation:normalize_prompt_translation_language",
         "kind": "static_from",
         "line": 8,
         "name": "normalize_prompt_translation_language",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "normalize_prompt_translation_provider",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 6
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_provider",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": ".prompt_translation:normalize_prompt_translation_provider",
         "kind": "static_from",
         "line": 8,
         "name": "normalize_prompt_translation_provider",
-        "optional": true,
+        "optional": false,
         "requested": ".prompt_translation",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "settings.py",
         "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "AtomicJsonStore",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "AtomicJsonStore",
+          "target": "storage.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
         "line": 17,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "storage",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "storage.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
         "line": 17,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "storage.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "kind": "static_from",
         "line": 18,
         "name": "DEFAULT_PROMPT_TRANSLATION_SOURCE",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
         "kind": "static_from",
         "line": 18,
         "name": "DEFAULT_PROMPT_TRANSLATION_TARGET",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PROMPT_TRANSLATION_PROVIDER_OFF",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
         "kind": "static_from",
         "line": 18,
         "name": "PROMPT_TRANSLATION_PROVIDER_OFF",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "PromptTranslationSettings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "PromptTranslationSettings",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "prompt_translation:PromptTranslationSettings",
         "kind": "static_from",
         "line": 18,
         "name": "PromptTranslationSettings",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "normalize_prompt_translation_language",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_language",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "prompt_translation:normalize_prompt_translation_language",
         "kind": "static_from",
         "line": 18,
         "name": "normalize_prompt_translation_language",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "normalize_prompt_translation_provider",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_translation_provider",
+          "target": "prompt_translation.py",
+          "try_line": 6
+        },
+        "conditional": true,
         "imported": "prompt_translation:normalize_prompt_translation_provider",
         "kind": "static_from",
         "line": 18,
         "name": "normalize_prompt_translation_provider",
         "optional": false,
         "requested": "prompt_translation",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "settings.py"
+        "source": "settings.py",
+        "target": "prompt_translation.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 271
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 272,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_comfy_settings_candidates",
         "source": "settings.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3849,11 +6280,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "errno",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3863,11 +6297,14 @@
         "name": null,
         "optional": false,
         "requested": "errno",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3877,11 +6314,14 @@
         "name": null,
         "optional": false,
         "requested": "json",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3891,11 +6331,14 @@
         "name": null,
         "optional": false,
         "requested": "os",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "tempfile",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3905,11 +6348,14 @@
         "name": null,
         "optional": false,
         "requested": "tempfile",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3919,11 +6365,14 @@
         "name": null,
         "optional": false,
         "requested": "threading",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "contextmanager",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3933,11 +6382,14 @@
         "name": "contextmanager",
         "optional": false,
         "requested": "contextlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3947,11 +6399,14 @@
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3961,11 +6416,14 @@
         "name": "Callable",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "Iterator",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3975,11 +6433,14 @@
         "name": "Iterator",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "TypeVar",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -3989,25 +6450,39 @@
         "name": "TypeVar",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 19
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 20,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_resolve_user_data_dir",
         "source": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4017,11 +6492,14 @@
         "name": "annotations",
         "optional": false,
         "requested": "__future__",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "bisect",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4031,11 +6509,14 @@
         "name": null,
         "optional": false,
         "requested": "bisect",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "OrderedDict",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4045,11 +6526,14 @@
         "name": "OrderedDict",
         "optional": false,
         "requested": "collections",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "fnmatch",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4059,11 +6543,14 @@
         "name": null,
         "optional": false,
         "requested": "fnmatch",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "hashlib",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4073,11 +6560,14 @@
         "name": null,
         "optional": false,
         "requested": "hashlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "math",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4087,11 +6577,14 @@
         "name": null,
         "optional": false,
         "requested": "math",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4101,11 +6594,14 @@
         "name": null,
         "optional": false,
         "requested": "os",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "random",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4115,11 +6611,14 @@
         "name": null,
         "optional": false,
         "requested": "random",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4129,11 +6628,14 @@
         "name": null,
         "optional": false,
         "requested": "re",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4143,11 +6645,14 @@
         "name": null,
         "optional": false,
         "requested": "threading",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4157,11 +6662,14 @@
         "name": "dataclass",
         "optional": false,
         "requested": "dataclasses",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4171,11 +6679,14 @@
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "MappingProxyType",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4185,11 +6696,14 @@
         "name": "MappingProxyType",
         "optional": false,
         "requested": "types",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "Iterable",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4199,11 +6713,14 @@
         "name": "Iterable",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4213,11 +6730,14 @@
         "name": "Mapping",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "Sequence",
+        "branch_context": [],
         "classification": "external",
         "column": 0,
         "conditional": false,
@@ -4227,99 +6747,215 @@
         "name": "Sequence",
         "optional": false,
         "requested": "typing",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": "np",
+        "bound_name": "np",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 17
+          }
+        ],
         "classification": "external",
         "column": 4,
-        "conditional": false,
+        "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
         "line": 18,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "numpy",
+        "role": "optional_dependency",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "yaml",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 22
+          }
+        ],
         "classification": "external",
         "column": 4,
-        "conditional": false,
+        "conditional": true,
         "imported": "yaml",
         "kind": "static_import",
         "line": 23,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "yaml",
+        "role": "optional_dependency",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 27
+          }
+        ],
         "classification": "internal",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 27
+        },
+        "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
         "line": 28,
         "name": "USER_DATA_DIR",
-        "optional": true,
+        "optional": false,
         "requested": ".storage",
+        "role": "compatibility_primary",
         "scope": "<module>",
         "source": "wildcard_engine.py",
         "target": "storage.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 29,
+            "kind": "try",
+            "line": 27
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 4,
-        "conditional": false,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 27
+        },
+        "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
         "line": 30,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
+        "role": "compatibility_fallback",
         "scope": "<module>",
-        "source": "wildcard_engine.py"
+        "source": "wildcard_engine.py",
+        "target": "storage.py"
       },
       {
         "alias": null,
+        "bound_name": "folder_paths",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 533
+          }
+        ],
         "classification": "external",
         "column": 8,
-        "conditional": false,
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 534,
         "name": null,
-        "optional": false,
+        "optional": true,
         "requested": "folder_paths",
+        "role": "optional_dependency",
         "scope": "_comfy_base_path",
         "source": "wildcard_engine.py"
       },
       {
         "alias": null,
+        "bound_name": "get_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 553,
+            "type_checking": false
+          },
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 554
+          }
+        ],
         "classification": "internal",
         "column": 12,
+        "compatibility_pair": {
+          "bound_name": "get_settings",
+          "target": "settings.py",
+          "try_line": 554
+        },
         "conditional": true,
         "imported": ".settings:get_settings",
         "kind": "static_from",
         "line": 555,
         "name": "get_settings",
-        "optional": true,
+        "optional": false,
         "requested": ".settings",
+        "role": "compatibility_primary",
         "scope": "resolve_wildcard_roots",
         "source": "wildcard_engine.py",
         "target": "settings.py"
       },
       {
         "alias": null,
-        "classification": "external",
+        "bound_name": "get_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 553,
+            "type_checking": false
+          },
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 556,
+            "kind": "try",
+            "line": 554
+          }
+        ],
+        "classification": "compatibility_fallback",
         "column": 12,
+        "compatibility_pair": {
+          "bound_name": "get_settings",
+          "target": "settings.py",
+          "try_line": 554
+        },
         "conditional": true,
         "imported": "settings:get_settings",
         "kind": "static_from",
@@ -4327,8 +6963,10 @@
         "name": "get_settings",
         "optional": false,
         "requested": "settings",
+        "role": "compatibility_fallback",
         "scope": "resolve_wildcard_roots",
-        "source": "wildcard_engine.py"
+        "source": "wildcard_engine.py",
+        "target": "settings.py"
       }
     ],
     "module_graph": [
@@ -4477,6 +7115,13 @@
         "to": "storage.py"
       }
     ],
+    "module_graph_policy": {
+      "duplicate_policy": "collapse by source and target path",
+      "included_classifications": [
+        "compatibility_fallback",
+        "internal"
+      ]
+    },
     "sccs": [
       {
         "cyclic": false,
@@ -4678,7 +7323,7 @@
         "top_level": {
           "class_count": 1,
           "function_count": 39,
-          "global_count": 12
+          "global_count": 14
         }
       },
       {
@@ -4750,7 +7395,7 @@
         "top_level": {
           "class_count": 12,
           "function_count": 39,
-          "global_count": 38
+          "global_count": 40
         }
       }
     ]
@@ -4938,1544 +7583,3077 @@
     "root": "__init__.py"
   },
   "registry": {
+    "compatibility_fallback_imports": [
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 45,
+            "kind": "try",
+            "line": 43
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "storage.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 45,
+            "kind": "try",
+            "line": 43
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "storage.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 24,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/knowledge.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt.models:TagSection",
+        "kind": "static_from",
+        "line": 25,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/models.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt.ordering:builtin_tag_section",
+        "kind": "static_from",
+        "line": 26,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/ordering.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 27,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 23,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:iter_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 28,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 44,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 44,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 45,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_naia_settings",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 46,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 51,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 43,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 52,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "storage:AtomicJsonStore",
+        "kind": "static_from",
+        "line": 17,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "storage.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 17,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "storage.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:PromptTranslationSettings",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:normalize_prompt_translation_language",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 6
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:normalize_prompt_translation_provider",
+        "kind": "static_from",
+        "line": 18,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "settings.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 29,
+            "kind": "try",
+            "line": 27
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 30,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "storage.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 553,
+            "type_checking": false
+          },
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 556,
+            "kind": "try",
+            "line": 554
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:get_settings",
+        "kind": "static_from",
+        "line": 557,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "wildcard_engine.py",
+        "target": "settings.py"
+      }
+    ],
     "entry_modules": [
       "__init__.py"
     ],
     "external_imports": [
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "logging",
         "kind": "static_import",
         "line": 2,
         "optional": false,
+        "role": "ordinary",
         "source": "__init__.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/correction.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/correction.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/correction.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/knowledge.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/knowledge.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/knowledge.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/models.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/models.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:field",
         "kind": "static_from",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/models.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "enum:Enum",
         "kind": "static_from",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/models.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/normalize.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/normalize.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/ordering.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/ordering.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/parser.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "anima_prompt/parser.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "atexit",
         "kind": "static_import",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "asyncio",
         "kind": "static_import",
         "line": 4,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "json",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "os",
         "kind": "static_import",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 7,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "threading",
         "kind": "static_import",
         "line": 8,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "concurrent.futures:Future",
         "kind": "static_from",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "concurrent.futures:ThreadPoolExecutor",
         "kind": "static_from",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
         "line": 10,
         "optional": false,
+        "role": "ordinary",
         "source": "api.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "server",
         "kind": "static_import",
         "line": 13,
         "optional": true,
+        "role": "optional_dependency",
         "source": "api.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
         "line": 14,
         "optional": true,
+        "role": "optional_dependency",
         "source": "api.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 302
+          }
+        ],
         "classification": "external",
-        "imported": "storage:AtomicJsonStore",
-        "kind": "static_from",
-        "line": 46,
-        "optional": false,
-        "source": "api.py"
-      },
-      {
-        "classification": "external",
-        "imported": "storage:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 46,
-        "optional": false,
-        "source": "api.py"
-      },
-      {
-        "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 303,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "api.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 328
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 329,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "api.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 629
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 630,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "api.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "csv",
         "kind": "static_import",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "heapq",
         "kind": "static_import",
         "line": 4,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "itertools",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "stat",
         "kind": "static_import",
         "line": 7,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "threading",
         "kind": "static_import",
         "line": 8,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "time",
         "kind": "static_import",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "unicodedata",
         "kind": "static_import",
         "line": 10,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "concurrent.futures:Future",
         "kind": "static_from",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 12,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
         "line": 13,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "types:MappingProxyType",
         "kind": "static_from",
         "line": 14,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Mapping",
         "kind": "static_from",
         "line": 15,
         "optional": false,
+        "role": "ordinary",
         "source": "autocomplete_dataset.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
-        "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
-        "kind": "static_from",
-        "line": 24,
-        "optional": false,
-        "source": "autocomplete_dataset.py"
-      },
-      {
-        "classification": "external",
-        "imported": "anima_prompt.models:TagSection",
-        "kind": "static_from",
-        "line": 25,
-        "optional": false,
-        "source": "autocomplete_dataset.py"
-      },
-      {
-        "classification": "external",
-        "imported": "anima_prompt.ordering:builtin_tag_section",
-        "kind": "static_from",
-        "line": 26,
-        "optional": false,
-        "source": "autocomplete_dataset.py"
-      },
-      {
-        "classification": "external",
-        "imported": "anima_prompt.parser:parse_prompt",
-        "kind": "static_from",
-        "line": 27,
-        "optional": false,
-        "source": "autocomplete_dataset.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:iter_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 28,
-        "optional": false,
-        "source": "autocomplete_dataset.py"
-      },
-      {
-        "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 2,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "inspect",
         "kind": "static_import",
         "line": 4,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "json",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "logging",
         "kind": "static_import",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "os",
         "kind": "static_import",
         "line": 7,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "random",
         "kind": "static_import",
         "line": 8,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "sys",
         "kind": "static_import",
         "line": 10,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "math:ceil",
         "kind": "static_from",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "math:gcd",
         "kind": "static_from",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "math:isfinite",
         "kind": "static_from",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "math:lcm",
         "kind": "static_from",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "math:log",
         "kind": "static_from",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "math:sqrt",
         "kind": "static_from",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
         "line": 12,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Optional",
         "kind": "static_from",
         "line": 12,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2043
+          }
+        ],
         "classification": "external",
-        "imported": "anima_prompt:correct_prompt",
-        "kind": "static_from",
-        "line": 44,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "anima_prompt:load_knowledge_base",
-        "kind": "static_from",
-        "line": 44,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "anima_prompt.parser:parse_prompt",
-        "kind": "static_from",
-        "line": 45,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "settings:resolve_metadata_filter_words",
-        "kind": "static_from",
-        "line": 46,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "settings:resolve_naia_settings",
-        "kind": "static_from",
-        "line": 46,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "settings:resolve_prompt_translation_settings",
-        "kind": "static_from",
-        "line": 46,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:has_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 51,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:translate_prompt_markers",
-        "kind": "static_from",
-        "line": 51,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:MAX_SEED",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:SEED_CONTROL_MODES",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:expand_wildcards",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:has_wildcard_syntax",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:next_seed",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:normalize_seed",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:normalize_wildcard_mode",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
-        "imported": "wildcard_engine:wildcard_sources_signature",
-        "kind": "static_from",
-        "line": 52,
-        "optional": false,
-        "source": "nodes.py"
-      },
-      {
-        "classification": "external",
+        "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
         "line": 2044,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2052
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
         "line": 2053,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2071
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
         "line": 2072,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2098
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 2099,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2110
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 2111,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2184
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
         "line": 2185,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2190
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
         "line": 2191,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2206
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
         "line": 2207,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2215
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
         "line": 2216,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2231
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
         "line": 2232,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2237
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
         "line": 2238,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2251
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
         "line": 2252,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2368
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
         "line": 2369,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2392
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 2393,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2398
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
         "line": 2399,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2404
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
         "line": 2405,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2410
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
         "line": 2411,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2866
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 2867,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2906
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
         "line": 2907,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 3368,
+            "type_checking": false
+          },
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 3369
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
         "line": 3370,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4169
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 4170,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4231
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
         "line": 4232,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 4259,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
         "line": 4260,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
         "line": 4261,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4452
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 4453,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4705
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "comfy.utils",
         "kind": "static_import",
         "line": 4706,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": false,
+            "exceptions": [
+              "Exception"
+            ],
+            "handler_line": 4709,
+            "kind": "try",
+            "line": 4705
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch.nn.functional",
         "kind": "static_import",
         "line": 4710,
         "optional": false,
+        "role": "ordinary",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5621
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5622,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5638
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5639,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5659
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5660,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5736
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 5737,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 6535
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 6536,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7560
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 7561,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7594
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "torch",
         "kind": "static_import",
         "line": 7595,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 7670
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "requests",
         "kind": "static_import",
         "line": 7671,
         "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7886
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
         "line": 7887,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7896
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 7897,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7918
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 7919,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8023
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
         "line": 8024,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8067
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 8068,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8092
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 8093,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "html",
         "kind": "static_import",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "threading",
         "kind": "static_import",
         "line": 4,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "time",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "collections:OrderedDict",
         "kind": "static_from",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "contextlib:contextmanager",
         "kind": "static_from",
         "line": 7,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 8,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Callable",
         "kind": "static_from",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Protocol",
         "kind": "static_from",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 169
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "googletrans:Translator",
         "kind": "static_from",
         "line": 170,
         "optional": true,
+        "role": "optional_dependency",
         "source": "prompt_translation.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
         "optional": false,
+        "role": "ordinary",
         "source": "settings.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "json",
         "kind": "static_import",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "settings.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
         "line": 4,
         "optional": false,
+        "role": "ordinary",
         "source": "settings.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 271
+          }
+        ],
         "classification": "external",
-        "imported": "storage:AtomicJsonStore",
-        "kind": "static_from",
-        "line": 17,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
-        "imported": "storage:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 17,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
-        "kind": "static_from",
-        "line": 18,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
-        "kind": "static_from",
-        "line": 18,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
-        "kind": "static_from",
-        "line": 18,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:PromptTranslationSettings",
-        "kind": "static_from",
-        "line": 18,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:normalize_prompt_translation_language",
-        "kind": "static_from",
-        "line": 18,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
-        "imported": "prompt_translation:normalize_prompt_translation_provider",
-        "kind": "static_from",
-        "line": 18,
-        "optional": false,
-        "source": "settings.py"
-      },
-      {
-        "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 272,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "settings.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "errno",
         "kind": "static_import",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "json",
         "kind": "static_import",
         "line": 4,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "os",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "tempfile",
         "kind": "static_import",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "threading",
         "kind": "static_import",
         "line": 7,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "contextlib:contextmanager",
         "kind": "static_from",
         "line": 8,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Callable",
         "kind": "static_from",
         "line": 10,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Iterator",
         "kind": "static_from",
         "line": 10,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:TypeVar",
         "kind": "static_from",
         "line": 10,
         "optional": false,
+        "role": "ordinary",
         "source": "storage.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 19
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 20,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "storage.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 1,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "bisect",
         "kind": "static_import",
         "line": 3,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "collections:OrderedDict",
         "kind": "static_from",
         "line": 4,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "fnmatch",
         "kind": "static_import",
         "line": 5,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "hashlib",
         "kind": "static_import",
         "line": 6,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "math",
         "kind": "static_import",
         "line": 7,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "os",
         "kind": "static_import",
         "line": 8,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "random",
         "kind": "static_import",
         "line": 9,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "re",
         "kind": "static_import",
         "line": 10,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "threading",
         "kind": "static_import",
         "line": 11,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "dataclasses:dataclass",
         "kind": "static_from",
         "line": 12,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
         "line": 13,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "types:MappingProxyType",
         "kind": "static_from",
         "line": 14,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Iterable",
         "kind": "static_from",
         "line": 15,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Mapping",
         "kind": "static_from",
         "line": 15,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [],
         "classification": "external",
+        "conditional": false,
         "imported": "typing:Sequence",
         "kind": "static_from",
         "line": 15,
         "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 17
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
         "line": 18,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 22
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "yaml",
         "kind": "static_import",
         "line": 23,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "wildcard_engine.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 533
+          }
+        ],
         "classification": "external",
-        "imported": "storage:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 30,
-        "optional": false,
-        "source": "wildcard_engine.py"
-      },
-      {
-        "classification": "external",
+        "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
         "line": 534,
-        "optional": false,
-        "source": "wildcard_engine.py"
-      },
-      {
-        "classification": "external",
-        "imported": "settings:get_settings",
-        "kind": "static_from",
-        "line": 557,
-        "optional": false,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "wildcard_engine.py"
       }
     ],
@@ -6484,423 +10662,998 @@
     "missing_internal_imports": [],
     "optional_imports": [
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "server",
         "kind": "static_import",
         "line": 13,
         "optional": true,
+        "role": "optional_dependency",
         "source": "api.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
         "classification": "external",
+        "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
         "line": 14,
         "optional": true,
+        "role": "optional_dependency",
         "source": "api.py"
       },
       {
-        "classification": "internal",
-        "imported": ".storage:AtomicJsonStore",
-        "kind": "static_from",
-        "line": 44,
-        "optional": true,
-        "source": "api.py",
-        "target": "storage.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".storage:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 44,
-        "optional": true,
-        "source": "api.py",
-        "target": "storage.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".anima_prompt.knowledge:PACKAGE_DATA_DIR",
-        "kind": "static_from",
-        "line": 18,
-        "optional": true,
-        "source": "autocomplete_dataset.py",
-        "target": "anima_prompt/knowledge.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".anima_prompt.models:TagSection",
-        "kind": "static_from",
-        "line": 19,
-        "optional": true,
-        "source": "autocomplete_dataset.py",
-        "target": "anima_prompt/models.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".anima_prompt.ordering:builtin_tag_section",
-        "kind": "static_from",
-        "line": 20,
-        "optional": true,
-        "source": "autocomplete_dataset.py",
-        "target": "anima_prompt/ordering.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".anima_prompt.parser:parse_prompt",
-        "kind": "static_from",
-        "line": 21,
-        "optional": true,
-        "source": "autocomplete_dataset.py",
-        "target": "anima_prompt/parser.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".prompt_translation:iter_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 22,
-        "optional": true,
-        "source": "autocomplete_dataset.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".anima_prompt:correct_prompt",
-        "kind": "static_from",
-        "line": 15,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "anima_prompt/__init__.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".anima_prompt:load_knowledge_base",
-        "kind": "static_from",
-        "line": 15,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "anima_prompt/__init__.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".anima_prompt.parser:parse_prompt",
-        "kind": "static_from",
-        "line": 16,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "anima_prompt/parser.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".settings:resolve_metadata_filter_words",
-        "kind": "static_from",
-        "line": 17,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "settings.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".settings:resolve_naia_settings",
-        "kind": "static_from",
-        "line": 17,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "settings.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".settings:resolve_prompt_translation_settings",
-        "kind": "static_from",
-        "line": 17,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "settings.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".prompt_translation:has_prompt_translation_markers",
-        "kind": "static_from",
-        "line": 22,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".prompt_translation:translate_prompt_markers",
-        "kind": "static_from",
-        "line": 22,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:MAX_SEED",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:SEED_CONTROL_MODES",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:expand_wildcards",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:has_wildcard_syntax",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:next_seed",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:normalize_seed",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:normalize_wildcard_mode",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".wildcard_engine:wildcard_sources_signature",
-        "kind": "static_from",
-        "line": 23,
-        "optional": true,
-        "source": "nodes.py",
-        "target": "wildcard_engine.py"
-      },
-      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 302
+          }
+        ],
         "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 303,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "api.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 328
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 329,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "api.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 629
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 630,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "api.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2043
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2044,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2052
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2053,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2071
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2072,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2098
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2099,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2110
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2111,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2184
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.core",
+        "kind": "static_import",
+        "line": 2185,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2190
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2191,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2206
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2207,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2215
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2216,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2231
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2232,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2237
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2238,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2251
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2252,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2368
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
+        "kind": "static_from",
+        "line": 2369,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2392
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.segs_nodes:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2393,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2398
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.segs_nodes:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2399,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2404
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2405,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2410
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:MaskToSEGS",
+        "kind": "static_from",
+        "line": 2411,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2866
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 2867,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2906
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.model_management",
+        "kind": "static_import",
+        "line": 2907,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "kind": "if",
+            "line": 3368,
+            "type_checking": false
+          },
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 3369
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
+        "kind": "static_from",
+        "line": 3370,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4169
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 4170,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4231
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "server:PromptServer",
+        "kind": "static_from",
+        "line": 4232,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 4259,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "numpy",
+        "kind": "static_import",
+        "line": 4260,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4258
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "PIL:Image",
+        "kind": "static_from",
+        "line": 4261,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4452
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 4453,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 4705
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.utils",
+        "kind": "static_import",
+        "line": 4706,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5621
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5622,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5638
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5639,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5659
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5660,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5736
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5737,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 6535
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 6536,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7560
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 7561,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7594
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 7595,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 7670
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
         "imported": "requests",
         "kind": "static_import",
         "line": 7671,
         "optional": true,
+        "role": "optional_dependency",
         "source": "nodes.py"
       },
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7886
+          }
+        ],
         "classification": "external",
+        "conditional": true,
+        "imported": "py.nodes.utils:apply_lora_syntax_format",
+        "kind": "static_from",
+        "line": 7887,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7896
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 7897,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 7918
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 7919,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8023
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "py.utils.utils:get_lora_info",
+        "kind": "static_from",
+        "line": 8024,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8067
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 8068,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 8092
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 8093,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 169
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
         "imported": "googletrans:Translator",
         "kind": "static_from",
         "line": 170,
         "optional": true,
+        "role": "optional_dependency",
         "source": "prompt_translation.py"
       },
       {
-        "classification": "internal",
-        "imported": ".storage:AtomicJsonStore",
-        "kind": "static_from",
-        "line": 7,
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 271
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 272,
         "optional": true,
-        "source": "settings.py",
-        "target": "storage.py"
+        "role": "optional_dependency",
+        "source": "settings.py"
       },
       {
-        "classification": "internal",
-        "imported": ".storage:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 7,
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 19
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 20,
         "optional": true,
-        "source": "settings.py",
-        "target": "storage.py"
+        "role": "optional_dependency",
+        "source": "storage.py"
       },
       {
-        "classification": "internal",
-        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_SOURCE",
-        "kind": "static_from",
-        "line": 8,
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "numpy",
+        "kind": "static_import",
+        "line": 18,
         "optional": true,
-        "source": "settings.py",
-        "target": "prompt_translation.py"
+        "role": "optional_dependency",
+        "source": "wildcard_engine.py"
       },
       {
-        "classification": "internal",
-        "imported": ".prompt_translation:DEFAULT_PROMPT_TRANSLATION_TARGET",
-        "kind": "static_from",
-        "line": 8,
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 22
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "yaml",
+        "kind": "static_import",
+        "line": 23,
         "optional": true,
-        "source": "settings.py",
-        "target": "prompt_translation.py"
+        "role": "optional_dependency",
+        "source": "wildcard_engine.py"
       },
       {
-        "classification": "internal",
-        "imported": ".prompt_translation:PROMPT_TRANSLATION_PROVIDER_OFF",
-        "kind": "static_from",
-        "line": 8,
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 533
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "folder_paths",
+        "kind": "static_import",
+        "line": 534,
         "optional": true,
-        "source": "settings.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".prompt_translation:PromptTranslationSettings",
-        "kind": "static_from",
-        "line": 8,
-        "optional": true,
-        "source": "settings.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".prompt_translation:normalize_prompt_translation_language",
-        "kind": "static_from",
-        "line": 8,
-        "optional": true,
-        "source": "settings.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".prompt_translation:normalize_prompt_translation_provider",
-        "kind": "static_from",
-        "line": 8,
-        "optional": true,
-        "source": "settings.py",
-        "target": "prompt_translation.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".storage:USER_DATA_DIR",
-        "kind": "static_from",
-        "line": 28,
-        "optional": true,
-        "source": "wildcard_engine.py",
-        "target": "storage.py"
-      },
-      {
-        "classification": "internal",
-        "imported": ".settings:get_settings",
-        "kind": "static_from",
-        "line": 555,
-        "optional": true,
-        "source": "wildcard_engine.py",
-        "target": "settings.py"
+        "role": "optional_dependency",
+        "source": "wildcard_engine.py"
       }
     ],
     "package_root": ".",
@@ -6940,7 +11693,7 @@
     ],
     "unreachable_shipped_python_modules": []
   },
-  "schema_version": 1,
+  "schema_version": 2,
   "side_effects": {
     "candidates": [
       {
@@ -8176,6 +12929,12 @@
         "line": 169,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
+      },
+      {
+        "kind": "dict",
+        "line": 168,
+        "module": "wildcard_engine.py",
+        "name": "_SNAPSHOT_CACHE"
       }
     ],
     "owner_candidates": [
@@ -8285,6 +13044,16 @@
         "line": 169,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
+      },
+      {
+        "categories": [
+          "cache",
+          "mutable_container"
+        ],
+        "initializer": "OrderedDict",
+        "line": 168,
+        "module": "wildcard_engine.py",
+        "name": "_SNAPSHOT_CACHE"
       }
     ]
   }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6,6 +6,10 @@
     "path_format": "repository-relative POSIX"
   },
   "imports": {
+    "dynamic_alias_policy": {
+      "control_flow_merge": "if/try branch bindings are visited in deterministic source order; conflicting branch aliases remain heuristic",
+      "lexical_scopes": "module, class, function, and lambda bindings are tracked; class namespaces are skipped for nested function lookup"
+    },
     "edges": [
       {
         "alias": null,

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANALYZER_PATH = ROOT / "tools" / "analyze_python_backend.py"
+BASELINE_PATH = ROOT / "tests" / "fixtures" / "python_backend_baseline.json"
+
+
+def load_analyzer():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_python_backend_analyzer",
+        ANALYZER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load analyzer: {ANALYZER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+analyzer = load_analyzer()
+
+
+def import_edges(report, *, source="__init__.py"):
+    return [edge for edge in report["imports"]["edges"] if edge["source"] == source]
+
+
+class PythonBackendAnalyzerTests(unittest.TestCase):
+    def test_fixture_generation_twice_is_byte_identical(self):
+        first = analyzer.render_json(analyzer.analyze_repository(ROOT)).encode("utf-8")
+        second = analyzer.render_json(analyzer.analyze_repository(ROOT)).encode("utf-8")
+
+        self.assertEqual(first, second)
+
+    def test_crlf_and_lf_sources_have_identical_reports(self):
+        lf_sources = {
+            "__init__.py": b"from .runtime import VALUE\nRESULT = build(VALUE)\n",
+            "runtime.py": b"VALUE = []\n",
+        }
+        crlf_sources = {
+            path: source.replace(b"\n", b"\r\n")
+            for path, source in lf_sources.items()
+        }
+
+        lf_report = analyzer.analyze_source_set(lf_sources, comfyignore=b"tests/\n")
+        crlf_report = analyzer.analyze_source_set(crlf_sources, comfyignore=b"tests/\r\n")
+
+        self.assertEqual(lf_report, crlf_report)
+
+    def test_alias_static_relative_and_literal_dynamic_import_edges(self):
+        sources = {
+            "__init__.py": """\
+from . import alias_target as aliased
+from .pkg import helper as helper_alias
+import importlib as il
+from importlib import import_module as load
+
+first = il.import_module(".literal", __package__)
+second = load("external.plugin")
+""",
+            "alias_target.py": "VALUE = 1\n",
+            "literal.py": "VALUE = 2\n",
+            "pkg/__init__.py": "from .helper import VALUE\n",
+            "pkg/helper.py": "VALUE = 3\n",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        edges = import_edges(report)
+        edge_keys = {
+            (
+                edge["kind"],
+                edge["imported"],
+                edge["classification"],
+                edge.get("target"),
+                edge["alias"],
+            )
+            for edge in edges
+        }
+
+        self.assertIn(
+            ("static_from", ".:alias_target", "internal", "alias_target.py", "aliased"),
+            edge_keys,
+        )
+        self.assertIn(
+            ("static_from", ".pkg:helper", "internal", "pkg/helper.py", "helper_alias"),
+            edge_keys,
+        )
+        self.assertIn(
+            ("literal_dynamic", ".literal", "internal", "literal.py", None),
+            edge_keys,
+        )
+        self.assertIn(
+            ("literal_dynamic", "external.plugin", "external", None, None),
+            edge_keys,
+        )
+
+    def test_scc_ordering_is_stable(self):
+        sources = {
+            "__init__.py": "from . import a\n",
+            "a.py": "from . import b\n",
+            "b.py": "from . import c\n",
+            "c.py": "from . import a\n",
+            "z.py": "VALUE = 1\n",
+        }
+
+        first = analyzer.analyze_source_set(sources)
+        second = analyzer.analyze_source_set(dict(reversed(list(sources.items()))))
+
+        self.assertEqual(first["imports"]["sccs"], second["imports"]["sccs"])
+        self.assertIn(
+            {"modules": ["a.py", "b.py", "c.py"], "cyclic": True},
+            first["imports"]["sccs"],
+        )
+
+    def test_mutable_globals_and_state_owner_candidates_are_classified(self):
+        sources = {
+            "__init__.py": """\
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+
+CACHE = {}
+VALUES = []
+SEEN = set()
+LOCK = threading.RLock()
+INFLIGHT: dict[str, Future] = {}
+EXECUTOR = ThreadPoolExecutor()
+CLIENT = ApiClient()
+""",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        mutable = {
+            (item["name"], item["kind"])
+            for item in report["state"]["mutable_globals"]
+        }
+        owners = {
+            item["name"]: set(item["categories"])
+            for item in report["state"]["owner_candidates"]
+        }
+
+        self.assertEqual(
+            mutable,
+            {
+                ("CACHE", "dict"),
+                ("INFLIGHT", "dict"),
+                ("SEEN", "set"),
+                ("VALUES", "list"),
+            },
+        )
+        self.assertIn("cache", owners["CACHE"])
+        self.assertIn("lock", owners["LOCK"])
+        self.assertIn("future", owners["INFLIGHT"])
+        self.assertIn("single_flight", owners["INFLIGHT"])
+        self.assertIn("executor", owners["EXECUTOR"])
+        self.assertIn("client", owners["CLIENT"])
+
+    def test_import_time_side_effect_candidates_exclude_function_bodies(self):
+        sources = {
+            "__init__.py": """\
+routes = build_routes()
+ROOT.mkdir(parents=True)
+
+@routes.get("/inventory")
+def inventory_route():
+    hidden_client = ApiClient()
+    HIDDEN.mkdir()
+    return hidden_client
+
+def lazy_operation():
+    return requests.get("https://example.invalid")
+""",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        candidates = report["side_effects"]["candidates"]
+        by_callee = {item["callee"]: item["kind"] for item in candidates}
+
+        self.assertEqual(by_callee["build_routes"], "route_registry_creation")
+        self.assertEqual(by_callee["ROOT.mkdir"], "directory_creation")
+        self.assertEqual(by_callee["routes.get"], "route_registration")
+        self.assertNotIn("ApiClient", by_callee)
+        self.assertNotIn("HIDDEN.mkdir", by_callee)
+        self.assertNotIn("requests.get", by_callee)
+
+    def test_registry_closure_separates_shipped_missing_external_and_optional(self):
+        sources = {
+            "__init__.py": """\
+from .runtime import run
+from .missing import unavailable
+try:
+    import optional_dependency
+except ImportError:
+    optional_dependency = None
+""",
+            "runtime.py": "def run():\n    return 1\n",
+            "tests/test_runtime.py": "import runtime\n",
+            "tools/dev_helper.py": "import runtime\n",
+        }
+
+        report = analyzer.analyze_source_set(
+            sources,
+            comfyignore="tests/\ntools/\n",
+        )
+        registry = report["registry"]
+
+        self.assertEqual(
+            registry["shipped_python_modules"],
+            ["__init__.py", "runtime.py"],
+        )
+        self.assertEqual(
+            registry["runtime_import_closure"],
+            ["__init__.py", "runtime.py"],
+        )
+        self.assertEqual(len(registry["missing_internal_imports"]), 1)
+        self.assertEqual(
+            registry["missing_internal_imports"][0]["imported"],
+            ".missing:unavailable",
+        )
+        self.assertIn(
+            "optional_dependency",
+            {item["imported"] for item in registry["external_imports"]},
+        )
+        self.assertEqual(
+            [item["imported"] for item in registry["optional_imports"]],
+            ["optional_dependency"],
+        )
+
+    def test_analyzer_source_has_no_production_import_or_execution_escape_hatch(self):
+        tree = ast.parse(ANALYZER_PATH.read_text(encoding="utf-8"))
+        imported_roots = set()
+        call_names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_roots.add(node.module.split(".", 1)[0])
+            elif isinstance(node, ast.Call):
+                call_names.add(analyzer._call_name(node.func))
+
+        self.assertTrue(
+            imported_roots.isdisjoint(
+                {
+                    "api",
+                    "autocomplete_dataset",
+                    "nodes",
+                    "prompt_translation",
+                    "settings",
+                    "storage",
+                    "wildcard_engine",
+                    "requests",
+                    "socket",
+                    "subprocess",
+                    "urllib",
+                }
+            )
+        )
+        self.assertTrue(
+            call_names.isdisjoint(
+                {
+                    "__import__",
+                    "eval",
+                    "exec",
+                    "os.system",
+                    "subprocess.Popen",
+                    "subprocess.run",
+                }
+            )
+        )
+
+    def test_current_repository_fixture_matches_and_uses_real_runtime_surface(self):
+        report = analyzer.analyze_repository(ROOT)
+        expected_text = BASELINE_PATH.read_text(encoding="utf-8")
+
+        self.assertEqual(analyzer.render_json(report), expected_text)
+        self.assertGreaterEqual(report["inventory"]["module_count"], 10)
+        self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
+        self.assertIn("api.py", report["registry"]["runtime_import_closure"])
+        self.assertNotIn(
+            "tests/test_python_backend_analyzer.py",
+            report["registry"]["shipped_python_modules"],
+        )
+        self.assertNotIn(
+            "tools/analyze_python_backend.py",
+            report["registry"]["shipped_python_modules"],
+        )
+        json.loads(expected_text)
+
+    def test_human_render_has_module_edge_and_state_review_sections(self):
+        report = analyzer.analyze_source_set(
+            {
+                "__init__.py": "from .runtime import VALUE\nCACHE = {}\n",
+                "runtime.py": "VALUE = 1\n",
+            }
+        )
+
+        rendered = analyzer.render_text(report)
+
+        self.assertIn("[modules]\n", rendered)
+        self.assertIn("[edges]\n", rendered)
+        self.assertIn("[state.mutable_globals]\n", rendered)
+        self.assertIn("[state.owner_candidates]\n", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -607,6 +607,18 @@ ignored/
         self.assertGreaterEqual(report["inventory"]["module_count"], 10)
         self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
         self.assertIn("api.py", report["registry"]["runtime_import_closure"])
+        self.assertIn(
+            "api_contract.py",
+            report["registry"]["shipped_python_modules"],
+        )
+        self.assertIn(
+            "api_contract.py",
+            report["registry"]["runtime_import_closure"],
+        )
+        self.assertIn(
+            {"from": "api.py", "to": "api_contract.py"},
+            report["imports"]["module_graph"],
+        )
         self.assertNotIn(
             "tests/test_python_backend_analyzer.py",
             report["registry"]["shipped_python_modules"],

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import importlib.util
 import json
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -29,6 +30,19 @@ analyzer = load_analyzer()
 
 def import_edges(report, *, source="__init__.py"):
     return [edge for edge in report["imports"]["edges"] if edge["source"] == source]
+
+
+def git_paths(*args):
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+    )
+    return {line for line in result.stdout.splitlines() if line}
 
 
 class PythonBackendAnalyzerTests(unittest.TestCase):
@@ -100,6 +114,112 @@ second = load("external.plugin")
             edge_keys,
         )
 
+    def test_literal_dynamic_aliases_do_not_leak_between_lexical_scopes(self):
+        sources = {
+            "__init__.py": """\
+from importlib import import_module as module_load
+
+def dynamic_loader():
+    from importlib import import_module as load
+    return load(".plugin", __package__)
+
+def parameter_loader(load):
+    return load("not.a.dynamic.import")
+
+def assigned_loader():
+    load = user_loader
+    return load("also.not.dynamic")
+
+def lexical_late_shadow():
+    value = module_load("still.not.dynamic")
+    module_load = user_loader
+    return value
+""",
+            "plugin.py": "VALUE = 1\n",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        dynamic_edges = [
+            edge
+            for edge in report["imports"]["edges"]
+            if edge["kind"] == "literal_dynamic"
+        ]
+
+        self.assertEqual(
+            [(edge["scope"], edge["imported"], edge.get("target")) for edge in dynamic_edges],
+            [("dynamic_loader", ".plugin", "plugin.py")],
+        )
+
+    def test_try_branch_context_and_compatibility_fallback_taxonomy(self):
+        sources = {
+            "__init__.py": """\
+try:
+    from .runtime import VALUE
+except ImportError:
+    from runtime import VALUE
+
+try:
+    import optional_dependency
+except ImportError:
+    optional_dependency = None
+else:
+    import else_dependency
+finally:
+    import final_dependency
+""",
+            "runtime.py": "VALUE = 1\n",
+            "nodes.py": """\
+def comfy_runtime():
+    try:
+        import nodes as comfy_nodes
+    except Exception:
+        return None
+    return comfy_nodes
+""",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        root_edges = import_edges(report)
+        primary = next(edge for edge in root_edges if edge["imported"] == ".runtime:VALUE")
+        fallback = next(edge for edge in root_edges if edge["imported"] == "runtime:VALUE")
+        optional = next(edge for edge in root_edges if edge["imported"] == "optional_dependency")
+        else_edge = next(edge for edge in root_edges if edge["imported"] == "else_dependency")
+        finally_edge = next(edge for edge in root_edges if edge["imported"] == "final_dependency")
+        comfy_nodes = next(
+            edge
+            for edge in import_edges(report, source="nodes.py")
+            if edge["imported"] == "nodes"
+        )
+
+        self.assertEqual(primary["classification"], "internal")
+        self.assertEqual(primary["role"], "compatibility_primary")
+        self.assertFalse(primary["optional"])
+        self.assertEqual(primary["branch_context"][-1]["branch"], "body")
+        self.assertEqual(fallback["classification"], "compatibility_fallback")
+        self.assertEqual(fallback["target"], "runtime.py")
+        self.assertEqual(fallback["role"], "compatibility_fallback")
+        self.assertTrue(fallback["conditional"])
+        self.assertFalse(fallback["optional"])
+        self.assertEqual(fallback["branch_context"][-1]["branch"], "except")
+        self.assertEqual(
+            fallback["branch_context"][-1]["exceptions"],
+            ["ImportError"],
+        )
+        self.assertEqual(optional["role"], "optional_dependency")
+        self.assertTrue(optional["optional"])
+        self.assertEqual(else_edge["branch_context"][-1]["branch"], "else")
+        self.assertEqual(finally_edge["branch_context"][-1]["branch"], "finally")
+        self.assertEqual(comfy_nodes["classification"], "external")
+        self.assertNotEqual(comfy_nodes["role"], "compatibility_fallback")
+        self.assertEqual(
+            report["imports"]["module_graph"],
+            [{"from": "__init__.py", "to": "runtime.py"}],
+        )
+        self.assertEqual(
+            report["imports"]["module_graph_policy"]["duplicate_policy"],
+            "collapse by source and target path",
+        )
+
     def test_scc_ordering_is_stable(self):
         sources = {
             "__init__.py": "from . import a\n",
@@ -159,6 +279,54 @@ CLIENT = ApiClient()
         self.assertIn("single_flight", owners["INFLIGHT"])
         self.assertIn("executor", owners["EXECUTOR"])
         self.assertIn("client", owners["CLIENT"])
+
+    def test_module_control_flow_mutables_and_extended_constructors_are_stable(self):
+        lf_source = """\
+from collections import OrderedDict, defaultdict, deque
+
+if ENABLED:
+    IF_CACHE = {}
+try:
+    TRY_VALUES = []
+except Exception:
+    FALLBACK_SET = set()
+with manager():
+    WITH_CACHE = OrderedDict()
+match mode:
+    case "queue":
+        MATCH_QUEUE = deque()
+    case _:
+        MATCH_MAP = defaultdict(list)
+
+def ignored_function():
+    LOCAL_CACHE = {}
+
+class IgnoredClass:
+    CLASS_CACHE = {}
+"""
+        lf_report = analyzer.analyze_source_set({"__init__.py": lf_source})
+        crlf_report = analyzer.analyze_source_set(
+            {"__init__.py": lf_source.replace("\n", "\r\n")}
+        )
+        mutable = [
+            (item["name"], item["line"], item["kind"])
+            for item in lf_report["state"]["mutable_globals"]
+        ]
+
+        self.assertEqual(lf_report, crlf_report)
+        self.assertEqual(
+            mutable,
+            [
+                ("FALLBACK_SET", 8, "set"),
+                ("IF_CACHE", 4, "dict"),
+                ("MATCH_MAP", 15, "dict"),
+                ("MATCH_QUEUE", 13, "list"),
+                ("TRY_VALUES", 6, "list"),
+                ("WITH_CACHE", 10, "dict"),
+            ],
+        )
+        self.assertNotIn("LOCAL_CACHE", {item[0] for item in mutable})
+        self.assertNotIn("CLASS_CACHE", {item[0] for item in mutable})
 
     def test_import_time_side_effect_candidates_exclude_function_bodies(self):
         sources = {
@@ -231,17 +399,88 @@ except ImportError:
             ["optional_dependency"],
         )
 
+    def test_comfyignore_anchoring_slashes_negation_and_escaped_markers(self):
+        sources = {
+            "__init__.py": "VALUE = 1\n",
+            "autocomplete/root.py": "VALUE = 1\n",
+            "nested/autocomplete/keep.py": "VALUE = 1\n",
+            "web_version/dev/root.py": "VALUE = 1\n",
+            "nested/web_version/dev/keep.py": "VALUE = 1\n",
+            "#literal.py": "VALUE = 1\n",
+            "!literal.py": "VALUE = 1\n",
+            "drop.tmp.py": "VALUE = 1\n",
+            "keep.tmp.py": "VALUE = 1\n",
+            "nested/direct.py": "VALUE = 1\n",
+            "nested/deeper/direct.py": "VALUE = 1\n",
+            "ignored/keep.py": "VALUE = 1\n",
+        }
+        ignore = r"""\
+/autocomplete/
+web_version/dev/
+\#literal.py
+\!literal.py
+*.tmp.py
+!keep.tmp.py
+nested/*.py
+ignored/
+!ignored/keep.py
+"""
+
+        report = analyzer.analyze_source_set(sources, comfyignore=ignore)
+
+        self.assertEqual(
+            report["registry"]["shipped_python_modules"],
+            [
+                "__init__.py",
+                "keep.tmp.py",
+                "nested/autocomplete/keep.py",
+                "nested/deeper/direct.py",
+                "nested/web_version/dev/keep.py",
+            ],
+        )
+
+    def test_current_registry_python_surface_matches_git_exclude_contract(self):
+        report = analyzer.analyze_repository(ROOT)
+        tracked = git_paths("ls-files", "--cached")
+        ignored = git_paths(
+            "ls-files",
+            "--cached",
+            "--ignored",
+            "--exclude-from=.comfyignore",
+        )
+        expected = sorted(
+            path
+            for path in tracked - ignored
+            if path.endswith(".py")
+        )
+
+        self.assertEqual(report["registry"]["shipped_python_modules"], expected)
+
     def test_analyzer_source_has_no_production_import_or_execution_escape_hatch(self):
         tree = ast.parse(ANALYZER_PATH.read_text(encoding="utf-8"))
         imported_roots = set()
-        call_names = set()
+        aliases = {}
+        call_nodes = []
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
-                imported_roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+                for alias in node.names:
+                    imported_roots.add(alias.name.split(".", 1)[0])
+                    aliases[alias.asname or alias.name.split(".", 1)[0]] = alias.name
             elif isinstance(node, ast.ImportFrom) and node.module:
                 imported_roots.add(node.module.split(".", 1)[0])
+                for alias in node.names:
+                    aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
             elif isinstance(node, ast.Call):
-                call_names.add(analyzer._call_name(node.func))
+                call_nodes.append(node)
+
+        resolved_call_names = set()
+        for node in call_nodes:
+            callee = analyzer._call_name(node.func)
+            root, separator, suffix = callee.partition(".")
+            target = aliases.get(root)
+            resolved_call_names.add(
+                f"{target}.{suffix}" if target and separator else target or callee
+            )
 
         self.assertTrue(
             imported_roots.isdisjoint(
@@ -253,7 +492,9 @@ except ImportError:
                     "settings",
                     "storage",
                     "wildcard_engine",
+                    "importlib",
                     "requests",
+                    "runpy",
                     "socket",
                     "subprocess",
                     "urllib",
@@ -261,16 +502,24 @@ except ImportError:
             )
         )
         self.assertTrue(
-            call_names.isdisjoint(
+            resolved_call_names.isdisjoint(
                 {
                     "__import__",
+                    "builtins.eval",
+                    "builtins.exec",
                     "eval",
                     "exec",
+                    "importlib.import_module",
                     "os.system",
+                    "runpy.run_module",
+                    "runpy.run_path",
                     "subprocess.Popen",
                     "subprocess.run",
                 }
             )
+        )
+        self.assertFalse(
+            [name for name in resolved_call_names if name.startswith("subprocess.")]
         )
 
     def test_current_repository_fixture_matches_and_uses_real_runtime_surface(self):
@@ -278,6 +527,7 @@ except ImportError:
         expected_text = BASELINE_PATH.read_text(encoding="utf-8")
 
         self.assertEqual(analyzer.render_json(report), expected_text)
+        self.assertEqual(report["schema_version"], 2)
         self.assertGreaterEqual(report["inventory"]["module_count"], 10)
         self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
         self.assertIn("api.py", report["registry"]["runtime_import_closure"])
@@ -289,12 +539,55 @@ except ImportError:
             "tools/analyze_python_backend.py",
             report["registry"]["shipped_python_modules"],
         )
+        fallback_targets = {
+            (item["source"], item["target"])
+            for item in report["registry"]["compatibility_fallback_imports"]
+        }
+        self.assertTrue(
+            {
+                ("api.py", "storage.py"),
+                ("nodes.py", "prompt_translation.py"),
+                ("nodes.py", "settings.py"),
+                ("nodes.py", "wildcard_engine.py"),
+                ("wildcard_engine.py", "settings.py"),
+            }.issubset(fallback_targets)
+        )
+        self.assertFalse(
+            [
+                item
+                for item in report["registry"]["external_imports"]
+                if (item["source"], item.get("target")) in fallback_targets
+            ]
+        )
+        mutable_by_name = {
+            (item["module"], item["name"]): item["kind"]
+            for item in report["state"]["mutable_globals"]
+        }
+        self.assertEqual(
+            mutable_by_name[("wildcard_engine.py", "_SNAPSHOT_CACHE")],
+            "dict",
+        )
+        owner_by_name = {
+            (item["module"], item["name"]): set(item["categories"])
+            for item in report["state"]["owner_candidates"]
+        }
+        self.assertIn(
+            "cache",
+            owner_by_name[("wildcard_engine.py", "_SNAPSHOT_CACHE")],
+        )
         json.loads(expected_text)
 
     def test_human_render_has_module_edge_and_state_review_sections(self):
         report = analyzer.analyze_source_set(
             {
-                "__init__.py": "from .runtime import VALUE\nCACHE = {}\n",
+                "__init__.py": """\
+try:
+    from .runtime import VALUE
+except ImportError:
+    from runtime import VALUE
+import os
+CACHE = {}
+""",
                 "runtime.py": "VALUE = 1\n",
             }
         )
@@ -305,6 +598,9 @@ except ImportError:
         self.assertIn("[edges]\n", rendered)
         self.assertIn("[state.mutable_globals]\n", rendered)
         self.assertIn("[state.owner_candidates]\n", rendered)
+        self.assertIn("ordinary", rendered)
+        self.assertIn("compatibility_fallback", rendered)
+        self.assertIn("try@", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -150,6 +150,82 @@ def lexical_late_shadow():
             [("dynamic_loader", ".plugin", "plugin.py")],
         )
 
+    def test_lambda_arguments_shadow_aliases_but_defaults_use_outer_scope(self):
+        sources = {
+            "__init__.py": """\
+from importlib import import_module as load
+module_value = load(".plugin", __package__)
+posonly = lambda load, /: load("not.posonly")
+regular = lambda load: load("not.regular")
+kwonly = lambda *, load: load("not.kwonly")
+vararg = lambda *load: load("not.vararg")
+kwarg = lambda **load: load("not.kwarg")
+defaulted = lambda value=load(".plugin", __package__): value
+closure = lambda: load(".plugin", __package__)
+""",
+            "plugin.py": "VALUE = 1\n",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        dynamic_edges = [
+            edge
+            for edge in report["imports"]["edges"]
+            if edge["kind"] == "literal_dynamic"
+        ]
+
+        self.assertEqual(
+            [(edge["scope"], edge["imported"]) for edge in dynamic_edges],
+            [
+                ("<module>", ".plugin"),
+                ("<module>", ".plugin"),
+                ("<lambda>@9", ".plugin"),
+            ],
+        )
+
+    def test_method_lookup_skips_class_alias_scope_but_definitions_use_it(self):
+        sources = {
+            "__init__.py": """\
+from importlib import import_module as load
+
+class UsesModuleAlias:
+    load = custom_loader
+
+    def method(self):
+        return load(".plugin", __package__)
+
+class UsesClassAlias:
+    from importlib import import_module as class_load
+    class_value = class_load(".class_body", __package__)
+
+    def method(
+        self,
+        value: class_load(".annotation", __package__) = class_load(".default", __package__),
+    ):
+        return class_load("not.a.dynamic.import")
+""",
+            "annotation.py": "VALUE = 1\n",
+            "class_body.py": "VALUE = 1\n",
+            "default.py": "VALUE = 1\n",
+            "plugin.py": "VALUE = 1\n",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        dynamic_edges = [
+            edge
+            for edge in report["imports"]["edges"]
+            if edge["kind"] == "literal_dynamic"
+        ]
+
+        self.assertEqual(
+            {(edge["scope"], edge["imported"]) for edge in dynamic_edges},
+            {
+                ("UsesClassAlias", ".annotation"),
+                ("UsesClassAlias", ".class_body"),
+                ("UsesClassAlias", ".default"),
+                ("UsesModuleAlias.method", ".plugin"),
+            },
+        )
+
     def test_try_branch_context_and_compatibility_fallback_taxonomy(self):
         sources = {
             "__init__.py": """\
@@ -601,6 +677,7 @@ CACHE = {}
         self.assertIn("ordinary", rendered)
         self.assertIn("compatibility_fallback", rendered)
         self.assertIn("try@", rendered)
+        self.assertIn("conflicting branch aliases remain heuristic", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -475,6 +475,85 @@ except ImportError:
             ["optional_dependency"],
         )
 
+    def test_type_checking_edges_are_preserved_but_excluded_from_runtime_views(self):
+        sources = {
+            "__init__.py": """\
+from typing import TYPE_CHECKING
+from .runtime import VALUE
+
+if TYPE_CHECKING:
+    from .typing_only import T
+    from .missing_type import M
+""",
+            "runtime.py": "VALUE = 1\n",
+            "typing_only.py": "T = object\n",
+        }
+
+        report = analyzer.analyze_source_set(sources)
+        reversed_report = analyzer.analyze_source_set(
+            dict(reversed(list(sources.items())))
+        )
+        type_edges = {
+            edge["imported"]: edge
+            for edge in import_edges(report)
+            if edge["imported"] in {".typing_only:T", ".missing_type:M"}
+        }
+
+        self.assertEqual(report, reversed_report)
+        self.assertEqual(set(type_edges), {".typing_only:T", ".missing_type:M"})
+        for edge in type_edges.values():
+            self.assertTrue(edge["conditional"])
+            self.assertTrue(edge["optional"])
+            self.assertEqual(
+                edge["branch_context"][-1],
+                {
+                    "kind": "if",
+                    "line": 4,
+                    "branch": "body",
+                    "type_checking": True,
+                },
+            )
+        self.assertEqual(type_edges[".typing_only:T"]["classification"], "internal")
+        self.assertEqual(type_edges[".typing_only:T"]["target"], "typing_only.py")
+        self.assertEqual(
+            type_edges[".missing_type:M"]["classification"],
+            "missing_internal",
+        )
+
+        registry = report["registry"]
+        self.assertEqual(
+            report["imports"]["module_graph"],
+            [{"from": "__init__.py", "to": "runtime.py"}],
+        )
+        self.assertEqual(
+            registry["runtime_import_closure"],
+            ["__init__.py", "runtime.py"],
+        )
+        self.assertEqual(
+            registry["unreachable_shipped_python_modules"],
+            ["typing_only.py"],
+        )
+        self.assertEqual(registry["missing_internal_imports"], [])
+        self.assertFalse(
+            {".typing_only:T", ".missing_type:M"}
+            & {item["imported"] for item in registry["optional_imports"]}
+        )
+        self.assertNotIn(
+            "typing_only.py",
+            {
+                module
+                for component in report["imports"]["sccs"]
+                for module in component["modules"]
+            },
+        )
+        self.assertTrue(
+            {"T", "M"}.isdisjoint(report["public_surface"]["compatibility_names"])
+        )
+        self.assertEqual(
+            report["imports"]["module_graph_policy"]["excluded_branch_contexts"],
+            [{"kind": "if", "branch": "body", "type_checking": True}],
+        )
+
     def test_comfyignore_anchoring_slashes_negation_and_escaped_markers(self):
         sources = {
             "__init__.py": "VALUE = 1\n",
@@ -604,7 +683,14 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertGreaterEqual(report["inventory"]["module_count"], 10)
+        self.assertEqual(report["inventory"]["module_count"], 16)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 16)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 16)
+        self.assertEqual(report["registry"]["missing_internal_imports"], [])
+        self.assertEqual(
+            report["registry"]["unreachable_shipped_python_modules"],
+            [],
+        )
         self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
         self.assertIn("api.py", report["registry"]["runtime_import_closure"])
         self.assertIn(
@@ -690,6 +776,7 @@ CACHE = {}
         self.assertIn("compatibility_fallback", rendered)
         self.assertIn("try@", rendered)
         self.assertIn("conflicting branch aliases remain heuristic", rendered)
+        self.assertIn("TYPE_CHECKING", rendered)
 
 
 if __name__ == "__main__":

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -350,11 +350,34 @@ def _function_local_names(
     return visitor.names - visitor.global_names - visitor.nonlocal_names
 
 
+def _lambda_local_names(node: ast.Lambda) -> set[str]:
+    visitor = _FunctionLocalBindingVisitor()
+    visitor.visit(node.body)
+    return visitor.names - visitor.global_names - visitor.nonlocal_names
+
+
+def _argument_names(arguments: ast.arguments) -> set[str]:
+    names = {
+        argument.arg
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        )
+    }
+    if arguments.vararg:
+        names.add(arguments.vararg.arg)
+    if arguments.kwarg:
+        names.add(arguments.kwarg.arg)
+    return names
+
+
 class _ImportCandidateVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.candidates: list[dict[str, object]] = []
         self.scope_parts: list[str] = []
         self.alias_scopes: list[dict[str, set[str] | None]] = [{}]
+        self.alias_scope_kinds = ["module"]
         self.branch_context: list[dict[str, object]] = []
 
     @property
@@ -371,7 +394,15 @@ class _ImportCandidateVisitor(ast.NodeVisitor):
     def _resolve_callee_aliases(self, callee: str) -> set[str]:
         resolved = {callee}
         root, separator, suffix = callee.partition(".")
-        for aliases in reversed(self.alias_scopes):
+        crossed_function_scope = False
+        for aliases, scope_kind in zip(
+            reversed(self.alias_scopes),
+            reversed(self.alias_scope_kinds),
+        ):
+            if scope_kind in {"function", "lambda"}:
+                crossed_function_scope = True
+            elif scope_kind == "class" and crossed_function_scope:
+                continue
             if root not in aliases:
                 continue
             targets = aliases[root]
@@ -429,47 +460,72 @@ class _ImportCandidateVisitor(ast.NodeVisitor):
             }
         )
 
-    def _visit_function_scope(
+    def _visit_function_definition_expressions(
         self,
         node: ast.FunctionDef | ast.AsyncFunctionDef,
     ) -> None:
         for decorator in node.decorator_list:
             self.visit(decorator)
+        arguments = (
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+        )
+        for argument in arguments:
+            if argument.annotation:
+                self.visit(argument.annotation)
+        if node.args.vararg and node.args.vararg.annotation:
+            self.visit(node.args.vararg.annotation)
+        if node.args.kwarg and node.args.kwarg.annotation:
+            self.visit(node.args.kwarg.annotation)
+        if node.returns:
+            self.visit(node.returns)
         for default in (
             *node.args.defaults,
             *[item for item in node.args.kw_defaults if item],
         ):
             self.visit(default)
-        argument_names = {
-            argument.arg
-            for argument in (
-                *node.args.posonlyargs,
-                *node.args.args,
-                *node.args.kwonlyargs,
-            )
-        }
-        if node.args.vararg:
-            argument_names.add(node.args.vararg.arg)
-        if node.args.kwarg:
-            argument_names.add(node.args.kwarg.arg)
+
+    def _visit_function_body(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
         self.scope_parts.append(node.name)
-        local_names = argument_names | _function_local_names(node)
+        local_names = _argument_names(node.args) | _function_local_names(node)
         self.alias_scopes.append({name: None for name in local_names})
+        self.alias_scope_kinds.append("function")
         for statement in node.body:
             self.visit(statement)
+        self.alias_scope_kinds.pop()
         self.alias_scopes.pop()
         self.scope_parts.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function_definition_expressions(node)
         self._shadow_names([node.name])
-        self._visit_function_scope(node)
+        self._visit_function_body(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function_definition_expressions(node)
         self._shadow_names([node.name])
-        self._visit_function_scope(node)
+        self._visit_function_body(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in (
+            *node.args.defaults,
+            *[item for item in node.args.kw_defaults if item],
+        ):
+            self.visit(default)
+        self.scope_parts.append(f"<lambda>@{node.lineno}")
+        local_names = _argument_names(node.args) | _lambda_local_names(node)
+        self.alias_scopes.append({name: None for name in local_names})
+        self.alias_scope_kinds.append("lambda")
+        self.visit(node.body)
+        self.alias_scope_kinds.pop()
+        self.alias_scopes.pop()
+        self.scope_parts.pop()
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        self._shadow_names([node.name])
         for decorator in node.decorator_list:
             self.visit(decorator)
         for base in node.bases:
@@ -478,10 +534,13 @@ class _ImportCandidateVisitor(ast.NodeVisitor):
             self.visit(keyword.value)
         self.scope_parts.append(node.name)
         self.alias_scopes.append({})
+        self.alias_scope_kinds.append("class")
         for statement in node.body:
             self.visit(statement)
+        self.alias_scope_kinds.pop()
         self.alias_scopes.pop()
         self.scope_parts.pop()
+        self._shadow_names([node.name])
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -1430,6 +1489,16 @@ def analyze_source_set(
         "imports": {
             "edges": edges,
             "module_graph": graph_records,
+            "dynamic_alias_policy": {
+                "lexical_scopes": (
+                    "module, class, function, and lambda bindings are tracked; "
+                    "class namespaces are skipped for nested function lookup"
+                ),
+                "control_flow_merge": (
+                    "if/try branch bindings are visited in deterministic source order; "
+                    "conflicting branch aliases remain heuristic"
+                ),
+            },
             "module_graph_policy": {
                 "included_classifications": [
                     "compatibility_fallback",
@@ -1544,6 +1613,11 @@ def render_text(report: Mapping[str, object]) -> str:
     for component in report["imports"]["sccs"]:
         marker = "cycle" if component["cyclic"] else "acyclic"
         lines.append(f"{marker} | {', '.join(component['modules'])}")
+
+    alias_policy = report["imports"]["dynamic_alias_policy"]
+    lines.extend(("", "[analysis_policy]"))
+    lines.append(f"dynamic_alias_lexical_scopes: {alias_policy['lexical_scopes']}")
+    lines.append(f"dynamic_alias_control_flow: {alias_policy['control_flow_merge']}")
 
     lines.extend(("", "[state.mutable_globals]"))
     for item in report["state"]["mutable_globals"]:

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -1324,6 +1324,17 @@ def _edge_summary(edge: Mapping[str, object]) -> dict[str, object]:
     return summary
 
 
+def _is_runtime_relevant_edge(edge: Mapping[str, object]) -> bool:
+    """Exclude imports guarded by an if TYPE_CHECKING body from runtime views."""
+
+    return not any(
+        context.get("kind") == "if"
+        and context.get("branch") == "body"
+        and bool(context.get("type_checking"))
+        for context in edge["branch_context"]
+    )
+
+
 def _public_surface(
     root_analysis: Mapping[str, object],
     edges: Sequence[Mapping[str, object]],
@@ -1439,10 +1450,11 @@ def analyze_source_set(
             str(item.get("alias")),
         )
     )
+    runtime_edges = [edge for edge in edges if _is_runtime_relevant_edge(edge)]
     graph_edges = sorted(
         {
             (str(edge["source"]), str(edge["target"]))
-            for edge in edges
+            for edge in runtime_edges
             if edge["classification"]
             in {"compatibility_fallback", "internal"}
         }
@@ -1450,7 +1462,12 @@ def analyze_source_set(
     graph_records = [{"from": source, "to": target} for source, target in graph_edges]
     closure = _registry_closure(shipped_paths, graph_records)
     closure_set = set(closure)
-    closure_edges = [edge for edge in edges if edge["source"] in closure_set]
+    closure_edges = [
+        edge for edge in runtime_edges if edge["source"] in closure_set
+    ]
+    closure_graph_records = [
+        edge for edge in graph_records if edge["from"] in closure_set
+    ]
 
     mutable_globals = sorted(
         (item for analysis in analyses.values() for item in analysis["mutable_globals"]),
@@ -1505,8 +1522,20 @@ def analyze_source_set(
                     "internal",
                 ],
                 "duplicate_policy": "collapse by source and target path",
+                "excluded_branch_contexts": [
+                    {
+                        "kind": "if",
+                        "branch": "body",
+                        "type_checking": True,
+                    }
+                ],
+                "type_checking_policy": (
+                    "exclude edges nested in if TYPE_CHECKING body from runtime "
+                    "graph, SCC, public surface, and Registry runtime taxonomies"
+                ),
+                "scc_node_scope": "runtime_import_closure",
             },
-            "sccs": _strongly_connected_components(shipped_paths, graph_records),
+            "sccs": _strongly_connected_components(closure, closure_graph_records),
         },
         "state": {
             "mutable_globals": mutable_globals,
@@ -1515,7 +1544,10 @@ def analyze_source_set(
         "side_effects": {
             "candidates": side_effects,
         },
-        "public_surface": _public_surface(analyses["__init__.py"], edges),
+        "public_surface": _public_surface(
+            analyses["__init__.py"],
+            runtime_edges,
+        ),
         "registry": {
             "package_root": ".",
             "ignore_file": ".comfyignore",
@@ -1615,9 +1647,12 @@ def render_text(report: Mapping[str, object]) -> str:
         lines.append(f"{marker} | {', '.join(component['modules'])}")
 
     alias_policy = report["imports"]["dynamic_alias_policy"]
+    graph_policy = report["imports"]["module_graph_policy"]
     lines.extend(("", "[analysis_policy]"))
     lines.append(f"dynamic_alias_lexical_scopes: {alias_policy['lexical_scopes']}")
     lines.append(f"dynamic_alias_control_flow: {alias_policy['control_flow_merge']}")
+    lines.append(f"runtime_type_checking: {graph_policy['type_checking_policy']}")
+    lines.append(f"runtime_scc_node_scope: {graph_policy['scc_node_scope']}")
 
     lines.extend(("", "[state.mutable_globals]"))
     for item in report["state"]["mutable_globals"]:

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import argparse
 import ast
-import fnmatch
 import hashlib
 import json
+import re
 from collections import deque
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
@@ -29,9 +29,16 @@ from typing import Iterable, Mapping, Sequence
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 ROOT_MODULE = "__root__"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DYNAMIC_IMPORT_CALLEES = frozenset({"__import__", "importlib.import_module"})
 MUTABLE_CONSTRUCTORS = {
+    "ChainMap": "dict",
+    "Counter": "dict",
+    "OrderedDict": "dict",
+    "UserDict": "dict",
+    "UserList": "list",
+    "defaultdict": "dict",
+    "deque": "list",
     "dict": "dict",
     "list": "list",
     "set": "set",
@@ -92,18 +99,27 @@ def _internal_name(module_name: str) -> str:
     return "" if module_name == ROOT_MODULE else module_name
 
 
+def _strip_unescaped_trailing_spaces(line: str) -> str:
+    while line.endswith(" ") and not line.endswith("\\ "):
+        line = line[:-1]
+    return line.replace("\\ ", " ")
+
+
 def _ignore_rules(ignore_text: str) -> list[dict[str, object]]:
     rules = []
     for line_number, raw_line in enumerate(ignore_text.splitlines(), start=1):
-        stripped = raw_line.strip()
-        if not stripped or stripped.startswith("#"):
+        line = _strip_unescaped_trailing_spaces(raw_line)
+        if not line:
             continue
-        negated = stripped.startswith("!")
-        pattern = stripped[1:] if negated else stripped
+        escaped_marker = line.startswith((r"\#", r"\!"))
+        if line.startswith("#") and not escaped_marker:
+            continue
+        negated = line.startswith("!") and not escaped_marker
+        pattern = line[1:] if negated or escaped_marker else line
         directory_only = pattern.endswith("/")
         pattern = pattern.rstrip("/")
         anchored = pattern.startswith("/")
-        pattern = pattern.lstrip("/")
+        pattern = pattern[1:] if anchored else pattern
         if not pattern:
             continue
         rules.append(
@@ -118,84 +134,124 @@ def _ignore_rules(ignore_text: str) -> list[dict[str, object]]:
     return rules
 
 
-def _match_path_pattern(path: str, pattern: str, *, anchored: bool) -> bool:
-    if "/" not in pattern:
-        return fnmatch.fnmatchcase(path.rsplit("/", 1)[-1], pattern)
-    if fnmatch.fnmatchcase(path, pattern):
-        return True
-    if anchored:
-        return False
-    parts = path.split("/")
-    return any(
-        fnmatch.fnmatchcase("/".join(parts[index:]), pattern)
-        for index in range(1, len(parts))
-    )
+def _glob_regex(pattern: str) -> re.Pattern[str]:
+    pieces = ["^"]
+    index = 0
+    while index < len(pattern):
+        character = pattern[index]
+        if character == "\\" and index + 1 < len(pattern):
+            index += 1
+            pieces.append(re.escape(pattern[index]))
+        elif pattern.startswith("**/", index):
+            pieces.append("(?:.*/)?")
+            index += 2
+        elif pattern.startswith("**", index):
+            pieces.append(".*")
+            index += 1
+        elif character == "*":
+            pieces.append("[^/]*")
+        elif character == "?":
+            pieces.append("[^/]")
+        elif character == "[":
+            closing = pattern.find("]", index + 1)
+            if closing == -1:
+                pieces.append(r"\[")
+            else:
+                content = pattern[index + 1 : closing]
+                if content.startswith("!"):
+                    content = "^" + content[1:]
+                elif content.startswith("^"):
+                    content = "\\" + content
+                pieces.append(f"(?!/)[{content}]")
+                index = closing
+        else:
+            pieces.append(re.escape(character))
+        index += 1
+    pieces.append("$")
+    return re.compile("".join(pieces))
 
 
-def _rule_matches(path: str, rule: Mapping[str, object]) -> bool:
+def _match_path_pattern(path: str, pattern: str) -> bool:
+    return bool(_glob_regex(pattern).fullmatch(path))
+
+
+def _rule_matches(
+    path: str,
+    rule: Mapping[str, object],
+    *,
+    is_directory: bool,
+) -> bool:
     parts = path.split("/")
     pattern = str(rule["pattern"])
     anchored = bool(rule["anchored"])
-    if bool(rule["directory_only"]):
-        directories = ["/".join(parts[:index]) for index in range(1, len(parts))]
-        if "/" not in pattern and not anchored:
-            return any(fnmatch.fnmatchcase(part, pattern) for part in parts[:-1])
-        return any(
-            _match_path_pattern(directory, pattern, anchored=anchored)
-            for directory in directories
-        )
-    return _match_path_pattern(path, pattern, anchored=anchored)
+    directory_only = bool(rule["directory_only"])
+    candidates = []
+    for length in range(1, len(parts) + 1):
+        candidate_is_directory = length < len(parts) or is_directory
+        if directory_only and not candidate_is_directory:
+            continue
+        candidate = "/".join(parts[:length])
+        candidates.append((candidate, candidate.rsplit("/", 1)[-1]))
+    if anchored or "/" in pattern:
+        return any(_match_path_pattern(candidate, pattern) for candidate, _ in candidates)
+    return any(_match_path_pattern(basename, pattern) for _, basename in candidates)
 
 
-def _is_ignored(path: str, rules: Sequence[Mapping[str, object]]) -> bool:
+def _is_ignored(
+    path: str,
+    rules: Sequence[Mapping[str, object]],
+    *,
+    is_directory: bool = False,
+) -> bool:
     ignored = False
-    for rule in rules:
-        if _rule_matches(path, rule):
-            ignored = not bool(rule["negated"])
+    for index, rule in enumerate(rules):
+        if not _rule_matches(path, rule, is_directory=is_directory):
+            continue
+        if not bool(rule["negated"]):
+            ignored = True
+            continue
+        parent_parts = path.split("/")[:-1]
+        parent_is_ignored = any(
+            _is_ignored(
+                "/".join(parent_parts[:length]),
+                rules[:index],
+                is_directory=True,
+            )
+            for length in range(1, len(parent_parts) + 1)
+        )
+        if not parent_is_ignored:
+            ignored = False
     return ignored
 
 
-def _collect_dynamic_aliases(tree: ast.AST) -> dict[str, set[str]]:
-    aliases: dict[str, set[str]] = {}
-
-    def bind(name: str, target: str) -> None:
-        aliases.setdefault(name, set()).add(target)
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.asname:
-                    bind(alias.asname, alias.name)
-                else:
-                    bind(alias.name.split(".", 1)[0], alias.name.split(".", 1)[0])
-        elif isinstance(node, ast.ImportFrom):
-            module = "." * node.level + (node.module or "")
-            for alias in node.names:
-                if alias.name != "*":
-                    target = f"{module}.{alias.name}" if module else alias.name
-                    bind(alias.asname or alias.name, target)
-    return aliases
-
-
-def _resolve_callee_aliases(callee: str, aliases: Mapping[str, set[str]]) -> set[str]:
-    resolved = {callee}
-    root, separator, suffix = callee.partition(".")
-    for target in aliases.get(root, set()):
-        resolved.add(f"{target}.{suffix}" if separator else target)
-    return resolved
-
-
-def _caught_import_error(handler_type: ast.AST | None) -> bool:
+def _handler_exception_names(handler_type: ast.AST | None) -> list[str]:
     if handler_type is None:
-        return True
-    names = (
-        handler_type.elts
-        if isinstance(handler_type, ast.Tuple)
-        else [handler_type]
+        return ["<bare>"]
+    nodes = handler_type.elts if isinstance(handler_type, ast.Tuple) else [handler_type]
+    return sorted(
+        {
+            _call_name(node).rsplit(".", 1)[-1] or "<expression>"
+            for node in nodes
+        }
     )
-    return any(
-        _call_name(item).rsplit(".", 1)[-1] in {"ImportError", "ModuleNotFoundError"}
-        for item in names
+
+
+def _catches_import_error(handler_type: ast.AST | None) -> bool:
+    names = set(_handler_exception_names(handler_type))
+    return bool(names & {"<bare>", "ImportError", "ModuleNotFoundError"})
+
+
+def _catches_import_failure(handler_type: ast.AST | None) -> bool:
+    names = set(_handler_exception_names(handler_type))
+    return bool(
+        names
+        & {
+            "<bare>",
+            "BaseException",
+            "Exception",
+            "ImportError",
+            "ModuleNotFoundError",
+        }
     )
 
 
@@ -203,17 +259,151 @@ def _is_type_checking_test(node: ast.AST) -> bool:
     return _call_name(node).rsplit(".", 1)[-1] == "TYPE_CHECKING"
 
 
+class _FunctionLocalBindingVisitor(ast.NodeVisitor):
+    """Find names statically local to one function without entering nested scopes."""
+
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+        self.global_names: set[str] = set()
+        self.nonlocal_names: set[str] = set()
+
+    def _add_target(self, target: ast.AST) -> None:
+        self.names.update(_assigned_names(target))
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self.global_names.update(node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self.nonlocal_names.update(node.names)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.names.add(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return None
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self.names.update(
+            alias.asname or alias.name.split(".", 1)[0]
+            for alias in node.names
+        )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        self.names.update(
+            alias.asname or alias.name
+            for alias in node.names
+            if alias.name != "*"
+        )
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            self._add_target(target)
+        self.visit(node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._add_target(node.target)
+        if node.value:
+            self.visit(node.value)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._add_target(node.target)
+        self.visit(node.value)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self._add_target(node.target)
+        self.visit(node.value)
+
+    def visit_For(self, node: ast.For) -> None:
+        self._add_target(node.target)
+        self.generic_visit(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self.visit_For(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        for item in node.items:
+            if item.optional_vars:
+                self._add_target(item.optional_vars)
+        self.generic_visit(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self.visit_With(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name:
+            self.names.add(node.name)
+        self.generic_visit(node)
+
+
+def _function_local_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str]:
+    visitor = _FunctionLocalBindingVisitor()
+    for statement in node.body:
+        visitor.visit(statement)
+    return visitor.names - visitor.global_names - visitor.nonlocal_names
+
+
 class _ImportCandidateVisitor(ast.NodeVisitor):
-    def __init__(self, aliases: Mapping[str, set[str]]) -> None:
-        self.aliases = aliases
+    def __init__(self) -> None:
         self.candidates: list[dict[str, object]] = []
         self.scope_parts: list[str] = []
-        self.optional_depth = 0
-        self.conditional_depth = 0
+        self.alias_scopes: list[dict[str, set[str] | None]] = [{}]
+        self.branch_context: list[dict[str, object]] = []
 
     @property
     def scope(self) -> str:
         return ".".join(self.scope_parts) if self.scope_parts else "<module>"
+
+    def _bind_alias(self, name: str, target: str) -> None:
+        self.alias_scopes[-1][name] = {target}
+
+    def _shadow_names(self, names: Iterable[str]) -> None:
+        for name in names:
+            self.alias_scopes[-1][name] = None
+
+    def _resolve_callee_aliases(self, callee: str) -> set[str]:
+        resolved = {callee}
+        root, separator, suffix = callee.partition(".")
+        for aliases in reversed(self.alias_scopes):
+            if root not in aliases:
+                continue
+            targets = aliases[root]
+            if targets:
+                resolved.update(
+                    f"{target}.{suffix}" if separator else target
+                    for target in targets
+                )
+            break
+        return resolved
+
+    def _push_branch(self, context: dict[str, object]) -> None:
+        self.branch_context.append(context)
+
+    def _pop_branch(self) -> None:
+        self.branch_context.pop()
+
+    def _optional_candidate(self) -> bool:
+        for context in self.branch_context:
+            if (
+                context["kind"] == "try"
+                and context["branch"] == "body"
+                and context.get("handles_import_failure")
+            ):
+                return True
+            if (
+                context["kind"] == "if"
+                and context["branch"] == "body"
+                and context.get("type_checking")
+            ):
+                return True
+        return False
 
     def _append(
         self,
@@ -233,24 +423,65 @@ class _ImportCandidateVisitor(ast.NodeVisitor):
                 "line": node.lineno,
                 "column": node.col_offset,
                 "scope": self.scope,
-                "optional": self.optional_depth > 0,
-                "conditional": self.conditional_depth > 0,
+                "branch_context": [dict(item) for item in self.branch_context],
+                "optional_candidate": self._optional_candidate(),
+                "conditional": bool(self.branch_context),
             }
         )
 
-    def _visit_scope(self, node: ast.AST, name: str) -> None:
-        self.scope_parts.append(name)
-        self.generic_visit(node)
+    def _visit_function_scope(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in (
+            *node.args.defaults,
+            *[item for item in node.args.kw_defaults if item],
+        ):
+            self.visit(default)
+        argument_names = {
+            argument.arg
+            for argument in (
+                *node.args.posonlyargs,
+                *node.args.args,
+                *node.args.kwonlyargs,
+            )
+        }
+        if node.args.vararg:
+            argument_names.add(node.args.vararg.arg)
+        if node.args.kwarg:
+            argument_names.add(node.args.kwarg.arg)
+        self.scope_parts.append(node.name)
+        local_names = argument_names | _function_local_names(node)
+        self.alias_scopes.append({name: None for name in local_names})
+        for statement in node.body:
+            self.visit(statement)
+        self.alias_scopes.pop()
         self.scope_parts.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self._visit_scope(node, node.name)
+        self._shadow_names([node.name])
+        self._visit_function_scope(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        self._visit_scope(node, node.name)
+        self._shadow_names([node.name])
+        self._visit_function_scope(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        self._visit_scope(node, node.name)
+        self._shadow_names([node.name])
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self.scope_parts.append(node.name)
+        self.alias_scopes.append({})
+        for statement in node.body:
+            self.visit(statement)
+        self.alias_scopes.pop()
+        self.scope_parts.pop()
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -261,6 +492,11 @@ class _ImportCandidateVisitor(ast.NodeVisitor):
                 name=None,
                 alias=alias.asname,
             )
+            if alias.asname:
+                self._bind_alias(alias.asname, alias.name)
+            else:
+                root_name = alias.name.split(".", 1)[0]
+                self._bind_alias(root_name, root_name)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         requested = "." * node.level + (node.module or "")
@@ -272,10 +508,18 @@ class _ImportCandidateVisitor(ast.NodeVisitor):
                 name=alias.name,
                 alias=alias.asname,
             )
+            if alias.name != "*":
+                if requested.endswith("."):
+                    target = f"{requested}{alias.name}"
+                elif requested:
+                    target = f"{requested}.{alias.name}"
+                else:
+                    target = alias.name
+                self._bind_alias(alias.asname or alias.name, target)
 
     def visit_Call(self, node: ast.Call) -> None:
         callee = _call_name(node.func)
-        if _resolve_callee_aliases(callee, self.aliases).intersection(DYNAMIC_IMPORT_CALLEES):
+        if self._resolve_callee_aliases(callee).intersection(DYNAMIC_IMPORT_CALLEES):
             if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
                 self._append(
                     node=node,
@@ -286,33 +530,120 @@ class _ImportCandidateVisitor(ast.NodeVisitor):
                 )
         self.generic_visit(node)
 
-    def visit_Try(self, node: ast.Try) -> None:
-        catches_import_error = any(_caught_import_error(handler.type) for handler in node.handlers)
-        if catches_import_error:
-            self.optional_depth += 1
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        self._shadow_names(
+            name
+            for target in node.targets
+            for name in _assigned_names(target)
+        )
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value:
+            self.visit(node.value)
+        self._shadow_names(_assigned_names(node.target))
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.visit(node.value)
+        self._shadow_names(_assigned_names(node.target))
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self._shadow_names(_assigned_names(node.target))
+
+    def visit_For(self, node: ast.For) -> None:
+        self.visit(node.iter)
+        self._shadow_names(_assigned_names(node.target))
+        for statement in (*node.body, *node.orelse):
+            self.visit(statement)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self.visit_For(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars:
+                self._shadow_names(_assigned_names(item.optional_vars))
         for statement in node.body:
             self.visit(statement)
-        if catches_import_error:
-            self.optional_depth -= 1
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self.visit_With(node)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        catches_import_error = any(
+            _catches_import_error(handler.type) for handler in node.handlers
+        )
+        handles_import_failure = any(
+            _catches_import_failure(handler.type) for handler in node.handlers
+        )
+        self._push_branch(
+            {
+                "kind": "try",
+                "line": node.lineno,
+                "branch": "body",
+                "handles_import_failure": handles_import_failure,
+                "has_import_fallback_handler": catches_import_error,
+            }
+        )
+        for statement in node.body:
+            self.visit(statement)
+        self._pop_branch()
         for handler in node.handlers:
-            self.visit(handler)
+            self._push_branch(
+                {
+                    "kind": "try",
+                    "line": node.lineno,
+                    "branch": "except",
+                    "handler_line": handler.lineno,
+                    "exceptions": _handler_exception_names(handler.type),
+                    "catches_import_error": _catches_import_error(handler.type),
+                }
+            )
+            for statement in handler.body:
+                self.visit(statement)
+            self._pop_branch()
+        self._push_branch(
+            {"kind": "try", "line": node.lineno, "branch": "else"}
+        )
         for statement in node.orelse:
             self.visit(statement)
+        self._pop_branch()
+        self._push_branch(
+            {"kind": "try", "line": node.lineno, "branch": "finally"}
+        )
         for statement in node.finalbody:
             self.visit(statement)
+        self._pop_branch()
+
+    visit_TryStar = visit_Try
 
     def visit_If(self, node: ast.If) -> None:
         self.visit(node.test)
-        self.conditional_depth += 1
-        if _is_type_checking_test(node.test):
-            self.optional_depth += 1
+        type_checking = _is_type_checking_test(node.test)
+        self._push_branch(
+            {
+                "kind": "if",
+                "line": node.lineno,
+                "branch": "body",
+                "type_checking": type_checking,
+            }
+        )
         for statement in node.body:
             self.visit(statement)
-        if _is_type_checking_test(node.test):
-            self.optional_depth -= 1
+        self._pop_branch()
+        self._push_branch(
+            {
+                "kind": "if",
+                "line": node.lineno,
+                "branch": "else",
+                "type_checking": type_checking,
+            }
+        )
         for statement in node.orelse:
             self.visit(statement)
-        self.conditional_depth -= 1
+        self._pop_branch()
 
 
 def _mutable_kind(value: ast.AST | None) -> str | None:
@@ -377,20 +708,53 @@ def _owner_categories(
     return sorted(categories)
 
 
-def _direct_assignments(tree: ast.Module) -> list[tuple[str, int, ast.AST | None]]:
-    assignments = []
-    for statement in tree.body:
-        if isinstance(statement, ast.Assign):
-            for target in statement.targets:
-                for name in _assigned_names(target):
-                    assignments.append((name, statement.lineno, statement.value))
-        elif isinstance(statement, ast.AnnAssign):
-            for name in _assigned_names(statement.target):
-                assignments.append((name, statement.lineno, statement.value))
-        elif isinstance(statement, ast.AugAssign):
-            for name in _assigned_names(statement.target):
-                assignments.append((name, statement.lineno, statement.value))
-    return assignments
+class _ModuleAssignmentVisitor(ast.NodeVisitor):
+    """Collect assignments executed in module control flow, excluding local scopes."""
+
+    def __init__(self) -> None:
+        self.assignments: list[tuple[str, int, ast.AST | None]] = []
+
+    def _append(self, target: ast.AST, line: int, value: ast.AST | None) -> None:
+        self.assignments.extend(
+            (name, line, value)
+            for name in _assigned_names(target)
+        )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return None
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        return None
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        return None
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return None
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            self._append(target, node.lineno, node.value)
+        self.visit(node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._append(node.target, node.lineno, node.value)
+        if node.value:
+            self.visit(node.value)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._append(node.target, node.lineno, node.value)
+        self.visit(node.value)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self._append(node.target, node.lineno, node.value)
+        self.visit(node.value)
+
+
+def _module_assignments(tree: ast.Module) -> list[tuple[str, int, ast.AST | None]]:
+    visitor = _ModuleAssignmentVisitor()
+    visitor.visit(tree)
+    return visitor.assignments
 
 
 def _context_assignment_names(node: ast.Assign | ast.AnnAssign | ast.AugAssign) -> list[str]:
@@ -518,7 +882,7 @@ def _analyze_module(path: str, data: bytes) -> dict[str, object]:
         elif isinstance(statement, ast.ClassDef):
             class_count += 1
 
-    assignments = _direct_assignments(tree)
+    assignments = _module_assignments(tree)
     globals_by_name: dict[str, int] = {}
     mutable_globals = []
     owner_candidates = []
@@ -555,8 +919,7 @@ def _analyze_module(path: str, data: bytes) -> dict[str, object]:
         if name == "__all__":
             declared_all = _literal_string_sequence(value)
 
-    aliases = _collect_dynamic_aliases(tree)
-    import_visitor = _ImportCandidateVisitor(aliases)
+    import_visitor = _ImportCandidateVisitor()
     import_visitor.visit(tree)
     side_effect_visitor = _ImportTimeCallVisitor()
     side_effect_visitor.visit(tree)
@@ -610,6 +973,50 @@ def _edge_display(candidate: Mapping[str, object]) -> str:
     return f"{requested}:{name}" if name else requested
 
 
+def _bound_name(candidate: Mapping[str, object]) -> str | None:
+    alias = candidate.get("alias")
+    if alias:
+        return str(alias)
+    imported_name = candidate.get("name")
+    if imported_name and imported_name != "*":
+        return str(imported_name)
+    if candidate["kind"] == "static_import":
+        return str(candidate["requested"]).split(".", 1)[0]
+    return None
+
+
+def _nearest_try_context(
+    edge: Mapping[str, object],
+    branch: str,
+) -> Mapping[str, object] | None:
+    for context in reversed(edge["branch_context"]):
+        if context["kind"] == "try" and context["branch"] == branch:
+            return context
+    return None
+
+
+def _absolute_local_target(
+    edge: Mapping[str, object],
+    path_by_internal_name: Mapping[str, str],
+) -> str | None:
+    requested = str(edge["requested"])
+    if requested.startswith("."):
+        return None
+    options = []
+    imported_name = edge.get("name")
+    if imported_name and imported_name != "*":
+        options.append(f"{requested}.{imported_name}")
+    options.append(requested)
+    return next(
+        (
+            path_by_internal_name[option]
+            for option in options
+            if option in path_by_internal_name
+        ),
+        None,
+    )
+
+
 def _resolve_import_candidate(
     candidate: Mapping[str, object],
     *,
@@ -654,13 +1061,98 @@ def _resolve_import_candidate(
         "requested": requested,
         "name": imported_name,
         "alias": candidate.get("alias"),
-        "optional": bool(candidate["optional"]),
+        "bound_name": _bound_name(candidate),
+        "branch_context": candidate["branch_context"],
+        "optional": bool(candidate["optional_candidate"]),
         "conditional": bool(candidate["conditional"]),
         "classification": classification,
+        "role": (
+            "optional_dependency"
+            if candidate["optional_candidate"]
+            else "ordinary"
+        ),
     }
     if target is not None:
         edge["target"] = target
     return edge
+
+
+def _classify_compatibility_fallbacks(
+    edges: list[dict[str, object]],
+    *,
+    path_by_internal_name: Mapping[str, str],
+) -> None:
+    primary_by_key: dict[
+        tuple[str, str, int, str, str],
+        list[dict[str, object]],
+    ] = {}
+    for edge in edges:
+        context = _nearest_try_context(edge, "body")
+        bound_name = edge.get("bound_name")
+        target = edge.get("target")
+        if (
+            edge["classification"] != "internal"
+            or not str(edge["requested"]).startswith(".")
+            or context is None
+            or not context.get("has_import_fallback_handler")
+            or not bound_name
+            or not target
+        ):
+            continue
+        key = (
+            str(edge["source"]),
+            str(edge["scope"]),
+            int(context["line"]),
+            str(bound_name),
+            str(target),
+        )
+        primary_by_key.setdefault(key, []).append(edge)
+
+    for fallback in edges:
+        context = _nearest_try_context(fallback, "except")
+        bound_name = fallback.get("bound_name")
+        if (
+            fallback["classification"] != "external"
+            or context is None
+            or not context.get("catches_import_error")
+            or not bound_name
+        ):
+            continue
+        target = _absolute_local_target(fallback, path_by_internal_name)
+        if target is None:
+            continue
+        key = (
+            str(fallback["source"]),
+            str(fallback["scope"]),
+            int(context["line"]),
+            str(bound_name),
+            target,
+        )
+        primaries = primary_by_key.get(key)
+        if not primaries:
+            continue
+        pair = {
+            "try_line": int(context["line"]),
+            "bound_name": str(bound_name),
+            "target": target,
+        }
+        fallback.update(
+            {
+                "classification": "compatibility_fallback",
+                "target": target,
+                "role": "compatibility_fallback",
+                "optional": False,
+                "compatibility_pair": pair,
+            }
+        )
+        for primary in primaries:
+            primary.update(
+                {
+                    "role": "compatibility_primary",
+                    "optional": False,
+                    "compatibility_pair": pair,
+                }
+            )
 
 
 def _strongly_connected_components(
@@ -763,7 +1255,10 @@ def _edge_summary(edge: Mapping[str, object]) -> dict[str, object]:
         "kind": edge["kind"],
         "imported": edge["imported"],
         "classification": edge["classification"],
+        "role": edge["role"],
         "optional": edge["optional"],
+        "conditional": edge["conditional"],
+        "branch_context": edge["branch_context"],
     }
     if "target" in edge:
         summary["target"] = edge["target"]
@@ -871,6 +1366,10 @@ def analyze_source_set(
                     path_by_internal_name=path_by_internal_name,
                 )
             )
+    _classify_compatibility_fallbacks(
+        edges,
+        path_by_internal_name=path_by_internal_name,
+    )
     edges.sort(
         key=lambda item: (
             str(item["source"]),
@@ -885,7 +1384,8 @@ def analyze_source_set(
         {
             (str(edge["source"]), str(edge["target"]))
             for edge in edges
-            if edge["classification"] == "internal"
+            if edge["classification"]
+            in {"compatibility_fallback", "internal"}
         }
     )
     graph_records = [{"from": source, "to": target} for source, target in graph_edges]
@@ -930,6 +1430,13 @@ def analyze_source_set(
         "imports": {
             "edges": edges,
             "module_graph": graph_records,
+            "module_graph_policy": {
+                "included_classifications": [
+                    "compatibility_fallback",
+                    "internal",
+                ],
+                "duplicate_policy": "collapse by source and target path",
+            },
             "sccs": _strongly_connected_components(shipped_paths, graph_records),
         },
         "state": {
@@ -952,6 +1459,11 @@ def analyze_source_set(
                 _edge_summary(edge)
                 for edge in closure_edges
                 if edge["classification"] == "missing_internal"
+            ],
+            "compatibility_fallback_imports": [
+                _edge_summary(edge)
+                for edge in closure_edges
+                if edge["classification"] == "compatibility_fallback"
             ],
             "external_imports": [
                 _edge_summary(edge)
@@ -986,6 +1498,17 @@ def render_json(report: Mapping[str, object]) -> str:
     return json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
 
 
+def _render_branch_context(contexts: Sequence[Mapping[str, object]]) -> str:
+    labels = []
+    for context in contexts:
+        label = f"{context['kind']}@{context['line']}:{context['branch']}"
+        exceptions = context.get("exceptions")
+        if exceptions:
+            label += f"[{','.join(str(item) for item in exceptions)}]"
+        labels.append(label)
+    return " > ".join(labels) if labels else "module"
+
+
 def render_text(report: Mapping[str, object]) -> str:
     lines = [
         f"Python backend inventory schema {report['schema_version']}",
@@ -1003,12 +1526,19 @@ def render_text(report: Mapping[str, object]) -> str:
     lines.extend(("", "[edges]"))
     for edge in report["imports"]["edges"]:
         target = edge.get("target", edge["imported"])
-        flags = [str(edge["classification"]), str(edge["kind"])]
+        flags = [
+            str(edge["classification"]),
+            str(edge["role"]),
+            str(edge["kind"]),
+        ]
         if edge["optional"]:
             flags.append("optional")
         if edge["conditional"]:
             flags.append("conditional")
-        lines.append(f"{edge['source']}:{edge['line']} -> {target} | {', '.join(flags)}")
+        lines.append(
+            f"{edge['source']}:{edge['line']} -> {target} | "
+            f"{', '.join(flags)} | {_render_branch_context(edge['branch_context'])}"
+        )
 
     lines.extend(("", "[scc]"))
     for component in report["imports"]["sccs"]:
@@ -1049,6 +1579,10 @@ def render_text(report: Mapping[str, object]) -> str:
         f"{', '.join(registry['unreachable_shipped_python_modules']) or '<none>'}"
     )
     lines.append(f"missing_internal_imports: {len(registry['missing_internal_imports'])}")
+    lines.append(
+        f"compatibility_fallback_imports: "
+        f"{len(registry['compatibility_fallback_imports'])}"
+    )
     lines.append(f"external_imports: {len(registry['external_imports'])}")
     lines.append(f"optional_imports: {len(registry['optional_imports'])}")
     return "\n".join(lines) + "\n"

--- a/tools/analyze_python_backend.py
+++ b/tools/analyze_python_backend.py
@@ -1,0 +1,1074 @@
+#!/usr/bin/env python3
+"""Build a deterministic, AST-only inventory of the production Python backend.
+
+The analyzer reads source files and ``.comfyignore`` only.  It never imports
+production modules, starts ComfyUI, invokes Git, opens a network connection, or
+executes repository code.
+
+Deterministic output rules:
+
+* paths are repository-relative POSIX paths;
+* CRLF and bare CR are normalized to LF before parsing and blob hashing;
+* module, edge, state, side-effect, and SCC collections are sorted;
+* JSON object keys are sorted and the rendered document ends with one LF;
+* no absolute paths, user names, object ids, timestamps, or runtime values are
+  included.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import hashlib
+import json
+from collections import deque
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+ROOT_MODULE = "__root__"
+SCHEMA_VERSION = 1
+DYNAMIC_IMPORT_CALLEES = frozenset({"__import__", "importlib.import_module"})
+MUTABLE_CONSTRUCTORS = {
+    "dict": "dict",
+    "list": "list",
+    "set": "set",
+}
+ROUTE_METHODS = frozenset(
+    {
+        "delete",
+        "get",
+        "patch",
+        "post",
+        "put",
+        "route",
+    }
+)
+
+
+def _normalize_newlines(data: bytes) -> bytes:
+    return data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def _normalized_git_blob_sha1(data: bytes) -> str:
+    normalized = _normalize_newlines(data)
+    header = f"blob {len(normalized)}\0".encode("ascii")
+    return hashlib.sha1(header + normalized).hexdigest()
+
+
+def _decode_source(data: bytes) -> str:
+    return _normalize_newlines(data).decode("utf-8-sig")
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def _assigned_names(node: ast.AST) -> Iterable[str]:
+    if isinstance(node, ast.Name):
+        yield node.id
+    elif isinstance(node, (ast.List, ast.Tuple)):
+        for item in node.elts:
+            yield from _assigned_names(item)
+
+
+def _module_identity(path: str) -> tuple[str, bool]:
+    parts = list(Path(path).with_suffix("").parts)
+    is_package = bool(parts and parts[-1] == "__init__")
+    if is_package:
+        parts.pop()
+    internal_name = ".".join(parts)
+    return (internal_name or ROOT_MODULE), is_package
+
+
+def _internal_name(module_name: str) -> str:
+    return "" if module_name == ROOT_MODULE else module_name
+
+
+def _ignore_rules(ignore_text: str) -> list[dict[str, object]]:
+    rules = []
+    for line_number, raw_line in enumerate(ignore_text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        negated = stripped.startswith("!")
+        pattern = stripped[1:] if negated else stripped
+        directory_only = pattern.endswith("/")
+        pattern = pattern.rstrip("/")
+        anchored = pattern.startswith("/")
+        pattern = pattern.lstrip("/")
+        if not pattern:
+            continue
+        rules.append(
+            {
+                "line": line_number,
+                "pattern": pattern,
+                "negated": negated,
+                "directory_only": directory_only,
+                "anchored": anchored,
+            }
+        )
+    return rules
+
+
+def _match_path_pattern(path: str, pattern: str, *, anchored: bool) -> bool:
+    if "/" not in pattern:
+        return fnmatch.fnmatchcase(path.rsplit("/", 1)[-1], pattern)
+    if fnmatch.fnmatchcase(path, pattern):
+        return True
+    if anchored:
+        return False
+    parts = path.split("/")
+    return any(
+        fnmatch.fnmatchcase("/".join(parts[index:]), pattern)
+        for index in range(1, len(parts))
+    )
+
+
+def _rule_matches(path: str, rule: Mapping[str, object]) -> bool:
+    parts = path.split("/")
+    pattern = str(rule["pattern"])
+    anchored = bool(rule["anchored"])
+    if bool(rule["directory_only"]):
+        directories = ["/".join(parts[:index]) for index in range(1, len(parts))]
+        if "/" not in pattern and not anchored:
+            return any(fnmatch.fnmatchcase(part, pattern) for part in parts[:-1])
+        return any(
+            _match_path_pattern(directory, pattern, anchored=anchored)
+            for directory in directories
+        )
+    return _match_path_pattern(path, pattern, anchored=anchored)
+
+
+def _is_ignored(path: str, rules: Sequence[Mapping[str, object]]) -> bool:
+    ignored = False
+    for rule in rules:
+        if _rule_matches(path, rule):
+            ignored = not bool(rule["negated"])
+    return ignored
+
+
+def _collect_dynamic_aliases(tree: ast.AST) -> dict[str, set[str]]:
+    aliases: dict[str, set[str]] = {}
+
+    def bind(name: str, target: str) -> None:
+        aliases.setdefault(name, set()).add(target)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    bind(alias.asname, alias.name)
+                else:
+                    bind(alias.name.split(".", 1)[0], alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            module = "." * node.level + (node.module or "")
+            for alias in node.names:
+                if alias.name != "*":
+                    target = f"{module}.{alias.name}" if module else alias.name
+                    bind(alias.asname or alias.name, target)
+    return aliases
+
+
+def _resolve_callee_aliases(callee: str, aliases: Mapping[str, set[str]]) -> set[str]:
+    resolved = {callee}
+    root, separator, suffix = callee.partition(".")
+    for target in aliases.get(root, set()):
+        resolved.add(f"{target}.{suffix}" if separator else target)
+    return resolved
+
+
+def _caught_import_error(handler_type: ast.AST | None) -> bool:
+    if handler_type is None:
+        return True
+    names = (
+        handler_type.elts
+        if isinstance(handler_type, ast.Tuple)
+        else [handler_type]
+    )
+    return any(
+        _call_name(item).rsplit(".", 1)[-1] in {"ImportError", "ModuleNotFoundError"}
+        for item in names
+    )
+
+
+def _is_type_checking_test(node: ast.AST) -> bool:
+    return _call_name(node).rsplit(".", 1)[-1] == "TYPE_CHECKING"
+
+
+class _ImportCandidateVisitor(ast.NodeVisitor):
+    def __init__(self, aliases: Mapping[str, set[str]]) -> None:
+        self.aliases = aliases
+        self.candidates: list[dict[str, object]] = []
+        self.scope_parts: list[str] = []
+        self.optional_depth = 0
+        self.conditional_depth = 0
+
+    @property
+    def scope(self) -> str:
+        return ".".join(self.scope_parts) if self.scope_parts else "<module>"
+
+    def _append(
+        self,
+        *,
+        node: ast.AST,
+        kind: str,
+        requested: str,
+        name: str | None,
+        alias: str | None,
+    ) -> None:
+        self.candidates.append(
+            {
+                "kind": kind,
+                "requested": requested,
+                "name": name,
+                "alias": alias,
+                "line": node.lineno,
+                "column": node.col_offset,
+                "scope": self.scope,
+                "optional": self.optional_depth > 0,
+                "conditional": self.conditional_depth > 0,
+            }
+        )
+
+    def _visit_scope(self, node: ast.AST, name: str) -> None:
+        self.scope_parts.append(name)
+        self.generic_visit(node)
+        self.scope_parts.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._append(
+                node=node,
+                kind="static_import",
+                requested=alias.name,
+                name=None,
+                alias=alias.asname,
+            )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        requested = "." * node.level + (node.module or "")
+        for alias in node.names:
+            self._append(
+                node=node,
+                kind="static_from",
+                requested=requested,
+                name=alias.name,
+                alias=alias.asname,
+            )
+
+    def visit_Call(self, node: ast.Call) -> None:
+        callee = _call_name(node.func)
+        if _resolve_callee_aliases(callee, self.aliases).intersection(DYNAMIC_IMPORT_CALLEES):
+            if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+                self._append(
+                    node=node,
+                    kind="literal_dynamic",
+                    requested=node.args[0].value,
+                    name=None,
+                    alias=None,
+                )
+        self.generic_visit(node)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        catches_import_error = any(_caught_import_error(handler.type) for handler in node.handlers)
+        if catches_import_error:
+            self.optional_depth += 1
+        for statement in node.body:
+            self.visit(statement)
+        if catches_import_error:
+            self.optional_depth -= 1
+        for handler in node.handlers:
+            self.visit(handler)
+        for statement in node.orelse:
+            self.visit(statement)
+        for statement in node.finalbody:
+            self.visit(statement)
+
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        self.conditional_depth += 1
+        if _is_type_checking_test(node.test):
+            self.optional_depth += 1
+        for statement in node.body:
+            self.visit(statement)
+        if _is_type_checking_test(node.test):
+            self.optional_depth -= 1
+        for statement in node.orelse:
+            self.visit(statement)
+        self.conditional_depth -= 1
+
+
+def _mutable_kind(value: ast.AST | None) -> str | None:
+    if isinstance(value, ast.Dict):
+        return "dict"
+    if isinstance(value, ast.List):
+        return "list"
+    if isinstance(value, ast.Set):
+        return "set"
+    if isinstance(value, ast.Call):
+        return MUTABLE_CONSTRUCTORS.get(_call_name(value.func).rsplit(".", 1)[-1])
+    return None
+
+
+def _initializer_name(value: ast.AST | None) -> str:
+    if isinstance(value, ast.Call):
+        return _call_name(value.func)
+    if value is None:
+        return ""
+    return type(value).__name__
+
+
+def _owner_categories(
+    name: str,
+    initializer: str,
+    mutable_kind: str | None,
+    *,
+    is_call_initializer: bool,
+) -> list[str]:
+    haystack = f"{name} {initializer}".lower().replace("-", "_")
+    initializer_lower = initializer.lower()
+    categories = set()
+    if any(token in initializer_lower for token in ("rlock", "lock")) or (
+        mutable_kind and "lock" in name.lower()
+    ):
+        categories.add("lock")
+    if "future" in initializer_lower or (
+        mutable_kind and any(token in haystack for token in ("inflight", "in_flight"))
+    ):
+        categories.add("future")
+    if is_call_initializer and any(
+        token in initializer_lower for token in ("executor", "worker", "threadpool", "processpool")
+    ):
+        categories.add("executor")
+    if (
+        is_call_initializer
+        and any(token in haystack for token in ("client", "session", "translator"))
+    ) or (
+        mutable_kind
+        and "provider_instances" in name.lower()
+    ):
+        categories.add("client")
+    if (mutable_kind and "cache" in name.lower()) or "cache" in initializer_lower:
+        categories.add("cache")
+    if mutable_kind and any(
+        token in haystack
+        for token in ("single_flight", "singleflight", "inflight", "in_flight", "building")
+    ):
+        categories.add("single_flight")
+    if mutable_kind and categories:
+        categories.add("mutable_container")
+    return sorted(categories)
+
+
+def _direct_assignments(tree: ast.Module) -> list[tuple[str, int, ast.AST | None]]:
+    assignments = []
+    for statement in tree.body:
+        if isinstance(statement, ast.Assign):
+            for target in statement.targets:
+                for name in _assigned_names(target):
+                    assignments.append((name, statement.lineno, statement.value))
+        elif isinstance(statement, ast.AnnAssign):
+            for name in _assigned_names(statement.target):
+                assignments.append((name, statement.lineno, statement.value))
+        elif isinstance(statement, ast.AugAssign):
+            for name in _assigned_names(statement.target):
+                assignments.append((name, statement.lineno, statement.value))
+    return assignments
+
+
+def _context_assignment_names(node: ast.Assign | ast.AnnAssign | ast.AugAssign) -> list[str]:
+    if isinstance(node, ast.Assign):
+        return sorted({name for target in node.targets for name in _assigned_names(target)})
+    return sorted(set(_assigned_names(node.target)))
+
+
+class _ImportTimeCallVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.scope_parts: list[str] = []
+        self.context = "expression"
+
+    @property
+    def scope(self) -> str:
+        return ".".join(self.scope_parts) if self.scope_parts else "<module>"
+
+    def _visit_with_context(self, node: ast.AST | None, context: str) -> None:
+        if node is None:
+            return
+        previous = self.context
+        self.context = context
+        self.visit(node)
+        self.context = previous
+
+    def _visit_function_definition(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self._visit_with_context(decorator, f"decorator:{node.name}")
+        for default in (
+            *node.args.defaults,
+            *[item for item in node.args.kw_defaults if item],
+        ):
+            self._visit_with_context(default, f"default:{node.name}")
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function_definition(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function_definition(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in (*node.args.defaults, *[item for item in node.args.kw_defaults if item]):
+            self._visit_with_context(default, "lambda_default")
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self._visit_with_context(decorator, f"decorator:{node.name}")
+        for base in node.bases:
+            self._visit_with_context(base, f"class_base:{node.name}")
+        for keyword in node.keywords:
+            self._visit_with_context(keyword.value, f"class_keyword:{node.name}")
+        self.scope_parts.append(node.name)
+        for statement in node.body:
+            self.visit(statement)
+        self.scope_parts.pop()
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        names = _context_assignment_names(node)
+        self._visit_with_context(node.value, f"assign:{','.join(names)}")
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        names = _context_assignment_names(node)
+        self._visit_with_context(node.value, f"assign:{','.join(names)}")
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        names = _context_assignment_names(node)
+        self._visit_with_context(node.value, f"assign:{','.join(names)}")
+
+    def visit_Call(self, node: ast.Call) -> None:
+        callee = _call_name(node.func)
+        lowered = callee.lower()
+        tail = lowered.rsplit(".", 1)[-1]
+        context_lower = self.context.lower()
+        if self.context.startswith("decorator:") and (
+            tail in ROUTE_METHODS or "route" in lowered
+        ):
+            kind = "route_registration"
+        elif tail in {"mkdir", "makedirs"} or "ensure_default_wildcard_root" in lowered:
+            kind = "directory_creation"
+        elif self.context.startswith("assign:") and (
+            "route" in context_lower or "route" in lowered
+        ):
+            kind = "route_registry_creation"
+        elif self.context.startswith("assign:") and any(
+            token in context_lower or token in lowered
+            for token in ("client", "session", "translator")
+        ):
+            kind = "client_creation"
+        else:
+            kind = "import_time_call"
+        self.calls.append(
+            {
+                "line": node.lineno,
+                "column": node.col_offset,
+                "scope": self.scope,
+                "context": self.context,
+                "callee": callee or "<callable-expression>",
+                "kind": kind,
+            }
+        )
+        self.generic_visit(node)
+
+
+def _literal_string_sequence(value: ast.AST | None) -> list[str]:
+    if not isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+        return []
+    values = [
+        item.value
+        for item in value.elts
+        if isinstance(item, ast.Constant) and isinstance(item.value, str)
+    ]
+    return values if len(values) == len(value.elts) else []
+
+
+def _analyze_module(path: str, data: bytes) -> dict[str, object]:
+    source = _decode_source(data)
+    module_name, is_package = _module_identity(path)
+    tree = ast.parse(source, filename=path)
+    function_count = 0
+    class_count = 0
+    for statement in tree.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            function_count += 1
+        elif isinstance(statement, ast.ClassDef):
+            class_count += 1
+
+    assignments = _direct_assignments(tree)
+    globals_by_name: dict[str, int] = {}
+    mutable_globals = []
+    owner_candidates = []
+    declared_all: list[str] = []
+    for name, line, value in assignments:
+        globals_by_name.setdefault(name, line)
+        mutable_kind = _mutable_kind(value)
+        initializer = _initializer_name(value)
+        if mutable_kind:
+            mutable_globals.append(
+                {
+                    "module": path,
+                    "name": name,
+                    "line": line,
+                    "kind": mutable_kind,
+                }
+            )
+        categories = _owner_categories(
+            name,
+            initializer,
+            mutable_kind,
+            is_call_initializer=isinstance(value, ast.Call),
+        )
+        if categories:
+            owner_candidates.append(
+                {
+                    "module": path,
+                    "name": name,
+                    "line": line,
+                    "initializer": initializer,
+                    "categories": categories,
+                }
+            )
+        if name == "__all__":
+            declared_all = _literal_string_sequence(value)
+
+    aliases = _collect_dynamic_aliases(tree)
+    import_visitor = _ImportCandidateVisitor(aliases)
+    import_visitor.visit(tree)
+    side_effect_visitor = _ImportTimeCallVisitor()
+    side_effect_visitor.visit(tree)
+
+    record = {
+        "module": module_name,
+        "path": path,
+        "is_package": is_package,
+        "normalized_git_blob_sha1": _normalized_git_blob_sha1(data),
+        "loc": len(source.splitlines()),
+        "top_level": {
+            "function_count": function_count,
+            "class_count": class_count,
+            "global_count": len(globals_by_name),
+        },
+    }
+    return {
+        "record": record,
+        "imports": import_visitor.candidates,
+        "mutable_globals": mutable_globals,
+        "owner_candidates": owner_candidates,
+        "side_effects": side_effect_visitor.calls,
+        "declared_all": declared_all,
+        "public_global_names": sorted(
+            name for name in globals_by_name if not name.startswith("_")
+        ),
+    }
+
+
+def _resolve_relative_name(requested: str, *, source_name: str, is_package: bool) -> str:
+    level = len(requested) - len(requested.lstrip("."))
+    if level == 0:
+        return requested
+    remainder = requested[level:]
+    package_parts = (
+        source_name.split(".")
+        if is_package and source_name
+        else source_name.split(".")[:-1]
+    )
+    remove_count = max(0, level - 1)
+    if remove_count:
+        package_parts = package_parts[: max(0, len(package_parts) - remove_count)]
+    if remainder:
+        package_parts.extend(remainder.split("."))
+    return ".".join(part for part in package_parts if part)
+
+
+def _edge_display(candidate: Mapping[str, object]) -> str:
+    requested = str(candidate["requested"])
+    name = candidate.get("name")
+    return f"{requested}:{name}" if name else requested
+
+
+def _resolve_import_candidate(
+    candidate: Mapping[str, object],
+    *,
+    source_name: str,
+    is_package: bool,
+    path_by_internal_name: Mapping[str, str],
+) -> dict[str, object]:
+    requested = str(candidate["requested"])
+    resolved_base = _resolve_relative_name(
+        requested,
+        source_name=source_name,
+        is_package=is_package,
+    )
+    options = []
+    imported_name = candidate.get("name")
+    if imported_name and imported_name != "*":
+        options.append(".".join(part for part in (resolved_base, str(imported_name)) if part))
+    options.append(resolved_base)
+    is_relative = requested.startswith(".")
+    target_internal_name = (
+        next(
+            (option for option in options if option in path_by_internal_name),
+            None,
+        )
+        if is_relative
+        else None
+    )
+    if target_internal_name is not None:
+        classification = "internal"
+        target = path_by_internal_name[target_internal_name]
+    else:
+        classification = "missing_internal" if is_relative else "external"
+        target = None
+
+    edge = {
+        "source": str(candidate["source"]),
+        "line": int(candidate["line"]),
+        "column": int(candidate["column"]),
+        "scope": str(candidate["scope"]),
+        "kind": str(candidate["kind"]),
+        "imported": _edge_display(candidate),
+        "requested": requested,
+        "name": imported_name,
+        "alias": candidate.get("alias"),
+        "optional": bool(candidate["optional"]),
+        "conditional": bool(candidate["conditional"]),
+        "classification": classification,
+    }
+    if target is not None:
+        edge["target"] = target
+    return edge
+
+
+def _strongly_connected_components(
+    nodes: Sequence[str],
+    graph_edges: Sequence[Mapping[str, str]],
+) -> list[dict[str, object]]:
+    adjacency = {node: set() for node in nodes}
+    self_edges = set()
+    for edge in graph_edges:
+        source = edge["from"]
+        target = edge["to"]
+        adjacency[source].add(target)
+        if source == target:
+            self_edges.add(source)
+
+    index = 0
+    indices: dict[str, int] = {}
+    low_links: dict[str, int] = {}
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    components: list[list[str]] = []
+
+    def visit(node: str) -> None:
+        nonlocal index
+        indices[node] = index
+        low_links[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for target in sorted(adjacency[node]):
+            if target not in indices:
+                visit(target)
+                low_links[node] = min(low_links[node], low_links[target])
+            elif target in on_stack:
+                low_links[node] = min(low_links[node], indices[target])
+
+        if low_links[node] == indices[node]:
+            component = []
+            while True:
+                member = stack.pop()
+                on_stack.remove(member)
+                component.append(member)
+                if member == node:
+                    break
+            components.append(sorted(component))
+
+    for node in sorted(nodes):
+        if node not in indices:
+            visit(node)
+
+    components.sort()
+    return [
+        {
+            "modules": component,
+            "cyclic": len(component) > 1 or component[0] in self_edges,
+        }
+        for component in components
+    ]
+
+
+def _package_ancestors(path: str, available_paths: set[str]) -> list[str]:
+    parts = path.split("/")[:-1]
+    ancestors = []
+    for length in range(1, len(parts) + 1):
+        candidate = "/".join((*parts[:length], "__init__.py"))
+        if candidate in available_paths:
+            ancestors.append(candidate)
+    return ancestors
+
+
+def _registry_closure(
+    nodes: Sequence[str],
+    graph_edges: Sequence[Mapping[str, str]],
+) -> list[str]:
+    if "__init__.py" not in nodes:
+        return []
+    available = set(nodes)
+    adjacency = {node: set() for node in nodes}
+    for edge in graph_edges:
+        adjacency[edge["from"]].add(edge["to"])
+    pending = deque(["__init__.py"])
+    visited = set()
+    while pending:
+        node = pending.popleft()
+        if node in visited:
+            continue
+        visited.add(node)
+        targets = set(adjacency.get(node, set()))
+        for target in tuple(targets):
+            targets.update(_package_ancestors(target, available))
+        pending.extend(sorted(targets - visited))
+    return sorted(visited)
+
+
+def _edge_summary(edge: Mapping[str, object]) -> dict[str, object]:
+    summary = {
+        "source": edge["source"],
+        "line": edge["line"],
+        "kind": edge["kind"],
+        "imported": edge["imported"],
+        "classification": edge["classification"],
+        "optional": edge["optional"],
+    }
+    if "target" in edge:
+        summary["target"] = edge["target"]
+    return summary
+
+
+def _public_surface(
+    root_analysis: Mapping[str, object],
+    edges: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    declared_all = list(root_analysis["declared_all"])
+    public_globals = list(root_analysis["public_global_names"])
+    reexports = []
+    for edge in edges:
+        if (
+            edge["source"] != "__init__.py"
+            or edge["scope"] != "<module>"
+            or edge["classification"] != "internal"
+            or edge["kind"] == "literal_dynamic"
+        ):
+            continue
+        bound_name = edge["alias"] or edge["name"]
+        if not bound_name:
+            bound_name = str(edge["requested"]).split(".", 1)[0]
+        if not bound_name or str(bound_name).startswith("_"):
+            continue
+        reexports.append(
+            {
+                "name": str(bound_name),
+                "source": str(edge["target"]),
+                "imported": str(edge["imported"]),
+                "line": int(edge["line"]),
+                "declared_in_all": str(bound_name) in declared_all,
+            }
+        )
+    reexports.sort(
+        key=lambda item: (
+            str(item["name"]),
+            str(item["source"]),
+            int(item["line"]),
+        )
+    )
+    compatibility_names = sorted(
+        set(declared_all)
+        | set(public_globals)
+        | {str(item["name"]) for item in reexports}
+    )
+    return {
+        "root": "__init__.py",
+        "declared_all": declared_all,
+        "reexports": reexports,
+        "public_globals": public_globals,
+        "compatibility_names": compatibility_names,
+    }
+
+
+def analyze_source_set(
+    sources: Mapping[str, bytes | str],
+    *,
+    comfyignore: bytes | str = b"",
+) -> dict[str, object]:
+    """Analyze an in-memory repository surface without executing its sources."""
+
+    source_bytes = {
+        Path(path).as_posix(): (
+            value.encode("utf-8") if isinstance(value, str) else value
+        )
+        for path, value in sources.items()
+    }
+    ignore_bytes = (
+        comfyignore.encode("utf-8")
+        if isinstance(comfyignore, str)
+        else comfyignore
+    )
+    ignore_text = _decode_source(ignore_bytes)
+    rules = _ignore_rules(ignore_text)
+    shipped_paths = sorted(
+        path
+        for path in source_bytes
+        if path.endswith(".py") and not _is_ignored(path, rules)
+    )
+    if "__init__.py" not in shipped_paths:
+        raise ValueError("Registry Python surface must include the root __init__.py entry module.")
+
+    analyses = {
+        path: _analyze_module(path, source_bytes[path])
+        for path in shipped_paths
+    }
+    path_by_internal_name = {
+        _internal_name(str(analysis["record"]["module"])): path
+        for path, analysis in analyses.items()
+    }
+    edges = []
+    for path in shipped_paths:
+        analysis = analyses[path]
+        module_name = _internal_name(str(analysis["record"]["module"]))
+        is_package = bool(analysis["record"]["is_package"])
+        for candidate in analysis["imports"]:
+            candidate = {**candidate, "source": path}
+            edges.append(
+                _resolve_import_candidate(
+                    candidate,
+                    source_name=module_name,
+                    is_package=is_package,
+                    path_by_internal_name=path_by_internal_name,
+                )
+            )
+    edges.sort(
+        key=lambda item: (
+            str(item["source"]),
+            int(item["line"]),
+            int(item["column"]),
+            str(item["kind"]),
+            str(item["imported"]),
+            str(item.get("alias")),
+        )
+    )
+    graph_edges = sorted(
+        {
+            (str(edge["source"]), str(edge["target"]))
+            for edge in edges
+            if edge["classification"] == "internal"
+        }
+    )
+    graph_records = [{"from": source, "to": target} for source, target in graph_edges]
+    closure = _registry_closure(shipped_paths, graph_records)
+    closure_set = set(closure)
+    closure_edges = [edge for edge in edges if edge["source"] in closure_set]
+
+    mutable_globals = sorted(
+        (item for analysis in analyses.values() for item in analysis["mutable_globals"]),
+        key=lambda item: (str(item["module"]), str(item["name"]), int(item["line"])),
+    )
+    owner_candidates = sorted(
+        (item for analysis in analyses.values() for item in analysis["owner_candidates"]),
+        key=lambda item: (str(item["module"]), str(item["name"]), int(item["line"])),
+    )
+    side_effects = sorted(
+        (
+            {**item, "module": path}
+            for path, analysis in analyses.items()
+            for item in analysis["side_effects"]
+        ),
+        key=lambda item: (
+            str(item["module"]),
+            int(item["line"]),
+            int(item["column"]),
+            str(item["callee"]),
+        ),
+    )
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "determinism": {
+            "encoding": "utf-8-sig",
+            "newline_normalization": "CRLF and CR become LF before parsing and hashing",
+            "path_format": "repository-relative POSIX",
+            "ordering": "paths, modules, edges, candidates, SCCs, and JSON keys are sorted",
+        },
+        "inventory": {
+            "module_count": len(shipped_paths),
+            "modules": [analyses[path]["record"] for path in shipped_paths],
+        },
+        "imports": {
+            "edges": edges,
+            "module_graph": graph_records,
+            "sccs": _strongly_connected_components(shipped_paths, graph_records),
+        },
+        "state": {
+            "mutable_globals": mutable_globals,
+            "owner_candidates": owner_candidates,
+        },
+        "side_effects": {
+            "candidates": side_effects,
+        },
+        "public_surface": _public_surface(analyses["__init__.py"], edges),
+        "registry": {
+            "package_root": ".",
+            "ignore_file": ".comfyignore",
+            "ignore_file_normalized_git_blob_sha1": _normalized_git_blob_sha1(ignore_bytes),
+            "entry_modules": ["__init__.py"],
+            "shipped_python_modules": shipped_paths,
+            "runtime_import_closure": closure,
+            "unreachable_shipped_python_modules": sorted(set(shipped_paths) - closure_set),
+            "missing_internal_imports": [
+                _edge_summary(edge)
+                for edge in closure_edges
+                if edge["classification"] == "missing_internal"
+            ],
+            "external_imports": [
+                _edge_summary(edge)
+                for edge in closure_edges
+                if edge["classification"] == "external"
+            ],
+            "optional_imports": [
+                _edge_summary(edge)
+                for edge in closure_edges
+                if edge["optional"]
+            ],
+        },
+    }
+    return report
+
+
+def analyze_repository(root: Path = REPOSITORY_ROOT) -> dict[str, object]:
+    root = root.resolve()
+    ignore_path = root / ".comfyignore"
+    ignore_bytes = ignore_path.read_bytes()
+    rules = _ignore_rules(_decode_source(ignore_bytes))
+    sources = {}
+    for path in sorted(root.rglob("*.py")):
+        relative = path.relative_to(root).as_posix()
+        if _is_ignored(relative, rules):
+            continue
+        sources[relative] = path.read_bytes()
+    return analyze_source_set(sources, comfyignore=ignore_bytes)
+
+
+def render_json(report: Mapping[str, object]) -> str:
+    return json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def render_text(report: Mapping[str, object]) -> str:
+    lines = [
+        f"Python backend inventory schema {report['schema_version']}",
+        "",
+        "[modules]",
+    ]
+    for module in report["inventory"]["modules"]:
+        top_level = module["top_level"]
+        lines.append(
+            f"{module['path']} | module={module['module']} | loc={module['loc']} | "
+            f"functions={top_level['function_count']} | classes={top_level['class_count']} | "
+            f"globals={top_level['global_count']}"
+        )
+
+    lines.extend(("", "[edges]"))
+    for edge in report["imports"]["edges"]:
+        target = edge.get("target", edge["imported"])
+        flags = [str(edge["classification"]), str(edge["kind"])]
+        if edge["optional"]:
+            flags.append("optional")
+        if edge["conditional"]:
+            flags.append("conditional")
+        lines.append(f"{edge['source']}:{edge['line']} -> {target} | {', '.join(flags)}")
+
+    lines.extend(("", "[scc]"))
+    for component in report["imports"]["sccs"]:
+        marker = "cycle" if component["cyclic"] else "acyclic"
+        lines.append(f"{marker} | {', '.join(component['modules'])}")
+
+    lines.extend(("", "[state.mutable_globals]"))
+    for item in report["state"]["mutable_globals"]:
+        lines.append(f"{item['module']}:{item['line']} {item['name']} | {item['kind']}")
+
+    lines.extend(("", "[state.owner_candidates]"))
+    for item in report["state"]["owner_candidates"]:
+        lines.append(
+            f"{item['module']}:{item['line']} {item['name']} | "
+            f"{', '.join(item['categories'])} | {item['initializer']}"
+        )
+
+    lines.extend(("", "[side_effects]"))
+    for item in report["side_effects"]["candidates"]:
+        lines.append(
+            f"{item['module']}:{item['line']} {item['callee']} | "
+            f"{item['kind']} | {item['context']}"
+        )
+
+    lines.extend(("", "[public_surface]"))
+    lines.append(f"declared_all: {', '.join(report['public_surface']['declared_all'])}")
+    lines.append(
+        f"compatibility_names: {', '.join(report['public_surface']['compatibility_names'])}"
+    )
+
+    registry = report["registry"]
+    lines.extend(("", "[registry]"))
+    lines.append(f"entry_modules: {', '.join(registry['entry_modules'])}")
+    lines.append(f"shipped_python_modules: {len(registry['shipped_python_modules'])}")
+    lines.append(f"runtime_import_closure: {len(registry['runtime_import_closure'])}")
+    lines.append(
+        f"unreachable_shipped_python_modules: "
+        f"{', '.join(registry['unreachable_shipped_python_modules']) or '<none>'}"
+    )
+    lines.append(f"missing_internal_imports: {len(registry['missing_internal_imports'])}")
+    lines.append(f"external_imports: {len(registry['external_imports'])}")
+    lines.append(f"optional_imports: {len(registry['optional_imports'])}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPOSITORY_ROOT)
+    parser.add_argument("--format", choices=("json", "text"), default="json")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+
+    report = analyze_repository(args.root)
+    rendered = render_json(report) if args.format == "json" else render_text(report)
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8", newline="\n")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 범위

Relates to #191

이 PR은 **PR A-01 — Python backend inventory**만 구현합니다. Production Python 동작, A-02/A-03 strict gate, package move는 변경하지 않습니다.

PR #193과 #194가 반영된 최신 `dev` `8b9a91412b2244e45f911c6594600cb183b61429`를 통합했으며, `api_contract.py`를 포함한 schema v2 baseline을 재생성했습니다.

## 변경 내용

- `tools/analyze_python_backend.py`
  - production Python module, normalized repository-relative path, LOC, top-level function/class/global 수
  - static import 및 deterministic literal dynamic import 후보
  - try body/except/else/finally branch context와 `conditional` 정보
  - paired relative import + 동일 bound-name 근거의 `compatibility_primary` / `compatibility_fallback` 분류
  - internal + compatibility fallback graph, source/target 중복 collapse, deterministic SCC
  - `if TYPE_CHECKING:` body import는 전체 edge와 branch metadata에 보존하되 runtime graph/closure/SCC/public surface/Registry taxonomy에서 제외
  - SCC node 범위를 `runtime_import_closure`로 명시
  - lexical dynamic alias scope
    - function local binding과 sibling scope 격리
    - lambda parameter/local shadow 및 outer-scope default
    - method lookup에서 class namespace 제외, decorator/default/annotation은 정의 시점 scope 유지
  - module execution control-flow 아래 mutable assignment 탐색(함수/class body 제외)
  - dict/list/set 및 OrderedDict/defaultdict/deque 등 명시적 mutable constructor
  - Lock/RLock/Future/executor/client/cache/single-flight 후보
  - import-time call, route registration, directory/client 생성 후보
  - root public re-export/compatibility surface
  - Registry Python runtime import closure
  - JSON 및 사람이 읽을 수 있는 module/edge/state/policy 출력
- `tests/fixtures/python_backend_baseline.json`
  - schema version 2
  - `api_contract.py` 포함 16개 production Python module baseline
  - module/edge/state/side-effect/public-surface/Registry 단위 review 가능
- `tests/test_python_backend_analyzer.py`
  - 결정성, CRLF/LF, import alias/relative/dynamic, branch context/fallback taxonomy, lexical scope, SCC, nested module state, side-effect, Registry closure, .comfyignore parity, AST-only 안전성, current fixture 회귀
  - TYPE_CHECKING internal/missing edge full inventory 보존 및 runtime taxonomy 제외 회귀
  - `api_contract.py` shipped/closure 포함 및 `api.py → api_contract.py` graph edge 회귀

## schema v2와 결정성

- v1의 외부 import 의미를 바꾸므로 `schema_version`을 2로 올림
- edge에 `bound_name`, `branch_context`, `conditional`, `role`, compatibility pair를 기록
- graph policy, TYPE_CHECKING runtime exclusion, SCC node scope와 dynamic alias policy를 machine-readable 및 human render에 기록
- source와 `.comfyignore`의 CRLF/bare CR을 LF로 정규화한 뒤 parse/hash
- repository-relative POSIX path만 기록하고 path/edge/candidate/SCC/JSON key를 정렬
- 절대 경로, 사용자명, object id, 실행 시각 없음
- 동일 HEAD 두 번 생성 결과 byte-identical 회귀 포함
- production module import, network, subprocess, runpy, ComfyUI/GPU 초기화 없음

## Registry 판단

- package root와 실제 `.comfyignore`로 shipped Python surface를 계산
- matcher는 현재 계약의 anchoring, slash glob(`*`는 `/` 비통과), directory pattern, negation, escaped `#`/`!`를 처리
- current shipped set을 `git ls-files --cached --ignored --exclude-from=.comfyignore` 결과와 회귀 비교
- root `__init__.py`를 closure entry로 사용
- `compatibility_fallback`은 closure/graph에 포함하고 동일 source-target edge는 하나로 collapse
- TYPE_CHECKING body edge는 full `imports.edges`에 optional/branch context와 함께 남지만 runtime dependency로 계산하지 않음
- ordinary ComfyUI `import nodes as comfy_nodes`는 paired relative/bound-name 근거가 없어 external 유지
- 최신 dev 통합 baseline:
  - shipped 16 / closure 16 / missing internal 0 / unreachable 0
  - graph edges 37 / SCC 16, cyclic SCC 0
  - ordinary external 154 / compatibility fallback 43 / optional 52
  - mutable globals 53 / owner candidates 13
  - `api_contract.py`: LOC 138 / top-level class 1 / function 7 / global 0
  - `api.py → api_contract.py` internal edge 및 새 `_FILE_IO_LIMITERS_LOCK` owner 후보 기록
  - `wildcard_engine.py:_SNAPSHOT_CACHE`를 mutable dict/cache owner로 기록
- `tests/`와 `tools/`는 runtime closure에서 제외

## 검증

최신 `dev` 통합, TYPE_CHECKING 수정 및 fixture 재생성 후 실행했습니다.

- `python -m unittest discover -s tests -p test_python_backend_analyzer.py -v`
  - 18 tests passed
- `tools/check_project.ps1 -Profile quick -Python <Codex test Python>`
  - Python compile 통과
  - frontend 110 files 통과
  - Git diff check 통과
- `git diff --check`
  - 통과
- 공식 `tools/check_custom_node.ps1 -Profile full` (exact HEAD `8b10a7c`): passed
  - Python unittest: 577 tests OK
  - frontend: 110 JavaScript files 및 semantic smoke passed
  - TypeScript 6.0.3, Python compile, git diff check passed
- Live ComfyUI/API/browser smoke: 실행하지 않음(AST-only tooling 변경)

## 메인 검토

- 메인 actual diff 검토와 독립 AST/snapshot 검토를 수행했습니다.
- 발견된 TYPE_CHECKING runtime taxonomy P2는 공통 runtime-edge predicate와 synthetic 회귀로 수정했습니다.
- 최종 HEAD에서 추가 병합 차단점이 없음을 확인했습니다.

## 남은 위험

- compatibility fallback은 동일 try/scope/bound-name/target의 paired relative import를 요구하는 안전한 heuristic입니다. 다른 형태의 compatibility shim은 ordinary external로 남을 수 있습니다.
- if/try sibling branch alias binding은 deterministic source order로 방문하며, 서로 다른 branch가 상충하는 alias를 만드는 경우 merge는 아직 heuristic입니다. 현행 repository의 literal dynamic 후보는 0개라 current baseline 오분류는 확인되지 않았습니다.
- non-literal dynamic import는 결정적으로 해석하지 않고 후보 범위에서 제외합니다.
- mutable owner와 import-time side-effect는 AST 후보이므로 일부 false positive/negative가 남을 수 있습니다.
