### PR TITLE
refactor: API 오류 계약 표준화와 경로 노출 제거

### DIFF
--- a/api.py
+++ b/api.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import threading
+import weakref
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 
@@ -39,6 +40,15 @@ from .prompt_translation import (
     TranslationCancelledError,
     TranslationTimeoutError,
     translate_prompt_markers,
+)
+from .api_contract import (
+    ApiContractError,
+    error_payload,
+    json_boolean,
+    json_integer,
+    json_object,
+    json_string,
+    parse_json_object,
 )
 try:
     from .storage import AtomicJsonStore, USER_DATA_DIR
@@ -80,6 +90,15 @@ WINDOWS_RESERVED_FILE_BASENAMES = {
     *(f"lpt{index}" for index in ("¹", "²", "³")),
 }
 PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS = 15.0
+FILE_IO_MAX_IN_FLIGHT = 4
+
+
+class InvalidProfileDataError(ValueError):
+    pass
+
+
+_FILE_IO_LIMITERS_LOCK = threading.Lock()
+_FILE_IO_LIMITERS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 
 class _PromptTranslationWorker:
@@ -166,13 +185,58 @@ def _prompt_translation_error_response(exc: PromptTranslationError):
     )
 
 
-def _parse_json_boolean(data: dict, key: str, *, default: bool = False) -> bool:
-    if key not in data:
-        return default
-    value = data[key]
-    if type(value) is not bool:
-        raise ValueError(f"{key} must be a JSON boolean")
-    return value
+def _error_response(
+    status: int,
+    code: str,
+    message: str,
+    *,
+    details: dict | None = None,
+):
+    return web.json_response(
+        error_payload(code, message, details=details),
+        status=status,
+    )
+
+
+def _contract_error_response(exc: ApiContractError):
+    return _error_response(
+        exc.status,
+        exc.code,
+        exc.message,
+        details=exc.details,
+    )
+
+
+def _file_io_limiter() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    with _FILE_IO_LIMITERS_LOCK:
+        limiter = _FILE_IO_LIMITERS.get(loop)
+        if limiter is None:
+            limiter = asyncio.Semaphore(FILE_IO_MAX_IN_FLIGHT)
+            _FILE_IO_LIMITERS[loop] = limiter
+        return limiter
+
+
+def _release_file_io_slot(limiter: asyncio.Semaphore, worker: asyncio.Task) -> None:
+    limiter.release()
+    if worker.cancelled():
+        return
+    # Retrieve failures even when the request that submitted the worker was
+    # cancelled. A live caller still receives the same exception from await.
+    worker.exception()
+
+
+async def _run_file_io(function, /, *args, **kwargs):
+    limiter = _file_io_limiter()
+    await limiter.acquire()
+    worker = asyncio.create_task(asyncio.to_thread(function, *args, **kwargs))
+    worker.add_done_callback(
+        lambda completed, owned_limiter=limiter: _release_file_io_slot(
+            owned_limiter,
+            completed,
+        )
+    )
+    return await asyncio.shield(worker)
 
 
 def _windows_profile_filename_identity(name: str) -> str:
@@ -585,7 +649,7 @@ def _load_aio_profile(name: str) -> dict:
     try:
         data = _read_profile_json(path)
     except json.JSONDecodeError as exc:
-        raise ValueError("Profile data is invalid") from exc
+        raise InvalidProfileDataError("Profile data is invalid") from exc
     return _normalize_aio_profile_payload(path.stem, data if isinstance(data, dict) else {})
 
 
@@ -653,6 +717,128 @@ def _resolve_lora_preview_path(lora_name: str):
     return None
 
 
+_SAFE_PROFILE_VALIDATION_MESSAGES = frozenset(
+    {
+        "Profile name is required",
+        "Profile name is reserved on Windows",
+        "Invalid profile path",
+        "System profile names are reserved",
+        "Profile settings must be an object",
+        "Profile settings are too large",
+        f"A maximum of {MAX_AIO_PROFILES} profiles can be saved",
+    }
+)
+
+
+def _profile_error_response(exc: Exception):
+    if isinstance(exc, FileExistsError):
+        return _error_response(409, "profile_exists", "Profile already exists")
+    if isinstance(exc, FileNotFoundError):
+        return _error_response(404, "profile_not_found", "Profile not found")
+    if isinstance(exc, (json.JSONDecodeError, InvalidProfileDataError)):
+        return _error_response(422, "invalid_profile_data", "Profile data is invalid")
+    if isinstance(exc, ValueError):
+        message = str(exc)
+        if message not in _SAFE_PROFILE_VALIDATION_MESSAGES:
+            message = "Request validation failed"
+        return _error_response(422, "invalid_request", message)
+    raise exc
+
+
+def _get_settings_payload_sync() -> dict:
+    return public_settings()
+
+
+def _save_setting_payload_sync(key: str, value) -> dict:
+    save_setting(key, value)
+    return {"status": "ok", **public_settings()}
+
+
+def _get_long_text_settings_payload_sync() -> dict:
+    return {
+        "status": "ok",
+        "values": load_long_text_settings(),
+        "settings": public_settings(),
+    }
+
+
+def _save_long_text_settings_payload_sync(values: dict) -> dict:
+    return {
+        "status": "ok",
+        "values": save_long_text_settings(values),
+        "settings": public_settings(),
+    }
+
+
+def _wildcards_payload_sync() -> dict:
+    settings = public_settings()
+    extra_paths = settings.get("wildcard.extra_paths", "")
+    roots = resolve_wildcard_roots(extra_paths)
+    sources = [
+        {
+            "id": f"wildcard:{index}",
+            "label": f"Wildcard source {index}",
+            "exists": root.is_dir(),
+        }
+        for index, root in enumerate(roots, start=1)
+    ]
+    return {
+        "status": "ok",
+        "items": list_wildcards(roots=roots),
+        # Preserve the legacy list-of-strings type without publishing paths.
+        "roots": [source["id"] for source in sources],
+        "sources": sources,
+    }
+
+
+def _autocomplete_status_payload_sync() -> dict:
+    selected_source = resolve_autocomplete_source()
+    source_key, path = resolve_autocomplete_source_path(selected_source)
+    status = dict(autocomplete_status(path))
+    status.pop("path", None)
+    sources = []
+    source_label = source_key
+    for source in available_autocomplete_sources(source_key):
+        public_source = {
+            key: value
+            for key, value in source.items()
+            if key != "path"
+        }
+        sources.append(public_source)
+        if public_source.get("selected"):
+            source_label = str(public_source.get("label") or source_key)
+    return {
+        **status,
+        "source": source_key,
+        "source_label": source_label,
+        "sources": sources,
+    }
+
+
+def _search_autocomplete_payload_sync(
+    query: str,
+    requested_limit: str | None,
+    category_filter: str | None,
+):
+    default_limit = resolve_autocomplete_limit()
+    try:
+        limit = int(requested_limit) if requested_limit is not None else default_limit
+    except ValueError:
+        limit = default_limit
+    _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
+    return search_autocomplete(
+        query,
+        limit=limit,
+        path=path,
+        category=category_filter,
+    )
+
+
+def _classify_prompt_payload_sync(text: str, limit: int):
+    _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
+    return classify_prompt_text(text, limit=limit, path=path)
+
+
 def _get_prompt_routes():
     if server is None:
         return None
@@ -667,77 +853,49 @@ if web is not None and routes is not None:
 
     @routes.get("/easyuse_anima/settings")
     async def get_settings_handler(request):
-        return web.json_response(public_settings())
+        return web.json_response(await _run_file_io(_get_settings_payload_sync))
 
     @routes.post("/easyuse_anima/set_setting")
     async def set_setting_handler(request):
-        data = await request.json()
-        key = data.get("key")
-        if key is None:
-            return web.json_response(
-                {"status": "error", "message": "Setting key not provided"},
-                status=400,
-            )
         try:
-            save_setting(str(key), data.get("value", ""))
-        except KeyError as exc:
-            return web.json_response(
-                {"status": "error", "message": str(exc)},
-                status=400,
+            data = await parse_json_object(request)
+            key = json_string(data, "key", allow_empty=False)
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        try:
+            payload = await _run_file_io(
+                _save_setting_payload_sync,
+                key,
+                data.get("value", ""),
             )
-        return web.json_response({"status": "ok", **public_settings()})
+        except KeyError:
+            return _error_response(422, "unknown_setting", "Unknown setting")
+        return web.json_response(payload)
 
     @routes.get("/easyuse_anima/long_text_settings")
     async def get_long_text_settings_handler(request):
         return web.json_response(
-            {
-                "status": "ok",
-                "values": load_long_text_settings(),
-                "settings": public_settings(),
-            }
+            await _run_file_io(_get_long_text_settings_payload_sync)
         )
 
     @routes.get("/easyuse_anima/wildcards")
     async def get_wildcards_handler(request):
-        settings = public_settings()
-        extra_paths = settings.get("wildcard.extra_paths", "")
-        return web.json_response(
-            {
-                "status": "ok",
-                "items": list_wildcards(extra_paths=extra_paths),
-                "roots": [str(path) for path in resolve_wildcard_roots(extra_paths)],
-            }
-        )
+        return web.json_response(await _run_file_io(_wildcards_payload_sync))
 
     @routes.post("/easyuse_anima/long_text_settings/save")
     async def save_long_text_settings_handler(request):
-        data = await request.json()
-        values = data.get("values", data)
-        if not isinstance(values, dict):
-            return web.json_response(
-                {"status": "error", "message": "Long text values must be an object"},
-                status=400,
-            )
-        saved = save_long_text_settings(values)
+        try:
+            data = await parse_json_object(request)
+            values = json_object(data, "values") if "values" in data else data
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
         return web.json_response(
-            {
-                "status": "ok",
-                "values": saved,
-                "settings": public_settings(),
-            }
+            await _run_file_io(_save_long_text_settings_payload_sync, values)
         )
 
     @routes.get("/easyuse_anima/autocomplete_status")
     async def autocomplete_status_handler(request):
-        selected_source = resolve_autocomplete_source()
-        source_key, path = resolve_autocomplete_source_path(selected_source)
-        return web.json_response(
-            {
-                **autocomplete_status(path),
-                "source": source_key,
-                "sources": available_autocomplete_sources(source_key),
-            }
-        )
+        return web.json_response(await _run_file_io(_autocomplete_status_payload_sync))
 
     @routes.get("/easyuse_anima/autocomplete")
     async def autocomplete_handler(request):
@@ -747,44 +905,52 @@ if web is not None and routes is not None:
             "artist": "artist",
             "artist_or_general": "artist,general",
         }.get(category)
