### PR TITLE
chore: API 오류에 request ID correlation 추가

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import atexit
 import asyncio
 import json
+import logging
 import os
 import re
 import threading
 import weakref
 from concurrent.futures import Future, ThreadPoolExecutor
+from functools import wraps
 from pathlib import Path
 
 try:
@@ -43,6 +45,9 @@ from .prompt_translation import (
 )
 from .api_contract import (
     ApiContractError,
+    attach_request_id_header,
+    correlate_response,
+    create_request_id,
     error_payload,
     json_boolean,
     json_integer,
@@ -91,6 +96,7 @@ WINDOWS_RESERVED_FILE_BASENAMES = {
 }
 PROMPT_TRANSLATION_ROUTE_TIMEOUT_SECONDS = 15.0
 FILE_IO_MAX_IN_FLIGHT = 4
+_LOGGER = logging.getLogger(__name__)
 
 
 class InvalidProfileDataError(ValueError):
@@ -175,13 +181,10 @@ async def _translate_prompt_for_route(text: str) -> str:
 
 
 def _prompt_translation_error_response(exc: PromptTranslationError):
-    return web.json_response(
-        {
-            "status": "error",
-            "code": exc.code,
-            "message": exc.message,
-        },
-        status=exc.status,
+    return _error_response(
+        exc.status,
+        exc.code,
+        exc.message,
     )
 
 
@@ -205,6 +208,34 @@ def _contract_error_response(exc: ApiContractError):
         exc.message,
         details=exc.details,
     )
+
+
+def _request_correlated(handler):
+    @wraps(handler)
+    async def correlated_handler(request):
+        request_id = create_request_id()
+        try:
+            response = await handler(request)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            http_exception_type = getattr(web, "HTTPException", ())
+            if isinstance(exc, http_exception_type):
+                attach_request_id_header(exc, request_id)
+                raise
+            _LOGGER.exception(
+                "Unhandled EasyUseAnima API error (request_id=%s)",
+                request_id,
+            )
+            response = _error_response(
+                500,
+                "internal_error",
+                "An unexpected server error occurred.",
+            )
+        return correlate_response(response, request_id)
+
+    correlated_handler._easyuse_anima_request_correlation = True
+    return correlated_handler
 
 
 def _file_io_limiter() -> asyncio.Semaphore:
@@ -897,10 +928,12 @@ routes = _get_prompt_routes()
 if web is not None and routes is not None:
 
     @routes.get("/easyuse_anima/settings")
+    @_request_correlated
     async def get_settings_handler(request):
         return web.json_response(await _run_file_io(_get_settings_payload_sync))
 
     @routes.post("/easyuse_anima/set_setting")
+    @_request_correlated
     async def set_setting_handler(request):
         try:
             data = await parse_json_object(request)
@@ -918,16 +951,19 @@ if web is not None and routes is not None:
         return web.json_response(payload)
 
     @routes.get("/easyuse_anima/long_text_settings")
+    @_request_correlated
     async def get_long_text_settings_handler(request):
         return web.json_response(
             await _run_file_io(_get_long_text_settings_payload_sync)
         )
 
     @routes.get("/easyuse_anima/wildcards")
+    @_request_correlated
     async def get_wildcards_handler(request):
         return web.json_response(await _run_file_io(_wildcards_payload_sync))
 
     @routes.post("/easyuse_anima/long_text_settings/save")
+    @_request_correlated
     async def save_long_text_settings_handler(request):
         try:
             data = await parse_json_object(request)
@@ -939,10 +975,12 @@ if web is not None and routes is not None:
         )
 
     @routes.get("/easyuse_anima/autocomplete_status")
+    @_request_correlated
     async def autocomplete_status_handler(request):
         return web.json_response(await _run_file_io(_autocomplete_status_payload_sync))
 
     @routes.get("/easyuse_anima/autocomplete")
+    @_request_correlated
     async def autocomplete_handler(request):
         query = request.query.get("q", "")
         category = request.query.get("category", "")
@@ -960,6 +998,7 @@ if web is not None and routes is not None:
         )
 
     @routes.post("/easyuse_anima/classify_prompt")
+    @_request_correlated
     async def classify_prompt_handler(request):
         try:
             data = await parse_json_object(request)
@@ -978,6 +1017,7 @@ if web is not None and routes is not None:
         )
 
     @routes.post("/easyuse_anima/translate_prompt")
+    @_request_correlated
     async def translate_prompt_handler(request):
         try:
             data = await parse_json_object(request)
@@ -991,6 +1031,7 @@ if web is not None and routes is not None:
         return web.json_response({"status": "ok", "text": translated})
 
     @routes.get("/easyuse_anima/lora_preview")
+    @_request_correlated
     async def lora_preview_handler(request):
         preview_path = await _run_file_io(
             _resolve_lora_preview_path,
@@ -1004,14 +1045,17 @@ if web is not None and routes is not None:
         )
 
     @routes.get("/easyuse_anima/loras")
+    @_request_correlated
     async def loras_handler(request):
         return web.json_response({"loras": await _run_file_io(_list_loras)})
 
     @routes.get("/easyuse_anima/lora_profiles")
+    @_request_correlated
     async def lora_profiles_handler(request):
         return web.json_response({"profiles": await _run_file_io(_list_lora_profiles)})
 
     @routes.post("/easyuse_anima/lora_profiles/save")
+    @_request_correlated
     async def save_lora_profile_handler(request):
         try:
             data = await parse_json_object(request)
