### PR TITLE
chore: autocomplete 검색을 versioned SQLite index로 전환

### DIFF
--- a/autocomplete_dataset.py
+++ b/autocomplete_dataset.py
@@ -15,17 +15,33 @@ from types import MappingProxyType
 from typing import Mapping
 
 try:
+    from .autocomplete_index import (
+        AutocompleteIndexDiagnostics,
+        AutocompleteIndexSource,
+        AutocompleteIndexUnavailable,
+        search_autocomplete_index,
+    )
     from .anima_prompt.knowledge import PACKAGE_DATA_DIR
     from .anima_prompt.models import TagSection
     from .anima_prompt.ordering import builtin_tag_section
     from .anima_prompt.parser import parse_prompt
     from .prompt_translation import iter_prompt_translation_markers
+    from .storage import PACKAGE_DATA_DIR as STORAGE_PACKAGE_DATA_DIR
+    from .storage import USER_DATA_DIR
 except ImportError:
+    from autocomplete_index import (
+        AutocompleteIndexDiagnostics,
+        AutocompleteIndexSource,
+        AutocompleteIndexUnavailable,
+        search_autocomplete_index,
+    )
     from anima_prompt.knowledge import PACKAGE_DATA_DIR
     from anima_prompt.models import TagSection
     from anima_prompt.ordering import builtin_tag_section
     from anima_prompt.parser import parse_prompt
     from prompt_translation import iter_prompt_translation_markers
+    from storage import PACKAGE_DATA_DIR as STORAGE_PACKAGE_DATA_DIR
+    from storage import USER_DATA_DIR
 
 DBR_TAG_ARCHIVE_SOURCE = "https://github.com/DraconicDragon/dbr-e621-lists-archive"
 DBR_TAG_ARCHIVE_LICENSE = "Unlicense"