-        try:
-            limit = int(request.query.get("limit", resolve_autocomplete_limit()))
-        except ValueError:
-            limit = resolve_autocomplete_limit()
-        _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
         return web.json_response(
-            search_autocomplete(
+            await _run_file_io(
+                _search_autocomplete_payload_sync,
                 query,
-                limit=limit,
-                path=path,
-                category=category_filter,
+                request.query.get("limit"),
+                category_filter,
             )
         )
 
     @routes.post("/easyuse_anima/classify_prompt")
     async def classify_prompt_handler(request):
-        data = await request.json()
         try:
-            limit = int(data.get("limit", 240))
-        except (TypeError, ValueError):
-            limit = 240
-        _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
+            data = await parse_json_object(request)
+            text = json_string(data, "text")
+            limit = json_integer(
+                data,
+                "limit",
+                default=240,
+                minimum=1,
+                maximum=500,
+            )
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
         return web.json_response(
-            classify_prompt_text(str(data.get("text") or ""), limit=limit, path=path)
+            await _run_file_io(_classify_prompt_payload_sync, text, limit)
         )
 
     @routes.post("/easyuse_anima/translate_prompt")
     async def translate_prompt_handler(request):
-        data = await request.json()
         try:
-            translated = await _translate_prompt_for_route(str(data.get("text") or ""))
+            data = await parse_json_object(request)
+            text = json_string(data, "text")
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        try:
+            translated = await _translate_prompt_for_route(text)
         except PromptTranslationError as exc:
             return _prompt_translation_error_response(exc)
         return web.json_response({"status": "ok", "text": translated})
 
     @routes.get("/easyuse_anima/lora_preview")
     async def lora_preview_handler(request):
-        preview_path = _resolve_lora_preview_path(request.query.get("name", ""))
+        preview_path = await _run_file_io(
+            _resolve_lora_preview_path,
+            request.query.get("name", ""),
+        )
         if not preview_path:
             return web.Response(status=404)
         return web.FileResponse(
@@ -794,99 +960,121 @@ if web is not None and routes is not None:
 
     @routes.get("/easyuse_anima/loras")
     async def loras_handler(request):
-        return web.json_response({"loras": _list_loras()})
+        return web.json_response({"loras": await _run_file_io(_list_loras)})
 
     @routes.get("/easyuse_anima/lora_profiles")
     async def lora_profiles_handler(request):
-        return web.json_response({"profiles": _list_lora_profiles()})
+        return web.json_response({"profiles": await _run_file_io(_list_lora_profiles)})
 
     @routes.post("/easyuse_anima/lora_profiles/save")
     async def save_lora_profile_handler(request):
-        data = await request.json()
         try:
-            overwrite = _parse_json_boolean(data, "overwrite")
-            payload = _save_lora_profile(
-                str(data.get("name") or ""),
+            data = await parse_json_object(request)
+            name = json_string(data, "name", allow_empty=False)
+            overwrite = json_boolean(data, "overwrite")
+            if "profile_data" in data:
+                json_object(data, "profile_data")
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        try:
+            payload = await _run_file_io(
+                _save_lora_profile,
+                name,
                 data,
                 overwrite=overwrite,
             )
-        except FileExistsError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=409)
-        except ValueError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=400)
+        except (FileExistsError, ValueError) as exc:
+            return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.get("/easyuse_anima/lora_profiles/load")
     async def load_lora_profile_handler(request):
         try:
-            payload = _load_lora_profile(request.query.get("name", ""))
-        except ValueError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=400)
-        except FileNotFoundError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=404)
+            payload = await _run_file_io(
+                _load_lora_profile,
+                request.query.get("name", ""),
+            )
+        except (json.JSONDecodeError, FileNotFoundError, ValueError) as exc:
+            return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.get("/easyuse_anima/aio_profiles")
     async def aio_profiles_handler(request):
-        return web.json_response({"status": "ok", "profiles": _list_aio_profiles()})
+        return web.json_response(
+            {"status": "ok", "profiles": await _run_file_io(_list_aio_profiles)}
+        )
 
     @routes.post("/easyuse_anima/aio_profiles/save")
     async def save_aio_profile_handler(request):
-        data = await request.json()
         try:
-            overwrite = _parse_json_boolean(data, "overwrite")
-            payload = _save_aio_profile(
-                str(data.get("name") or ""),
+            data = await parse_json_object(request)
+            name = json_string(data, "name", allow_empty=False)
+            json_object(data, "settings")
+            overwrite = json_boolean(data, "overwrite")
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        try:
+            payload = await _run_file_io(
+                _save_aio_profile,
+                name,
                 data,
                 overwrite=overwrite,
             )
-        except FileExistsError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=409)
-        except ValueError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=400)
+        except (FileExistsError, ValueError) as exc:
+            return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.get("/easyuse_anima/aio_profiles/load")
     async def load_aio_profile_handler(request):
         try:
-            payload = _load_aio_profile(request.query.get("name", ""))
-        except ValueError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=400)
-        except FileNotFoundError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=404)
+            payload = await _run_file_io(
+                _load_aio_profile,
+                request.query.get("name", ""),
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.post("/easyuse_anima/aio_profiles/delete")
     async def delete_aio_profile_handler(request):
-        data = await request.json()
         try:
-            payload = _delete_aio_profile(str(data.get("name") or ""))
-        except ValueError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=400)
-        except FileNotFoundError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=404)
+            data = await parse_json_object(request)
+            name = json_string(data, "name", allow_empty=False)
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        try:
+            payload = await _run_file_io(_delete_aio_profile, name)
+        except (FileNotFoundError, ValueError) as exc:
+            return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.post("/easyuse_anima/aio_profiles/rename")
     async def rename_aio_profile_handler(request):
-        data = await request.json()
         try:
-            overwrite = _parse_json_boolean(data, "overwrite")
-            payload = _rename_aio_profile(
-                str(data.get("old_name") or ""),
-                str(data.get("new_name") or ""),
+            data = await parse_json_object(request)
+            old_name = json_string(data, "old_name", allow_empty=False)
+            new_name = json_string(data, "new_name", allow_empty=False)
+            overwrite = json_boolean(data, "overwrite")
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        try:
+            payload = await _run_file_io(
+                _rename_aio_profile,
+                old_name,
+                new_name,
                 overwrite=overwrite,
             )
-        except FileExistsError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=409)
-        except ValueError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=400)
-        except FileNotFoundError as exc:
-            return web.json_response({"status": "error", "message": str(exc)}, status=404)
+        except (FileExistsError, FileNotFoundError, ValueError) as exc:
+            return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.post("/easyuse_anima/lora_profiles/fix")
     async def fix_lora_profile_handler(request):
-        data = await request.json()
-        payload = _fix_lora_profile_payload(data if isinstance(data, dict) else {})
+        try:
+            data = await parse_json_object(request)
+            if "profile_data" in data:
+                json_object(data, "profile_data")
+        except ApiContractError as exc:
+            return _contract_error_response(exc)
+        payload = await _run_file_io(_fix_lora_profile_payload, data)
         return web.json_response({"status": "ok", "profile": payload})

--- a/api.py
+++ b/api.py
@@ -657,6 +657,15 @@ def _save_aio_profile(name: str, data: dict, *, overwrite: bool = False) -> dict
     return payload
 
 
+def _normalize_stored_aio_profile_payload(name: str, data) -> dict:
+    if not isinstance(data, dict):
+        raise InvalidProfileDataError("Profile data is invalid")
+    try:
+        return _normalize_aio_profile_payload(name, data)
+    except ValueError as exc:
+        raise InvalidProfileDataError(str(exc)) from exc
+
+
 def _load_aio_profile(name: str) -> dict:
     path = _find_aio_profile_path(name)
     if path is None or not path.is_file():
@@ -665,12 +674,7 @@ def _load_aio_profile(name: str) -> dict:
         data = _read_profile_json(path)
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise InvalidProfileDataError("Profile data is invalid") from exc
-    if not isinstance(data, dict):
-        raise InvalidProfileDataError("Profile data is invalid")
-    try:
-        return _normalize_aio_profile_payload(path.stem, data)
-    except ValueError as exc:
-        raise InvalidProfileDataError(str(exc)) from exc
+    return _normalize_stored_aio_profile_payload(path.stem, data)
 
 
 def _delete_aio_profile(name: str) -> dict:
@@ -702,9 +706,9 @@ def _rename_aio_profile(old_name: str, new_name: str, *, overwrite: bool = False
         AtomicJsonStore(source),
         overwrite=overwrite,
         backup_target=True,
-        transform=lambda data: _normalize_aio_profile_payload(
+        transform=lambda data: _normalize_stored_aio_profile_payload(
             target_path.stem,
-            data if isinstance(data, dict) else {},
+            data,
         ),
     )
 

--- a/api.py
+++ b/api.py
@@ -210,10 +210,15 @@ def _contract_error_response(exc: ApiContractError):
 def _file_io_limiter() -> asyncio.Semaphore:
     loop = asyncio.get_running_loop()
     with _FILE_IO_LIMITERS_LOCK:
-        limiter = _FILE_IO_LIMITERS.get(loop)
+        limiter_ref = _FILE_IO_LIMITERS.get(loop)
+        limiter = limiter_ref() if limiter_ref is not None else None
         if limiter is None:
             limiter = asyncio.Semaphore(FILE_IO_MAX_IN_FLIGHT)
-            _FILE_IO_LIMITERS[loop] = limiter
+            # A contended Semaphore binds itself to the event loop. Store only
+            # a weak value so the registry cannot root a closed loop through
+            # registry -> semaphore -> loop. Active/waiting calls and worker
+            # callbacks keep their limiter alive until the real work finishes.
+            _FILE_IO_LIMITERS[loop] = weakref.ref(limiter)
         return limiter
 
 
@@ -559,7 +564,17 @@ def _load_lora_profile(name: str) -> dict:
         raise FileNotFoundError("Profile not found")
     data = _read_profile_json(path)
     if not isinstance(data, dict):
-        data = {}
+        raise InvalidProfileDataError("Profile data is invalid")
+    profile_data = data.get("profile_data", {})
+    if isinstance(profile_data, str):
+        try:
+            decoded_profile_data = json.loads(profile_data or "{}")
+        except (TypeError, ValueError) as exc:
+            raise InvalidProfileDataError("Profile data is invalid") from exc
+        if not isinstance(decoded_profile_data, dict):
+            raise InvalidProfileDataError("Profile data is invalid")
+    elif not isinstance(profile_data, dict):
+        raise InvalidProfileDataError("Profile data is invalid")
     payload = _normalize_lora_profile_payload(data)
     payload["name"] = path.stem
     return payload
@@ -648,9 +663,14 @@ def _load_aio_profile(name: str) -> dict:
         raise FileNotFoundError("Profile not found")
     try:
         data = _read_profile_json(path)
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise InvalidProfileDataError("Profile data is invalid") from exc
-    return _normalize_aio_profile_payload(path.stem, data if isinstance(data, dict) else {})
+    if not isinstance(data, dict):
+        raise InvalidProfileDataError("Profile data is invalid")
+    try:
+        return _normalize_aio_profile_payload(path.stem, data)
+    except ValueError as exc:
+        raise InvalidProfileDataError(str(exc)) from exc
 
 
 def _delete_aio_profile(name: str) -> dict:
@@ -735,7 +755,10 @@ def _profile_error_response(exc: Exception):
         return _error_response(409, "profile_exists", "Profile already exists")
     if isinstance(exc, FileNotFoundError):
         return _error_response(404, "profile_not_found", "Profile not found")
-    if isinstance(exc, (json.JSONDecodeError, InvalidProfileDataError)):
+    if isinstance(
+        exc,
+        (json.JSONDecodeError, UnicodeDecodeError, InvalidProfileDataError),
+    ):
         return _error_response(422, "invalid_profile_data", "Profile data is invalid")
     if isinstance(exc, ValueError):
         message = str(exc)
@@ -794,8 +817,7 @@ def _wildcards_payload_sync() -> dict:
 def _autocomplete_status_payload_sync() -> dict:
     selected_source = resolve_autocomplete_source()
     source_key, path = resolve_autocomplete_source_path(selected_source)
-    status = dict(autocomplete_status(path))
-    status.pop("path", None)
+    status = _public_autocomplete_status(autocomplete_status(path))
     sources = []
     source_label = source_key
     for source in available_autocomplete_sources(source_key):
@@ -815,6 +837,21 @@ def _autocomplete_status_payload_sync() -> dict:
     }
 
 