@@ -1033,6 +1077,7 @@ if web is not None and routes is not None:
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.get("/easyuse_anima/lora_profiles/load")
+    @_request_correlated
     async def load_lora_profile_handler(request):
         try:
             payload = await _run_file_io(
@@ -1049,12 +1094,14 @@ if web is not None and routes is not None:
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.get("/easyuse_anima/aio_profiles")
+    @_request_correlated
     async def aio_profiles_handler(request):
         return web.json_response(
             {"status": "ok", "profiles": await _run_file_io(_list_aio_profiles)}
         )
 
     @routes.post("/easyuse_anima/aio_profiles/save")
+    @_request_correlated
     async def save_aio_profile_handler(request):
         try:
             data = await parse_json_object(request)
@@ -1075,6 +1122,7 @@ if web is not None and routes is not None:
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.get("/easyuse_anima/aio_profiles/load")
+    @_request_correlated
     async def load_aio_profile_handler(request):
         try:
             payload = await _run_file_io(
@@ -1086,6 +1134,7 @@ if web is not None and routes is not None:
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.post("/easyuse_anima/aio_profiles/delete")
+    @_request_correlated
     async def delete_aio_profile_handler(request):
         try:
             data = await parse_json_object(request)
@@ -1099,6 +1148,7 @@ if web is not None and routes is not None:
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.post("/easyuse_anima/aio_profiles/rename")
+    @_request_correlated
     async def rename_aio_profile_handler(request):
         try:
             data = await parse_json_object(request)
@@ -1119,6 +1169,7 @@ if web is not None and routes is not None:
         return web.json_response({"status": "ok", "profile": payload})
 
     @routes.post("/easyuse_anima/lora_profiles/fix")
+    @_request_correlated
     async def fix_lora_profile_handler(request):
         try:
             data = await parse_json_object(request)

--- a/api_contract.py
+++ b/api_contract.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import json
+import uuid
 from typing import Any, Mapping
+
+
+REQUEST_ID_HEADER = "X-Request-ID"
 
 
 class ApiContractError(ValueError):
@@ -38,6 +42,43 @@ def error_payload(
     if details is not None:
         payload["details"] = dict(details)
     return payload
+
+
+def create_request_id() -> str:
+    """Create one server-owned correlation ID for an API request."""
+
+    return str(uuid.uuid4())
+
+
+def attach_request_id_header(response, request_id: str):
+    """Attach correlation metadata without requiring a global middleware."""
+
+    headers = getattr(response, "headers", None)
+    if headers is not None:
+        headers[REQUEST_ID_HEADER] = request_id
+    return response
+
+
+def correlate_response(response, request_id: str):
+    """Correlate JSON errors while preserving non-JSON response bodies."""
+
+    attach_request_id_header(response, request_id)
+    if (
+        getattr(response, "status", 0) < 400
+        or getattr(response, "content_type", "") != "application/json"
+    ):
+        return response
+
+    try:
+        payload = json.loads(response.text)
+    except (AttributeError, json.JSONDecodeError, TypeError, UnicodeDecodeError):
+        return response
+    if not isinstance(payload, dict):
+        return response
+
+    payload["request_id"] = request_id
+    response.text = json.dumps(payload, ensure_ascii=False)
+    return response
 
 
 async def parse_json_object(request) -> dict[str, Any]:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -1216,6 +1216,23 @@
       },
       {
         "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
         "bound_name": "os",
         "branch_context": [],
         "classification": "external",
@@ -1223,7 +1240,7 @@
         "conditional": false,
         "imported": "os",
         "kind": "static_import",
-        "line": 6,
+        "line": 7,
         "name": null,
         "optional": false,
         "requested": "os",
@@ -1240,7 +1257,7 @@
         "conditional": false,
         "imported": "re",
         "kind": "static_import",
-        "line": 7,
+        "line": 8,
         "name": null,
         "optional": false,
         "requested": "re",
@@ -1257,7 +1274,7 @@
         "conditional": false,
         "imported": "threading",
         "kind": "static_import",
-        "line": 8,
+        "line": 9,
         "name": null,
         "optional": false,
         "requested": "threading",
@@ -1274,7 +1291,7 @@
         "conditional": false,
         "imported": "weakref",
         "kind": "static_import",
-        "line": 9,
+        "line": 10,
         "name": null,
         "optional": false,
         "requested": "weakref",
@@ -1291,7 +1308,7 @@
         "conditional": false,
         "imported": "concurrent.futures:Future",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "Future",
         "optional": false,
         "requested": "concurrent.futures",
@@ -1308,10 +1325,27 @@
         "conditional": false,
         "imported": "concurrent.futures:ThreadPoolExecutor",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "name": "ThreadPoolExecutor",
         "optional": false,
         "requested": "concurrent.futures",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "wraps",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "functools:wraps",
+        "kind": "static_from",
+        "line": 12,
+        "name": "wraps",
+        "optional": false,
+        "requested": "functools",
         "role": "ordinary",
         "scope": "<module>",
         "source": "api.py"
@@ -1325,7 +1359,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 11,
+        "line": 13,
         "name": "Path",
         "optional": false,
         "requested": "pathlib",
@@ -1342,7 +1376,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 13
+            "line": 15
           }
         ],
         "classification": "external",
@@ -1350,7 +1384,7 @@
         "conditional": true,
         "imported": "server",
         "kind": "static_import",
-        "line": 14,
+        "line": 16,
         "name": null,
         "optional": true,
         "requested": "server",
@@ -1367,7 +1401,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 13
+            "line": 15
           }
         ],
         "classification": "external",
@@ -1375,7 +1409,7 @@
         "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
-        "line": 15,
+        "line": 17,
         "name": "web",
         "optional": true,
         "requested": "aiohttp",
@@ -1392,7 +1426,7 @@
         "conditional": false,
         "imported": ".settings:load_long_text_settings",
         "kind": "static_from",
-        "line": 20,
+        "line": 22,
         "name": "load_long_text_settings",
         "optional": false,
         "requested": ".settings",
@@ -1410,7 +1444,7 @@
         "conditional": false,
         "imported": ".settings:public_settings",
         "kind": "static_from",
-        "line": 20,
+        "line": 22,
         "name": "public_settings",
         "optional": false,
         "requested": ".settings",
@@ -1428,7 +1462,7 @@
         "conditional": false,
         "imported": ".settings:resolve_autocomplete_limit",
         "kind": "static_from",
-        "line": 20,
+        "line": 22,
         "name": "resolve_autocomplete_limit",
         "optional": false,
         "requested": ".settings",
@@ -1446,7 +1480,7 @@
         "conditional": false,
         "imported": ".settings:resolve_autocomplete_source",
         "kind": "static_from",
-        "line": 20,
+        "line": 22,
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": ".settings",
@@ -1464,7 +1498,7 @@
         "conditional": false,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 20,
+        "line": 22,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -1482,7 +1516,7 @@
         "conditional": false,
         "imported": ".settings:save_long_text_settings",
         "kind": "static_from",
-        "line": 20,
+        "line": 22,
         "name": "save_long_text_settings",
         "optional": false,
         "requested": ".settings",
@@ -1500,7 +1534,7 @@
         "conditional": false,
         "imported": ".settings:save_setting",
         "kind": "static_from",
