### PR TITLE
chore: add Python backend package skeleton

### DIFF
--- a/easyuse_anima/__init__.py
+++ b/easyuse_anima/__init__.py
@@ -1,0 +1,3 @@
+"""Internal package boundary for EasyUse Anima backend modules."""
+
+__all__ = ()

--- a/easyuse_anima/aio/__init__.py
+++ b/easyuse_anima/aio/__init__.py
@@ -1,0 +1,3 @@
+"""AiO feature package boundary."""
+
+__all__ = ()

--- a/easyuse_anima/image/__init__.py
+++ b/easyuse_anima/image/__init__.py
@@ -1,0 +1,3 @@
+"""Image feature package boundary."""
+
+__all__ = ()

--- a/easyuse_anima/infrastructure/__init__.py
+++ b/easyuse_anima/infrastructure/__init__.py
@@ -1,0 +1,3 @@
+"""Infrastructure adapter package boundary."""
+
+__all__ = ()

--- a/easyuse_anima/infrastructure/comfy/__init__.py
+++ b/easyuse_anima/infrastructure/comfy/__init__.py
@@ -1,0 +1,3 @@
+"""ComfyUI infrastructure adapter package boundary."""
+
+__all__ = ()

--- a/easyuse_anima/nodes/__init__.py
+++ b/easyuse_anima/nodes/__init__.py
@@ -1,0 +1,3 @@
+"""Node implementation package boundary."""
+
+__all__ = ()

--- a/easyuse_anima/prompt/__init__.py
+++ b/easyuse_anima/prompt/__init__.py
@@ -1,0 +1,3 @@
+"""Prompt feature package boundary."""
+
+__all__ = ()

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8024,7 +8024,7 @@
     ]
   },
   "inventory": {
-    "module_count": 17,
+    "module_count": 24,
     "modules": [
       {
         "is_package": true,
@@ -8168,6 +8168,90 @@
           "class_count": 6,
           "function_count": 15,
           "global_count": 4
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima",
+        "normalized_git_blob_sha1": "9929d9f7b1b98cbd8ae63bae889e60307115c260",
+        "path": "easyuse_anima/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.aio",
+        "normalized_git_blob_sha1": "cdd29d4a45e7bc038001e6e791811c2bd22220ef",
+        "path": "easyuse_anima/aio/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.image",
+        "normalized_git_blob_sha1": "2fd82a5b8e61b6263a880f228253dc606839a60a",
+        "path": "easyuse_anima/image/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.infrastructure",
+        "normalized_git_blob_sha1": "ab60081d39183567dcdb11aabd81f06726a9c83c",
+        "path": "easyuse_anima/infrastructure/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.infrastructure.comfy",
+        "normalized_git_blob_sha1": "f34c540f23ec0305ad547ba436d953c688d9cec0",
+        "path": "easyuse_anima/infrastructure/comfy/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.nodes",
+        "normalized_git_blob_sha1": "f980638ca8dbf3ba310d407154513156bcbf4502",
+        "path": "easyuse_anima/nodes/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
+        "module": "easyuse_anima.prompt",
+        "normalized_git_blob_sha1": "afa59976058fdbd03ff11463234c7813b532df28",
+        "path": "easyuse_anima/prompt/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
         }
       },
       {
@@ -12824,13 +12908,28 @@
       "api_contract.py",
       "autocomplete_dataset.py",
       "autocomplete_index.py",
+      "easyuse_anima/__init__.py",
+      "easyuse_anima/aio/__init__.py",
+      "easyuse_anima/image/__init__.py",
+      "easyuse_anima/infrastructure/__init__.py",
+      "easyuse_anima/infrastructure/comfy/__init__.py",
+      "easyuse_anima/nodes/__init__.py",
+      "easyuse_anima/prompt/__init__.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
       "storage.py",
       "wildcard_engine.py"
     ],
-    "unreachable_shipped_python_modules": []
+    "unreachable_shipped_python_modules": [
+      "easyuse_anima/__init__.py",
+      "easyuse_anima/aio/__init__.py",
+      "easyuse_anima/image/__init__.py",
+      "easyuse_anima/infrastructure/__init__.py",
+      "easyuse_anima/infrastructure/comfy/__init__.py",
+      "easyuse_anima/nodes/__init__.py",
+      "easyuse_anima/prompt/__init__.py"
+    ]
   },
   "schema_version": 2,
   "side_effects": {

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,13 +683,32 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 17)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 17)
+        self.assertEqual(report["inventory"]["module_count"], 24)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 24)
         self.assertEqual(len(report["registry"]["runtime_import_closure"]), 17)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