+def _public_autocomplete_status(status) -> dict:
+    public_status = dict(status) if isinstance(status, dict) else {}
+    public_status.pop("path", None)
+    return public_status
+
+
+def _public_autocomplete_payload(payload) -> dict:
+    public_payload = dict(payload) if isinstance(payload, dict) else {}
+    if "status" in public_payload:
+        public_payload["status"] = _public_autocomplete_status(
+            public_payload["status"]
+        )
+    return public_payload
+
+
 def _search_autocomplete_payload_sync(
     query: str,
     requested_limit: str | None,
@@ -826,17 +863,21 @@ def _search_autocomplete_payload_sync(
     except ValueError:
         limit = default_limit
     _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
-    return search_autocomplete(
-        query,
-        limit=limit,
-        path=path,
-        category=category_filter,
+    return _public_autocomplete_payload(
+        search_autocomplete(
+            query,
+            limit=limit,
+            path=path,
+            category=category_filter,
+        )
     )
 
 
 def _classify_prompt_payload_sync(text: str, limit: int):
     _, path = resolve_autocomplete_source_path(resolve_autocomplete_source())
-    return classify_prompt_text(text, limit=limit, path=path)
+    return _public_autocomplete_payload(
+        classify_prompt_text(text, limit=limit, path=path)
+    )
 
 
 def _get_prompt_routes():
@@ -994,7 +1035,12 @@ if web is not None and routes is not None:
                 _load_lora_profile,
                 request.query.get("name", ""),
             )
-        except (json.JSONDecodeError, FileNotFoundError, ValueError) as exc:
+        except (
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            FileNotFoundError,
+            ValueError,
+        ) as exc:
             return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 

--- a/api_contract.py
+++ b/api_contract.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+class ApiContractError(ValueError):
+    """A public request-contract error with a stable HTTP mapping."""
+
+    def __init__(
+        self,
+        status: int,
+        code: str,
+        message: str,
+        *,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = dict(details) if details is not None else None
+
+
+def error_payload(
+    code: str,
+    message: str,
+    *,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Keep the legacy status/message shape while adding a stable code."""
+
+    payload: dict[str, Any] = {
+        "status": "error",
+        "code": code,
+        "message": message,
+    }
+    if details is not None:
+        payload["details"] = dict(details)
+    return payload
+
+
+async def parse_json_object(request) -> dict[str, Any]:
+    try:
+        data = await request.json()
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise ApiContractError(
+            400,
+            "malformed_json",
+            "Request body must contain valid JSON.",
+        ) from exc
+    if not isinstance(data, dict):
+        raise ApiContractError(
+            400,
+            "json_object_required",
+            "Request body must be a JSON object.",
+        )
+    return data
+
+
+def _field_error(field: str, expectation: str) -> ApiContractError:
+    return ApiContractError(
+        422,
+        "invalid_request",
+        f"{field} must be {expectation}.",
+        details={"field": field},
+    )
+
+
+def json_object(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    required: bool = True,
+    default: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if field not in data:
+        if required:
+            raise _field_error(field, "a JSON object")
+        return dict(default or {})
+    value = data[field]
+    if not isinstance(value, dict):
+        raise _field_error(field, "a JSON object")
+    return value
+
+
+def json_string(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    required: bool = True,
+    default: str = "",
+    allow_empty: bool = True,
+) -> str:
+    if field not in data:
+        if required:
+            raise _field_error(field, "a JSON string")
+        return default
+    value = data[field]
+    if not isinstance(value, str):
+        raise _field_error(field, "a JSON string")
+    if not allow_empty and not value.strip():
+        raise _field_error(field, "a non-empty JSON string")
+    return value
+
+
+def json_boolean(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    default: bool = False,
+) -> bool:
+    if field not in data:
+        return default
+    value = data[field]
+    if type(value) is not bool:
+        raise _field_error(field, "a JSON boolean")
+    return value
+
+
+def json_integer(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    default: int,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if field not in data:
+        return default
+    value = data[field]
+    if type(value) is not int:
+        raise _field_error(field, "a JSON integer")
+    if minimum is not None and value < minimum:
+        raise _field_error(field, f"an integer greater than or equal to {minimum}")
+    if maximum is not None and value > maximum:
+        raise _field_error(field, f"an integer less than or equal to {maximum}")
+    return value

--- a/docs/architecture/python-backend.md
+++ b/docs/architecture/python-backend.md
@@ -27,6 +27,11 @@ At the baseline above, the migration has not started:
 - `api.py`, `settings.py`, `storage.py`, `autocomplete_dataset.py`,
   `wildcard_engine.py`, `prompt_translation.py`, and `anima_prompt/` are still
   implementation modules, not compatibility shims.
+- Issue #165 Phase C adds root `api_contract.py` as a temporary implementation
+  surface for JSON-object parsing, typed request fields, and additive stable
+  error payloads. D-02 moves that responsibility to
+  `easyuse_anima.api.requests`/`responses`/`errors`; D-14 freezes any root shim
+  that consumer evidence still requires.
 - PR [#189](https://github.com/n0va39/ComfyUI-EasyUseAnima/pull/189)
   added the 0.5.2 node/workflow contract fixture and an import-boundary analyzer
   seed. Those files are useful A-02/A-03 foundations, but they do not complete
@@ -111,6 +116,7 @@ ComfyUI-EasyUseAnima/
 |-- __init__.py                         # ComfyUI entrypoint
 |-- nodes.py                            # public node compatibility shim
 |-- api.py                              # temporary API compatibility shim
+|-- api_contract.py                     # temporary Phase C implementation; D-02/D-14 target
 |-- settings.py                         # temporary settings shim
 |-- storage.py                          # temporary storage shim
 |-- autocomplete_dataset.py             # temporary autocomplete shim

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -44,6 +44,7 @@ not added to a shim merely because tests import them.
 | Root `__init__.py` exports | Permanent ComfyUI entrypoint, not a shim | root entrypoint plus `easyuse_anima.registration`/`bootstrap` | #184/#185 | Existing 0.5.2 surface; B-11 rewires internals | ComfyUI loader; node contract fixture | Not removable as a package entrypoint |
 | `nodes.py` mapped public classes | Current implementation; planned node shim | `easyuse_anima.nodes.*_nodes` | #184 B-11, #188 | Existing 0.5.2 surface; convert in B-11 | Root mappings, workflows, tests, possible external Python imports | No scheduled removal; public breaking-change gate after N+1 at earliest |
 | `api.py` route-registration surface | Current implementation; planned API shim | `easyuse_anima.api.router` and `easyuse_anima.api.routes.*` | #165, #186 D-02-D-07 | Existing 0.5.2 surface; convert during D-02-D-07/D-14 | Root entrypoint side-effect import, frontend endpoints, API tests | Unscheduled; N+1 gate and route parity |
+| `api_contract.py` request/error helpers | Phase C temporary implementation; D-02 move and D-14 shim decision pending | `easyuse_anima.api.requests`, `responses`, and `errors` | #165, #186 D-02/D-14 | Introduced by #165; convert in D-02 and freeze any required root shim in D-14 | `api.py`, API contract tests, Registry package-closure test | Unscheduled; internal consumers canonical and contract/package parity pass |
 | `settings.py` | Current implementation; planned settings shim | `easyuse_anima.settings.*` | #163, #186 D-09 | Existing 0.5.2 surface; convert in D-09/D-14 | `api.py`, `nodes.py`, `wildcard_engine.py`, settings tests | Unscheduled; N+1 gate and settings migration/round-trip |
 | `storage.py` | Current implementation; planned filesystem shim | `easyuse_anima.infrastructure.filesystem.*` | #163, #186 D-08 | Existing 0.5.2 surface; convert in D-08/D-14 | `api.py`, `settings.py`, `wildcard_engine.py`, storage/profile tests | Unscheduled; N+1 gate and last-known-good/atomic-write parity |
 | `autocomplete_dataset.py` | Current implementation; planned autocomplete shim | `easyuse_anima.autocomplete.*` | #162, #186 D-11 | Existing 0.5.2 surface; convert in D-11/D-14 | `api.py`, autocomplete/frontend API tests | Unscheduled; N+1 gate and result/ranking/API parity |
@@ -108,6 +109,19 @@ EasyUseAnimaWildcard
 - Removal gate: root entrypoint no longer imports `api.py`; repeated initialize
   registers no duplicate routes; the #165 request/error matrix and 0.5.2 API
   parity pass; actual package import succeeds.
+
+### `api_contract.py`
+
+- Candidate scope: the internal JSON-object parser, typed field validators,
+  stable error type, and additive error-payload helper introduced by #165.
+- State: temporary Phase C root implementation, not a declared public Python
+  API. D-02 moves the implementation and `api.py` consumer to
+  `easyuse_anima.api.requests`, `responses`, and `errors`; D-14 decides whether
+  consumer evidence requires a supported root re-export shim.
+- Removal gate: the #165 request/error and frontend compatibility matrices pass,
+  internal imports are canonical, and the actual Registry package retains
+  import closure. If a root shim is retained, ADR-002 identity and N+1 gates
+  apply.
 
 ### `settings.py`
 

--- a/tests/frontend_aio_profile_api_client_smoke.mjs
+++ b/tests/frontend_aio_profile_api_client_smoke.mjs
@@ -7,6 +7,7 @@ function dataModule(relativePath) {
 }
 
 const apiClientModule = await import(dataModule("../web/js/aio/profile_api_client.js"));
+const sharedApiModule = await import(dataModule("../web/js/easyuse_anima_api.js"));
 
 assert.deepEqual(
   Object.keys(apiClientModule),
@@ -50,6 +51,48 @@ assert.deepEqual(Object.keys(client).sort(), [
 ]);
 assert.equal(calls.length, 0, "factory creation must not make a request");
 assert.equal(encodedValues.length, 0, "factory creation must not encode a name");
+
+const errorContracts = [
+  {
+    payload: { status: "error", message: "Legacy conflict" },
+    expected: { message: "Legacy conflict", status: 409, code: undefined, details: undefined },
+  },
+  {
+    payload: {
+      status: "error",
+      code: "profile_exists",
+      message: "Profile already exists",
+      details: { field: "name" },
+    },
+    expected: {
+      message: "Profile already exists",
+      status: 409,
+      code: "profile_exists",
+      details: { field: "name" },
+    },
+  },
+];
+
+for (const { payload, expected } of errorContracts) {
+  await assert.rejects(
+    sharedApiModule.easyuseAnimaFetchJson("/contract", {
+      fetcher: async () => ({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+        json: async () => payload,
+      }),
+    }),
+    (error) => {
+      assert.equal(error.message, expected.message);
+      assert.equal(error.status, expected.status);
+      assert.equal(error.code, expected.code);
+      assert.deepEqual(error.details, expected.details);
+      return true;
+    },
+    "shared API transport must accept legacy and coded error payloads",
+  );
+}
 
 const profilesResponse = { profiles: [{ name: "Portrait" }] };
 responses.push(profilesResponse);

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -452,12 +452,16 @@ class AIOProfileStorageTests(unittest.TestCase):
     def test_rename_rejects_invalid_source_schema_before_publish(self):
         api = load_api_module()
         invalid_payloads = (
-            ("array", []),
-            ("empty object", {}),
-            ("non-object settings", {"settings": []}),
+            ("array", [], "Profile data is invalid"),
+            ("empty object", {}, "Profile settings must be an object"),
+            (
+                "non-object settings",
+                {"settings": []},
+                "Profile settings must be an object",
+            ),
         )
 
-        for label, invalid_payload in invalid_payloads:
+        for label, invalid_payload, message in invalid_payloads:
             with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
                 root = Path(tmp)
                 source = root / "Source.json"
@@ -469,7 +473,7 @@ class AIOProfileStorageTests(unittest.TestCase):
                 source_bytes = source.read_bytes()
 
                 with patch.object(api, "AIO_PROFILE_DIR", root):
-                    with self.assertRaisesRegex(ValueError, "Profile settings must be an object"):
+                    with self.assertRaisesRegex(api.InvalidProfileDataError, message):
                         api._rename_aio_profile("Source", "Target")
 
                 self.assertEqual(source.read_bytes(), source_bytes)

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -637,10 +637,11 @@ class AIOProfileApiRouteTests(unittest.TestCase):
                             handler(JsonRequest({**base_payload, "overwrite": overwrite}))
                         )
 
-                    self.assertEqual(response["status"], 400)
+                    self.assertEqual(response["status"], 422)
+                    self.assertEqual(response["payload"]["code"], "invalid_request")
                     self.assertEqual(
                         response["payload"]["message"],
-                        "overwrite must be a JSON boolean",
+                        "overwrite must be a JSON boolean.",
                     )
                     operation.assert_not_called()
 
@@ -660,7 +661,11 @@ class AIOProfileApiRouteTests(unittest.TestCase):
                 self.assertEqual(response["status"], 409)
                 self.assertEqual(
                     response["payload"],
-                    {"status": "error", "message": "Profile already exists"},
+                    {
+                        "status": "error",
+                        "code": "profile_exists",
+                        "message": "Profile already exists",
+                    },
                 )
 
     def test_delete_missing_profile_preserves_404_response_contract(self):
@@ -677,7 +682,11 @@ class AIOProfileApiRouteTests(unittest.TestCase):
         self.assertEqual(response["status"], 404)
         self.assertEqual(
             response["payload"],
-            {"status": "error", "message": "Profile not found"},
+            {
+                "status": "error",
+                "code": "profile_not_found",
+                "message": "Profile not found",
+            },
         )
 
 

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import importlib.util
 import json
 import re
@@ -10,6 +11,7 @@ import threading
 import time
 import types
 import unittest
+import weakref
 from itertools import count
 from pathlib import Path
 from unittest.mock import patch
@@ -236,6 +238,131 @@ class ApiRequestContractTests(unittest.TestCase):
                     self.assertEqual(response["payload"]["code"], "invalid_profile_data")
                     self.assertEqual(response["payload"]["message"], "Profile data is invalid")
 
+    def test_stored_profile_shape_errors_have_stable_422_code(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "/easyuse_anima/lora_profiles/load",
+                "LORA_PROFILE_DIR",
+                "[]",
+            ),
+            (
+                "/easyuse_anima/lora_profiles/load",
+                "LORA_PROFILE_DIR",
+                '{"profile_data": []}',
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                "AIO_PROFILE_DIR",
+                "null",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                "AIO_PROFILE_DIR",
+                '{"settings": []}',
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for route, directory_name, content in cases:
+                with self.subTest(route=route, content=content):
+                    (root / "Invalid.json").write_text(content, encoding="utf-8")
+                    with patch.object(api, directory_name, root):
+                        response = asyncio.run(
+                            routes.handlers[route](JsonRequest(query={"name": "Invalid"}))
+                        )
+                    self.assertEqual(response["status"], 422)
+                    self.assertEqual(response["payload"]["code"], "invalid_profile_data")
+                    self.assertEqual(
+                        response["payload"]["message"],
+                        "Profile data is invalid",
+                    )
+
+    def test_invalid_utf8_profile_files_have_stable_redacted_422_code(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("/easyuse_anima/lora_profiles/load", "LORA_PROFILE_DIR"),
+            ("/easyuse_anima/aio_profiles/load", "AIO_PROFILE_DIR"),
+        )
+        secret_bytes = b"\xffC:\\Users\\alice\\secret.json API_TOKEN=top-secret"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for route, directory_name in cases:
+                with self.subTest(route=route):
+                    (root / "BrokenUtf8.json").write_bytes(secret_bytes)
+                    with patch.object(api, directory_name, root):
+                        response = asyncio.run(
+                            routes.handlers[route](
+                                JsonRequest(query={"name": "BrokenUtf8"})
+                            )
+                        )
+                    self.assertEqual(response["status"], 422)
+                    self.assertEqual(response["payload"]["code"], "invalid_profile_data")
+                    self.assertEqual(
+                        response["payload"]["message"],
+                        "Profile data is invalid",
+                    )
+                    serialized = json.dumps(response["payload"])
+                    for forbidden in (
+                        "alice",
+                        "secret.json",
+                        "API_TOKEN",
+                        "top-secret",
+                        str(root),
+                    ):
+                        self.assertNotIn(forbidden, serialized)
+
+    def test_empty_profile_file_compatibility_boundary_is_preserved(self):
+        api, routes = load_api_routes()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Empty.json").write_text("", encoding="utf-8")
+
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                lora_response = asyncio.run(
+                    routes.handlers["/easyuse_anima/lora_profiles/load"](
+                        JsonRequest(query={"name": "Empty"})
+                    )
+                )
+            self.assertEqual(lora_response["status"], 200)
+            self.assertEqual(lora_response["payload"]["profile"]["profile_data"], {})
+            self.assertEqual(lora_response["payload"]["profile"]["profile_count"], 1)
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                aio_response = asyncio.run(
+                    routes.handlers["/easyuse_anima/aio_profiles/load"](
+                        JsonRequest(query={"name": "Empty"})
+                    )
+                )
+            self.assertEqual(aio_response["status"], 422)
+            self.assertEqual(aio_response["payload"]["code"], "invalid_profile_data")
+
+    def test_legacy_lora_profile_data_json_string_remains_compatible(self):
+        api, routes = load_api_routes()
+        stored = {
+            "profile_data": json.dumps(
+                {"1": {"style_prompt": "legacy", "loras": []}}
+            )
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Legacy.json").write_text(
+                json.dumps(stored),
+                encoding="utf-8",
+            )
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                response = asyncio.run(
+                    routes.handlers["/easyuse_anima/lora_profiles/load"](
+                        JsonRequest(query={"name": "Legacy"})
+                    )
+                )
+
+        self.assertEqual(response["status"], 200)
+        self.assertEqual(
+            response["payload"]["profile"]["profile_data"]["1"]["style_prompt"],
+            "legacy",
+        )
+
     def test_public_validation_error_does_not_echo_path_stack_or_secret(self):
         api, routes = load_api_routes()
         secret = "C:\\Users\\alice\\profile.json API_TOKEN=top-secret"
@@ -297,6 +424,10 @@ class ApiPathRedactionTests(unittest.TestCase):
             self.assertIsNone(re.match(r"^[A-Za-z]:[\\/]", value), value)
             self.assertFalse(value.startswith("/home/"), value)
             self.assertFalse(value.startswith("/Users/"), value)
+        serialized = json.dumps(payload, ensure_ascii=False)
+        self.assertIsNone(re.search(r"[A-Za-z]:[\\/]", serialized), serialized)
+        self.assertNotIn("/home/", serialized)
+        self.assertNotIn("/Users/", serialized)
 
     def test_autocomplete_status_replaces_all_paths_with_public_source_metadata(self):
         api, routes = load_api_routes()
@@ -342,6 +473,81 @@ class ApiPathRedactionTests(unittest.TestCase):
         self.assertTrue(all("path" not in source for source in payload["sources"]))
         self.assert_no_absolute_path(payload)
 
+    def test_autocomplete_search_redacts_nested_status_path_only(self):
+        api, routes = load_api_routes()
+        produced = {
+            "query": "cat",
+            "results": [{"tag": "cat", "score": 7}],
+            "status": {
+                "path": r"C:\Users\alice\secret.csv",
+                "exists": True,
+                "count": 5,
+                "mtime": 1,
+            },
+            "future": {"kept": True},
+        }
+        with (
+            patch.object(api, "resolve_autocomplete_limit", return_value=20),
+            patch.object(api, "resolve_autocomplete_source", return_value="selected"),
+            patch.object(
+                api,
+                "resolve_autocomplete_source_path",
+                return_value=("selected", Path(r"C:\Users\alice\secret.csv")),
+            ),
+            patch.object(api, "search_autocomplete", return_value=produced),
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/autocomplete"](
+                    JsonRequest(query={"q": "cat", "limit": "10"})
+                )
+            )
+
+        payload = response["payload"]
+        self.assertEqual(payload["query"], produced["query"])
+        self.assertEqual(payload["results"], produced["results"])
+        self.assertEqual(payload["future"], produced["future"])
+        self.assertEqual(
+            payload["status"],
+            {"exists": True, "count": 5, "mtime": 1},
+        )
+        self.assert_no_absolute_path(payload)
+
+    def test_classify_prompt_redacts_nested_status_path_only(self):
+        api, routes = load_api_routes()
+        produced = {
+            "tokens": [{"text": "cat", "category": "general"}],
+            "status": {
+                "path": "/home/alice/secret.csv",
+                "exists": True,
+                "count": 9,
+                "mtime": 2,
+            },
+            "future": ["kept"],
+        }
+        with (
+            patch.object(api, "resolve_autocomplete_source", return_value="selected"),
+            patch.object(
+                api,
+                "resolve_autocomplete_source_path",
+                return_value=("selected", Path("/home/alice/secret.csv")),
+            ),
+            patch.object(api, "classify_prompt_text", return_value=produced),
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/classify_prompt"](
+                    JsonRequest({"text": "cat", "limit": 10})
+                )
+            )
+
+        payload = response["payload"]
+        self.assertEqual(payload["tokens"], produced["tokens"])
+        self.assertEqual(payload["future"], produced["future"])
+        self.assertEqual(
+            payload["status"],
+            {"exists": True, "count": 9, "mtime": 2},
+        )
+        self.assert_no_absolute_path(payload)
+
     def test_wildcard_roots_keep_string_list_compatibility_without_paths(self):
         api, routes = load_api_routes()
         secret_roots = [Path(r"C:\Users\alice\wildcards"), Path("/home/alice/wildcards")]
@@ -373,6 +579,32 @@ class ApiPathRedactionTests(unittest.TestCase):
 
 
 class ApiFileIoOffloadTests(unittest.TestCase):
+    def test_closed_loop_limiter_registry_converges_after_gc(self):
+        api, _routes = load_api_routes()
+        loop_refs = []
+
+        async def bind_limiter_to_loop():
+            loop_refs.append(weakref.ref(asyncio.get_running_loop()))
+            limiter = api._file_io_limiter()
+            for _index in range(api.FILE_IO_MAX_IN_FLIGHT):
+                await limiter.acquire()
+            waiter = asyncio.create_task(limiter.acquire())
+            await asyncio.sleep(0)
+            self.assertFalse(waiter.done())
+            limiter.release()
+            await waiter
+            for _index in range(api.FILE_IO_MAX_IN_FLIGHT):
+                limiter.release()
+
+        for _index in range(12):
+            asyncio.run(bind_limiter_to_loop())
+
+        for _index in range(3):
+            gc.collect()
+
+        self.assertTrue(all(loop_ref() is None for loop_ref in loop_refs))
+        self.assertEqual(len(api._FILE_IO_LIMITERS), 0)
+
     def test_slow_scan_save_and_stat_leave_event_loop_heartbeat_running(self):
         api, routes = load_api_routes()
         cases = (

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import re
+import sys
+import tempfile
+import threading
+import time
+import types
+import unittest
+from itertools import count
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+_LOAD_COUNTER = count()
+
+
+class RouteRegistry:
+    def __init__(self):
+        self.handlers = {}
+
+    def get(self, path):
+        def register(handler):
+            self.handlers[path] = handler
+            return handler
+
+        return register
+
+    def post(self, path):
+        return self.get(path)
+
+
+class JsonRequest:
+    def __init__(self, payload=None, *, error=None, query=None):
+        self.payload = payload
+        self.error = error
+        self.query = query or {}
+
+    async def json(self):
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+
+def load_api_routes():
+    package_name = f"easyuse_anima_api_contract_test_package_{next(_LOAD_COUNTER)}"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(ROOT)]
+    sys.modules[package_name] = package
+
+    routes = RouteRegistry()
+    fake_server = types.ModuleType("server")
+    fake_server.PromptServer = type(
+        "PromptServer",
+        (),
+        {"instance": types.SimpleNamespace(routes=routes)},
+    )
+    fake_aiohttp = types.ModuleType("aiohttp")
+    fake_aiohttp.web = types.SimpleNamespace(
+        json_response=lambda payload, status=200: {"payload": payload, "status": status},
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.api",
+        ROOT / "api.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with patch.dict(sys.modules, {"server": fake_server, "aiohttp": fake_aiohttp}):
+        spec.loader.exec_module(module)
+    return module, routes
+
+
+def response_strings(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield str(key)
+            yield from response_strings(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from response_strings(item)
+    elif isinstance(value, str):
+        yield value
+
+
+class ApiRequestContractTests(unittest.TestCase):
+    POST_ROUTES = (
+        "/easyuse_anima/set_setting",
+        "/easyuse_anima/long_text_settings/save",
+        "/easyuse_anima/classify_prompt",
+        "/easyuse_anima/translate_prompt",
+        "/easyuse_anima/lora_profiles/save",
+        "/easyuse_anima/aio_profiles/save",
+        "/easyuse_anima/aio_profiles/delete",
+        "/easyuse_anima/aio_profiles/rename",
+        "/easyuse_anima/lora_profiles/fix",
+    )
+
+    def test_all_json_routes_reject_malformed_and_non_object_bodies_before_submit(self):
+        api, routes = load_api_routes()
+        malformed = json.JSONDecodeError("C:\\Users\\alice\\secret", "{", 1)
+        cases = (
+            (JsonRequest(error=malformed), "malformed_json"),
+            (JsonRequest([]), "json_object_required"),
+            (JsonRequest(None), "json_object_required"),
+            (JsonRequest("scalar"), "json_object_required"),
+            (JsonRequest(7), "json_object_required"),
+        )
+
+        with (
+            patch.object(api.asyncio, "to_thread") as submit,
+            patch.object(api, "_translate_prompt_for_route") as translate,
+        ):
+            for route in self.POST_ROUTES:
+                for request, code in cases:
+                    with self.subTest(route=route, code=code, body=request.payload):
+                        response = asyncio.run(routes.handlers[route](request))
+                        self.assertEqual(response["status"], 400)
+                        self.assertEqual(response["payload"]["status"], "error")
+                        self.assertEqual(response["payload"]["code"], code)
+                        self.assertNotIn("secret", json.dumps(response["payload"]))
+
+            submit.assert_not_called()
+            translate.assert_not_called()
+
+    def test_endpoint_field_type_errors_are_422_before_submit(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("/easyuse_anima/set_setting", {"key": 1}, "key"),
+            ("/easyuse_anima/long_text_settings/save", {"values": []}, "values"),
+            ("/easyuse_anima/classify_prompt", {"text": []}, "text"),
+            ("/easyuse_anima/classify_prompt", {"text": "x", "limit": "10"}, "limit"),
+            ("/easyuse_anima/translate_prompt", {"text": None}, "text"),
+            ("/easyuse_anima/lora_profiles/save", {"name": 3}, "name"),
+            (
+                "/easyuse_anima/lora_profiles/save",
+                {"name": "Preset", "profile_data": []},
+                "profile_data",
+            ),
+            (
+                "/easyuse_anima/lora_profiles/save",
+                {"name": "Preset", "overwrite": "false"},
+                "overwrite",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/save",
+                {"name": "Preset", "settings": []},
+                "settings",
+            ),
+            ("/easyuse_anima/aio_profiles/delete", {"name": 4}, "name"),
+            (
+                "/easyuse_anima/aio_profiles/rename",
+                {"old_name": "Old", "new_name": []},
+                "new_name",
+            ),
+            (
+                "/easyuse_anima/lora_profiles/fix",
+                {"profile_data": []},
+                "profile_data",
+            ),
+        )
+
+        with (
+            patch.object(api.asyncio, "to_thread") as submit,
+            patch.object(api, "_translate_prompt_for_route") as translate,
+        ):
+            for route, payload, field in cases:
+                with self.subTest(route=route, field=field):
+                    response = asyncio.run(routes.handlers[route](JsonRequest(payload)))
+                    self.assertEqual(response["status"], 422)
+                    self.assertEqual(response["payload"]["code"], "invalid_request")
+                    self.assertEqual(response["payload"]["details"], {"field": field})
+
+            submit.assert_not_called()
+            translate.assert_not_called()
+
+    def test_profile_conflict_not_found_and_delete_race_have_stable_codes(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "/easyuse_anima/aio_profiles/save",
+                JsonRequest({"name": "Saved", "settings": {}}),
+                "_save_aio_profile",
+                FileExistsError("C:\\private\\existing.json"),
+                409,
+                "profile_exists",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                JsonRequest(query={"name": "Missing"}),
+                "_load_aio_profile",
+                FileNotFoundError("/home/alice/missing.json"),
+                404,
+                "profile_not_found",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/delete",
+                JsonRequest({"name": "Raced"}),
+                "_delete_aio_profile",
+                FileNotFoundError("deleted after lookup"),
+                404,
+                "profile_not_found",
+            ),
+        )
+
+        for route, request, operation_name, error, status, code in cases:
+            with self.subTest(route=route, code=code):
+                with patch.object(api, operation_name, side_effect=error):
+                    response = asyncio.run(routes.handlers[route](request))
+                self.assertEqual(response["status"], status)
+                self.assertEqual(response["payload"]["code"], code)
+                serialized = json.dumps(response["payload"])
+                self.assertNotIn("private", serialized)
+                self.assertNotIn("/home/", serialized)
+
+    def test_invalid_profile_json_files_have_stable_422_code(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("/easyuse_anima/aio_profiles/load", "AIO_PROFILE_DIR"),
+            ("/easyuse_anima/lora_profiles/load", "LORA_PROFILE_DIR"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for route, directory_name in cases:
+                with self.subTest(route=route):
+                    (root / "Broken.json").write_text("{", encoding="utf-8")
+                    with patch.object(api, directory_name, root):
+                        response = asyncio.run(
+                            routes.handlers[route](JsonRequest(query={"name": "Broken"}))
+                        )
+                    self.assertEqual(response["status"], 422)
+                    self.assertEqual(response["payload"]["code"], "invalid_profile_data")
+                    self.assertEqual(response["payload"]["message"], "Profile data is invalid")
+
+    def test_public_validation_error_does_not_echo_path_stack_or_secret(self):
+        api, routes = load_api_routes()
+        secret = "C:\\Users\\alice\\profile.json API_TOKEN=top-secret"
+        with patch.object(api, "_save_aio_profile", side_effect=ValueError(secret)):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/aio_profiles/save"](
+                    JsonRequest({"name": "Safe", "settings": {}})
+                )
+            )
+
+        self.assertEqual(response["status"], 422)
+        self.assertEqual(response["payload"]["code"], "invalid_request")
+        self.assertEqual(response["payload"]["message"], "Request validation failed")
+        serialized = json.dumps(response["payload"])
+        for forbidden in ("alice", "profile.json", "API_TOKEN", "top-secret", "Traceback"):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_unexpected_worker_exception_is_not_reclassified(self):
+        api, routes = load_api_routes()
+        with patch.object(
+            api,
+            "_list_aio_profiles",
+            side_effect=RuntimeError("storage programming error"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "storage programming error"):
+                asyncio.run(routes.handlers["/easyuse_anima/aio_profiles"](JsonRequest()))
+
+    def test_normal_settings_and_profile_success_payloads_remain_compatible(self):
+        api, routes = load_api_routes()
+        settings_payload = {
+            "autocomplete.source": "dbr_danbooru_2025_09_01",
+            "autocomplete.limit": 20,
+        }
+        with patch.object(api, "_get_settings_payload_sync", return_value=settings_payload):
+            settings_response = asyncio.run(
+                routes.handlers["/easyuse_anima/settings"](JsonRequest())
+            )
+        self.assertEqual(settings_response, {"payload": settings_payload, "status": 200})
+
+        saved_profile = {"name": "Saved", "settings": {"future": {"kept": True}}}
+        with patch.object(api, "_save_aio_profile", return_value=saved_profile):
+            profile_response = asyncio.run(
+                routes.handlers["/easyuse_anima/aio_profiles/save"](
+                    JsonRequest({"name": "Saved", "settings": saved_profile["settings"]})
+                )
+            )
+        self.assertEqual(
+            profile_response,
+            {
+                "payload": {"status": "ok", "profile": saved_profile},
+                "status": 200,
+            },
+        )
+
+
+class ApiPathRedactionTests(unittest.TestCase):
+    def assert_no_absolute_path(self, payload):
+        for value in response_strings(payload):
+            self.assertIsNone(re.match(r"^[A-Za-z]:[\\/]", value), value)
+            self.assertFalse(value.startswith("/home/"), value)
+            self.assertFalse(value.startswith("/Users/"), value)
+
+    def test_autocomplete_status_replaces_all_paths_with_public_source_metadata(self):
+        api, routes = load_api_routes()
+        with (
+            patch.object(api, "resolve_autocomplete_source", return_value="selected"),
+            patch.object(
+                api,
+                "resolve_autocomplete_source_path",
+                return_value=("selected", Path(r"C:\Users\alice\secret.csv")),
+            ),
+            patch.object(
+                api,
+                "autocomplete_status",
+                return_value={
+                    "path": r"C:\Users\alice\secret.csv",
+                    "exists": True,
+                    "count": 5,
+                    "mtime": 1,
+                },
+            ),
+            patch.object(
+                api,
+                "available_autocomplete_sources",
+                return_value=[
+                    {
+                        "key": "selected",
+                        "label": "Selected dataset",
+                        "path": "/home/alice/secret.csv",
+                        "exists": True,
+                        "selected": True,
+                    }
+                ],
+            ),
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/autocomplete_status"](JsonRequest())
+            )
+
+        payload = response["payload"]
+        self.assertEqual(payload["source"], "selected")
+        self.assertEqual(payload["source_label"], "Selected dataset")
+        self.assertNotIn("path", payload)
+        self.assertTrue(all("path" not in source for source in payload["sources"]))
+        self.assert_no_absolute_path(payload)
+
+    def test_wildcard_roots_keep_string_list_compatibility_without_paths(self):
+        api, routes = load_api_routes()
+        secret_roots = [Path(r"C:\Users\alice\wildcards"), Path("/home/alice/wildcards")]
+        with (
+            patch.object(
+                api,
+                "public_settings",
+                return_value={
+                    "wildcard.extra_paths": "C:\\Users\\alice\\wildcards\n/home/alice/wildcards"
+                },
+            ),
+            patch.object(api, "resolve_wildcard_roots", return_value=secret_roots),
+            patch.object(api, "list_wildcards", return_value=["artist/name"]),
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/wildcards"](JsonRequest())
+            )
+
+        payload = response["payload"]
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["items"], ["artist/name"])
+        self.assertEqual(payload["roots"], ["wildcard:1", "wildcard:2"])
+        self.assertTrue(all(isinstance(root, str) for root in payload["roots"]))
+        self.assertEqual(
+            [source["label"] for source in payload["sources"]],
+            ["Wildcard source 1", "Wildcard source 2"],
+        )
+        self.assert_no_absolute_path(payload)
+
+
+class ApiFileIoOffloadTests(unittest.TestCase):
+    def test_slow_scan_save_and_stat_leave_event_loop_heartbeat_running(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "/easyuse_anima/autocomplete_status",
+                JsonRequest(),
+                "_autocomplete_status_payload_sync",
+                {"source": "safe", "source_label": "Safe", "sources": []},
+            ),
+            (
+                "/easyuse_anima/aio_profiles/save",
+                JsonRequest({"name": "Saved", "settings": {}}),
+                "_save_aio_profile",
+                {"name": "Saved", "settings": {}},
+            ),
+            (
+                "/easyuse_anima/aio_profiles",
+                JsonRequest(),
+                "_list_aio_profiles",
+                [],
+            ),
+        )
+
+        for route, request, operation_name, result in cases:
+            started = threading.Event()
+
+            def slow_operation(*_args, owned_result=result, **_kwargs):
+                started.set()
+                time.sleep(0.05)
+                return owned_result
+
+            async def exercise():
+                heartbeat = 0
+                task = asyncio.create_task(routes.handlers[route](request))
+                while not started.is_set():
+                    await asyncio.sleep(0)
+                while not task.done():
+                    heartbeat += 1
+                    await asyncio.sleep(0.002)
+                return await task, heartbeat
+
+            with self.subTest(route=route):
+                with patch.object(api, operation_name, side_effect=slow_operation):
+                    response, heartbeat = asyncio.run(exercise())
+                self.assertEqual(response["status"], 200)
+                self.assertGreaterEqual(heartbeat, 3)
+
+    def test_file_io_result_exception_and_cancellation_meanings_are_preserved(self):
+        api, _routes = load_api_routes()
+
+        self.assertEqual(asyncio.run(api._run_file_io(lambda: "ok")), "ok")
+        with self.assertRaisesRegex(RuntimeError, "worker failed"):
+            asyncio.run(
+                api._run_file_io(
+                    lambda: (_ for _ in ()).throw(RuntimeError("worker failed"))
+                )
+            )
+
+        started = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+
+        def slow_worker():
+            started.set()
+            release.wait(timeout=1)
+            completed.set()
+
+        async def cancel_wait_only():
+            task = asyncio.create_task(api._run_file_io(slow_worker))
+            while not started.is_set():
+                await asyncio.sleep(0)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            self.assertFalse(completed.is_set())
+            release.set()
+            deadline = asyncio.get_running_loop().time() + 1
+            while not completed.is_set() and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.001)
+            self.assertTrue(completed.is_set())
+
+        asyncio.run(cancel_wait_only())
+
+    def test_repeated_cancellation_does_not_release_slots_before_workers_finish(self):
+        api, _routes = load_api_routes()
+        submitted = 0
+        active = 0
+        peak_active = 0
+
+        async def exercise():
+            nonlocal submitted, active, peak_active
+            release = asyncio.Event()
+
+            async def fake_to_thread(_function, *_args, **_kwargs):
+                nonlocal submitted, active, peak_active
+                submitted += 1
+                active += 1
+                peak_active = max(peak_active, active)
+                try:
+                    await release.wait()
+                finally:
+                    active -= 1
+
+            with patch.object(api.asyncio, "to_thread", new=fake_to_thread):
+                first = [
+                    asyncio.create_task(api._run_file_io(lambda: None))
+                    for _index in range(20)
+                ]
+                while submitted < api.FILE_IO_MAX_IN_FLIGHT:
+                    await asyncio.sleep(0)
+                for task in first:
+                    task.cancel()
+                await asyncio.gather(*first, return_exceptions=True)
+
+                repeated = [
+                    asyncio.create_task(api._run_file_io(lambda: None))
+                    for _index in range(20)
+                ]
+                for _index in range(20):
+                    await asyncio.sleep(0)
+
+                self.assertEqual(submitted, api.FILE_IO_MAX_IN_FLIGHT)
+                self.assertEqual(active, api.FILE_IO_MAX_IN_FLIGHT)
+                self.assertEqual(peak_active, api.FILE_IO_MAX_IN_FLIGHT)
+
+                for task in repeated:
+                    task.cancel()
+                await asyncio.gather(*repeated, return_exceptions=True)
+                release.set()
+                deadline = asyncio.get_running_loop().time() + 1
+                while active and asyncio.get_running_loop().time() < deadline:
+                    await asyncio.sleep(0)
+                self.assertEqual(active, 0)
+                self.assertEqual(submitted, api.FILE_IO_MAX_IN_FLIGHT)
+
+        asyncio.run(exercise())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -312,6 +312,53 @@ class ApiRequestContractTests(unittest.TestCase):
                     ):
                         self.assertNotIn(forbidden, serialized)
 
+    def test_aio_rename_rejects_stored_corruption_without_moving_source(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("non-object root", b"[]"),
+            ("invalid settings", b'{"settings": []}'),
+            ("invalid JSON", b"{"),
+            (
+                "invalid UTF-8",
+                b"\xffC:\\Users\\alice\\secret.json API_TOKEN=top-secret",
+            ),
+        )
+        handler = routes.handlers["/easyuse_anima/aio_profiles/rename"]
+
+        for label, source_bytes in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                source = root / "Source.json"
+                target = root / "Target.json"
+                source.write_bytes(source_bytes)
+
+                with patch.object(api, "AIO_PROFILE_DIR", root):
+                    response = asyncio.run(
+                        handler(
+                            JsonRequest(
+                                {"old_name": "Source", "new_name": "Target"}
+                            )
+                        )
+                    )
+
+                self.assertEqual(response["status"], 422)
+                self.assertEqual(response["payload"]["code"], "invalid_profile_data")
+                self.assertEqual(
+                    response["payload"]["message"],
+                    "Profile data is invalid",
+                )
+                self.assertEqual(source.read_bytes(), source_bytes)
+                self.assertFalse(target.exists())
+                self.assertFalse((root / "Target.json.bak").exists())
+                serialized = json.dumps(response["payload"])
+                for forbidden in (
+                    "alice",
+                    "secret.json",
+                    "API_TOKEN",
+                    "top-secret",
+                ):
+                    self.assertNotIn(forbidden, serialized)
+
     def test_empty_profile_file_compatibility_boundary_is_preserved(self):
         api, routes = load_api_routes()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_lora_profiles.py
+++ b/tests/test_lora_profiles.py
@@ -418,10 +418,15 @@ class LoraProfileApiRouteTests(unittest.TestCase):
                         handler(JsonRequest({**self.BASE_PAYLOAD, "overwrite": overwrite}))
                     )
 
-                self.assertEqual(response["status"], 400)
+                self.assertEqual(response["status"], 422)
                 self.assertEqual(
                     response["payload"],
-                    {"status": "error", "message": "overwrite must be a JSON boolean"},
+                    {
+                        "status": "error",
+                        "code": "invalid_request",
+                        "message": "overwrite must be a JSON boolean.",
+                        "details": {"field": "overwrite"},
+                    },
                 )
                 operation.assert_not_called()
 
@@ -439,7 +444,11 @@ class LoraProfileApiRouteTests(unittest.TestCase):
         self.assertEqual(response["status"], 409)
         self.assertEqual(
             response["payload"],
-            {"status": "error", "message": "Profile already exists"},
+            {
+                "status": "error",
+                "code": "profile_exists",
+                "message": "Profile already exists",
+            },
         )
 
 

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -256,27 +256,47 @@ class PromptTranslationApiTests(unittest.TestCase):
         api, routes, translation = self.load_routes()
         handler = routes.handlers[ROUTE]
         settings = translation.PromptTranslationSettings(provider="google")
-        with (
-            patch.object(api, "resolve_prompt_translation_settings", return_value=settings),
-            patch.object(
-                api,
-                "translate_prompt_markers",
-                side_effect=translation.TranslationProviderUnavailableError(),
+        cases = (
+            (
+                translation.TranslationProviderUnavailableError(),
+                503,
+                "translation_provider_unavailable",
+                "The selected translation provider is unavailable.",
             ),
-        ):
-            response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
-
-        self.assertEqual(
-            response,
-            {
-                "payload": {
-                    "status": "error",
-                    "code": "translation_provider_unavailable",
-                    "message": "The selected translation provider is unavailable.",
-                },
-                "status": 503,
-            },
+            (
+                translation.TranslationUpstreamError(),
+                502,
+                "translation_upstream_error",
+                "The translation provider request failed.",
+            ),
         )
+        for error, status, code, message in cases:
+            with self.subTest(code=code):
+                with (
+                    patch.object(
+                        api,
+                        "resolve_prompt_translation_settings",
+                        return_value=settings,
+                    ),
+                    patch.object(
+                        api,
+                        "translate_prompt_markers",
+                        side_effect=error,
+                    ),
+                ):
+                    response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+
+                self.assertEqual(
+                    response,
+                    {
+                        "payload": {
+                            "status": "error",
+                            "code": code,
+                            "message": message,
+                        },
+                        "status": status,
+                    },
+                )
 
     def test_route_does_not_mask_settings_or_payload_programming_errors_as_upstream(self):
         api, routes, _translation = self.load_routes()
@@ -295,8 +315,9 @@ class PromptTranslationApiTests(unittest.TestCase):
                     with self.assertRaisesRegex(type(error), str(error)):
                         asyncio.run(handler(JsonRequest({"text": "%{text}"})))
 
-        with self.assertRaises(AttributeError):
-            asyncio.run(handler(JsonRequest([])))
+        response = asyncio.run(handler(JsonRequest([])))
+        self.assertEqual(response["status"], 400)
+        self.assertEqual(response["payload"]["code"], "json_object_required")
 
     def test_all_marker_budgets_return_413_before_provider_resolution(self):
         api, routes, translation = self.load_routes()

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -104,14 +104,27 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "GOOGLE_TRANSLATION_API_KEY",
             "os.environ",
         )
-        for filename in ("__init__.py", "api.py", "nodes.py", "prompt_translation.py", "settings.py"):
+        for filename in (
+            "__init__.py",
+            "api.py",
+            "api_contract.py",
+            "nodes.py",
+            "prompt_translation.py",
+            "settings.py",
+        ):
             source = (ROOT / filename).read_text(encoding="utf-8")
             for pattern in patterns:
                 with self.subTest(filename=filename, pattern=pattern):
                     self.assertNotIn(pattern, source)
 
     def test_naia_is_only_documented_runtime_post_call(self):
-        runtime_files = ("api.py", "nodes.py", "prompt_translation.py", "settings.py")
+        runtime_files = (
+            "api.py",
+            "api_contract.py",
+            "nodes.py",
+            "prompt_translation.py",
+            "settings.py",
+        )
         matches = []
         for filename in runtime_files:
             source = (ROOT / filename).read_text(encoding="utf-8")
@@ -225,6 +238,22 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             f"autocomplete static import closure is excluded from the Registry package: "
             f"{sorted(closure & ignored)}",
         )
+
+    def test_api_contract_runtime_module_is_in_registry_package_surface(self):
+        runtime_path = "api_contract.py"
+        self.assertTrue((ROOT / runtime_path).is_file())
+        self.assertIn("from .api_contract import (", (ROOT / "api.py").read_text(encoding="utf-8"))
+
+        tracked = _git_paths("ls-files", "--cached")
+        self.assertIn(runtime_path, tracked)
+
+        ignored = _git_paths(
+            "ls-files",
+            "--cached",
+            "--ignored",
+            "--exclude-from=.comfyignore",
+        )
+        self.assertNotIn(runtime_path, ignored)
 
     def test_registry_safety_doc_is_linked_from_development_entry(self):
         entry = (ROOT / "docs" / "development" / "README.md").read_text(encoding="utf-8")

--- a/web/js/easyuse_anima_api.js
+++ b/web/js/easyuse_anima_api.js
@@ -24,6 +24,24 @@ export async function easyuseAnimaReadTextResponse(response, fallback = "") {
   }
 }
 
+function easyuseAnimaApiError(response, data, errorMessage) {
+  const message = data?.message
+    || response.statusText
+    || (response.status ? `HTTP ${response.status}` : errorMessage)
+    || DEFAULT_REQUEST_FAILED;
+  const error = /** @type {Error & {status: number, code?: string, details?: any}} */ (
+    new Error(message)
+  );
+  error.status = Number(response?.status) || 0;
+  if (typeof data?.code === "string" && data.code) {
+    error.code = data.code;
+  }
+  if (data?.details !== undefined) {
+    error.details = data.details;
+  }
+  return error;
+}
+
 export async function easyuseAnimaFetchJson(url, options = {}) {
   const {
     fetcher = fetch,
@@ -34,7 +52,7 @@ export async function easyuseAnimaFetchJson(url, options = {}) {
   const response = await fetcher(url, fetchOptions);
   const data = await easyuseAnimaReadJsonResponse(response, fallbackJson);
   if (!response.ok) {
-    throw new Error(data?.message || response.statusText || (response.status ? `HTTP ${response.status}` : errorMessage) || DEFAULT_REQUEST_FAILED);
+    throw easyuseAnimaApiError(response, data, errorMessage);
   }
   return data;
 }


### PR DESCRIPTION
## 변경 요약

- handler별 JSON body 처리를 `api_contract.py`의 공통 JSON object parser와 typed field validation으로 정리했습니다.
- 오류 응답은 기존 `{status, message}` 소비를 유지하면서 stable `code`와 안전한 경우의 `details`를 additive로 제공합니다.
- malformed/non-object/schema/profile conflict/not-found/stored-data 오류를 400/422/409/404 계약으로 고정했습니다.
- 저장된 LoRA/AiO profile의 non-object root, invalid schema, invalid JSON, invalid UTF-8를 422 `invalid_profile_data`로 정규화하고 경로·원문 노출을 막았습니다. AIO load/rename은 같은 stored-payload normalizer를 공유하며 손상 source rename은 원본을 보존하고 target을 만들지 않습니다. LoRA 빈 파일 및 JSON-string `profile_data` legacy 호환은 유지했습니다.
- autocomplete status/search/classify의 nested `status.path`와 wildcard root 절대 경로를 public source ID/display metadata로 대체했습니다.
- settings/profile/autocomplete/wildcard의 명시된 bounded file 작업을 event loop 밖으로 이동했습니다. caller cancellation은 기다림만 중단하며 실제 worker 완료 callback이 4-slot admission 해제와 예외 회수를 담당합니다.
- loop별 limiter registry는 weak value를 사용해 contended semaphore가 closed loop를 되살리지 않도록 했습니다.
- frontend shared API transport가 legacy 오류와 coded 오류를 모두 처리하고 `status/code/details`를 Error에 additive로 전달합니다.
- #164의 translation 전용 worker와 499/502/503/504 route-local mapping은 그대로 유지합니다.
- 최신 `dev`의 #193을 통합하고 root `api_contract.py`를 Phase C 임시 표면, 장기 D-02/D-14 이동 대상으로 문서화했습니다.

Relates to #165

## 주요 파일

- `api_contract.py`: JSON object parsing, additive error payload, typed field validation
- `api.py`: 대상 route mapping, profile stored-data taxonomy, path redaction, bounded blocking-I/O offload
- `web/js/easyuse_anima_api.js`: legacy/new error response migration compatibility
- `tests/test_api_contract.py`: parser/schema/error/redaction/heartbeat/cancellation/loop-GC/stored-data deterministic regressions
- `tests/test_aio_profiles.py`, `tests/test_lora_profiles.py`, `tests/test_prompt_translation_api.py`: 기존 profile/translation 계약 회귀
- `tests/test_registry_scanner_safety.py`: `.comfyignore` 및 Registry package closure
- `tests/frontend_aio_profile_api_client_smoke.mjs`: legacy/coded frontend error compatibility
- `docs/architecture/python-backend.md`, `docs/architecture/python-compatibility-shims.md`: Phase C current state와 D-02/D-14 target/inventory

## 호환 및 보안 전략

- 성공 payload는 기존 형태를 유지합니다.
- 오류 payload의 기존 `status: "error"`와 `message`는 유지하고 `code`를 추가했습니다.
- wildcard `roots`는 기존 list-of-strings 타입을 유지하되 절대 경로 대신 `wildcard:N` source ID를 반환하고 additive `sources` display metadata를 제공합니다.
- autocomplete status/search/classify는 `status.path`만 제거하고 query/results/tokens 및 다른 status/additive 필드는 유지합니다.
- request ID, debug/admin flag, 전역 middleware, RuntimeServices, package migration은 추가하지 않았습니다.
- 내부 예외의 stack, 로컬 절대 경로, invalid UTF-8 원문, secret 문자열은 public error에 반영하지 않습니다.

## Focused 검증

- `python -m unittest discover -s tests -p test_api_contract.py -v`: 20 tests OK
- `python -m unittest discover -s tests -p test_prompt_translation_api.py -v`: 6 tests OK
- `python -m unittest discover -s tests -p test_aio_profiles.py`: 25 tests OK
- `python -m unittest discover -s tests -p test_lora_profiles.py`: 18 tests OK
- `python -m unittest discover -s tests -p test_registry_scanner_safety.py -v`: 7 tests OK
- `node tests/frontend_aio_profile_api_client_smoke.mjs`: passed
- `tools/check_project.ps1 -Profile quick`: passed
  - Python compile
  - frontend syntax/semantic smokes
  - 110 JavaScript files
  - TypeScript 6.0.3
  - staged/unstaged diff check
- `git diff --check origin/dev...HEAD`: passed
- 공식 `tools/check_custom_node.ps1 -Profile full` (exact HEAD `7ecee711`): passed
  - Python unittest: 559 tests OK
  - frontend: 110 JavaScript files 및 semantic smoke passed
  - TypeScript 6.0.3, Python compile, git diff check passed

## 검증 표면과 남은 위험

- ComfyUI Codex test environment: focused unittest 및 static/frontend smoke
- Python full unittest suite: 559 tests OK
- Live ComfyUI API/browser smoke: 미실행 — deterministic API route/storage/frontend smoke로 이번 변경 표면을 검증
- limiter는 Issue #165 범위의 최소 loop-local helper이며 장기 runtime ownership은 이 PR 범위 밖입니다.
- `api_contract.py`는 Phase C 임시 root implementation이며 D-02/D-14 이동 전까지 Registry closure를 유지해야 합니다.
- 메인 actual diff 검토와 독립 최종 리뷰에서 추가 차단점이 없음을 확인했습니다.
- `request_id`와 debug/admin 경계는 이 PR 범위에서 제외하며 #165 후속으로 유지합니다.