-        "line": 20,
+        "line": 22,
         "name": "save_setting",
         "optional": false,
         "requested": ".settings",
@@ -1518,7 +1552,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:autocomplete_status",
         "kind": "static_from",
-        "line": 29,
+        "line": 31,
         "name": "autocomplete_status",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1536,7 +1570,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:available_autocomplete_sources",
         "kind": "static_from",
-        "line": 29,
+        "line": 31,
         "name": "available_autocomplete_sources",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1554,7 +1588,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:classify_prompt_text",
         "kind": "static_from",
-        "line": 29,
+        "line": 31,
         "name": "classify_prompt_text",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1572,7 +1606,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:resolve_autocomplete_source",
         "kind": "static_from",
-        "line": 29,
+        "line": 31,
         "name": "resolve_autocomplete_source",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1590,7 +1624,7 @@
         "conditional": false,
         "imported": ".autocomplete_dataset:search_autocomplete",
         "kind": "static_from",
-        "line": 29,
+        "line": 31,
         "name": "search_autocomplete",
         "optional": false,
         "requested": ".autocomplete_dataset",
@@ -1608,7 +1642,7 @@
         "conditional": false,
         "imported": ".wildcard_engine:list_wildcards",
         "kind": "static_from",
-        "line": 36,
+        "line": 38,
         "name": "list_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -1626,7 +1660,7 @@
         "conditional": false,
         "imported": ".wildcard_engine:resolve_wildcard_roots",
         "kind": "static_from",
-        "line": 36,
+        "line": 38,
         "name": "resolve_wildcard_roots",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -1644,7 +1678,7 @@
         "conditional": false,
         "imported": ".prompt_translation:PromptTranslationError",
         "kind": "static_from",
-        "line": 37,
+        "line": 39,
         "name": "PromptTranslationError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1662,7 +1696,7 @@
         "conditional": false,
         "imported": ".prompt_translation:TranslationBusyError",
         "kind": "static_from",
-        "line": 37,
+        "line": 39,
         "name": "TranslationBusyError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1680,7 +1714,7 @@
         "conditional": false,
         "imported": ".prompt_translation:TranslationCancelledError",
         "kind": "static_from",
-        "line": 37,
+        "line": 39,
         "name": "TranslationCancelledError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1698,7 +1732,7 @@
         "conditional": false,
         "imported": ".prompt_translation:TranslationTimeoutError",
         "kind": "static_from",
-        "line": 37,
+        "line": 39,
         "name": "TranslationTimeoutError",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1716,7 +1750,7 @@
         "conditional": false,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 37,
+        "line": 39,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -1734,8 +1768,62 @@
         "conditional": false,
         "imported": ".api_contract:ApiContractError",
         "kind": "static_from",
-        "line": 44,
+        "line": 46,
         "name": "ApiContractError",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "attach_request_id_header",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:attach_request_id_header",
+        "kind": "static_from",
+        "line": 46,
+        "name": "attach_request_id_header",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correlate_response",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:correlate_response",
+        "kind": "static_from",
+        "line": 46,
+        "name": "correlate_response",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "create_request_id",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:create_request_id",
+        "kind": "static_from",
+        "line": 46,
+        "name": "create_request_id",
         "optional": false,
         "requested": ".api_contract",
         "role": "ordinary",
@@ -1752,7 +1840,7 @@
         "conditional": false,
         "imported": ".api_contract:error_payload",
         "kind": "static_from",
-        "line": 44,
+        "line": 46,
         "name": "error_payload",
         "optional": false,
         "requested": ".api_contract",
@@ -1770,7 +1858,7 @@
         "conditional": false,
         "imported": ".api_contract:json_boolean",
         "kind": "static_from",
-        "line": 44,
+        "line": 46,
         "name": "json_boolean",
         "optional": false,
         "requested": ".api_contract",
@@ -1788,7 +1876,7 @@
         "conditional": false,
         "imported": ".api_contract:json_integer",
         "kind": "static_from",
-        "line": 44,
+        "line": 46,
         "name": "json_integer",
         "optional": false,
         "requested": ".api_contract",
@@ -1806,7 +1894,7 @@
         "conditional": false,
         "imported": ".api_contract:json_object",
         "kind": "static_from",
-        "line": 44,
+        "line": 46,
         "name": "json_object",
         "optional": false,
         "requested": ".api_contract",
@@ -1824,7 +1912,7 @@
         "conditional": false,
         "imported": ".api_contract:json_string",
         "kind": "static_from",
-        "line": 44,
+        "line": 46,
         "name": "json_string",
         "optional": false,
         "requested": ".api_contract",
@@ -1842,7 +1930,7 @@
         "conditional": false,
         "imported": ".api_contract:parse_json_object",
         "kind": "static_from",
-        "line": 44,
+        "line": 46,
         "name": "parse_json_object",
         "optional": false,
         "requested": ".api_contract",
@@ -1860,7 +1948,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 53
+            "line": 58
           }
         ],
         "classification": "internal",
@@ -1868,12 +1956,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 53
+          "try_line": 58
         },
         "conditional": true,
         "imported": ".storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 54,
+        "line": 59,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": ".storage",
@@ -1891,7 +1979,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 53
+            "line": 58
           }
         ],
         "classification": "internal",
@@ -1899,12 +1987,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 53
+          "try_line": 58
         },
         "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 54,
+        "line": 59,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -1923,9 +2011,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 55,
+            "handler_line": 60,
             "kind": "try",
-            "line": 53
+            "line": 58
           }
         ],
         "classification": "compatibility_fallback",
@@ -1933,12 +2021,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 53
+          "try_line": 58
         },
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 56,
+        "line": 61,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "storage",
@@ -1957,9 +2045,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 55,
+            "handler_line": 60,
             "kind": "try",
-            "line": 53
+            "line": 58
           }
         ],
         "classification": "compatibility_fallback",
@@ -1967,12 +2055,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 53
+          "try_line": 58
         },
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 56,
+        "line": 61,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -1990,7 +2078,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 371
+            "line": 402
           }
         ],
         "classification": "external",
@@ -1998,7 +2086,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 372,
+        "line": 403,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -2015,7 +2103,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 397
+            "line": 428
           }
         ],
         "classification": "external",
@@ -2023,7 +2111,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 398,
+        "line": 429,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -2040,7 +2128,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 717
+            "line": 748
           }
         ],
         "classification": "external",