@@ -95,6 +111,19 @@ _MERGED_E621_CATEGORY_NAMES = {
 _AUTOCOMPLETE_CACHE_SCHEMA_VERSION = 1
 _AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS = 4
 _MISSING_FILE_STAT = -1
+
+
+def _default_autocomplete_index_dir() -> Path | None:
+    user_data_dir = Path(USER_DATA_DIR).resolve(strict=False)
+    package_data_dir = Path(STORAGE_PACKAGE_DATA_DIR).resolve(strict=False)
+    if user_data_dir == package_data_dir:
+        # Standalone imports do not have a ComfyUI-owned writable user-data
+        # boundary. Keep the source/package tree immutable in that case.
+        return None
+    return user_data_dir / "autocomplete_index"
+
+
+_AUTOCOMPLETE_INDEX_DIR = _default_autocomplete_index_dir()
 _COUNT_RE = re.compile(
     r"^\d+\s*(girl|girls|boy|boys|person|people|other|others|animal|animals|"
     r"female|females|male|males|child|children)s?$",
@@ -812,33 +841,104 @@ def _top_autocomplete_matches(
     )
 
 
-def search_autocomplete(
+def _index_source(key: _AutocompleteCacheKey) -> AutocompleteIndexSource:
+    return AutocompleteIndexSource(
+        resolved_path=key.resolved_path,
+        revision=f"{key.schema_version}:{key.mtime_ns}:{key.size}",
+    )
+
+
+def _validate_index_source(key: _AutocompleteCacheKey) -> None:
+    if _cache_key_from_resolved_path(Path(key.resolved_path)) != key:
+        raise _AutocompleteSourceChanged(key.resolved_path)
+
+
+def _fallback_index_diagnostics(
+    key: _AutocompleteCacheKey,
+    snapshot: _AutocompleteSnapshot,
+    reason: str,
+) -> AutocompleteIndexDiagnostics:
+    return AutocompleteIndexDiagnostics(
+        outcome="fallback",
+        reason=reason,
+        backend="python_snapshot",
+        source_revision=_index_source(key).revision,
+        entry_count=len(snapshot.entries),
+        index_path=None,
+    )
+
+
+def _search_autocomplete_with_diagnostics(
     query: str,
     limit: int = 20,
     path: Path = AUTOCOMPLETE_CSV,
     category: str | None = None,
-) -> dict:
+) -> tuple[dict, AutocompleteIndexDiagnostics]:
     started = time.perf_counter()
     effective_limit = max(1, min(limit, 100))
     normalized_query = _normalize(query)
     category = str(category or "").strip()
     categories = {item.strip() for item in category.split(",") if item.strip()}
-    if not normalized_query:
-        return {
-            "query": query,
-            "results": [],
-            "status": autocomplete_status(path),
-            "elapsed_ms": 0,
-        }
 
-    snapshot = _snapshot(path)
-    limited = _top_autocomplete_matches(
-        snapshot.entries,
-        normalized_query,
-        categories,
-        effective_limit,
-    )
-    return {
+    for _attempt in range(_AUTOCOMPLETE_CACHE_LOAD_ATTEMPTS):
+        key = _cache_key(path)
+        if key.mtime_ns == _MISSING_FILE_STAT:
+            snapshot = _snapshot(path)
+            key = snapshot.key
+            if key.mtime_ns != _MISSING_FILE_STAT:
+                continue
+            diagnostics = _fallback_index_diagnostics(key, snapshot, "missing_source")
+            limited: list[tuple[int, AutocompleteEntry]] = []
+            entry_count = 0
+            indexed_entries = None
+            break
+
+        try:
+            indexed = search_autocomplete_index(
+                root=_AUTOCOMPLETE_INDEX_DIR,
+                source=_index_source(key),
+                normalized_query=normalized_query,
+                categories=categories,
+                limit=effective_limit,
+                load_entries=lambda: _load_entries(Path(key.resolved_path)),
+                validate_source=lambda: _validate_index_source(key),
+            )
+        except _AutocompleteSourceChanged:
+            continue
+        except AutocompleteIndexUnavailable as error:
+            snapshot = _snapshot(path)
+            key = snapshot.key
+            diagnostics = _fallback_index_diagnostics(key, snapshot, error.reason)
+            limited = _top_autocomplete_matches(
+                snapshot.entries,
+                normalized_query,
+                categories,
+                effective_limit,
+            )
+            entry_count = len(snapshot.entries)
+            indexed_entries = None
+        else:
+            try:
+                _validate_index_source(key)
+            except _AutocompleteSourceChanged:
+                continue
+            diagnostics = indexed.diagnostics
+            limited = []
+            entry_count = indexed.diagnostics.entry_count
+            indexed_entries = indexed.entries
+        break
+    else:
+        resolved_path = Path(path).resolve(strict=False)
+        raise RuntimeError(
+            f"Autocomplete dataset changed repeatedly while loading: {resolved_path}"
+        ) from None
+
+    if indexed_entries is None:
+        result_entries = [entry for _, entry in limited]
+    else:
+        result_entries = indexed_entries
+
+    payload = {
         "query": query,
         "category": category,
         "results": [
@@ -848,8 +948,32 @@ def search_autocomplete(
                 "count": entry.count,
                 "description": entry.description,
             }
-            for _, entry in limited
+            for entry in result_entries
         ],
-        "status": _snapshot_status(snapshot, path),
+        "status": _status_from_key(key, path, entry_count),
         "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
     }
+    return payload, diagnostics
+
+
+def search_autocomplete(
+    query: str,
+    limit: int = 20,
+    path: Path = AUTOCOMPLETE_CSV,
+    category: str | None = None,
+) -> dict:
+    normalized_query = _normalize(query)
+    if not normalized_query:
+        return {
+            "query": query,
+            "results": [],
+            "status": autocomplete_status(path),
+            "elapsed_ms": 0,
+        }
+    payload, _diagnostics = _search_autocomplete_with_diagnostics(
+        query,
+        limit=limit,
+        path=path,
+        category=category,
+    )
+    return payload

--- a/autocomplete_index.py
+++ b/autocomplete_index.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import tempfile
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+
+AUTOCOMPLETE_INDEX_SCHEMA_VERSION = 1
+_SQLITE_TIMEOUT_SECONDS = 0.1
+
+
+@dataclass(frozen=True, slots=True)
+class AutocompleteIndexSource:
+    resolved_path: str
+    revision: str
+
+    @property
+    def identity(self) -> str:
+        normalized = os.path.normcase(self.resolved_path)
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class IndexedAutocompleteEntry:
+    tag: str
+    category: str
+    count: int
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class AutocompleteIndexDiagnostics:
+    outcome: str
+    reason: str
+    backend: str
+    source_revision: str
+    entry_count: int
+    index_path: Path | None
+
+
+@dataclass(frozen=True, slots=True)
+class AutocompleteIndexResult:
+    entries: tuple[IndexedAutocompleteEntry, ...]
+    diagnostics: AutocompleteIndexDiagnostics
+
+
+class AutocompleteIndexUnavailable(RuntimeError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class _InvalidAutocompleteIndex(RuntimeError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+_INDEX_LOCKS: dict[str, threading.Lock] = {}
+_INDEX_LOCKS_GUARD = threading.Lock()
+
+
+def _index_path(root: Path, source: AutocompleteIndexSource) -> Path:
+    return Path(root) / f"autocomplete-{source.identity[:24]}.sqlite3"
+
+
+def _index_lock(path: Path) -> threading.Lock:
+    # Do not use Path.resolve() here. On Windows its canonicalization can
+    # differ before and after the index directory is created, splitting first
+    # access across two locks for the same eventual file.
+    key = os.path.normcase(os.path.abspath(path))
+    with _INDEX_LOCKS_GUARD:
+        lock = _INDEX_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _INDEX_LOCKS[key] = lock
+        return lock
+
+
+def _is_locked_error(error: BaseException) -> bool:
+    message = str(error).casefold()
+    return "locked" in message or "busy" in message
+
+
+def _readonly_connection(path: Path) -> sqlite3.Connection:
+    if not path.is_file():
+        raise _InvalidAutocompleteIndex("missing")
+    uri = f"{path.resolve().as_uri()}?mode=ro"
+    connection: sqlite3.Connection | None = None
+    try:
+        connection = sqlite3.connect(
+            uri,
+            uri=True,
+            timeout=_SQLITE_TIMEOUT_SECONDS,
+        )
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA query_only = ON")
+        return connection
+    except sqlite3.OperationalError as error:
+        if connection is not None:
+            connection.close()
+        if _is_locked_error(error):
+            raise AutocompleteIndexUnavailable("locked") from error
+        raise _InvalidAutocompleteIndex("unreadable") from error
+    except (OSError, sqlite3.DatabaseError) as error:
+        if connection is not None:
+            connection.close()
+        raise _InvalidAutocompleteIndex("unreadable") from error
+
+
+def _read_metadata(
+    connection: sqlite3.Connection,
+    source: AutocompleteIndexSource,
+) -> tuple[int, str]:
+    try:
+        user_version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        row = connection.execute(
+            "SELECT schema_version, source_identity, source_revision, "
+            "entry_count, backend FROM autocomplete_index_metadata WHERE id = 1"
+        ).fetchone()
+    except sqlite3.OperationalError as error:
+        if _is_locked_error(error):
+            raise AutocompleteIndexUnavailable("locked") from error
+        raise _InvalidAutocompleteIndex("corrupt") from error
+    except sqlite3.DatabaseError as error:
+        raise _InvalidAutocompleteIndex("corrupt") from error
+
+    if row is None:
+        raise _InvalidAutocompleteIndex("corrupt")
+    try:
+        schema_version = int(row["schema_version"])
+    except (TypeError, ValueError) as error:
+        raise _InvalidAutocompleteIndex("corrupt") from error
+    if user_version != AUTOCOMPLETE_INDEX_SCHEMA_VERSION or (
+        schema_version != AUTOCOMPLETE_INDEX_SCHEMA_VERSION
+    ):
+        raise _InvalidAutocompleteIndex("schema_mismatch")
+    if str(row["source_identity"]) != source.identity:
+        raise _InvalidAutocompleteIndex("source_identity_mismatch")
+    if str(row["source_revision"]) != source.revision:
+        raise _InvalidAutocompleteIndex("source_revision_mismatch")
+
+    backend = str(row["backend"])
+    if backend not in {"fts5_trigram", "sqlite_prefix"}:
+        raise _InvalidAutocompleteIndex("schema_mismatch")
+    try:
+        entry_count = int(row["entry_count"])
+    except (TypeError, ValueError) as error:
+        raise _InvalidAutocompleteIndex("corrupt") from error
+    if entry_count < 0:
+        raise _InvalidAutocompleteIndex("corrupt")
+    return entry_count, backend
+
+
+def _prefix_upper_bound(value: str) -> str | None:
+    codepoints = [ord(character) for character in value]
+    for index in range(len(codepoints) - 1, -1, -1):
+        if codepoints[index] < 0x10FFFF:
+            codepoints[index] += 1
+            return "".join(chr(codepoint) for codepoint in codepoints[: index + 1])
+    return None
+
+
+def _like_pattern(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _category_clause(categories: set[str]) -> tuple[str, list[str]]:
+    if not categories:
+        return "", []
+    ordered = sorted(categories)
+    placeholders = ", ".join("?" for _ in ordered)
+    return f" AND e.category IN ({placeholders})", ordered
+
+
+def _fetch_tier(
+    connection: sqlite3.Connection,
+    from_clause: str,
+    conditions: str,
+    parameters: list[object],
+    categories: set[str],
+    limit: int,
+) -> list[sqlite3.Row]:
+    if limit <= 0:
+        return []
+    category_sql, category_parameters = _category_clause(categories)
+    sql = (
+        "SELECT e.tag, e.category, e.count, e.description "
+        f"FROM {from_clause} WHERE {conditions}{category_sql} "
+        "ORDER BY e.count DESC, e.tag ASC, e.id ASC LIMIT ?"
+    )
+    try:
+        return list(
+            connection.execute(
+                sql,
+                [*parameters, *category_parameters, limit],
+            ).fetchall()
+        )
+    except sqlite3.OperationalError as error:
+        if _is_locked_error(error):
+            raise AutocompleteIndexUnavailable("locked") from error
+        raise _InvalidAutocompleteIndex("corrupt") from error
+    except sqlite3.DatabaseError as error:
+        raise _InvalidAutocompleteIndex("corrupt") from error
+
+
+def _query_rows(
+    connection: sqlite3.Connection,
+    normalized_query: str,
+    categories: set[str],
+    limit: int,
+    backend: str,
+) -> tuple[IndexedAutocompleteEntry, ...]:
+    rows: list[sqlite3.Row] = []
+
+    rows.extend(
+        _fetch_tier(
+            connection,
+            "autocomplete_entries AS e",
+            "e.tag_key = ?",
+            [normalized_query],
+            categories,
+            limit,
+        )
+    )
+
+    remaining = limit - len(rows)
+    upper_bound = _prefix_upper_bound(normalized_query)
+    if remaining > 0 and upper_bound is not None:
+        rows.extend(
+            _fetch_tier(
+                connection,
+                "autocomplete_entries AS e",
+                "e.tag_key >= ? AND e.tag_key < ? AND e.tag_key <> ?",
+                [normalized_query, upper_bound, normalized_query],
+                categories,
+                remaining,
+            )
+        )
+
+    remaining = limit - len(rows)
+    use_trigram = backend == "fts5_trigram" and len(normalized_query) >= 3
+    if remaining > 0:
+        if use_trigram:
+            from_clause = (
+                "autocomplete_entries_fts AS f "
+                "JOIN autocomplete_entries AS e ON e.id = f.rowid"
+            )
+            conditions = (
+                "f.tag_key LIKE ? ESCAPE '\\' "
+                "AND instr(e.tag_key, ?) > 0 "
+                "AND substr(e.tag_key, 1, length(?)) <> ?"
+            )
+            parameters = [
+                _like_pattern(normalized_query),
+                normalized_query,
+                normalized_query,
+                normalized_query,
+            ]
+        else:
+            from_clause = "autocomplete_entries AS e"
+            conditions = (
+                "instr(e.tag_key, ?) > 0 "
+                "AND substr(e.tag_key, 1, length(?)) <> ?"
+            )
+            parameters = [normalized_query, normalized_query, normalized_query]
+        rows.extend(
+            _fetch_tier(
+                connection,
+                from_clause,
+                conditions,
+                parameters,
+                categories,
+                remaining,
+            )
+        )
+
+    remaining = limit - len(rows)
+    if remaining > 0:
+        if use_trigram:
+            from_clause = (
+                "autocomplete_entries_fts AS f "
+                "JOIN autocomplete_entries AS e ON e.id = f.rowid"
+            )
+            conditions = (
+                "f.search LIKE ? ESCAPE '\\' "
+                "AND instr(e.search, ?) > 0 AND instr(e.tag_key, ?) = 0"
+            )
+            parameters = [
+                _like_pattern(normalized_query),
+                normalized_query,
+                normalized_query,
+            ]
+        else:
+            from_clause = "autocomplete_entries AS e"
+            conditions = "instr(e.search, ?) > 0 AND instr(e.tag_key, ?) = 0"
+            parameters = [normalized_query, normalized_query]
+        rows.extend(
+            _fetch_tier(
+                connection,
+                from_clause,
+                conditions,
+                parameters,
+                categories,
+                remaining,
+            )
+        )
+
+    return tuple(
+        IndexedAutocompleteEntry(
+            tag=str(row["tag"]),
+            category=str(row["category"]),
+            count=int(row["count"]),
+            description=str(row["description"]),
+        )
+        for row in rows
+    )
+
+
+def _query_index(
+    path: Path,
+    source: AutocompleteIndexSource,
+    normalized_query: str,
+    categories: set[str],
+    limit: int,
+) -> tuple[tuple[IndexedAutocompleteEntry, ...], int, str]:
+    connection = _readonly_connection(path)
+    try:
+        entry_count, backend = _read_metadata(connection, source)
+        rows = _query_rows(
+            connection,
+            normalized_query,
+            categories,
+            limit,
+            backend,
+        )
+        return rows, entry_count, backend
+    finally:
+        connection.close()
+
+
+def _create_schema(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE autocomplete_index_metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            schema_version INTEGER NOT NULL,
+            source_identity TEXT NOT NULL,
+            source_revision TEXT NOT NULL,
+            entry_count INTEGER NOT NULL,
+            backend TEXT NOT NULL
+        );
+        CREATE TABLE autocomplete_entries (
+            id INTEGER PRIMARY KEY,
+            tag TEXT NOT NULL,
+            tag_key TEXT NOT NULL,
+            category TEXT NOT NULL,
+            count INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            search TEXT NOT NULL
+        );
+        """
+    )
+
+
+def _build_index(
+    path: Path,
+    source: AutocompleteIndexSource,
+    entries: Iterable[object],
+    validate_source: Callable[[], None],
+) -> tuple[int, str]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    os.close(descriptor)
+    temporary_path = Path(temporary_name)
+    connection: sqlite3.Connection | None = None
+    try:
+        connection = sqlite3.connect(temporary_path, timeout=_SQLITE_TIMEOUT_SECONDS)
+        connection.execute("PRAGMA journal_mode = DELETE")
+        connection.execute("PRAGMA synchronous = FULL")
+        connection.execute("BEGIN IMMEDIATE")
+        _create_schema(connection)
+        connection.executemany(
+            "INSERT INTO autocomplete_entries "
+            "(id, tag, tag_key, category, count, description, search) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                (
+                    index,
+                    entry.tag,
+                    entry.tag_key,
+                    entry.category,
+                    entry.count,
+                    entry.description,
+                    entry.search,
+                )
+                for index, entry in enumerate(entries, start=1)
+            ),
+        )
+        entry_count = int(
+            connection.execute("SELECT COUNT(*) FROM autocomplete_entries").fetchone()[0]
+        )
+        connection.executescript(
+            """
+            CREATE INDEX autocomplete_entries_tag_key_idx
+                ON autocomplete_entries(tag_key);
+            CREATE INDEX autocomplete_entries_category_tag_key_idx
+                ON autocomplete_entries(category, tag_key);
+            """
+        )
+
+        backend = "sqlite_prefix"
+        try:
+            connection.execute(
+                "CREATE VIRTUAL TABLE autocomplete_entries_fts USING fts5("
+                "tag_key, search, content='autocomplete_entries', content_rowid='id', "
+                "tokenize='trigram')"
+            )
+            connection.execute(
+                "INSERT INTO autocomplete_entries_fts(autocomplete_entries_fts) "
+                "VALUES ('rebuild')"
+            )
+            backend = "fts5_trigram"
+        except sqlite3.OperationalError:
+            connection.execute("DROP TABLE IF EXISTS autocomplete_entries_fts")
+
+        connection.execute(
+            "INSERT INTO autocomplete_index_metadata "
+            "(id, schema_version, source_identity, source_revision, entry_count, backend) "
+            "VALUES (1, ?, ?, ?, ?, ?)",
+            (
+                AUTOCOMPLETE_INDEX_SCHEMA_VERSION,
+                source.identity,
+                source.revision,
+                entry_count,
+                backend,
+            ),
+        )
+        connection.execute(f"PRAGMA user_version = {AUTOCOMPLETE_INDEX_SCHEMA_VERSION}")
+        connection.commit()
+        connection.close()
+        connection = None
+
+        validate_source()
+        os.replace(temporary_path, path)
+        return entry_count, backend
+    finally:
+        if connection is not None:
+            connection.close()
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _query_or_invalid(
+    path: Path,
+    source: AutocompleteIndexSource,
+    normalized_query: str,
+    categories: set[str],
+    limit: int,
+) -> tuple[tuple[IndexedAutocompleteEntry, ...], int, str]:
+    try:
+        return _query_index(path, source, normalized_query, categories, limit)
+    except AutocompleteIndexUnavailable:
+        raise
+    except _InvalidAutocompleteIndex:
+        raise
+    except sqlite3.OperationalError as error:
+        if _is_locked_error(error):
+            raise AutocompleteIndexUnavailable("locked") from error
+        raise _InvalidAutocompleteIndex("corrupt") from error
+    except sqlite3.DatabaseError as error:
+        raise _InvalidAutocompleteIndex("corrupt") from error
+    except OSError as error:
+        raise AutocompleteIndexUnavailable("unreadable") from error
+
+
+def search_autocomplete_index(
+    *,
+    root: Path | None,
+    source: AutocompleteIndexSource,
+    normalized_query: str,
+    categories: set[str],
+    limit: int,
+    load_entries: Callable[[], Iterable[object]],
+    validate_source: Callable[[], None],
+) -> AutocompleteIndexResult:
+    if root is None:
+        raise AutocompleteIndexUnavailable("disabled")
+
+    path = _index_path(Path(root), source)
+    try:
+        rows, entry_count, backend = _query_or_invalid(
+            path,
+            source,
+            normalized_query,
+            categories,
+            limit,
+        )
+    except _InvalidAutocompleteIndex:
+        with _index_lock(path):
+            try:
+                rows, entry_count, backend = _query_or_invalid(
+                    path,
+                    source,
+                    normalized_query,
+                    categories,
+                    limit,
+                )
+            except _InvalidAutocompleteIndex as current_invalid:
+                rebuild_reason = current_invalid.reason
+                try:
+                    _build_index(
+                        path,
+                        source,
+                        load_entries(),
+                        validate_source,
+                    )
+                    rows, entry_count, backend = _query_or_invalid(
+                        path,
+                        source,
+                        normalized_query,
+                        categories,
+                        limit,
+                    )
+                except AutocompleteIndexUnavailable:
+                    raise
+                except _InvalidAutocompleteIndex as error:
+                    raise AutocompleteIndexUnavailable("rebuild_unreadable") from error
+                except sqlite3.OperationalError as error:
+                    reason = "locked" if _is_locked_error(error) else "build_failed"
+                    raise AutocompleteIndexUnavailable(reason) from error
+                except (OSError, sqlite3.DatabaseError) as error:
+                    raise AutocompleteIndexUnavailable("build_failed") from error
+                diagnostics = AutocompleteIndexDiagnostics(
+                    outcome="rebuild",
+                    reason=rebuild_reason,
+                    backend=backend,
+                    source_revision=source.revision,
+                    entry_count=entry_count,
+                    index_path=path,
+                )
+                return AutocompleteIndexResult(entries=rows, diagnostics=diagnostics)
+            else:
+                diagnostics = AutocompleteIndexDiagnostics(
+                    outcome="hit",
+                    reason="concurrent_reuse",
+                    backend=backend,
+                    source_revision=source.revision,
+                    entry_count=entry_count,
+                    index_path=path,
+                )
+                return AutocompleteIndexResult(entries=rows, diagnostics=diagnostics)
+    else:
+        diagnostics = AutocompleteIndexDiagnostics(
+            outcome="hit",
+            reason="valid",
+            backend=backend,
+            source_revision=source.revision,
+            entry_count=entry_count,
+            index_path=path,
+        )
+        return AutocompleteIndexResult(entries=rows, diagnostics=diagnostics)
+
+    raise AssertionError("unreachable autocomplete index state")

--- a/autocomplete_index.py
+++ b/autocomplete_index.py
@@ -166,9 +166,13 @@ def _prefix_upper_bound(value: str) -> str | None:
     return None
 
 
-def _like_pattern(value: str) -> str:
-    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"%{escaped}%"
+def _glob_pattern(value: str) -> str:
+    # GLOB has no ESCAPE clause. Bracket expressions quote its three pattern
+    # metacharacters while leaving normalized percent signs, underscores,
+    # quotes, and FTS operators literal. Keeping this as GLOB (not LIKE with
+    # ESCAPE) lets the FTS5 trigram virtual table select its indexed G0 plan.
+    escaped = value.replace("[", "[[]").replace("*", "[*]").replace("?", "[?]")
+    return f"*{escaped}*"
 
 
 def _category_clause(categories: set[str]) -> tuple[str, list[str]]:
@@ -253,12 +257,12 @@ def _query_rows(
                 "JOIN autocomplete_entries AS e ON e.id = f.rowid"
             )
             conditions = (
-                "f.tag_key LIKE ? ESCAPE '\\' "
+                "f.tag_key GLOB ? "
                 "AND instr(e.tag_key, ?) > 0 "
                 "AND substr(e.tag_key, 1, length(?)) <> ?"
             )
             parameters = [
-                _like_pattern(normalized_query),
+                _glob_pattern(normalized_query),
                 normalized_query,
                 normalized_query,
                 normalized_query,
@@ -289,11 +293,11 @@ def _query_rows(
                 "JOIN autocomplete_entries AS e ON e.id = f.rowid"
             )
             conditions = (
-                "f.search LIKE ? ESCAPE '\\' "
+                "f.search GLOB ? "
                 "AND instr(e.search, ?) > 0 AND instr(e.tag_key, ?) = 0"
             )
             parameters = [
-                _like_pattern(normalized_query),
+                _glob_pattern(normalized_query),
                 normalized_query,
                 normalized_query,
             ]

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8160,9 +8160,9 @@
       },
       {
         "is_package": false,
-        "loc": 576,
+        "loc": 580,
         "module": "autocomplete_index",
-        "normalized_git_blob_sha1": "8f6efd75c9ff057ea77c44d192f0237d164d0a2b",
+        "normalized_git_blob_sha1": "885fefac3b7ba0b71f5ce22a3aa6ce070ee62c62",
         "path": "autocomplete_index.py",
         "top_level": {
           "class_count": 6,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -2364,6 +2364,130 @@
       },
       {
         "alias": null,
+        "bound_name": "AutocompleteIndexDiagnostics",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AutocompleteIndexDiagnostics",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": ".autocomplete_index:AutocompleteIndexDiagnostics",
+        "kind": "static_from",
+        "line": 18,
+        "name": "AutocompleteIndexDiagnostics",
+        "optional": false,
+        "requested": ".autocomplete_index",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AutocompleteIndexSource",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AutocompleteIndexSource",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": ".autocomplete_index:AutocompleteIndexSource",
+        "kind": "static_from",
+        "line": 18,
+        "name": "AutocompleteIndexSource",
+        "optional": false,
+        "requested": ".autocomplete_index",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AutocompleteIndexUnavailable",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AutocompleteIndexUnavailable",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": ".autocomplete_index:AutocompleteIndexUnavailable",
+        "kind": "static_from",
+        "line": 18,
+        "name": "AutocompleteIndexUnavailable",
+        "optional": false,
+        "requested": ".autocomplete_index",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "search_autocomplete_index",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "search_autocomplete_index",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": ".autocomplete_index:search_autocomplete_index",
+        "kind": "static_from",
+        "line": 18,
+        "name": "search_autocomplete_index",
+        "optional": false,
+        "requested": ".autocomplete_index",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PACKAGE_DATA_DIR",
         "branch_context": [
           {
@@ -2384,7 +2508,7 @@
         "conditional": true,
         "imported": ".anima_prompt.knowledge:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 18,
+        "line": 24,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": ".anima_prompt.knowledge",
@@ -2415,7 +2539,7 @@
         "conditional": true,
         "imported": ".anima_prompt.models:TagSection",
         "kind": "static_from",
-        "line": 19,
+        "line": 25,
         "name": "TagSection",
         "optional": false,
         "requested": ".anima_prompt.models",
@@ -2446,7 +2570,7 @@
         "conditional": true,
         "imported": ".anima_prompt.ordering:builtin_tag_section",
         "kind": "static_from",
-        "line": 20,
+        "line": 26,
         "name": "builtin_tag_section",
         "optional": false,
         "requested": ".anima_prompt.ordering",
@@ -2477,7 +2601,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 21,
+        "line": 27,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -2508,7 +2632,7 @@
         "conditional": true,
         "imported": ".prompt_translation:iter_prompt_translation_markers",
         "kind": "static_from",
-        "line": 22,
+        "line": 28,
         "name": "iter_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -2516,6 +2640,204 @@
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
         "target": "prompt_translation.py"
+      },
+      {
+        "alias": "STORAGE_PACKAGE_DATA_DIR",
+        "bound_name": "STORAGE_PACKAGE_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "STORAGE_PACKAGE_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": ".storage:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 29,
+        "name": "PACKAGE_DATA_DIR",
+        "optional": false,
+        "requested": ".storage",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": ".storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 30,
+        "name": "USER_DATA_DIR",
+        "optional": false,
+        "requested": ".storage",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AutocompleteIndexDiagnostics",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AutocompleteIndexDiagnostics",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": "autocomplete_index:AutocompleteIndexDiagnostics",
+        "kind": "static_from",
+        "line": 32,
+        "name": "AutocompleteIndexDiagnostics",
+        "optional": false,
+        "requested": "autocomplete_index",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AutocompleteIndexSource",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AutocompleteIndexSource",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": "autocomplete_index:AutocompleteIndexSource",
+        "kind": "static_from",
+        "line": 32,
+        "name": "AutocompleteIndexSource",
+        "optional": false,
+        "requested": "autocomplete_index",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "AutocompleteIndexUnavailable",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "AutocompleteIndexUnavailable",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": "autocomplete_index:AutocompleteIndexUnavailable",
+        "kind": "static_from",
+        "line": 32,
+        "name": "AutocompleteIndexUnavailable",
+        "optional": false,
+        "requested": "autocomplete_index",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "search_autocomplete_index",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "search_autocomplete_index",
+          "target": "autocomplete_index.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": "autocomplete_index:search_autocomplete_index",
+        "kind": "static_from",
+        "line": 32,
+        "name": "search_autocomplete_index",
+        "optional": false,
+        "requested": "autocomplete_index",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
       },
       {
         "alias": null,
@@ -2527,7 +2849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -2542,7 +2864,7 @@
         "conditional": true,
         "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 24,
+        "line": 38,
         "name": "PACKAGE_DATA_DIR",
         "optional": false,
         "requested": "anima_prompt.knowledge",
@@ -2561,7 +2883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -2576,7 +2898,7 @@
         "conditional": true,
         "imported": "anima_prompt.models:TagSection",
         "kind": "static_from",
-        "line": 25,
+        "line": 39,
         "name": "TagSection",
         "optional": false,
         "requested": "anima_prompt.models",
@@ -2595,7 +2917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -2610,7 +2932,7 @@
         "conditional": true,
         "imported": "anima_prompt.ordering:builtin_tag_section",
         "kind": "static_from",
-        "line": 26,
+        "line": 40,
         "name": "builtin_tag_section",
         "optional": false,
         "requested": "anima_prompt.ordering",
@@ -2629,7 +2951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -2644,7 +2966,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 27,
+        "line": 41,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -2663,7 +2985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -2678,7 +3000,7 @@
         "conditional": true,
         "imported": "prompt_translation:iter_prompt_translation_markers",
         "kind": "static_from",
-        "line": 28,
+        "line": 42,
         "name": "iter_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -2686,6 +3008,244 @@
         "scope": "<module>",
         "source": "autocomplete_dataset.py",
         "target": "prompt_translation.py"
+      },
+      {
+        "alias": "STORAGE_PACKAGE_DATA_DIR",
+        "bound_name": "STORAGE_PACKAGE_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "STORAGE_PACKAGE_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": "storage:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 43,
+        "name": "PACKAGE_DATA_DIR",
+        "optional": false,
+        "requested": "storage",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "USER_DATA_DIR",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "USER_DATA_DIR",
+          "target": "storage.py",
+          "try_line": 17
+        },
+        "conditional": true,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 44,
+        "name": "USER_DATA_DIR",
+        "optional": false,
+        "requested": "storage",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "autocomplete_dataset.py",
+        "target": "storage.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "hashlib",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "hashlib",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "hashlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "sqlite3",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "sqlite3",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "sqlite3",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "tempfile",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "tempfile",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "tempfile",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 7,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 8,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Callable",
+        "kind": "static_from",
+        "line": 10,
+        "name": "Callable",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Iterable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Iterable",
+        "kind": "static_from",
+        "line": 10,
+        "name": "Iterable",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "autocomplete_index.py"
       },
       {
         "alias": null,
@@ -7295,7 +7855,15 @@
       },
       {
         "from": "autocomplete_dataset.py",
+        "to": "autocomplete_index.py"
+      },
+      {
+        "from": "autocomplete_dataset.py",
         "to": "prompt_translation.py"
+      },
+      {
+        "from": "autocomplete_dataset.py",
+        "to": "storage.py"
       },
       {
         "from": "nodes.py",
@@ -7420,6 +7988,12 @@
       {
         "cyclic": false,
         "modules": [
+          "autocomplete_index.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "nodes.py"
         ]
       },
@@ -7450,7 +8024,7 @@
     ]
   },
   "inventory": {
-    "module_count": 16,
+    "module_count": 17,
     "modules": [
       {
         "is_package": true,
@@ -7574,14 +8148,26 @@
       },
       {
         "is_package": false,
-        "loc": 855,
+        "loc": 979,
         "module": "autocomplete_dataset",
-        "normalized_git_blob_sha1": "a705fa5d5838bd6427aaa65da12fba0ad6eeb3f2",
+        "normalized_git_blob_sha1": "518a25f783a0e95197feba4af7468456d0fcbf1d",
         "path": "autocomplete_dataset.py",
         "top_level": {
           "class_count": 4,
-          "function_count": 43,
-          "global_count": 28
+          "function_count": 48,
+          "global_count": 29
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 576,
+        "module": "autocomplete_index",
+        "normalized_git_blob_sha1": "8f6efd75c9ff057ea77c44d192f0237d164d0a2b",
+        "path": "autocomplete_index.py",
+        "top_level": {
+          "class_count": 6,
+          "function_count": 15,
+          "global_count": 4
         }
       },
       {
@@ -7884,7 +8470,99 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "autocomplete_index:AutocompleteIndexDiagnostics",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "autocomplete_index:AutocompleteIndexSource",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "autocomplete_index:AutocompleteIndexUnavailable",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "autocomplete_index:search_autocomplete_index",
+        "kind": "static_from",
+        "line": 32,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -7893,7 +8571,7 @@
         "conditional": true,
         "imported": "anima_prompt.knowledge:PACKAGE_DATA_DIR",
         "kind": "static_from",
-        "line": 24,
+        "line": 38,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -7907,7 +8585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -7916,7 +8594,7 @@
         "conditional": true,
         "imported": "anima_prompt.models:TagSection",
         "kind": "static_from",
-        "line": 25,
+        "line": 39,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -7930,7 +8608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -7939,7 +8617,7 @@
         "conditional": true,
         "imported": "anima_prompt.ordering:builtin_tag_section",
         "kind": "static_from",
-        "line": 26,
+        "line": 40,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -7953,7 +8631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -7962,7 +8640,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 27,
+        "line": 41,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
@@ -7976,7 +8654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 23,
+            "handler_line": 31,
             "kind": "try",
             "line": 17
           }
@@ -7985,11 +8663,57 @@
         "conditional": true,
         "imported": "prompt_translation:iter_prompt_translation_markers",
         "kind": "static_from",
-        "line": 28,
+        "line": 42,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "autocomplete_dataset.py",
         "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "storage:PACKAGE_DATA_DIR",
+        "kind": "static_from",
+        "line": 43,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "storage.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 31,
+            "kind": "try",
+            "line": 17
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "storage:USER_DATA_DIR",
+        "kind": "static_from",
+        "line": 44,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "autocomplete_dataset.py",
+        "target": "storage.py"
       },
       {
         "branch_context": [
@@ -9430,6 +10154,116 @@
         "optional": false,
         "role": "ordinary",
         "source": "autocomplete_dataset.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "hashlib",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "sqlite3",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "tempfile",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Callable",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Iterable",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "autocomplete_index.py"
       },
       {
         "branch_context": [],
@@ -11970,6 +12804,7 @@
       "api.py",
       "api_contract.py",
       "autocomplete_dataset.py",
+      "autocomplete_index.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -11988,6 +12823,7 @@
       "api.py",
       "api_contract.py",
       "autocomplete_dataset.py",
+      "autocomplete_index.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -12454,7 +13290,16 @@
         "column": 19,
         "context": "assign:_INLINE_SPACE_RE",
         "kind": "import_time_call",
-        "line": 69,
+        "line": 85,
+        "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_default_autocomplete_index_dir",
+        "column": 26,
+        "context": "assign:_AUTOCOMPLETE_INDEX_DIR",
+        "kind": "import_time_call",
+        "line": 126,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12463,7 +13308,7 @@
         "column": 12,
         "context": "assign:_COUNT_RE",
         "kind": "import_time_call",
-        "line": 98,
+        "line": 127,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12472,7 +13317,7 @@
         "column": 20,
         "context": "assign:_WEIGHT_NUMBER_RE",
         "kind": "import_time_call",
-        "line": 103,
+        "line": 132,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12481,7 +13326,7 @@
         "column": 21,
         "context": "assign:_WEIGHTED_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 104,
+        "line": 133,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12490,7 +13335,7 @@
         "column": 21,
         "context": "assign:_WILDCARD_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 105,
+        "line": 134,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12499,7 +13344,7 @@
         "column": 22,
         "context": "assign:_WILDCARD_SYNTAX_RE",
         "kind": "import_time_call",
-        "line": 106,
+        "line": 135,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12508,7 +13353,7 @@
         "column": 27,
         "context": "assign:_DYNAMIC_PROMPT_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 107,
+        "line": 136,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12517,7 +13362,7 @@
         "column": 28,
         "context": "assign:_DYNAMIC_PROMPT_SYNTAX_RE",
         "kind": "import_time_call",
-        "line": 108,
+        "line": 137,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12526,7 +13371,7 @@
         "column": 25,
         "context": "assign:_DESCRIPTION_PREFIX_RE",
         "kind": "import_time_call",
-        "line": 109,
+        "line": 138,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12535,7 +13380,7 @@
         "column": 14,
         "context": "assign:_COMMENT_RE",
         "kind": "import_time_call",
-        "line": 110,
+        "line": 139,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12544,7 +13389,7 @@
         "column": 1,
         "context": "decorator:AutocompleteEntry",
         "kind": "import_time_call",
-        "line": 112,
+        "line": 141,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12553,7 +13398,7 @@
         "column": 1,
         "context": "decorator:_AutocompleteCacheKey",
         "kind": "import_time_call",
-        "line": 122,
+        "line": 151,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12562,7 +13407,7 @@
         "column": 1,
         "context": "decorator:_AutocompleteSnapshot",
         "kind": "import_time_call",
-        "line": 130,
+        "line": 159,
         "module": "autocomplete_dataset.py",
         "scope": "<module>"
       },
@@ -12571,8 +13416,53 @@
         "column": 14,
         "context": "assign:_CACHE_LOCK",
         "kind": "import_time_call",
-        "line": 141,
+        "line": 170,
         "module": "autocomplete_dataset.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:AutocompleteIndexSource",
+        "kind": "import_time_call",
+        "line": 17,
+        "module": "autocomplete_index.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:IndexedAutocompleteEntry",
+        "kind": "import_time_call",
+        "line": 28,
+        "module": "autocomplete_index.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:AutocompleteIndexDiagnostics",
+        "kind": "import_time_call",
+        "line": 36,
+        "module": "autocomplete_index.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:AutocompleteIndexResult",
+        "kind": "import_time_call",
+        "line": 46,
+        "module": "autocomplete_index.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "threading.Lock",
+        "column": 21,
+        "context": "assign:_INDEX_LOCKS_GUARD",
+        "kind": "import_time_call",
+        "line": 65,
+        "module": "autocomplete_index.py",
         "scope": "<module>"
       },
       {
@@ -12998,39 +13888,45 @@
       },
       {
         "kind": "dict",
-        "line": 39,
+        "line": 55,
         "module": "autocomplete_dataset.py",
         "name": "AUTOCOMPLETE_SOURCES"
       },
       {
         "kind": "dict",
-        "line": 142,
+        "line": 171,
         "module": "autocomplete_dataset.py",
         "name": "_CACHE"
       },
       {
         "kind": "dict",
-        "line": 70,
+        "line": 86,
         "module": "autocomplete_dataset.py",
         "name": "_DANBOORU_CATEGORY_NAMES"
       },
       {
         "kind": "dict",
-        "line": 77,
+        "line": 93,
         "module": "autocomplete_dataset.py",
         "name": "_E621_CATEGORY_NAMES"
       },
       {
         "kind": "dict",
-        "line": 143,
+        "line": 172,
         "module": "autocomplete_dataset.py",
         "name": "_INFLIGHT"
       },
       {
         "kind": "dict",
-        "line": 86,
+        "line": 102,
         "module": "autocomplete_dataset.py",
         "name": "_MERGED_E621_CATEGORY_NAMES"
+      },
+      {
+        "kind": "dict",
+        "line": 64,
+        "module": "autocomplete_index.py",
+        "name": "_INDEX_LOCKS"
       },
       {
         "kind": "dict",
@@ -13292,7 +14188,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 142,
+        "line": 171,
         "module": "autocomplete_dataset.py",
         "name": "_CACHE"
       },
@@ -13301,7 +14197,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 141,
+        "line": 170,
         "module": "autocomplete_dataset.py",
         "name": "_CACHE_LOCK"
       },
@@ -13312,9 +14208,28 @@
           "single_flight"
         ],
         "initializer": "Dict",
-        "line": 143,
+        "line": 172,
         "module": "autocomplete_dataset.py",
         "name": "_INFLIGHT"
+      },
+      {
+        "categories": [
+          "lock",
+          "mutable_container"
+        ],
+        "initializer": "Dict",
+        "line": 64,
+        "module": "autocomplete_index.py",
+        "name": "_INDEX_LOCKS"
+      },
+      {
+        "categories": [
+          "lock"
+        ],
+        "initializer": "threading.Lock",
+        "line": 65,
+        "module": "autocomplete_index.py",
+        "name": "_INDEX_LOCKS_GUARD"
       },
       {
         "categories": [

--- a/tests/test_autocomplete_index.py
+++ b/tests/test_autocomplete_index.py
@@ -76,18 +76,28 @@ class AutocompleteIndexTests(unittest.TestCase):
                 'needle,1,2,"[작가] duplicate exact"',
                 'percent 100% ready,0,600,"[일반] literal percent"',
                 'korean description,0,500,"[일반] 한글 설명 검색"',
+                'literal under score,0,490,"[일반] normalized underscore"',
+                'glob*star literal,0,480,"[일반] literal asterisk"',
+                'glob?question literal,0,470,"[일반] literal question"',
+                'glob[bracket literal,0,460,"[일반] literal bracket"',
+                '"quote ""and"" or literal",0,450,"[일반] quote operator"',
             ],
         )
 
         cases = [
-            ("needle", 3, ""),
-            ("needle", 6, "artist"),
-            ("needle", 100, "artist,general"),
-            ("100%", 20, ""),
-            ("한글 설명", 20, "general"),
+            ("needle", 3, "", "needle"),
+            ("needle", 6, "artist", "needle"),
+            ("needle", 100, "artist,general", "needle"),
+            ("100%", 20, "", "percent 100% ready"),
+            ("한글 설명", 20, "general", "korean description"),
+            ("literal_under", 20, "", "literal under score"),
+            ("glob*star", 20, "", "glob*star literal"),
+            ("glob?question", 20, "", "glob?question literal"),
+            ("glob[bracket", 20, "", "glob[bracket literal"),
+            ('quote "and" OR', 20, "", 'quote "and" or literal'),
         ]
         outcomes = []
-        for query, limit, category in cases:
+        for query, limit, category, expected_first in cases:
             with self.subTest(query=query, limit=limit, category=category):
                 result, diagnostics = self._search(
                     query,
@@ -106,6 +116,7 @@ class AutocompleteIndexTests(unittest.TestCase):
                     ),
                 )
                 self.assertLessEqual(len(result["results"]), max(1, min(limit, 100)))
+                self.assertEqual(result["results"][0]["tag"], expected_first)
 
         self.assertEqual(outcomes[0], "rebuild")
         self.assertTrue(all(outcome == "hit" for outcome in outcomes[1:]))
@@ -118,6 +129,44 @@ class AutocompleteIndexTests(unittest.TestCase):
             warm, diagnostics = self._search("needle", path=path, limit=2)
         self.assertEqual(diagnostics.outcome, "hit")
         self.assertEqual(len(warm["results"]), 2)
+
+    def test_glob_candidate_pattern_is_literal_and_uses_the_trigram_plan(self):
+        self.assertEqual(
+            autocomplete_index._glob_pattern('%_"OR"*?[literal'),
+            '*%_"OR"[*][?][[]literal*',
+        )
+        path = self._write(
+            "query-plan.csv",
+            [
+                f'candidate tag {index:04d},0,{2000 - index},"[일반] indexed candidate"'
+                for index in range(1000)
+            ],
+        )
+        _result, diagnostics = self._search("candidate tag 050", path=path)
+        self.assertEqual(diagnostics.backend, "fts5_trigram")
+        self.assertIsNotNone(diagnostics.index_path)
+        assert diagnostics.index_path is not None
+
+        connection = sqlite3.connect(diagnostics.index_path)
+        try:
+            plan = connection.execute(
+                "EXPLAIN QUERY PLAN "
+                "SELECT e.tag FROM autocomplete_entries_fts AS f "
+                "JOIN autocomplete_entries AS e ON e.id = f.rowid "
+                "WHERE f.tag_key GLOB ? AND instr(e.tag_key, ?) > 0",
+                (
+                    autocomplete_index._glob_pattern("candidate tag 050"),
+                    "candidate tag 050",
+                ),
+            ).fetchall()
+        finally:
+            connection.close()
+
+        details = [str(row[3]) for row in plan]
+        self.assertTrue(
+            any("VIRTUAL TABLE INDEX 0:G0" in detail for detail in details),
+            details,
+        )
 
     def test_source_revision_change_rebuilds_the_same_index(self):
         path = self._write(

--- a/tests/test_autocomplete_index.py
+++ b/tests/test_autocomplete_index.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+import autocomplete_dataset as dataset
+import autocomplete_index
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AutocompleteIndexTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory(
+            prefix="easyuse-anima-index-test-"
+        )
+        self.root = Path(self.temporary_directory.name)
+        self.index_root = self.root / "index"
+
+    def tearDown(self) -> None:
+        with dataset._CACHE_LOCK:
+            dataset._CACHE.clear()
+            dataset._INFLIGHT.clear()
+        self.temporary_directory.cleanup()
+
+    def _write(self, name: str, rows: list[str]) -> Path:
+        path = self.root / name
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return path
+
+    def _search(self, query: str, *, path: Path, limit: int = 20, category: str = ""):
+        with patch.object(dataset, "_AUTOCOMPLETE_INDEX_DIR", self.index_root):
+            return dataset._search_autocomplete_with_diagnostics(
+                query,
+                limit=limit,
+                path=path,
+                category=category,
+            )
+
+    def _reference(self, query: str, *, path: Path, limit: int, category: str):
+        entries = dataset._load_entries(path)
+        categories = {item.strip() for item in category.split(",") if item.strip()}
+        matches = dataset._top_autocomplete_matches(
+            entries,
+            dataset._normalize(query),
+            categories,
+            max(1, min(limit, 100)),
+        )
+        return [
+            {
+                "tag": entry.tag,
+                "category": entry.category,
+                "count": entry.count,
+                "description": entry.description,
+            }
+            for _, entry in matches
+        ]
+
+    def test_index_preserves_exact_ranking_category_filter_and_top_n(self):
+        path = self._write(
+            "parity.csv",
+            [
+                'needle prefix high,0,900,"[일반] prefix"',
+                'needle prefix artist,1,850,"[작가] prefix"',
+                'popular needle middle,0,800,"[일반] substring"',
+                'description only,0,700,"[일반] needle description"',
+                'needle,0,1,"[일반] exact low count"',
+                'needle,1,2,"[작가] duplicate exact"',
+                'percent 100% ready,0,600,"[일반] literal percent"',
+                'korean description,0,500,"[일반] 한글 설명 검색"',
+            ],
+        )
+
+        cases = [
+            ("needle", 3, ""),
+            ("needle", 6, "artist"),
+            ("needle", 100, "artist,general"),
+            ("100%", 20, ""),
+            ("한글 설명", 20, "general"),
+        ]
+        outcomes = []
+        for query, limit, category in cases:
+            with self.subTest(query=query, limit=limit, category=category):
+                result, diagnostics = self._search(
+                    query,
+                    path=path,
+                    limit=limit,
+                    category=category,
+                )
+                outcomes.append(diagnostics.outcome)
+                self.assertEqual(
+                    result["results"],
+                    self._reference(
+                        query,
+                        path=path,
+                        limit=limit,
+                        category=category,
+                    ),
+                )
+                self.assertLessEqual(len(result["results"]), max(1, min(limit, 100)))
+
+        self.assertEqual(outcomes[0], "rebuild")
+        self.assertTrue(all(outcome == "hit" for outcome in outcomes[1:]))
+
+        with patch.object(
+            dataset,
+            "_load_entries",
+            side_effect=AssertionError("warm indexed search must not load or scan CSV entries"),
+        ):
+            warm, diagnostics = self._search("needle", path=path, limit=2)
+        self.assertEqual(diagnostics.outcome, "hit")
+        self.assertEqual(len(warm["results"]), 2)
+
+    def test_source_revision_change_rebuilds_the_same_index(self):
+        path = self._write(
+            "revision.csv",
+            ['alpha tag,0,100,"[일반] alpha"'],
+        )
+        first, first_diagnostics = self._search("alpha", path=path)
+        second, second_diagnostics = self._search("alpha", path=path)
+        with patch.object(
+            dataset,
+            "_validate_index_source",
+            side_effect=[dataset._AutocompleteSourceChanged(str(path)), None],
+        ) as validate_source:
+            retried, retried_diagnostics = self._search("alpha", path=path)
+
+        previous_stat = path.stat()
+        path.write_text(
+            'beta replacement tag,0,90,"[일반] beta replacement"\n',
+            encoding="utf-8",
+        )
+        next_mtime = previous_stat.st_mtime_ns + 1_000_000_000
+        os.utime(path, ns=(next_mtime, next_mtime))
+        third, third_diagnostics = self._search("beta", path=path)
+
+        self.assertEqual(first["results"][0]["tag"], "alpha tag")
+        self.assertEqual(second_diagnostics.outcome, "hit")
+        self.assertEqual(retried["results"], second["results"])
+        self.assertEqual(retried_diagnostics.outcome, "hit")
+        self.assertEqual(validate_source.call_count, 2)
+        self.assertEqual(third["results"][0]["tag"], "beta replacement tag")
+        self.assertEqual(third_diagnostics.outcome, "rebuild")
+        self.assertEqual(third_diagnostics.reason, "source_revision_mismatch")
+        self.assertNotEqual(
+            first_diagnostics.source_revision,
+            third_diagnostics.source_revision,
+        )
+        self.assertEqual(first_diagnostics.index_path, third_diagnostics.index_path)
+
+    def test_corrupt_and_schema_mismatch_indexes_rebuild_safely(self):
+        path = self._write(
+            "rebuild.csv",
+            ['recoverable tag,0,100,"[일반] recoverable"'],
+        )
+        expected, initial = self._search("recoverable", path=path)
+        self.assertIsNotNone(initial.index_path)
+        index_path = initial.index_path
+        assert index_path is not None
+
+        index_path.write_bytes(b"not a sqlite database")
+        recovered, corrupt = self._search("recoverable", path=path)
+        self.assertEqual(recovered["results"], expected["results"])
+        self.assertEqual(corrupt.outcome, "rebuild")
+        self.assertIn(corrupt.reason, {"corrupt", "unreadable"})
+
+        connection = sqlite3.connect(index_path)
+        try:
+            connection.execute(
+                "UPDATE autocomplete_index_metadata "
+                "SET schema_version = 'not-an-integer' WHERE id = 1"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        malformed_result, malformed = self._search("recoverable", path=path)
+        self.assertEqual(malformed_result["results"], expected["results"])
+        self.assertEqual(malformed.outcome, "rebuild")
+        self.assertEqual(malformed.reason, "corrupt")
+
+        connection = sqlite3.connect(index_path)
+        try:
+            connection.execute(
+                "UPDATE autocomplete_index_metadata SET schema_version = 0 WHERE id = 1"
+            )
+            connection.commit()
+        finally:
+            connection.close()
+        upgraded, schema = self._search("recoverable", path=path)
+        self.assertEqual(upgraded["results"], expected["results"])
+        self.assertEqual(schema.outcome, "rebuild")
+        self.assertEqual(schema.reason, "schema_mismatch")
+
+    def test_concurrent_first_access_coalesces_and_locked_read_falls_back(self):
+        path = self._write(
+            "concurrent.csv",
+            [f'shared tag {index:03d},0,{1000 - index},"[일반] shared"' for index in range(80)],
+        )
+        start = threading.Barrier(7)
+
+        def search_once():
+            start.wait(timeout=5)
+            return dataset._search_autocomplete_with_diagnostics("shared", path=path)
+
+        with patch.object(dataset, "_AUTOCOMPLETE_INDEX_DIR", self.index_root):
+            with ThreadPoolExecutor(max_workers=6) as executor:
+                futures = [executor.submit(search_once) for _ in range(6)]
+                start.wait(timeout=5)
+                searched = [future.result(timeout=10) for future in futures]
+
+        outcomes = [diagnostics.outcome for _, diagnostics in searched]
+        observations = [
+            (diagnostics.outcome, diagnostics.reason)
+            for _, diagnostics in searched
+        ]
+        self.assertEqual(outcomes.count("rebuild"), 1, observations)
+        self.assertEqual(outcomes.count("hit"), 5, observations)
+        self.assertTrue(all(result["results"] for result, _ in searched))
+
+        with patch.object(
+            autocomplete_index,
+            "_query_index",
+            side_effect=sqlite3.OperationalError("database is locked"),
+        ):
+            fallback, diagnostics = self._search("shared", path=path, limit=4)
+
+        self.assertEqual(diagnostics.outcome, "fallback")
+        self.assertEqual(diagnostics.reason, "locked")
+        self.assertEqual(
+            fallback["results"],
+            self._reference("shared", path=path, limit=4, category=""),
+        )
+
+    def test_custom_csv_keeps_exact_fallback_when_persistent_index_is_disabled(self):
+        path = self._write(
+            "custom-header.csv",
+            [
+                "name,category,post_count,description",
+                'custom character,4,90,"[캐릭터] 사용자 정의 설명"',
+                'custom general,0,100,"[일반] 사용자 정의 일반"',
+            ],
+        )
+        with patch.object(dataset, "_AUTOCOMPLETE_INDEX_DIR", None):
+            result, diagnostics = dataset._search_autocomplete_with_diagnostics(
+                "사용자 정의",
+                path=path,
+                category="character",
+            )
+
+        self.assertEqual(diagnostics.outcome, "fallback")
+        self.assertEqual(diagnostics.reason, "disabled")
+        self.assertEqual(result["results"][0]["tag"], "custom character")
+        self.assertEqual(result["results"][0]["category"], "character")
+        self.assertEqual(result["status"]["count"], 2)
+
+    def test_index_module_is_inside_registry_package_closure(self):
+        source = (ROOT / "autocomplete_dataset.py").read_text(encoding="utf-8")
+        self.assertIn("from .autocomplete_index import (", source)
+        ignored = subprocess.run(
+            [
+                "git",
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-from=.comfyignore",
+                "--",
+                "autocomplete_index.py",
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(ignored.returncode, 0, ignored.stdout + ignored.stderr)
+        self.assertEqual(ignored.stdout.strip(), "", ignored.stdout + ignored.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 16)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 16)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 16)
+        self.assertEqual(report["inventory"]["module_count"], 17)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 17)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 17)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
@@ -699,6 +699,14 @@ ignored/
         )
         self.assertIn(
             "api_contract.py",
+            report["registry"]["runtime_import_closure"],
+        )
+        self.assertIn(
+            "autocomplete_index.py",
+            report["registry"]["shipped_python_modules"],
+        )
+        self.assertIn(
+            "autocomplete_index.py",
             report["registry"]["runtime_import_closure"],
         )
         self.assertIn(

--- a/tools/benchmark_autocomplete.py
+++ b/tools/benchmark_autocomplete.py
@@ -4,20 +4,24 @@
 Examples:
   python tools/benchmark_autocomplete.py
   python tools/benchmark_autocomplete.py --fixture-entries 1000 --warm-runs 3
+  python tools/benchmark_autocomplete.py --fixture-entries 1000 --disable-index
   python tools/benchmark_autocomplete.py --verify-manifest
 """
 
 from __future__ import annotations
 
 import argparse
+import ctypes
 import gc
 import json
+import os
 import platform
 import statistics
 import sys
 import tempfile
 import time
 import tracemalloc
+from contextlib import contextmanager
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -53,29 +57,106 @@ def _clear_cached_source(path: Path) -> None:
         dataset._CACHE.pop(key.resolved_path, None)
 
 
-def _benchmark(path: Path, query: str, warm_runs: int) -> dict:
+@contextmanager
+def _using_index_root(root: Path | None):
+    previous = dataset._AUTOCOMPLETE_INDEX_DIR
+    dataset._AUTOCOMPLETE_INDEX_DIR = root
+    try:
+        yield
+    finally:
+        dataset._AUTOCOMPLETE_INDEX_DIR = previous
+
+
+def _process_rss_bytes() -> tuple[str, int | None]:
+    if os.name == "nt":
+        class ProcessMemoryCounters(ctypes.Structure):
+            _fields_ = [
+                ("cb", ctypes.c_ulong),
+                ("PageFaultCount", ctypes.c_ulong),
+                ("PeakWorkingSetSize", ctypes.c_size_t),
+                ("WorkingSetSize", ctypes.c_size_t),
+                ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+                ("PagefileUsage", ctypes.c_size_t),
+                ("PeakPagefileUsage", ctypes.c_size_t),
+            ]
+
+        counters = ProcessMemoryCounters()
+        counters.cb = ctypes.sizeof(counters)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+        process = kernel32.GetCurrentProcess()
+        get_process_memory_info = getattr(
+            kernel32,
+            "K32GetProcessMemoryInfo",
+            ctypes.WinDLL("psapi", use_last_error=True).GetProcessMemoryInfo,
+        )
+        get_process_memory_info.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ProcessMemoryCounters),
+            ctypes.c_ulong,
+        ]
+        get_process_memory_info.restype = ctypes.c_int
+        if get_process_memory_info(
+            process,
+            ctypes.byref(counters),
+            counters.cb,
+        ):
+            return "windows_working_set", int(counters.WorkingSetSize)
+        return "unavailable", None
+
+    try:
+        import resource
+    except ImportError:
+        return "unavailable", None
+    usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    scale = 1 if sys.platform == "darwin" else 1024
+    return "process_peak_rss", int(usage * scale)
+
+
+def _benchmark(
+    path: Path,
+    query: str,
+    warm_runs: int,
+    *,
+    index_root: Path | None,
+) -> dict:
     resolved_path = path.resolve(strict=False)
     _clear_cached_source(resolved_path)
     gc.collect()
 
-    tracemalloc.start()
-    try:
-        baseline_heap, _ = tracemalloc.get_traced_memory()
-        cold_started = time.perf_counter()
-        cold_result = dataset.search_autocomplete(query, path=resolved_path)
-        cold_ms = (time.perf_counter() - cold_started) * 1000
-        cold_heap_current, cold_heap_peak = tracemalloc.get_traced_memory()
+    rss_metric, baseline_rss = _process_rss_bytes()
+    with _using_index_root(index_root):
+        tracemalloc.start()
+        try:
+            baseline_heap, _ = tracemalloc.get_traced_memory()
+            cold_started = time.perf_counter()
+            cold_result, cold_index = dataset._search_autocomplete_with_diagnostics(
+                query,
+                path=resolved_path,
+            )
+            cold_ms = (time.perf_counter() - cold_started) * 1000
+            cold_heap_current, cold_heap_peak = tracemalloc.get_traced_memory()
+            _, cold_rss = _process_rss_bytes()
 
-        warm_times = []
-        warm_result = None
-        for _ in range(warm_runs):
-            warm_started = time.perf_counter()
-            warm_result = dataset.search_autocomplete(query, path=resolved_path)
-            warm_times.append((time.perf_counter() - warm_started) * 1000)
+            warm_times = []
+            warm_result = None
+            warm_indexes = []
+            for _ in range(warm_runs):
+                warm_started = time.perf_counter()
+                warm_result, warm_index = dataset._search_autocomplete_with_diagnostics(
+                    query,
+                    path=resolved_path,
+                )
+                warm_times.append((time.perf_counter() - warm_started) * 1000)
+                warm_indexes.append(warm_index)
 
-        heap_current, heap_peak = tracemalloc.get_traced_memory()
-    finally:
-        tracemalloc.stop()
+            heap_current, heap_peak = tracemalloc.get_traced_memory()
+            _, warm_rss = _process_rss_bytes()
+        finally:
+            tracemalloc.stop()
 
     if warm_result is None or warm_result["status"] != cold_result["status"]:
         raise RuntimeError("cold and warm searches did not use the same snapshot status")
@@ -94,6 +175,31 @@ def _benchmark(path: Path, query: str, warm_runs: int) -> dict:
         "cold_heap_peak_bytes": max(0, cold_heap_peak - baseline_heap),
         "overall_heap_retained_bytes": max(0, heap_current - baseline_heap),
         "overall_heap_peak_bytes": max(0, heap_peak - baseline_heap),
+        "rss_metric": rss_metric,
+        "baseline_rss_bytes": baseline_rss,
+        "cold_rss_bytes": cold_rss,
+        "cold_rss_delta_bytes": (
+            None
+            if baseline_rss is None or cold_rss is None
+            else cold_rss - baseline_rss
+        ),
+        "warm_rss_bytes": warm_rss,
+        "warm_rss_delta_bytes": (
+            None
+            if baseline_rss is None or warm_rss is None
+            else warm_rss - baseline_rss
+        ),
+        "index_cold_outcome": cold_index.outcome,
+        "index_cold_reason": cold_index.reason,
+        "index_warm_outcomes": [item.outcome for item in warm_indexes],
+        "index_warm_reasons": [item.reason for item in warm_indexes],
+        "index_backend": cold_index.backend,
+        "index_source_revision": cold_index.source_revision,
+        "index_file_size_bytes": (
+            cold_index.index_path.stat().st_size
+            if cold_index.index_path is not None and cold_index.index_path.is_file()
+            else None
+        ),
         "python": sys.version.replace("\n", " "),
         "platform": platform.platform(),
     }
@@ -162,6 +268,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--query", default="1girl", help="autocomplete query")
     parser.add_argument("--warm-runs", type=_positive_int, default=5)
     parser.add_argument(
+        "--disable-index",
+        action="store_true",
+        help="measure the exact Python snapshot fallback instead of the SQLite index",
+    )
+    parser.add_argument(
         "--verify-manifest",
         action="store_true",
         help="verify all built-in manifest counts and exit without benchmarking",
@@ -171,6 +282,7 @@ def _parse_args() -> argparse.Namespace:
         args.source_key is not None
         or args.source is not None
         or args.fixture_entries is not None
+        or args.disable_index
     ):
         parser.error("--verify-manifest cannot be combined with a source option")
     if not str(args.query).strip():
@@ -183,17 +295,34 @@ def main() -> int:
     if args.verify_manifest:
         return _verify_manifest()
 
-    if args.fixture_entries is not None:
-        with tempfile.TemporaryDirectory(prefix="easyuse-anima-autocomplete-") as tmp:
-            path = Path(tmp) / "fixture.csv"
+    with tempfile.TemporaryDirectory(prefix="easyuse-anima-autocomplete-") as tmp:
+        temporary_root = Path(tmp)
+        index_root = None if args.disable_index else temporary_root / "index"
+        if args.fixture_entries is not None:
+            path = temporary_root / "fixture.csv"
             _write_fixture(path, args.fixture_entries)
-            result = _benchmark(path, args.query, args.warm_runs)
+            result = _benchmark(
+                path,
+                args.query,
+                args.warm_runs,
+                index_root=index_root,
+            )
             result["fixture_entries"] = args.fixture_entries
-    elif args.source is not None:
-        result = _benchmark(args.source, args.query, args.warm_runs)
-    else:
-        _, path = dataset.resolve_autocomplete_source(args.source_key)
-        result = _benchmark(path, args.query, args.warm_runs)
+        elif args.source is not None:
+            result = _benchmark(
+                args.source,
+                args.query,
+                args.warm_runs,
+                index_root=index_root,
+            )
+        else:
+            _, path = dataset.resolve_autocomplete_source(args.source_key)
+            result = _benchmark(
+                path,
+                args.query,
+                args.warm_runs,
+                index_root=index_root,
+            )
 
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0


### PR DESCRIPTION
## 변경 요약

Issue #162 Phase 1B의 autocomplete 검색 경계를 versioned SQLite index repository로 전환합니다.

- exact / prefix는 SQLite B-tree 경계 조회, substring / description은 FTS5 trigram `GLOB` 후보 조회 후 `instr(...)`로 정확성을 재검증합니다.
- Python에는 각 ranking tier의 남은 top-N만 반환하며 warm indexed search는 CSV entry loader를 호출하지 않습니다.
- schema version과 source revision을 index metadata에 기록하고, source 변경·손상·schema mismatch는 원자적으로 rebuild합니다.
- lock/busy, 쓰기 불가, FTS 미지원 등 index 사용 불가 상황은 기존 Python snapshot 검색으로 fallback하여 결과 정확성을 보존합니다.
- index는 ComfyUI user-data storage 경계 아래에만 생성합니다. standalone import에서 user-data 경계를 확인할 수 없으면 package/source tree에 쓰지 않고 fallback합니다.

## 호환성

- 공개 CSV source, category filter, exact → prefix → tag substring → description ranking, count/tag tie-break, top-N 및 status payload 계약을 유지합니다.
- header/custom CSV와 특수문자(`%`, `_`, quotes/operators, `*`, `?`, `[`) query parity를 회귀로 고정했습니다.
- `api.py`와 API offload/path-redaction 계약은 변경하지 않았습니다.
- Python backend module 변경이므로 적용 시 ComfyUI 재시작이 필요합니다.

## A-01 ratchet update

새 production module `autocomplete_index.py` 추가에 맞춰 `tools/analyze_python_backend.py`로 baseline fixture를 결정적으로 재생성했습니다.

- inventory / shipped / runtime closure: 17 / 17 / 17
- missing internal imports: 0
- unreachable shipped modules: 0
- `autocomplete_index.py`의 shipped/runtime closure membership을 current-repository test에 추가했습니다.
- analyzer logic 자체는 수정하지 않았습니다.

## 검증

- SQLite capability probe: SQLite 3.50.4, FTS5 enabled, trigram query supported
- `python -m unittest discover -s tests -p test_autocomplete_index.py -v` — 7 tests passed
- `python -m unittest tests.test_prompt_corrector.AutocompleteDatasetTests -v` — 36 tests passed
- concurrent first-access regression — bounded 30/30 iterations passed
- A-01 deterministic fixture/current closure focused tests — 2 tests passed
- `EXPLAIN QUERY PLAN` — trigram candidate query uses `VIRTUAL TABLE INDEX 0:G0`
- `tools/check_project.ps1 -Profile quick` — passed
- `git diff origin/dev --check` — passed

10,000-row reproducible fixture comparison (absolute pass/fail threshold 없음):

- indexed: cold rebuild 912.437 ms, warm median 2.225 ms, retained Python heap 45,276 B, warm RSS delta 2,916,352 B
- Python fallback: cold 695.867 ms, warm median 3.170 ms, retained Python heap 4,282,868 B, warm RSS delta 11,137,024 B
- indexed warm runs: 3/3 hit, backend `fts5_trigram`

## 남은 위험 / 미확인

- cold path에는 CSV parse와 index build 비용이 있으며 source별 첫 검색에서 발생합니다.
- FTS5/trigram이 없는 Python에서는 정확성을 유지하지만 substring은 SQLite/Python fallback 경로가 더 느릴 수 있습니다.
- official full suite와 live browser/runtime smoke는 이 worker 범위에서 실행하지 않았으며 메인 owner가 최종 검증합니다.