-            [],
+            [
+                "easyuse_anima/__init__.py",
+                "easyuse_anima/aio/__init__.py",
+                "easyuse_anima/image/__init__.py",
+                "easyuse_anima/infrastructure/__init__.py",
+                "easyuse_anima/infrastructure/comfy/__init__.py",
+                "easyuse_anima/nodes/__init__.py",
+                "easyuse_anima/prompt/__init__.py",
+            ],
+        )
+        self.assertTrue(
+            {
+                "easyuse_anima/__init__.py",
+                "easyuse_anima/aio/__init__.py",
+                "easyuse_anima/image/__init__.py",
+                "easyuse_anima/infrastructure/__init__.py",
+                "easyuse_anima/infrastructure/comfy/__init__.py",
+                "easyuse_anima/nodes/__init__.py",
+                "easyuse_anima/prompt/__init__.py",
+            }.issubset(report["registry"]["shipped_python_modules"])
         )
         self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
         self.assertIn("api.py", report["registry"]["runtime_import_closure"])

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_MODULES = (
+    "easyuse_anima",
+    "easyuse_anima.aio",
+    "easyuse_anima.image",
+    "easyuse_anima.infrastructure",
+    "easyuse_anima.infrastructure.comfy",
+    "easyuse_anima.nodes",
+    "easyuse_anima.prompt",
+)
+
+
+class PythonPackageSkeletonTests(unittest.TestCase):
+    def test_direct_imports_have_empty_surface_and_no_runtime_side_effects(self):
+        script = f"""
+import importlib
+import json
+import os
+import socket
+import sys
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, {str(ROOT)!r})
+sys.dont_write_bytecode = True
+modules = {json.dumps(PACKAGE_MODULES)}
+forbidden_roots = {{
+    "aiohttp",
+    "comfy",
+    "folder_paths",
+    "numpy",
+    "requests",
+    "server",
+    "torch",
+}}
+before = set(sys.modules)
+
+def blocked(name):
+    def fail(*_args, **_kwargs):
+        raise AssertionError(f"package import attempted {{name}}")
+    return fail
+
+with ExitStack() as stack:
+    for owner, name in (
+        (os, "makedirs"),
+        (os, "mkdir"),
+        (os, "remove"),
+        (os, "rename"),
+        (os, "replace"),
+        (os, "unlink"),
+        (Path, "mkdir"),
+        (Path, "rename"),
+        (Path, "replace"),
+        (Path, "touch"),
+        (Path, "unlink"),
+        (Path, "write_bytes"),
+        (Path, "write_text"),
+        (socket, "create_connection"),
+        (socket.socket, "connect"),
+    ):
+        stack.enter_context(patch.object(owner, name, blocked(f"{{owner}}.{{name}}")))
+    imported = [importlib.import_module(name) for name in modules]
+
+new_forbidden = sorted(
+    root
+    for root in forbidden_roots
+    if root in sys.modules and root not in before
+)
+print(json.dumps({{
+    "declared_all": [module.__all__ for module in imported],
+    "modules": [module.__name__ for module in imported],
+    "new_forbidden": new_forbidden,
+}}))
+"""
+        result = subprocess.run(
+            [sys.executable, "-I", "-B", "-c", script],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["modules"], list(PACKAGE_MODULES))
+        self.assertEqual(payload["declared_all"], [[] for _ in PACKAGE_MODULES])
+        self.assertEqual(payload["new_forbidden"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -15,6 +15,15 @@ EXPECTED_AUTOCOMPLETE_MODULES = {
     "web/js/autocomplete/popup_geometry.js",
     "web/js/autocomplete/text_model.js",
 }
+EXPECTED_PYTHON_PACKAGE_FILES = {
+    "easyuse_anima/__init__.py",
+    "easyuse_anima/aio/__init__.py",
+    "easyuse_anima/image/__init__.py",
+    "easyuse_anima/infrastructure/__init__.py",
+    "easyuse_anima/infrastructure/comfy/__init__.py",
+    "easyuse_anima/nodes/__init__.py",
+    "easyuse_anima/prompt/__init__.py",
+}
 STATIC_IMPORT_FROM_RE = re.compile(
     r"""
     ^[ \t]*(?:import|export)[ \t\r\n]+
@@ -254,6 +263,30 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "--exclude-from=.comfyignore",
         )
         self.assertNotIn(runtime_path, ignored)
+
+    def test_python_package_skeleton_is_in_registry_package_surface(self):
+        for runtime_path in EXPECTED_PYTHON_PACKAGE_FILES:
+            with self.subTest(runtime_path=runtime_path):
+                self.assertTrue((ROOT / runtime_path).is_file())
+
+        tracked = _git_paths("ls-files", "--cached")
+        self.assertFalse(
+            EXPECTED_PYTHON_PACKAGE_FILES - tracked,
+            "package skeleton is not tracked: "
+            f"{sorted(EXPECTED_PYTHON_PACKAGE_FILES - tracked)}",
+        )
+
+        ignored = _git_paths(
+            "ls-files",
+            "--cached",
+            "--ignored",
+            "--exclude-from=.comfyignore",
+        )
+        self.assertFalse(
+            EXPECTED_PYTHON_PACKAGE_FILES & ignored,
+            "package skeleton is excluded from the Registry package: "
+            f"{sorted(EXPECTED_PYTHON_PACKAGE_FILES & ignored)}",
+        )
 
     def test_registry_safety_doc_is_linked_from_development_entry(self):
         entry = (ROOT / "docs" / "development" / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## 변경 요약

Issue #184의 B-01 범위로 Python 백엔드 canonical package 골격만 추가합니다.

- `easyuse_anima` 아래 7개 side-effect-free package initializer 추가
- 각 initializer는 문서 문자열과 빈 `__all__`만 소유
- 기존 root runtime, `nodes.py`, API 및 사용자 동작은 변경하지 않음
- Registry package closure와 backend analyzer baseline을 새 골격에 맞게 갱신

## 주요 파일

- `easyuse_anima/**/__init__.py`
- `tests/test_python_package_skeleton.py`
- `tests/test_python_backend_analyzer.py`
- `tests/test_registry_scanner_safety.py`
- `tests/fixtures/python_backend_baseline.json`

## 계약 확인

- shipped Python modules: 17 → 24
- runtime import closure: 17 유지
- intentional unreachable modules: 새 initializer 7개
- missing internal imports: 0
- analyzer import edges 및 import-time side-effect baseline 변화 없음

## 검증

- `python -m unittest discover -s tests -p test_python_package_skeleton.py -v` — 1 passed
- `python -m unittest discover -s tests -p test_registry_scanner_safety.py -v` — 8 passed
- `python -m unittest discover -s tests -p test_python_backend_analyzer.py -v` — 18 passed
- `python -m unittest discover -s tests -p test_node_contracts.py -v` — 6 passed
- `tools/check_project.ps1 -Profile quick` — passed
- 공식 `tools/check_custom_node.ps1 -Profile full` — passed
  - Python unittest: 586 passed
  - frontend: 110 JavaScript files passed
  - TypeScript: 6.0.3 passed
  - Python compile / diff checks passed
- `git diff --check HEAD^..HEAD` — passed

## 테스트 표면

- ComfyUI Codex test instance: package import/analyzer/Registry contract 및 공식 full
- Live ComfyUI smoke: not run (runtime behavior change 없음)
- Browser smoke: not run (frontend 변경 없음)

## 리뷰 및 남은 범위

- 메인 세션에서 actual diff와 정확한 원격 HEAD `0259a6a05f7c2c60eb71683bae657355d57be851`를 검토했습니다.
- 새 차단점은 없습니다.
- Python package 파일 추가이므로 실제 설치 환경 반영 시 ComfyUI 재시작이 필요합니다.
- 후속 B-02 공통 값/직렬화/기하 helper 이동은 별도 PR로 진행합니다.

Closes no issue; part of #184.