### PR TITLE
[A-04] Python backend ADR와 compatibility shim policy

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -58,6 +58,16 @@ This repository is prepared for future ComfyUI Manager / Comfy Registry registra
 - Do not dereference `server.PromptServer.instance` at module import time without a guard. Some ComfyUI, Manager, or validation import paths can import custom nodes before `PromptServer.instance` exists.
 - If ComfyUI Manager reports a nightly/latest install, confirm the actual installed commit with `git rev-parse HEAD`; Registry versions and Manager nightly installs can point to different refs.
 
+## Architecture Documents
+
+- Start Python backend architecture or migration work from
+  [`docs/architecture/README.md`](docs/architecture/README.md).
+- The architecture documents define a target and phased compatibility contract;
+  check their current-state sections before treating any package, runtime, or
+  shim phase as implemented.
+- Frontend JavaScript, DOM, canvas, and resize maintenance remains under the
+  development documents and is outside the Python backend ADR scope.
+
 ## Security Rules
 
 - Do not use `eval` or `exec`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,32 @@
+# Python Backend Architecture
+
+These documents define the target Python backend architecture and migration
+rules for ComfyUI EasyUse Anima.
+
+They are contracts for future work, not a claim that the target package layout
+already exists. Start with the current-state section in
+[`python-backend.md`](python-backend.md) before planning an implementation PR.
+
+## Documents
+
+- [`python-backend.md`](python-backend.md): living architecture, ownership,
+  execution phases, validation gates, and overall Definition of Done.
+- [`adr-001-modular-monolith.md`](adr-001-modular-monolith.md): why the backend
+  will converge on a feature-oriented modular monolith under `easyuse_anima`.
+- [`adr-002-compatibility-shims.md`](adr-002-compatibility-shims.md): policy for
+  introducing, supporting, and retiring root compatibility shims.
+- [`python-compatibility-shims.md`](python-compatibility-shims.md): registry
+  schema and initial inventory of current root/module surfaces.
+
+## Authority and scope
+
+- The current repository policy remains authoritative for branches, releases,
+  Registry publication, and validation: [`MAINTAINING.md`](../../MAINTAINING.md).
+- The development-document entry point remains
+  [`docs/development/README.md`](../development/README.md).
+- These documents cover the Python backend only. Frontend JavaScript,
+  TypeScript, DOM, canvas, resize, and visual UX work are explicitly excluded.
+- Implementation is tracked by
+  [Issue #191](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/191)
+  and its related backend issues. An ADR does not authorize a package move,
+  behavior change, release, or shim removal by itself.

--- a/docs/architecture/adr-001-modular-monolith.md
+++ b/docs/architecture/adr-001-modular-monolith.md
@@ -1,0 +1,129 @@
+# ADR-001: Feature-Oriented Python Modular Monolith
+
+- Status: Accepted
+- Decision date: 2026-07-19
+- Owners: [Issue #185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185)
+  with migration work in Issues
+  [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184) and
+  [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- Scope: Python backend only
+
+## Context
+
+The current backend is split between a large root `nodes.py` and several root
+implementation modules. Node contracts, HTTP adapters, feature behavior,
+persistence, external providers, ComfyUI invocation, and process-wide mutable
+state do not yet have consistent package ownership.
+
+PR [#189](https://github.com/n0va39/ComfyUI-EasyUseAnima/pull/189)
+established useful node/workflow and import-analyzer seeds, but the baseline
+still contains no production `easyuse_anima/` package. This ADR therefore
+records a target and migration constraint, not completed implementation.
+
+Issue #184 reduces the immediate `nodes.py` risk. It intentionally leaves
+`api.py`, `settings.py`, `storage.py`, `autocomplete_dataset.py`,
+`wildcard_engine.py`, `prompt_translation.py`, and `anima_prompt/` at the root,
+so its completion is an intermediate architecture rather than the final one.
+
+## Decision
+
+The Python backend will converge on a small, feature-oriented modular monolith
+whose canonical production import root is `easyuse_anima`.
+
+The dependency direction is:
+
+```text
+node and API adapters
+        -> feature services/use cases
+        -> feature domain and infrastructure contracts/adapters
+```
+
+Bootstrap is the composition root. `RuntimeServices` owns process-lifetime
+repositories, caches, locks, clients, executors, and ComfyUI capabilities.
+Registration remains a pure mapping surface. No inner layer imports node/API
+adapters, registration/bootstrap, or a root compatibility shim.
+
+Features are grouped vertically (`prompt`, `wildcard`, `autocomplete`,
+`profiles`, `settings`, `translation`, `naia`, `image`, and `aio`). Generic
+filesystem, HTTP, and ComfyUI integration live under `infrastructure`. Files are
+created for real responsibilities, not to impose an identical package template
+on every feature.
+
+Root files remain the ComfyUI entrypoint or temporary explicit re-export shims
+under [ADR-002](adr-002-compatibility-shims.md). Settings/profile/workflow
+migrations and the shared feature-error taxonomy follow the contracts in
+[`python-backend.md`](python-backend.md).
+
+Mechanical moves, contract changes, and behavior changes are separate PRs. This
+ADR does not authorize a package move or behavior change by itself.
+
+## Consequences
+
+Positive consequences:
+
+- a feature's primary code and tests have a discoverable owner;
+- ComfyUI and aiohttp types are confined to adapters;
+- repositories/providers can be tested through narrow Protocols;
+- process-wide state has explicit lifecycle and cleanup;
+- import direction, public identity, and Registry archive closure can be
+  checked automatically; and
+- individual Move PRs remain reviewable and reversible.
+
+Costs and constraints:
+
+- root and canonical import paths coexist during migration;
+- bootstrap wiring and explicit contracts add some code;
+- feature moves must wait for unstable #162-#169 behavior/contract work where
+  applicable;
+- the target cannot be reached by a single `nodes.py` split; and
+- the repository must maintain compatibility fixtures and a shim registry
+  through at least one published release.
+
+## Alternatives considered
+
+### Keep the root-module structure
+
+Rejected because ownership, back references, state lifecycle, and Registry
+closure would remain implicit. Smaller files alone would not prevent a new
+monolith.
+
+### Stop after Issue #184
+
+Rejected as the final architecture. It is the correct first extraction, but it
+would leave two production import systems and the existing root modules as
+long-term implementations.
+
+### Apply a framework-heavy Clean Architecture or DI container
+
+Rejected for current scale. Dataclasses, Protocols, constructors, and factory
+functions provide the required seams without adding a runtime framework or
+forcing ceremonial layers.
+
+### Organize only by technical layer
+
+Rejected because repository-wide `models/`, `services/`, and `repositories/`
+directories scatter one feature across the tree. Vertical feature packages
+make the change surface easier to find while preserving explicit adapter and
+infrastructure boundaries.
+
+## Reconsideration conditions
+
+Review this decision if one of the following becomes true:
+
+- a feature becomes a separately distributed Python package or process;
+- multiple independent ComfyUI entrypoints require incompatible runtime
+  compositions;
+- an intentionally supported external Python SDK needs a stable boundary that
+  the feature packages cannot provide;
+- measured startup, memory, or import isolation requirements cannot be met by a
+  single process-lifetime runtime; or
+- the import/ownership gates show that the chosen feature boundaries repeatedly
+  create cycles despite completed migrations.
+
+Reconsideration requires a new ADR. Temporary migration friction, file count,
+or a desire to remove shims early is not sufficient.
+
+## Explicit non-scope
+
+Frontend JavaScript/TypeScript, DOM, canvas, legacy-canvas/Node 2.0 layout,
+resize, CSS, and visual UX are not governed by this ADR.

--- a/docs/architecture/adr-002-compatibility-shims.md
+++ b/docs/architecture/adr-002-compatibility-shims.md
@@ -1,0 +1,145 @@
+# ADR-002: Python Compatibility Shim Lifecycle
+
+- Status: Accepted
+- Decision date: 2026-07-19
+- Owners: [Issue #188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188)
+  with root moves in
+  [Issue #186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186)
+- Registry: [python-compatibility-shims.md](python-compatibility-shims.md)
+
+## Context
+
+The backend currently exposes implementation through root `nodes.py`,
+`api.py`, `settings.py`, `storage.py`, `autocomplete_dataset.py`,
+`wildcard_engine.py`, `prompt_translation.py`, and `anima_prompt/`. Some paths
+are used internally, some are exercised by tests, and public node classes may
+also be imported by consumers outside this repository.
+
+Moving implementations to `easyuse_anima` without a lifecycle policy can
+silently change class identity, break 0.5.2 workflows or API consumers, omit
+files from the Registry archive, or leave permanent shims that regain business
+logic.
+
+## Decision
+
+Every compatibility shim is an explicit, registered migration surface.
+
+### Shim shape
+
+- A shim directly re-exports a canonical object. It does not wrap, subclass,
+  proxy, copy, or recreate that object.
+- Supported symbols are named explicitly in imports and `__all__`; star imports
+  are forbidden.
+- A shim contains no feature behavior, persistence, migration, route
+  implementation, filesystem initialization, client, cache, or lock.
+- Internal production code imports only `easyuse_anima`. Root shims are for
+  consumers at the migration boundary, never for internal convenience.
+- Public identity tests use `Legacy is Canonical`, not only equivalent names or
+  behavior.
+
+### Minimum support window
+
+Let release `N` be the first published Registry release that contains the
+canonical target and its compatibility shim. The shim remains supported for
+the whole of release `N`; removal is no earlier than a later release and only
+after all removal gates pass.
+
+This is a minimum, not an automatic deadline. Public node-class re-exports may
+remain indefinitely when their maintenance cost is low. If telemetry or
+consumer evidence is unavailable, ambiguous, or privacy-sensitive, the default
+is to retain the shim.
+
+The project does not add outbound telemetry merely to justify removal. Useful
+evidence includes repository import analysis, public docs/examples, issue and
+support reports, package/install smoke, and privacy-safe local warnings or logs
+that already exist.
+
+### Staged retirement
+
+1. Introduce the canonical path and direct root re-export in a Move PR.
+2. Migrate production imports, tests, and maintained docs/examples to the
+   canonical path.
+3. Publish and validate at least one release with both paths in the actual
+   Registry archive.
+4. Remove undocumented/private aliases first, each through its own reviewed
+   change.
+5. Decide each public re-export separately. Removal requires a breaking-change
+   issue, compatibility impact, release note, and rollback plan.
+
+Deprecation warnings are optional. An import-time warning that is noisy in
+ComfyUI or affects package validation must not be added solely for this policy.
+
+### Removal gates
+
+A shim may be removed only when all applicable gates pass:
+
+- its registry entry has an owner, canonical target, introduction release,
+  known dependents, evidence, and proposed earliest release;
+- at least one published release has contained both canonical and shim paths;
+- internal production imports of the shim are zero;
+- maintained tests/docs/examples use the canonical path except explicit
+  compatibility tests;
+- root/canonical object identity and public API snapshots have passed for the
+  support window;
+- 0.5.2 workflow, API, profile, and settings compatibility gates pass;
+- `comfy node validate`, actual `comfy node pack`, and packed-archive import
+  closure pass with required canonical modules and remaining shims;
+- optional providers disabled at import time do not break the package;
+- available consumer evidence supports removal; lack of evidence causes
+  conservative retention; and
+- a public removal has separate breaking-change approval and release notes.
+
+No calendar date or version is promised before these conditions are satisfied.
+
+## Consequences
+
+Positive consequences:
+
+- object identity and workflow mappings remain stable through moves;
+- Registry packaging is treated as part of compatibility, not an afterthought;
+- internal code converges on one import root instead of depending on shims;
+- removal decisions are evidence-based and reversible; and
+- unsupported private helpers can be retired before stable public classes.
+
+Costs and constraints:
+
+- the archive contains duplicate import entry paths during migration;
+- every shim needs ownership and compatibility tests;
+- public re-exports may live longer than the implementation move; and
+- a missing consumer signal delays removal rather than accelerating it.
+
+## Alternatives considered
+
+### Remove root modules in the same PR as the move
+
+Rejected because it combines a mechanical move with a breaking contract and
+provides no release window for external consumers.
+
+### Keep all root symbols forever
+
+Rejected as a blanket rule because private/test-only aliases expand the public
+surface and invite internal back references. Long-term support remains a valid
+per-symbol decision.
+
+### Use wrappers or subclasses for compatibility
+
+Rejected because class identity, `__module__`, mappings, serialization, and
+consumer type checks can change even when behavior looks equivalent.
+
+### Remove on a preselected date
+
+Rejected because releases, Registry evidence, and consumer adoption do not
+follow a reliable calendar. Gates are safer than speculative dates.
+
+## Reconsideration conditions
+
+Review this policy if:
+
+- the project publishes a formal external Python API with a defined semantic
+  versioning policy;
+- ComfyUI or the Registry introduces an authoritative alias/deprecation
+  mechanism that preserves identity and archive behavior;
+- privacy-safe, reliable consumer telemetry becomes available; or
+- long-lived shims create a demonstrated security, startup, or packaging risk.
+
+Any change requires a new ADR and an update to the shim registry.

--- a/docs/architecture/python-backend.md
+++ b/docs/architecture/python-backend.md
@@ -1,0 +1,402 @@
+# Python Backend Architecture
+
+## Document status
+
+- Status: target architecture and migration contract
+- Decision record: [ADR-001](adr-001-modular-monolith.md) and
+  [ADR-002](adr-002-compatibility-shims.md)
+- Primary tracking: [Issue #191](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/191)
+- Baseline: `dev` commit `247252a97aba3d0fea3da23e5310dd1eecb8163b`,
+  package/workflow compatibility version 0.5.2
+- Scope: Python backend only
+
+This document describes the state the backend must converge toward. It does not
+mark a phase complete merely because its target is documented.
+
+## Current implementation state
+
+At the baseline above, the migration has not started:
+
+- There is no tracked `easyuse_anima/` production package yet.
+- `nodes.py` remains the monolith that contains the mapped node classes and
+  substantial Prompt, Regional, Wildcard, NAIA, image, Detailer, LoRA, AiO,
+  cache, save, and metadata implementation.
+- Root `__init__.py` imports 18 mapped node classes from `nodes.py`, imports
+  `api.py` for route-registration side effects, creates the default wildcard
+  directory, and owns the node/display mappings.
+- `api.py`, `settings.py`, `storage.py`, `autocomplete_dataset.py`,
+  `wildcard_engine.py`, `prompt_translation.py`, and `anima_prompt/` are still
+  implementation modules, not compatibility shims.
+- PR [#189](https://github.com/n0va39/ComfyUI-EasyUseAnima/pull/189)
+  added the 0.5.2 node/workflow contract fixture and an import-boundary analyzer
+  seed. Those files are useful A-02/A-03 foundations, but they do not complete
+  the A-01 whole-backend inventory, a real package scan, import graph/SCC and
+  global-state baseline, Registry archive closure, or any package migration.
+
+The `nodes.py` extraction in
+[Issue #184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184)
+is an intermediate state. The final canonical structure belongs to Issues
+[#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185) through
+[#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188).
+
+## Goals and exclusions
+
+The backend migration must make feature ownership, dependencies, process-wide
+state, persisted-data contracts, and supported import paths explicit. It must
+preserve existing node, workflow, profile, settings, and API behavior while
+mechanical moves are in progress.
+
+The following work is excluded from this architecture track:
+
+- frontend JavaScript or TypeScript refactoring;
+- Prompt Studio DOM structure or lifecycle;
+- legacy-canvas or Node 2.0 canvas event handling;
+- node, textarea, preview, or panel resizing;
+- CSS, accessibility UI, and other visual UX work; and
+- new user-facing features.
+
+If a backend move exposes a behavior defect, the behavior change must be owned
+by its existing feature issue or a separate Behavior PR.
+
+## Architecture and dependency direction
+
+The canonical production import root is `easyuse_anima`. The required direction is:
+
+```text
+ComfyUI entrypoint / bootstrap / registration
+                         |
+                         v
+       node adapters and HTTP API adapters
+                         |
+                         v
+       feature services, use cases, typed contracts
+                         |
+                         v
+      feature domain and infrastructure ports/adapters
+```
+
+Bootstrap composes concrete repositories, providers, and infrastructure.
+Feature services receive the narrow contracts they need; they do not locate
+adapters or the process runtime themselves.
+
+Forbidden back references are:
+
+```text
+feature/domain       -> easyuse_anima.nodes
+feature/domain       -> easyuse_anima.api.routes
+feature/domain       -> registration or bootstrap
+feature/domain       -> root compatibility shims
+infrastructure       -> node classes
+infrastructure       -> aiohttp request/response types
+infrastructure       -> feature schema meaning
+internal production  -> any root compatibility shim
+registration         -> storage, network, routes, or service construction
+```
+
+`get_runtime()` is allowed only at bootstrap and adapter boundaries where
+ComfyUI constructs a node class directly. Domain and feature-service code must
+use constructor arguments or narrow Protocols instead.
+
+## Target directory and ownership
+
+The following is the canonical ownership tree. Leaf modules are created only
+when they have a real responsibility; every feature is not required to have the
+same `models.py`/`service.py`/`repository.py` template.
+
+```text
+ComfyUI-EasyUseAnima/
+|-- __init__.py                         # ComfyUI entrypoint
+|-- nodes.py                            # public node compatibility shim
+|-- api.py                              # temporary API compatibility shim
+|-- settings.py                         # temporary settings shim
+|-- storage.py                          # temporary storage shim
+|-- autocomplete_dataset.py             # temporary autocomplete shim
+|-- wildcard_engine.py                  # temporary wildcard shim
+|-- prompt_translation.py               # temporary translation shim
+|-- anima_prompt/                       # temporary prompt-package shim
+`-- easyuse_anima/
+    |-- __init__.py                     # minimal canonical public surface
+    |-- bootstrap.py                    # production composition and lifecycle
+    |-- runtime.py                      # RuntimeConfig/RuntimeServices access
+    |-- registration.py                 # pure node/display mapping composition
+    |-- errors.py                       # common feature error taxonomy
+    |-- common/                         # only truly cross-feature primitives
+    |   |-- values.py
+    |   `-- serialization.py
+    |-- nodes/
+    |   |-- prompt_nodes.py
+    |   |-- regional_nodes.py
+    |   |-- wildcard_nodes.py
+    |   |-- naia_nodes.py
+    |   |-- image_nodes.py
+    |   |-- lora_nodes.py
+    |   `-- aio_nodes.py
+    |-- api/
+    |   |-- router.py
+    |   |-- requests.py
+    |   |-- responses.py
+    |   |-- errors.py
+    |   `-- routes/
+    |       |-- settings.py
+    |       |-- profiles.py
+    |       |-- autocomplete.py
+    |       |-- wildcards.py
+    |       |-- translation.py
+    |       `-- naia.py
+    |-- prompt/
+    |-- wildcard/
+    |-- autocomplete/
+    |-- profiles/
+    |-- settings/
+    |-- translation/
+    |   `-- providers/
+    |-- naia/
+    |-- image/
+    |-- aio/
+    |   `-- stages/
+    `-- infrastructure/
+        |-- comfy/
+        |-- filesystem/
+        `-- http/
+```
+
+### Owner matrix
+
+| Surface | Owner | May own | Must not own or import |
+| --- | --- | --- | --- |
+| Root `__init__.py` | ComfyUI entrypoint | `WEB_DIRECTORY`, exported mappings, one guarded bootstrap call | feature rules, repositories, caches, route implementations |
+| Root compatibility files | [shim registry](python-compatibility-shims.md) | explicit direct re-exports and `__all__` | wrappers/subclasses, star imports, new logic, I/O, clients, caches |
+| `bootstrap.py` | production composition | `RuntimeConfig`, factories, route registration, user-directory initialization, initialize/shutdown | Prompt rules, schemas, ranking, AiO stages |
+| `runtime.py` | process runtime | access to the single production `RuntimeServices`, lifecycle state | feature behavior or request-local mutable state |
+| `registration.py` | node registration | class/display mapping composition | file/network access, routes, service creation, cache initialization |
+| `nodes/*_nodes.py` | ComfyUI adapters | node metadata, raw-to-typed conversion, service call, ComfyUI output/UI conversion | persistence, migration, provider HTTP, cache implementation, invoking another node class for reuse |
+| `api/router.py`, `api/routes/*` | HTTP adapters | route composition, request parse, service call, response/error mapping | repository internals, filesystem writes, source scanning, provider construction, mutable module cache |
+| Feature packages | feature owner | domain rules, typed request/result/config, validation, use cases, feature migrations and ports | node/API adapters, registration/bootstrap, root shims |
+| `infrastructure/comfy` | ComfyUI integration | capability discovery, invocation, resources, events, paths | feature schema meaning, node classes |
+| `infrastructure/filesystem` | generic persistence | atomic JSON publish, locks, path primitives | profile revisions, settings keys, workflow semantics |
+| `infrastructure/http` | transport | client lifecycle, timeout and transport primitives | provider-specific feature policy |
+| `common` | cross-feature primitives | coercion/serialization proven to be domain-neutral | Prompt, AiO, profile, or settings meaning; miscellaneous helpers |
+
+## RuntimeServices and lifecycle
+
+`RuntimeServices` is the process-lifetime owner of service/repository instances
+and all mutable shared resources reachable from them. This includes caches,
+locks, provider and HTTP clients, executors, repositories, and ComfyUI
+capability/resource lookup state.
+
+```python
+@dataclass
+class RuntimeServices:
+    settings: SettingsService
+    profiles: ProfileService
+    autocomplete: AutocompleteRepository
+    wildcards: WildcardService
+    translation: TranslationService
+    naia: NaiaService
+    comfy: ComfyCapabilities
+    seed_reservations: SeedReservationService
+    aio: AioOrchestrator
+    executor: ExecutorService
+    clock: Clock
+
+    def close(self) -> None:
+        ...
+```
+
+The exact members may evolve, but the ownership rules do not:
+
+- configuration and user paths are resolved once by bootstrap;
+- optional provider clients are created lazily only when enabled;
+- a repository/service owns its cache and lock and exposes clear/close as
+  required;
+- request-local state never leaks into a process-lifetime service field;
+- `initialize()` called twice does not duplicate routes, directories, clients,
+  executors, or caches;
+- `shutdown()` called twice is safe;
+- partial initialization failure closes already-created resources in reverse
+  order; and
+- tests can create isolated runtimes with in-memory repositories, fake clients,
+  fake clocks, deterministic executors, and separate user-data roots.
+
+Phase E is not complete until an inventory maps every mutable process-wide
+cache/lock/client/executor/repository/capability to an owner, lifetime,
+thread-safety rule, cleanup operation, and test fixture.
+
+## Persistence and error contracts
+
+Settings, profiles, and persisted workflow-owned backend data use the same
+versioned pipeline:
+
+```text
+raw JSON object
+  -> schema/version detection
+  -> one-step pure migrations (v1 -> v2 -> v3)
+  -> validation and normalization
+  -> typed model
+  -> atomic publish at the final write boundary
+```
+
+Each feature documents unknown-field preservation, downgrade support, and
+failure behavior. Migrations do no file I/O. A failed migration does not replace
+the original file or last known-good data.
+
+The shared taxonomy starts with these feature-level categories:
+
+```text
+EasyUseAnimaError
+|-- ValidationError
+|-- ConflictError
+|-- NotFoundError
+|-- CapabilityUnavailableError
+|-- UpstreamTimeoutError
+`-- StorageError
+```
+
+Feature code does not know HTTP status codes or ComfyUI UI payloads. API
+adapters map feature errors to stable `status`/`code`/`message`/request-id
+responses. Node adapters map them to the existing user-visible RuntimeError or
+UI-status contract. Error-contract changes are Contract or Behavior PRs, never
+hidden in a Move PR.
+
+## Compatibility contract
+
+The 0.5.2 fixtures and shipped surfaces are the migration baseline, not a
+promise that every private helper is public.
+
+| Surface | Compatibility requirement |
+| --- | --- |
+| Node mappings | Preserve mapping keys/order, display names, mapped class identity, inputs/defaults/ranges/flags, outputs, `FUNCTION`, `CATEGORY`, `OUTPUT_NODE`, and representative `IS_CHANGED`. |
+| Workflows | Preserve 0.5.2 class IDs, hidden inputs, `widgets_values` order/meaning, and load/save/reload behavior. |
+| Profiles/settings | Read existing files, preserve identity/revision and long-text behavior, run versioned migrations, and keep last known-good data on failure. |
+| HTTP API | Preserve endpoint URLs and existing success/error fields during migration; additive changes require the owning API contract PR. |
+| Python imports | A supported root symbol re-exports the same canonical object; wrappers and subclasses do not satisfy identity compatibility. |
+| Registry package | Include the canonical package and required shims in the actual archive, prove static/local import closure, and keep optional providers from breaking package import when disabled. |
+
+Removal policy and evidence live in
+[`python-compatibility-shims.md`](python-compatibility-shims.md). Every shim stays
+for at least one published release after its canonical target ships. If there
+is no trustworthy consumer/telemetry evidence, retention is conservative.
+
+## PR classification
+
+Every backend refactor PR is exactly one of these types:
+
+| Type | Allowed | Forbidden in the same PR |
+| --- | --- | --- |
+| Move | file moves, import updates, explicit identity aliases, parity tests, archive inclusion | cache/timeout/seed/error/schema-default behavior changes |
+| Contract | dataclass/Protocol, request/result schema, migration, public interface | large mechanical moves, performance-policy changes |
+| Behavior | async/offload, cache policy, seed reservation, error mapping, performance work | unrelated moves or broad contract redesign |
+
+Examples that must be split include moving `cache.py` while adding a byte
+budget, moving an API route while changing all status codes, or moving storage
+while changing profile migration semantics.
+
+## Phase and PR execution contract
+
+| Phase | PR units and prerequisites | Exit condition |
+| --- | --- | --- |
+| Phase A - baseline | A-01 whole-backend AST inventory; A-02 public node/workflow snapshot; A-03 report-only import gate; A-04 ADR/shim policy. PR #189 is only an A-02/A-03 seed. | Deterministic inventory, real current-surface reports, versioned public fixtures, and these docs exist independently. No production move is hidden here. |
+| Phase B - `nodes.py` extraction | B-01 package/archive skeleton; B-02 common primitives; B-03 Comfy adapters; B-04 through B-10 vertical Move PRs; B-11 registration/bootstrap and `nodes.py` shim. Owned by #184. | `nodes.py` is an explicit re-export shim, node implementations live under `easyuse_anima`, and node/workflow parity plus package closure pass. |
+| Phase C - feature contracts/behavior | #162 Autocomplete, #163 profile/storage, #164 translation, #165 API, #167 seed, #168 AiO schema, #169 AiO stage/cache. These PRs remain separate from moves. | Each feature's contract and behavior are stable enough for its D/E move; unresolved behavior is not smuggled into a move. |
+| Phase D - root consolidation | D-01 translation; D-02 router; D-03 through D-07 route groups; D-08 filesystem; D-09 settings; D-10 profiles; D-11 autocomplete; D-12 wildcard; D-13 `anima_prompt`; D-14 root shim surface freeze. Owned by #186. | All production implementations use `easyuse_anima`; root files are entrypoints or explicit shims; internal root-shim imports are zero. |
+| Phase E - runtime ownership | E-01 global-state inventory; E-02 base runtime; E-03 through E-08 feature owners; E-09 idempotent lifecycle; E-10 isolated test runtime. Owned by #187. | Every process-wide cache/lock/client/executor/repository/capability has one owner and tested initialize/shutdown/partial-failure behavior. |
+| Phase F - typed boundaries | Extend #163/#165/#168 patterns to settings/profile/workflow, API, Prompt, Wildcard, Autocomplete, and AiO; establish the common error taxonomy. | Raw dictionaries remain only at adapter/migration boundaries; migrations and error mappings are versioned and tested. |
+| Phase G - quality ratchet | G-01 Ruff report-only; G-02 Pyright baseline; G-03 import-boundary fail gate; G-04 public API snapshot; G-05 size/complexity ratchet; G-06 test ownership layout. Owned by #188. | Fixed-version, offline-reproducible gates reject new violations without hiding existing debt. |
+| Phase H - shim retirement | Introduce canonical paths, migrate internal consumers, verify at least one release, remove private aliases first, and decide public re-exports separately. | Every removal meets ADR-002 and registry gates; public removal has a breaking-change issue and release note, or is documented as long-term support. |
+
+The dependency is A before large B moves; feature-specific C contracts before
+their D/E migration; D before final H retirement. F and early G report-only
+work can advance incrementally, but they may not be used to claim D/E complete.
+
+## Quality ratchet
+
+Quality gates are staged rather than applied as a repository-wide rewrite:
+
+1. Record current debt without changing production code.
+2. Enforce the rule on new/changed modules.
+3. Expand to completed feature packages.
+4. Enforce across the canonical package.
+5. Enable root-shim retirement gates.
+
+G-series minimums are:
+
+- G-01: pinned Ruff maintenance tooling, initially `F`, `E4`, `E7`, `E9`,
+  `I`, and safe `UP`; it is not a runtime dependency.
+- G-02: Pyright `basic` for the canonical package, with strict allowlists
+  expanding from pure feature models/services. Dynamic Comfy/tensor types stay
+  in adapters.
+- G-03: reject new cycles, feature-to-adapter back references, internal root
+  shim imports, registration side effects, and relative/absolute fallback
+  imports.
+- G-04: snapshot node mappings, supported public classes, root/canonical object
+  identity, explicit `__all__`, public schema/result types, and Registry archive
+  closure.
+- G-05: after A-01 establishes the baseline, use reviewable ratchets. Initial
+  guidance is 800 lines for a new production module, 400 for an adapter, and
+  120 for a new function/method. Existing exceptions require an owner issue;
+  meaningless `utils2.py`/`misc.py` splits are forbidden.
+- G-06: align unit, integration, contract, and packaging tests with canonical
+  feature ownership while retaining the repository's `unittest` runner.
+
+## Overall Definition of Done
+
+The Python backend refactor is complete only when all of the following hold.
+
+### Structure and dependencies
+
+- [ ] `easyuse_anima` is the only production implementation root.
+- [ ] Root Python files are the ComfyUI entrypoint or registered shims.
+- [ ] Node/API adapters call feature services and contain no repository,
+      external HTTP, migration, or cache implementation.
+- [ ] Feature/domain and infrastructure code have no adapter, registration,
+      bootstrap, or root-shim back references.
+- [ ] The final owner matrix is enforced by an import-boundary gate.
+
+### State and lifecycle
+
+- [ ] Every process-wide cache, lock, client, executor, repository, and
+      capability has an owner, lifetime, thread-safety, and cleanup contract.
+- [ ] Initialize and shutdown are idempotent, including partial-failure cleanup.
+- [ ] Optional dependency failure is contained to its feature.
+- [ ] Runtime fixtures isolate user data and do not rely on private-global
+      patch/reload cleanup.
+
+### Data and compatibility
+
+- [ ] Settings, profiles, and workflow-owned backend data use versioned pure
+      migrations and atomic final writes.
+- [ ] API request/result/error and feature boundaries are typed.
+- [ ] 0.5.2 node/workflow/profile/settings/API fixtures pass.
+- [ ] Supported root and canonical objects have identity parity.
+- [ ] The actual Registry package contains the complete canonical/shim import
+      closure and imports with optional providers disabled.
+
+### Quality and operations
+
+- [ ] Pinned Ruff/Pyright or approved equivalents run in the official runner.
+- [ ] Cycle, forbidden import, public API, and size-growth ratchets block new
+      debt.
+- [ ] Every merged implementation PR is classified Move, Contract, or Behavior.
+- [ ] The shim registry has owners, evidence, and removal gates for every root
+      compatibility surface.
+- [ ] Private shims are retired only after the support window; each public shim
+      is either deliberately retained or removed through a reviewed breaking
+      change.
+- [ ] Final full runner, `comfy node validate`, actual `comfy node pack`, archive
+      closure, 0.5.2 compatibility, and representative ComfyUI execution gates
+      pass at the release/integration stage.
+
+## Tracking relationships
+
+- [#162](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/162): Autocomplete repository/index
+- [#163](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/163): Profile identity/storage migration
+- [#164](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/164): Translation provider/async boundary
+- [#165](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/165): API request/error contract
+- [#167](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/167): Backend seed reservation
+- [#168](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/168): AiO typed schema
+- [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169): AiO stage/cache behavior
+- [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184): Intermediate `nodes.py` extraction
+- [#185](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/185): Long-term architecture parent
+- [#186](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/186): Root package consolidation
+- [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187): RuntimeServices and lifecycle
+- [#188](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/188): Quality ratchet and shim retirement

--- a/docs/architecture/python-backend.md
+++ b/docs/architecture/python-backend.md
@@ -49,6 +49,9 @@ mechanical moves are in progress.
 The following work is excluded from this architecture track:
 
 - frontend JavaScript or TypeScript refactoring;
+- [Issue #166](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/166)
+  frontend lifecycle registry work, which is adjacent tracking only and has no
+  Python backend phase dependency;
 - Prompt Studio DOM structure or lifecycle;
 - legacy-canvas or Node 2.0 canvas event handling;
 - node, textarea, preview, or panel resizing;
@@ -297,7 +300,7 @@ while changing profile migration semantics.
 | --- | --- | --- |
 | Phase A - baseline | A-01 whole-backend AST inventory; A-02 public node/workflow snapshot; A-03 report-only import gate; A-04 ADR/shim policy. PR #189 is only an A-02/A-03 seed. | Deterministic inventory, real current-surface reports, versioned public fixtures, and these docs exist independently. No production move is hidden here. |
 | Phase B - `nodes.py` extraction | B-01 package/archive skeleton; B-02 common primitives; B-03 Comfy adapters; B-04 through B-10 vertical Move PRs; B-11 registration/bootstrap and `nodes.py` shim. Owned by #184. | `nodes.py` is an explicit re-export shim, node implementations live under `easyuse_anima`, and node/workflow parity plus package closure pass. |
-| Phase C - feature contracts/behavior | #162 Autocomplete, #163 profile/storage, #164 translation, #165 API, #167 seed, #168 AiO schema, #169 AiO stage/cache. These PRs remain separate from moves. | Each feature's contract and behavior are stable enough for its D/E move; unresolved behavior is not smuggled into a move. |
+| Phase C - feature contracts/behavior | #162 Autocomplete, #163 profile/storage, #164 translation, #165 API, #167 seed, #168 AiO schema, #169 AiO stage/cache. #166 is the adjacent frontend lifecycle registry and is explicitly excluded; it does not gate this or any other Python backend phase. These Python PRs remain separate from moves. | Each feature's contract and behavior are stable enough for its D/E move; unresolved behavior is not smuggled into a move. |
 | Phase D - root consolidation | D-01 translation; D-02 router; D-03 through D-07 route groups; D-08 filesystem; D-09 settings; D-10 profiles; D-11 autocomplete; D-12 wildcard; D-13 `anima_prompt`; D-14 root shim surface freeze. Owned by #186. | All production implementations use `easyuse_anima`; root files are entrypoints or explicit shims; internal root-shim imports are zero. |
 | Phase E - runtime ownership | E-01 global-state inventory; E-02 base runtime; E-03 through E-08 feature owners; E-09 idempotent lifecycle; E-10 isolated test runtime. Owned by #187. | Every process-wide cache/lock/client/executor/repository/capability has one owner and tested initialize/shutdown/partial-failure behavior. |
 | Phase F - typed boundaries | Extend #163/#165/#168 patterns to settings/profile/workflow, API, Prompt, Wildcard, Autocomplete, and AiO; establish the common error taxonomy. | Raw dictionaries remain only at adapter/migration boundaries; migrations and error mappings are versioned and tested. |
@@ -392,6 +395,7 @@ The Python backend refactor is complete only when all of the following hold.
 - [#163](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/163): Profile identity/storage migration
 - [#164](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/164): Translation provider/async boundary
 - [#165](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/165): API request/error contract
+- [#166](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/166): Frontend lifecycle registry; explicitly excluded, with no Python backend phase dependency
 - [#167](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/167): Backend seed reservation
 - [#168](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/168): AiO typed schema
 - [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169): AiO stage/cache behavior

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -1,0 +1,185 @@
+# Python Compatibility Shim Registry
+
+## Registry status
+
+- Inventory baseline: `dev` commit
+  `247252a97aba3d0fea3da23e5310dd1eecb8163b`
+- Compatibility provenance: package/workflow version 0.5.2
+- Policy: [ADR-002](adr-002-compatibility-shims.md)
+- Current state: initial inventory; the root implementation modules below have
+  not yet been converted to shims
+
+This is an actionable registry, not a removal schedule. `N` means the first
+published Registry release containing both a canonical target and its root
+shim. `N+1 gate` means no earlier than a later release and only after every
+removal gate passes; it does not promise removal in that release.
+
+## Required fields
+
+Every shim entry records:
+
+- **Surface/symbols:** the supported root import path and exact public scope.
+- **Owner:** the issue responsible for the canonical move and future decisions.
+- **Canonical target:** the only implementation path after conversion.
+- **Introduced/conversion:** when the current surface existed and the PR phase
+  that converts it to a shim.
+- **Known dependents:** current repository/runtime consumers and any confirmed
+  external consumer.
+- **Evidence:** static imports, fixtures, docs, issues, package smoke, or other
+  privacy-safe consumer evidence.
+- **Minimum support:** at least all of release `N` after canonical introduction.
+- **Removal gate:** specific checks in addition to ADR-002.
+- **Earliest release:** a gate expression, never an unsupported date promise.
+- **State:** implementation, planned shim, supported shim, deprecated, retained,
+  or removal-approved.
+
+If a symbol list is not frozen yet, the move owner must inventory actual
+consumers and add explicit `__all__` before conversion. New private helpers are
+not added to a shim merely because tests import them.
+
+## Initial inventory summary
+
+| Surface | Current role | Canonical target | Owner | Introduced / conversion | Known dependents and evidence | Earliest removal |
+| --- | --- | --- | --- | --- | --- | --- |
+| Root `__init__.py` exports | Permanent ComfyUI entrypoint, not a shim | root entrypoint plus `easyuse_anima.registration`/`bootstrap` | #184/#185 | Existing 0.5.2 surface; B-11 rewires internals | ComfyUI loader; node contract fixture | Not removable as a package entrypoint |
+| `nodes.py` mapped public classes | Current implementation; planned node shim | `easyuse_anima.nodes.*_nodes` | #184 B-11, #188 | Existing 0.5.2 surface; convert in B-11 | Root mappings, workflows, tests, possible external Python imports | No scheduled removal; public breaking-change gate after N+1 at earliest |
+| `api.py` route-registration surface | Current implementation; planned API shim | `easyuse_anima.api.router` and `easyuse_anima.api.routes.*` | #165, #186 D-02-D-07 | Existing 0.5.2 surface; convert during D-02-D-07/D-14 | Root entrypoint side-effect import, frontend endpoints, API tests | Unscheduled; N+1 gate and route parity |
+| `settings.py` | Current implementation; planned settings shim | `easyuse_anima.settings.*` | #163, #186 D-09 | Existing 0.5.2 surface; convert in D-09/D-14 | `api.py`, `nodes.py`, `wildcard_engine.py`, settings tests | Unscheduled; N+1 gate and settings migration/round-trip |
+| `storage.py` | Current implementation; planned filesystem shim | `easyuse_anima.infrastructure.filesystem.*` | #163, #186 D-08 | Existing 0.5.2 surface; convert in D-08/D-14 | `api.py`, `settings.py`, `wildcard_engine.py`, storage/profile tests | Unscheduled; N+1 gate and last-known-good/atomic-write parity |
+| `autocomplete_dataset.py` | Current implementation; planned autocomplete shim | `easyuse_anima.autocomplete.*` | #162, #186 D-11 | Existing 0.5.2 surface; convert in D-11/D-14 | `api.py`, autocomplete/frontend API tests | Unscheduled; N+1 gate and result/ranking/API parity |
+| `wildcard_engine.py` | Current implementation; planned wildcard shim | `easyuse_anima.wildcard.*` | #184, #186 D-12 | Existing 0.5.2 surface; convert in D-12/D-14 | root entrypoint, `nodes.py`, `api.py`, wildcard/workflow tests | Unscheduled; N+1 gate and seed/expansion/workflow parity |
+| `prompt_translation.py` | Current implementation; planned translation shim | `easyuse_anima.translation.*` | #164, #186 D-01 | Existing 0.5.2 surface; convert in D-01/D-14 | `settings.py`, `nodes.py`, `api.py`, `autocomplete_dataset.py`, translation tests | Unscheduled; N+1 gate and provider-off/API parity |
+| `anima_prompt/` package | Current implementation; planned package shim | `easyuse_anima.prompt.anima.*` | #184, #186 D-13 | Existing 0.5.2 surface; convert in D-13/D-14 | `nodes.py`, `autocomplete_dataset.py`, prompt tests | Unscheduled; N+1 gate and prompt correction/parser parity |
+
+## Entry details
+
+### Root `__init__.py` entrypoint
+
+- Surface/symbols: `NODE_CLASS_MAPPINGS`, `NODE_DISPLAY_NAME_MAPPINGS`, and
+  `WEB_DIRECTORY` through the ComfyUI package entrypoint.
+- State: permanent entrypoint; its implementation must become thin, but the
+  entrypoint itself is not a retirement candidate.
+- Removal gate: not applicable. B-11 must move mapping composition to
+  `easyuse_anima.registration` and guarded lifecycle work to bootstrap without
+  changing the exported objects or introducing duplicate initialization.
+
+### `nodes.py` public node-class surface
+
+The confirmed 0.5.2 mapped classes are:
+
+```text
+EasyUseAnimaAIOGenerator
+EasyUseAnimaDetailerAlignHook
+EasyUseAnimaArtistMixConditioning
+EasyUseAnimaInput
+EasyUseAnimaImageScaleByMultiple
+EasyUseAnimaLoraPreset
+EasyUseAnimaNAIARandomPrompt
+EasyUseAnimaPromptDataConditioning
+EasyUseAnimaPromptDataUnpack
+EasyUseAnimaPromptBuilder
+EasyUseAnimaPromptCorrector
+EasyUseAnimaPromptCorrectorSimple
+EasyUseAnimaPromptStudio
+EasyUseAnimaPromptStudioAdvanced
+EasyUseAnimaPromptStudioAdvancedV2
+EasyUseAnimaPromptStudioRegional
+EasyUseAnimaRegionalConditioning
+EasyUseAnimaWildcard
+```
+
+- Canonical target: corresponding modules under `easyuse_anima.nodes`.
+- Supported-shim shape: explicit direct imports and `__all__`; each root class
+  must be identical to the mapped canonical class.
+- Excluded by default: unmapped/private helpers and historical classes not in
+  the 0.5.2 public mapping. A separate consumer audit is required before
+  deciding that an unmapped symbol is supported.
+- Removal gate: 0.5.2 node/workflow fixture, mapping identity, direct import,
+  Registry archive closure, consumer evidence, separate breaking-change issue,
+  and release note. With no external-consumer evidence, retain these exports.
+
+### `api.py`
+
+- Candidate scope: the route registration compatibility surface. The current
+  frontend endpoint URLs and payloads are compatibility contracts, even if
+  Python route helpers are not declared as public.
+- Canonical target: `easyuse_anima.api.router`, requests/responses/errors, and
+  feature route modules.
+- Removal gate: root entrypoint no longer imports `api.py`; repeated initialize
+  registers no duplicate routes; the #165 request/error matrix and 0.5.2 API
+  parity pass; actual package import succeeds.
+
+### `settings.py`
+
+- Confirmed current internal consumers use settings load/save/public helpers,
+  long-text helpers, autocomplete/NAIA/metadata/translation resolvers, and
+  translation defaults/types.
+- Canonical target: `easyuse_anima.settings.schema`, `migrations`,
+  `repository`, and `service`.
+- Removal gate: all internal imports are canonical; 0.5.2 settings and long-text
+  fixtures migrate and round-trip; original data survives migration/write
+  failure; root/canonical supported-symbol identity passes.
+
+### `storage.py`
+
+- Confirmed candidate symbols: `AtomicJsonStore` and `USER_DATA_DIR`. Private
+  path-lock and fsync helpers are not automatically public.
+- Canonical target: `easyuse_anima.infrastructure.filesystem.atomic_json`,
+  `locks`, and `paths`, with user-path resolution supplied by runtime config.
+- Removal gate: settings/profile/wildcard consumers are canonical; lock and
+  atomic last-known-good behavior remains compatible; Windows path fixtures and
+  Registry archive closure pass.
+
+### `autocomplete_dataset.py`
+
+- Confirmed current API consumers use `autocomplete_status`,
+  `available_autocomplete_sources`, `classify_prompt_text`,
+  `resolve_autocomplete_source`, and `search_autocomplete`.
+- Canonical target: `easyuse_anima.autocomplete` feature modules after #162.
+- Removal gate: ranking/classification/source/result parity, API parity,
+  canonical internal imports, public snapshot, and archive closure.
+
+### `wildcard_engine.py`
+
+- Confirmed current consumers include root initialization, node expansion and
+  seed constants/helpers, and API list/root helpers.
+- Canonical target: `easyuse_anima.wildcard` models/sources/snapshot/expansion/
+  service modules.
+- Removal gate: #159/#160 behavior fixtures, seed and expansion parity,
+  0.5.2 workflow load/save/reload, root/canonical identity, and archive closure.
+
+### `prompt_translation.py`
+
+- Confirmed current consumers use settings/default normalization, marker
+  parsing, translation execution, and the translation error classes.
+- Canonical target: `easyuse_anima.translation.contracts`, `markers`, `service`,
+  and `providers.google` after #164 behavior is stable.
+- Removal gate: provider-off imports create no client or optional dependency,
+  timeout/cache/error/API parity passes, internal imports are canonical, and
+  both paths are present in the actual release archive through the support
+  window.
+
+### `anima_prompt/`
+
+- Confirmed current package `__all__`: `CorrectionResult`,
+  `KnowledgeBaseNotFound`, `ParsedPrompt`, `PromptKnowledgeBase`, `TagInfo`,
+  `TagToken`, `correct_prompt`, `inspect_prompt`, and `load_knowledge_base`.
+- Canonical target: `easyuse_anima.prompt.anima` after the #184 Prompt slices
+  stabilize.
+- Removal gate: Prompt correction/parser/order/knowledge tests use the
+  canonical package, supported objects retain identity, current prompt behavior
+  fixtures pass, and consumer evidence supports removal. Otherwise retain the
+  package shim.
+
+## Evidence and update procedure
+
+For every Move PR that creates or changes a shim:
+
+1. update the relevant entry in this file;
+2. list exact supported symbols in `__all__`;
+3. record the first published release `N` only after Registry publication;
+4. add root/canonical identity and archive-closure evidence;
+5. keep compatibility-only tests clearly separated from canonical service
+   tests; and
+6. do not change `Earliest removal` to a version/date unless the ADR-002 gates
+   have evidence and the appropriate breaking-change decision exists.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,10 +6,12 @@ conversation.
 ## Read Order
 
 1. `docs/development/current-policies.md`
-2. Active frontend maintenance execution plan:
+2. Python backend architecture or migration work:
+   [`docs/architecture/README.md`](../architecture/README.md)
+3. Active frontend maintenance execution plan:
    `docs/development/frontend-maintenance-execution-plan.md`
-3. Current release candidate: `docs/development/0.5.2.md`
-4. Relevant topic guide:
+4. Current release candidate: `docs/development/0.5.2.md`
+5. Relevant topic guide:
    - Registry publish or flagged-version prevention:
      `docs/development/registry-scanner-safety.md`
    - workflow docs or release templates: `docs/Anima AiO/Workflow_Management.md`
@@ -24,12 +26,14 @@ conversation.
    - deferred Node 2.0 DOM widget resize investigation:
      `docs/development/node2-dom-widget-resize-limitation.md`
    - language or locale work: `docs/development/language-management.md`
-5. `git status --short`
-6. Relevant source and tests for the target area.
+6. `git status --short`
+7. Relevant source and tests for the target area.
 
 ## Source Map
 
 - Current policy baseline: `docs/development/current-policies.md`
+- Python backend architecture and compatibility-shim registry:
+  [`docs/architecture/README.md`](../architecture/README.md)
 - Active frontend maintenance execution ledger:
   `docs/development/frontend-maintenance-execution-plan.md`
 - Current release candidate: `docs/development/0.5.2.md`


### PR DESCRIPTION
## 관련

- Relates to #191
- Phase A / PR A-04 문서 전용 변경
- Base: `dev`
- Head: `codex/issue-191-a04-backend-adr`

## 변경 문서

- `docs/architecture/python-backend.md`: canonical root, 의존 방향, 최종 구조/owner matrix, RuntimeServices, migration/error 계약, Phase A~H, quality ratchet, 전체 Definition of Done
- `docs/architecture/adr-001-modular-monolith.md`: feature-oriented modular monolith 결정
- `docs/architecture/adr-002-compatibility-shims.md`: 최소 한 release 지원, 증거 기반 단계적 retirement 결정
- `docs/architecture/python-compatibility-shims.md`: 현재 root/module surface의 initial inventory와 removal gate
- `docs/architecture/README.md`, `MAINTAINING.md`, `docs/development/README.md`: 발견 가능한 최소 인덱스와 링크

## 핵심 결정

- production canonical import root는 `easyuse_anima` 하나로 수렴합니다.
- node/API adapter → feature service/use case → domain/infrastructure 방향을 고정하고 역참조를 금지합니다.
- cache, lock, client, executor, repository, capability의 process lifetime owner는 RuntimeServices와 소유 service입니다.
- Move / Contract / Behavior PR을 엄격히 분리합니다.
- 0.5.2 workflow/API/profile/settings 계약과 실제 Registry package/archive import closure를 compatibility gate로 둡니다.
- shim은 canonical object를 직접 re-export하며 최소 한 published release를 유지합니다. telemetry/consumer 증거가 없으면 보수적으로 유지하고, 제거 version/date를 미리 약속하지 않습니다.

## 현재 상태와 비범위

- baseline `dev@247252a`에는 아직 production `easyuse_anima/` package가 없고 `nodes.py` 구현 monolith가 남아 있습니다.
- PR #189는 A-02/A-03 seed이며 A-01 전체 backend inventory, 실제 package gate, RuntimeServices, Registry closure를 완료한 것으로 서술하지 않았습니다.
- #184의 중간 `nodes.py` extraction과 #185~#188의 최종 canonical 구조를 별도 종료 조건으로 구분했습니다.
- #166은 frontend lifecycle registry의 인접 추적 항목으로만 기록하며, Python backend phase dependency가 아닙니다.
- docs-only입니다. production/test/tool 구현, A-01 analyzer, A-03 gate 변경, package Move, schema/error/cache behavior 변경은 포함하지 않습니다.
- frontend JavaScript/TypeScript, DOM, canvas, resize, visual UX는 명시적으로 제외했습니다.

## 검증

- Markdown 로컬 상대 링크: 18개 확인, 누락 0
- GitHub 참조: #162~#169, #184~#189, #191 존재 확인
- 필수 heading/용어/shim registry field focused 검사: 44개, 실패 0
- trailing whitespace 및 `git diff --check`: 통과
- 공식 full runner (PR exact HEAD `28e9e6c`): Python unittest 538개 통과, frontend 110개 파일 및 TypeScript 6.0.3 통과, Python compile/diff check 통과
- Live ComfyUI/API/browser smoke: 미실행 (문서 전용 변경으로 해당 없음)

## 남은 위험

- 이 문서는 목표 아키텍처 계약이며 구현 완료 보고가 아닙니다.
- 각 Move PR은 실제 consumer/import inventory와 Registry archive evidence를 추가해 shim registry를 갱신해야 합니다.