@@ -2048,7 +2136,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 718,
+        "line": 749,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -2092,6 +2180,23 @@
       },
       {
         "alias": null,
+        "bound_name": "uuid",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "uuid",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api_contract.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -2099,7 +2204,7 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 4,
+        "line": 5,
         "name": "Any",
         "optional": false,
         "requested": "typing",
@@ -2116,7 +2221,7 @@
         "conditional": false,
         "imported": "typing:Mapping",
         "kind": "static_from",
-        "line": 4,
+        "line": 5,
         "name": "Mapping",
         "optional": false,
         "requested": "typing",
@@ -9090,26 +9195,26 @@
       },
       {
         "is_package": false,
-        "loc": 1130,
+        "loc": 1181,
         "module": "api",
-        "normalized_git_blob_sha1": "ee5bf095b79089fc5f7ec9306df3e906d312abab",
+        "normalized_git_blob_sha1": "d92db7ffb0350bb478e4f669b33e9422e517c1cc",
         "path": "api.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 55,
-          "global_count": 18
+          "function_count": 56,
+          "global_count": 19
         }
       },
       {
         "is_package": false,
-        "loc": 138,
+        "loc": 179,
         "module": "api_contract",
-        "normalized_git_blob_sha1": "51acfd3601fe1ab671b5ddf3e7694cc2ba05c394",
+        "normalized_git_blob_sha1": "d6e98857583f2d1d400bf82a166d739d99861b39",
         "path": "api_contract.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 7,
-          "global_count": 0
+          "function_count": 10,
+          "global_count": 1
         }
       },
       {
@@ -9522,16 +9627,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 55,
+            "handler_line": 60,
             "kind": "try",
-            "line": 53
+            "line": 58
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 56,
+        "line": 61,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -9545,16 +9650,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 55,
+            "handler_line": 60,
             "kind": "try",
-            "line": 53
+            "line": 58
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 56,
+        "line": 61,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -11186,7 +11291,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "os",
+        "imported": "logging",
         "kind": "static_import",
         "line": 6,
         "optional": false,
@@ -11197,7 +11302,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "re",
+        "imported": "os",
         "kind": "static_import",
         "line": 7,
         "optional": false,
@@ -11208,7 +11313,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "threading",
+        "imported": "re",
         "kind": "static_import",
         "line": 8,
         "optional": false,
@@ -11219,7 +11324,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "weakref",
+        "imported": "threading",
         "kind": "static_import",
         "line": 9,
         "optional": false,
@@ -11230,9 +11335,20 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "weakref",
+        "kind": "static_import",
+        "line": 10,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "concurrent.futures:Future",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
         "optional": false,
         "role": "ordinary",
         "source": "api.py"
@@ -11243,7 +11359,18 @@
         "conditional": false,
         "imported": "concurrent.futures:ThreadPoolExecutor",
         "kind": "static_from",
-        "line": 10,
+        "line": 11,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "functools:wraps",
+        "kind": "static_from",
+        "line": 12,
         "optional": false,
         "role": "ordinary",
         "source": "api.py"
@@ -11254,7 +11381,7 @@
         "conditional": false,
         "imported": "pathlib:Path",
         "kind": "static_from",
-        "line": 11,
+        "line": 13,
         "optional": false,
         "role": "ordinary",
         "source": "api.py"
@@ -11266,14 +11393,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 13
+            "line": 15
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server",
         "kind": "static_import",
-        "line": 14,
+        "line": 16,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -11285,14 +11412,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 13
+            "line": 15
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
-        "line": 15,
+        "line": 17,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -11304,14 +11431,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 371
+            "line": 402
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 372,
+        "line": 403,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -11323,14 +11450,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 397
+            "line": 428
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 398,
+        "line": 429,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -11342,14 +11469,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 717
+            "line": 748
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 718,
+        "line": 749,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -11380,9 +11507,20 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "api_contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 4,
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "api_contract.py"
@@ -11393,7 +11531,7 @@
         "conditional": false,
         "imported": "typing:Mapping",
         "kind": "static_from",
-        "line": 4,
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "api_contract.py"
@@ -13233,14 +13371,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 13
+            "line": 15
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server",
         "kind": "static_import",
-        "line": 14,
+        "line": 16,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -13252,14 +13390,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 13
+            "line": 15
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "aiohttp:web",
         "kind": "static_from",
-        "line": 15,
+        "line": 17,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -13271,14 +13409,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 371
+            "line": 402
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 372,
+        "line": 403,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -13290,14 +13428,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 397
+            "line": 428
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 398,
+        "line": 429,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -13309,14 +13447,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 717
+            "line": 748
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 718,
+        "line": 749,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -14482,7 +14620,7 @@
         "column": 29,
         "context": "assign:INVALID_PROFILE_NAME_CHARS",
         "kind": "import_time_call",
-        "line": 62,
+        "line": 67,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14491,7 +14629,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 87,
+        "line": 92,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14500,7 +14638,16 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 88,
+        "line": 93,
+        "module": "api.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 10,
+        "context": "assign:_LOGGER",
+        "kind": "import_time_call",
+        "line": 99,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14509,7 +14656,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 100,
+        "line": 106,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14518,7 +14665,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 101,
+        "line": 107,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14527,7 +14674,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 150,
+        "line": 156,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14536,7 +14683,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 151,
+        "line": 157,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14545,7 +14692,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 744,
+        "line": 775,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14554,7 +14701,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 894,
+        "line": 925,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14563,7 +14710,7 @@
         "column": 5,
         "context": "decorator:get_settings_handler",
         "kind": "route_registration",
-        "line": 899,
+        "line": 930,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14572,7 +14719,7 @@
         "column": 5,
         "context": "decorator:set_setting_handler",
         "kind": "route_registration",
-        "line": 903,
+        "line": 935,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14581,7 +14728,7 @@
         "column": 5,
         "context": "decorator:get_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 920,
+        "line": 953,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14590,7 +14737,7 @@
         "column": 5,
         "context": "decorator:get_wildcards_handler",
         "kind": "route_registration",
-        "line": 926,
+        "line": 960,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14599,7 +14746,7 @@
         "column": 5,
         "context": "decorator:save_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 930,
+        "line": 965,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14608,7 +14755,7 @@
         "column": 5,
         "context": "decorator:autocomplete_status_handler",
         "kind": "route_registration",
-        "line": 941,
+        "line": 977,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14617,7 +14764,7 @@
         "column": 5,
         "context": "decorator:autocomplete_handler",
         "kind": "route_registration",
-        "line": 945,
+        "line": 982,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14626,7 +14773,7 @@
         "column": 5,
         "context": "decorator:classify_prompt_handler",
         "kind": "route_registration",
-        "line": 962,
+        "line": 1000,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14635,7 +14782,7 @@
         "column": 5,
         "context": "decorator:translate_prompt_handler",
         "kind": "route_registration",
-        "line": 980,
+        "line": 1019,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14644,7 +14791,7 @@
         "column": 5,
         "context": "decorator:lora_preview_handler",
         "kind": "route_registration",
-        "line": 993,
+        "line": 1033,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14653,7 +14800,7 @@
         "column": 5,
         "context": "decorator:loras_handler",
         "kind": "route_registration",
-        "line": 1006,
+        "line": 1047,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14662,7 +14809,7 @@
         "column": 5,
         "context": "decorator:lora_profiles_handler",
         "kind": "route_registration",
-        "line": 1010,
+        "line": 1052,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14671,7 +14818,7 @@
         "column": 5,
         "context": "decorator:save_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1014,
+        "line": 1057,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14680,7 +14827,7 @@
         "column": 5,
         "context": "decorator:load_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1035,
+        "line": 1079,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14689,7 +14836,7 @@
         "column": 5,
         "context": "decorator:aio_profiles_handler",
         "kind": "route_registration",
-        "line": 1051,
+        "line": 1096,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14698,7 +14845,7 @@
         "column": 5,
         "context": "decorator:save_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1057,
+        "line": 1103,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14707,7 +14854,7 @@
         "column": 5,
         "context": "decorator:load_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1077,
+        "line": 1124,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14716,7 +14863,7 @@
         "column": 5,
         "context": "decorator:delete_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1088,
+        "line": 1136,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14725,7 +14872,7 @@
         "column": 5,
         "context": "decorator:rename_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1101,
+        "line": 1150,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -14734,7 +14881,7 @@
         "column": 5,
         "context": "decorator:fix_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1121,
+        "line": 1171,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -15329,13 +15476,13 @@
       },
       {
         "kind": "set",
-        "line": 66,
+        "line": 71,
         "module": "api.py",
         "name": "AIO_RESERVED_PROFILE_NAMES"
       },
       {
         "kind": "set",
-        "line": 82,
+        "line": 87,
         "module": "api.py",
         "name": "WINDOWS_RESERVED_FILE_BASENAMES"
       },
@@ -15622,7 +15769,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 100,
+        "line": 106,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -15631,7 +15778,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 150,
+        "line": 156,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/frontend_aio_profile_api_client_smoke.mjs
+++ b/tests/frontend_aio_profile_api_client_smoke.mjs
@@ -55,7 +55,14 @@ assert.equal(encodedValues.length, 0, "factory creation must not encode a name")
 const errorContracts = [
   {
     payload: { status: "error", message: "Legacy conflict" },
-    expected: { message: "Legacy conflict", status: 409, code: undefined, details: undefined },
+    headerRequestId: "",
+    expected: {
+      message: "Legacy conflict",
+      status: 409,
+      code: undefined,
+      details: undefined,
+      requestId: undefined,
+    },
   },
   {
     payload: {
@@ -63,23 +70,40 @@ const errorContracts = [
       code: "profile_exists",
       message: "Profile already exists",
       details: { field: "name" },
+      request_id: "body-request-id",
     },
+    headerRequestId: "different-header-id",
     expected: {
       message: "Profile already exists",
       status: 409,
       code: "profile_exists",
       details: { field: "name" },
+      requestId: "body-request-id",
+    },
+  },
+  {
+    payload: { status: "error", message: "Raw legacy error" },
+    headerRequestId: "header-request-id",
+    expected: {
+      message: "Raw legacy error",
+      status: 409,
+      code: undefined,
+      details: undefined,
+      requestId: "header-request-id",
     },
   },
 ];
 
-for (const { payload, expected } of errorContracts) {
+for (const { payload, headerRequestId, expected } of errorContracts) {
   await assert.rejects(
     sharedApiModule.easyuseAnimaFetchJson("/contract", {
       fetcher: async () => ({
         ok: false,
         status: 409,
         statusText: "Conflict",
+        headers: {
+          get: (name) => name.toLowerCase() === "x-request-id" ? headerRequestId : null,
+        },
         json: async () => payload,
       }),
     }),
@@ -88,6 +112,7 @@ for (const { payload, expected } of errorContracts) {
       assert.equal(error.status, expected.status);
       assert.equal(error.code, expected.code);
       assert.deepEqual(error.details, expected.details);
+      assert.equal(error.requestId, expected.requestId);
       return true;
     },
     "shared API transport must accept legacy and coded error payloads",

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -11,6 +11,7 @@ import threading
 import time
 import types
 import unittest
+import uuid
 import weakref
 from itertools import count
 from pathlib import Path
@@ -34,6 +35,45 @@ class RouteRegistry:
 
     def post(self, path):
         return self.get(path)
+
+
+class FakeJsonResponse(dict):
+    def __init__(self, payload, status=200):
+        super().__init__(payload=payload, status=status)
+        self.status = status
+        self.headers = {}
+        self.content_type = "application/json"
+
+    @property
+    def text(self):
+        return json.dumps(self["payload"])
+
+    @text.setter
+    def text(self, value):
+        self["payload"] = json.loads(value)
+
+
+class FakeResponse:
+    def __init__(self, *, status=200, headers=None, body=b""):
+        self.status = status
+        self.headers = dict(headers or {})
+        self.body = body
+        self.content_type = "application/octet-stream"
+
+
+class FakeFileResponse(FakeResponse):
+    def __init__(self, path, *, headers=None):
+        super().__init__(headers=headers)
+        self.path = path
+
+
+class FakeHTTPException(Exception):
+    def __init__(self, *, status=400, body=b""):
+        super().__init__(f"HTTP {status}")
+        self.status = status
+        self.body = body
+        self.headers = {}
+        self.content_type = "text/plain"
 
 
 class JsonRequest:
@@ -63,7 +103,10 @@ def load_api_routes():
     )
     fake_aiohttp = types.ModuleType("aiohttp")
     fake_aiohttp.web = types.SimpleNamespace(
-        json_response=lambda payload, status=200: {"payload": payload, "status": status},
+        json_response=FakeJsonResponse,
+        Response=FakeResponse,
+        FileResponse=FakeFileResponse,
+        HTTPException=FakeHTTPException,
     )
 
     spec = importlib.util.spec_from_file_location(
@@ -87,6 +130,224 @@ def response_strings(value):
             yield from response_strings(item)
     elif isinstance(value, str):
         yield value
+
+
+class ApiRequestCorrelationTests(unittest.TestCase):
+    ROUTES = {
+        "/easyuse_anima/settings",
+        "/easyuse_anima/set_setting",
+        "/easyuse_anima/long_text_settings",
+        "/easyuse_anima/wildcards",
+        "/easyuse_anima/long_text_settings/save",
+        "/easyuse_anima/autocomplete_status",
+        "/easyuse_anima/autocomplete",
+        "/easyuse_anima/classify_prompt",
+        "/easyuse_anima/translate_prompt",
+        "/easyuse_anima/lora_preview",
+        "/easyuse_anima/loras",
+        "/easyuse_anima/lora_profiles",
+        "/easyuse_anima/lora_profiles/save",
+        "/easyuse_anima/lora_profiles/load",
+        "/easyuse_anima/aio_profiles",
+        "/easyuse_anima/aio_profiles/save",
+        "/easyuse_anima/aio_profiles/load",
+        "/easyuse_anima/aio_profiles/delete",
+        "/easyuse_anima/aio_profiles/rename",
+        "/easyuse_anima/lora_profiles/fix",
+    }
+
+    def test_every_owned_route_has_source_and_registration_correlation(self):
+        source = (ROOT / "api.py").read_text(encoding="utf-8")
+        decorated_paths = set(
+            re.findall(
+                r'@routes\.(?:get|post)\("(/easyuse_anima/[^"\n]+)"\)\s+'
+                r"@_request_correlated",
+                source,
+            )
+        )
+        self.assertEqual(decorated_paths, self.ROUTES)
+
+        _api, routes = load_api_routes()
+        self.assertEqual(set(routes.handlers), self.ROUTES)
+        for path, handler in routes.handlers.items():
+            with self.subTest(path=path):
+                self.assertTrue(
+                    getattr(handler, "_easyuse_anima_request_correlation", False)
+                )
+
+    def test_json_error_body_and_header_share_one_uuid(self):
+        api, routes = load_api_routes()
+        request_id = "12345678-1234-4567-89ab-1234567890ab"
+        with patch.object(api, "create_request_id", return_value=request_id):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/set_setting"](JsonRequest([]))
+            )
+
+        self.assertEqual(response["status"], 400)
+        self.assertEqual(response["payload"]["code"], "json_object_required")
+        self.assertEqual(response["payload"]["request_id"], request_id)
+        self.assertEqual(response.headers["X-Request-ID"], request_id)
+        self.assertEqual(str(uuid.UUID(response["payload"]["request_id"])), request_id)
+
+    def test_real_aiohttp_json_response_keeps_correlated_header_and_body(self):
+        from aiohttp import web as aiohttp_web
+
+        api, _routes = load_api_routes()
+        request_id = "17345678-1234-4567-89ab-1234567890ab"
+        response = aiohttp_web.json_response(
+            {
+                "status": "error",
+                "code": "invalid_request",
+                "message": "Request validation failed",
+                "details": {"field": "name"},
+            },
+            status=422,
+        )
+
+        correlated = api.correlate_response(response, request_id)
+
+        self.assertIs(correlated, response)
+        self.assertEqual(response.headers["X-Request-ID"], request_id)
+        self.assertEqual(json.loads(response.text)["request_id"], request_id)
+        self.assertEqual(response.status, 422)
+        self.assertEqual(response.content_type, "application/json")
+
+    def test_success_response_has_header_without_body_contract_change(self):
+        api, routes = load_api_routes()
+        request_id = "22345678-1234-4567-89ab-1234567890ab"
+        payload = {"future": {"kept": True}}
+        with (
+            patch.object(api, "create_request_id", return_value=request_id),
+            patch.object(api, "_get_settings_payload_sync", return_value=payload),
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/settings"](JsonRequest())
+            )
+
+        self.assertEqual(response["payload"], payload)
+        self.assertNotIn("request_id", response["payload"])
+        self.assertEqual(response.headers["X-Request-ID"], request_id)
+
+    def test_translation_status_taxonomy_keeps_request_correlation(self):
+        api, routes = load_api_routes()
+
+        class TranslationUpstreamTestError(api.PromptTranslationError):
+            status = 502
+            code = "translation_upstream_error"
+
+        cases = (
+            (api.TranslationCancelledError(), 499, "translation_cancelled"),
+            (TranslationUpstreamTestError(), 502, "translation_upstream_error"),
+            (api.TranslationBusyError(), 503, "translation_busy"),
+            (api.TranslationTimeoutError(), 504, "translation_timeout"),
+        )
+        handler = routes.handlers["/easyuse_anima/translate_prompt"]
+
+        for error, status, code in cases:
+            with self.subTest(code=code), patch.object(
+                api,
+                "_translate_prompt_for_route",
+                side_effect=error,
+            ):
+                response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+            self.assertEqual(response["status"], status)
+            self.assertEqual(response["payload"]["code"], code)
+            self.assertEqual(
+                response["payload"]["request_id"],
+                response.headers["X-Request-ID"],
+            )
+
+    def test_unexpected_exception_is_safe_500_and_logged_with_request_id(self):
+        api, routes = load_api_routes()
+        request_id = "32345678-1234-4567-89ab-1234567890ab"
+        secret = r"C:\Users\alice\secret.json API_TOKEN=top-secret"
+        with (
+            patch.object(api, "create_request_id", return_value=request_id),
+            patch.object(api, "_list_aio_profiles", side_effect=RuntimeError(secret)),
+            patch.object(api._LOGGER, "exception") as log_exception,
+        ):
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/aio_profiles"](JsonRequest())
+            )
+
+        self.assertEqual(response["status"], 500)
+        self.assertEqual(
+            response["payload"],
+            {
+                "status": "error",
+                "code": "internal_error",
+                "message": "An unexpected server error occurred.",
+                "request_id": request_id,
+            },
+        )
+        self.assertEqual(response.headers["X-Request-ID"], request_id)
+        log_exception.assert_called_once()
+        self.assertEqual(log_exception.call_args.args[1], request_id)
+        serialized = json.dumps(response["payload"])
+        for forbidden in ("alice", "secret.json", "API_TOKEN", "top-secret", "Traceback"):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_cancelled_request_is_not_normalized_or_logged(self):
+        api, routes = load_api_routes()
+        with (
+            patch.object(api, "_run_file_io", side_effect=asyncio.CancelledError()),
+            patch.object(api._LOGGER, "exception") as log_exception,
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                asyncio.run(
+                    routes.handlers["/easyuse_anima/aio_profiles"](JsonRequest())
+                )
+        log_exception.assert_not_called()
+
+    def test_http_exception_preserves_control_flow_and_body_with_header(self):
+        from aiohttp import web as aiohttp_web
+
+        api, _routes = load_api_routes()
+        request_id = "42345678-1234-4567-89ab-1234567890ab"
+        original = aiohttp_web.HTTPNotFound(text="not found")
+
+        @api._request_correlated
+        async def raises_http_exception(_request):
+            raise original
+
+        with (
+            patch.object(api, "create_request_id", return_value=request_id),
+            patch.object(api.web, "HTTPException", aiohttp_web.HTTPException),
+            patch.object(api._LOGGER, "exception") as log_exception,
+        ):
+            with self.assertRaises(aiohttp_web.HTTPNotFound) as raised:
+                asyncio.run(raises_http_exception(JsonRequest()))
+
+        self.assertEqual(raised.exception.status, 404)
+        self.assertEqual(raised.exception.text, "not found")
+        self.assertEqual(raised.exception.headers["X-Request-ID"], request_id)
+        log_exception.assert_not_called()
+
+    def test_lora_preview_keeps_raw_and_binary_contracts_with_header(self):
+        api, routes = load_api_routes()
+        handler = routes.handlers["/easyuse_anima/lora_preview"]
+
+        with patch.object(api, "_resolve_lora_preview_path", return_value=None):
+            missing = asyncio.run(handler(JsonRequest(query={"name": "missing"})))
+        self.assertIsInstance(missing, FakeResponse)
+        self.assertEqual(missing.status, 404)
+        self.assertEqual(missing.body, b"")
+        self.assertIn("X-Request-ID", missing.headers)
+
+        preview_path = r"C:\safe-test\preview.webp"
+        with patch.object(
+            api,
+            "_resolve_lora_preview_path",
+            return_value=preview_path,
+        ):
+            found = asyncio.run(handler(JsonRequest(query={"name": "preview"})))
+        self.assertIsInstance(found, FakeFileResponse)
+        self.assertEqual(found.path, preview_path)
+        self.assertEqual(
+            found.headers["Content-Disposition"],
+            'filename="preview.webp"',
+        )
+        self.assertIn("X-Request-ID", found.headers)
 
 
 class ApiRequestContractTests(unittest.TestCase):
@@ -427,15 +688,26 @@ class ApiRequestContractTests(unittest.TestCase):
         for forbidden in ("alice", "profile.json", "API_TOKEN", "top-secret", "Traceback"):
             self.assertNotIn(forbidden, serialized)
 
-    def test_unexpected_worker_exception_is_not_reclassified(self):
+    def test_unexpected_worker_exception_is_normalized_only_at_route_boundary(self):
         api, routes = load_api_routes()
-        with patch.object(
-            api,
-            "_list_aio_profiles",
-            side_effect=RuntimeError("storage programming error"),
+        with (
+            patch.object(
+                api,
+                "_list_aio_profiles",
+                side_effect=RuntimeError("storage programming error"),
+            ),
+            patch.object(api._LOGGER, "exception") as log_exception,
         ):
-            with self.assertRaisesRegex(RuntimeError, "storage programming error"):
-                asyncio.run(routes.handlers["/easyuse_anima/aio_profiles"](JsonRequest()))
+            response = asyncio.run(
+                routes.handlers["/easyuse_anima/aio_profiles"](JsonRequest())
+            )
+        self.assertEqual(response["status"], 500)
+        self.assertEqual(response["payload"]["code"], "internal_error")
+        self.assertEqual(
+            response["payload"]["request_id"],
+            response.headers["X-Request-ID"],
+        )
+        log_exception.assert_called_once()
 
     def test_normal_settings_and_profile_success_payloads_remain_compatible(self):
         api, routes = load_api_routes()

--- a/tests/test_prompt_translation_api.py
+++ b/tests/test_prompt_translation_api.py
@@ -307,13 +307,19 @@ class PromptTranslationApiTests(unittest.TestCase):
             TimeoutError("settings storage timeout"),
         ):
             with self.subTest(error=type(error).__name__):
-                with patch.object(
-                    api,
-                    "resolve_prompt_translation_settings",
-                    side_effect=error,
+                with (
+                    patch.object(
+                        api,
+                        "resolve_prompt_translation_settings",
+                        side_effect=error,
+                    ),
+                    patch.object(api._LOGGER, "exception") as log_exception,
                 ):
-                    with self.assertRaisesRegex(type(error), str(error)):
-                        asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+                    response = asyncio.run(handler(JsonRequest({"text": "%{text}"})))
+                self.assertEqual(response["status"], 500)
+                self.assertEqual(response["payload"]["code"], "internal_error")
+                self.assertNotEqual(response["payload"]["code"], "translation_upstream_error")
+                log_exception.assert_called_once()
 
         response = asyncio.run(handler(JsonRequest([])))
         self.assertEqual(response["status"], 400)

--- a/web/js/easyuse_anima_api.js
+++ b/web/js/easyuse_anima_api.js
@@ -29,7 +29,7 @@ function easyuseAnimaApiError(response, data, errorMessage) {
     || response.statusText
     || (response.status ? `HTTP ${response.status}` : errorMessage)
     || DEFAULT_REQUEST_FAILED;
-  const error = /** @type {Error & {status: number, code?: string, details?: any}} */ (
+  const error = /** @type {Error & {status: number, code?: string, details?: any, requestId?: string}} */ (
     new Error(message)
   );
   error.status = Number(response?.status) || 0;
@@ -38,6 +38,12 @@ function easyuseAnimaApiError(response, data, errorMessage) {
   }
   if (data?.details !== undefined) {
     error.details = data.details;
+  }
+  const requestId = (typeof data?.request_id === "string" && data.request_id)
+    || response?.headers?.get?.("X-Request-ID")
+    || "";
+  if (requestId) {
+    error.requestId = requestId;
   }
   return error;
 }


### PR DESCRIPTION
## 변경 요약

Issue #165 후속으로 EasyUseAnima 소유 API route에만 request ID/error correlation 계약을 추가합니다.

- 각 `/easyuse_anima/*` 요청마다 서버가 UUID request ID를 생성합니다.
- 모든 응답에 `X-Request-ID` header를 추가합니다.
- 4xx/5xx JSON object 오류에는 같은 값의 additive `request_id`를 추가합니다.
- 기존 `status/code/message/details`와 profile conflict/not-found/stored-data, translation 499/502/503/504 taxonomy는 유지합니다.
- 예상 밖 예외만 request ID와 함께 server log에 기록하고, client에는 경로·원문·secret·traceback이 없는 `500 internal_error` JSON을 반환합니다.
- `asyncio.CancelledError`와 `aiohttp.web.HTTPException` control-flow는 500으로 마스킹하지 않습니다. HTTPException은 기존 body/status를 유지하고 header correlation만 추가합니다.
- `lora_preview`의 raw 404와 binary `FileResponse` body 계약은 유지하고 header만 추가합니다.
- frontend API `Error`에 additive `requestId`를 노출합니다. JSON `request_id`를 우선하고 없으면 `X-Request-ID` header를 사용하며, 기존 legacy 오류 응답은 그대로 처리합니다.

Refs #165

## 최신 dev 통합

- PR #197(B-02)이 반영된 `dev@6b0e3000c6fe922e9a122201e6dee9448d28ad51`을 현재 branch에 merge했습니다.
- 강제 reset/rebase 없이 merge commit `ae95b49`로 비파괴 통합했습니다.
- 현재 PR merge-base는 `6b0e3000c6fe922e9a122201e6dee9448d28ad51`입니다.

## 독립 리뷰 blocker 수정

독립 리뷰가 이전 HEAD `4addb82f7015dfef9e211a6d833b9295d021a6e0`에서 아래 focused test의 1 test / 1 failure를 재현했습니다.

`python -m unittest tests.test_python_backend_analyzer.PythonBackendAnalyzerTests.test_current_repository_fixture_matches_and_uses_real_runtime_surface`

원인은 `api.py`의 `logging` / `functools.wraps` / import-time `_LOGGER`와 `api_contract.py`의 `uuid` 및 request correlation helpers가 deterministic backend baseline fixture에 반영되지 않은 것이었습니다.

최신 dev+B-02와 #198 변경이 함께 있는 branch에서 저장소 공식 analyzer로 fixture를 재생성했습니다.

`python tools/analyze_python_backend.py --root . --format json --output tests/fixtures/python_backend_baseline.json`

actual fixture diff 검토 결과:

- `api.py`: hash, LOC 1181, function 56, global 19, `logging` / `functools.wraps` imports, request helper imports, `logging.getLogger` import-time side-effect 및 line shifts
- `api_contract.py`: hash, LOC 179, function 10, global 1, `uuid` import
- B-02 common/image module hash와 import entries는 `origin/dev` baseline과 동일
- module count 28, runtime import closure 23, missing internal imports 0 유지
- 그 밖의 analyzer baseline 변화는 없음

## 변경 파일

- `api_contract.py`: UUID 생성, header 부착, JSON 오류 response correlation boundary
- `api.py`: EasyUseAnima route-local decorator, safe unexpected-500/logging, 20개 route 적용
- `web/js/easyuse_anima_api.js`: frontend `Error.requestId` 호환 필드
- `tests/test_api_contract.py`: source/registration inventory, 실제 aiohttp response, cancellation/HTTPException/raw/binary/500/taxonomy 회귀
- `tests/test_prompt_translation_api.py`: 예상 밖 programming error의 safe 500 boundary 회귀
- `tests/frontend_aio_profile_api_client_smoke.mjs`: body 우선/header fallback/legacy 호환 회귀
- `tests/fixtures/python_backend_baseline.json`: 최신 dev+B-02와 request correlation runtime surface baseline

## 검증

최신 dev+B-02 통합 후 현재 branch에서 실행했습니다.

- `python -m unittest tests.test_python_backend_analyzer.PythonBackendAnalyzerTests.test_current_repository_fixture_matches_and_uses_real_runtime_surface`
  - 1 test 통과
- `python -m unittest tests.test_api_contract tests.test_prompt_translation_api tests.test_aio_profiles tests.test_lora_profiles`
  - request correlation/API contract/profile/translation 포함 78 tests 통과
- `node --check web/js/easyuse_anima_api.js`
  - 통과
- `node tests/frontend_aio_profile_api_client_smoke.mjs`
  - 통과
- `tools/check_project.ps1 -Profile quick`
  - Python compile 통과
  - frontend 110 JavaScript files / TypeScript 6.0.3 통과
  - Git diff check 통과
- `git diff --check`
  - 통과

## 테스트 표면

- ComfyUI Codex test environment: focused unittest 및 repository quick checks
- 공식 full validation: 통과 — Python 598 tests, frontend 110 JavaScript, TypeScript 6.0.3, compile/diff checks
- ComfyUI 0.27.0 Codex test instance live API smoke: 통과
  - malformed JSON: 400 `malformed_json`, JSON `request_id`와 `X-Request-ID` 동일 UUID
  - settings success: 200, correlation header 존재, success body에 `request_id` 미주입
  - missing LoRA preview: raw 404 빈 body 유지, correlation header 존재
  - backend source/install 및 frontend source/install/served module hash 일치
- Browser smoke / Legacy canvas / Node 2.0: 미실행 (가시 UI 동작 변경 없음)

## 남은 위험

- route-local decorator이므로 handler 진입 전 router/outer middleware 오류에는 correlation ID가 붙지 않습니다. 이 범위는 전역 ComfyUI middleware를 건드리지 않기 위한 의도된 경계입니다.
- live smoke에서는 unexpected internal 500을 인위적으로 유발하지 않았으며, 해당 redaction/log correlation은 deterministic regression으로 검증했습니다.
- 향후 EasyUseAnima route를 추가할 때 decorator 누락을 막기 위해 source와 registration inventory 회귀가 현재 20개 route를 고정합니다.
