### PR TITLE
chore: Prompt Studio 중앙 lifecycle hook registry Phase 1

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -16,6 +16,7 @@
     "web/js/aio/**/*.js",
     "web/js/autocomplete/**/*.js",
     "web/js/lora_preset/**/*.js",
+    "web/js/lifecycle/**/*.js",
     "web/js/settings/**/*.js",
     "web/js/easyuse_anima_prompt_studio.js",
     "web/js/easyuse_anima_prompt_studio_regional.js",

--- a/tests/frontend_host_hook_registry_smoke.mjs
+++ b/tests/frontend_host_hook_registry_smoke.mjs
@@ -520,11 +520,27 @@ assert.deepEqual(Object.keys(registry).sort(), [
   host.queuePrompt("second-call");
   assert.deepEqual(events, ["second", "original"], "runtime replacement kept the stale closure");
   assert.equal(firstRuntime.dispose(), false, "a superseded runtime must not release the new lease");
+  assert.equal(
+    install(firstRuntime, "stale-reclaim"),
+    false,
+    "a superseded runtime must not reclaim the owner slot",
+  );
+  events.length = 0;
+  host.queuePrompt("second-after-stale-install");
+  assert.deepEqual(
+    events,
+    ["second", "original"],
+    "a superseded runtime replaced the current callback closure",
+  );
   assert.equal(secondRuntime.dispose(), true);
   assert.equal(host.queuePrompt, original);
 
   events.length = 0;
-  assert.equal(install(secondRuntime, "second-reinstalled"), true);
+  assert.equal(
+    install(secondRuntime, "second-reinstalled"),
+    true,
+    "an ordinary disposed runtime must remain reinstallable when the owner slot is free",
+  );
   host.queuePrompt("reinstalled-call");
   assert.deepEqual(events, ["second-reinstalled", "original"]);
   assert.equal(secondRuntime.dispose(), true);

--- a/tests/frontend_host_hook_registry_smoke.mjs
+++ b/tests/frontend_host_hook_registry_smoke.mjs
@@ -1,0 +1,428 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const registry = await import(dataModule(
+  "../web/js/lifecycle/host_hook_registry.js",
+));
+const loraSaveSync = await import(dataModule(
+  "../web/js/lora_preset/save_sync.js",
+));
+const aioQueueRuntime = await import(dataModule(
+  "../web/js/aio/generator_queue_runtime.js",
+));
+
+assert.deepEqual(Object.keys(registry), ["registerHostHookCallbacks"]);
+
+{
+  const events = [];
+  const returnValue = { serialized: true };
+  const firstArg = { first: true };
+  const secondArg = { second: true };
+  const receiver = { receiver: true };
+  const serializeHost = {
+    serialize(...args) {
+      events.push(["original", this, args]);
+      return returnValue;
+    },
+  };
+  const original = serializeHost.serialize;
+  const ownerA = Symbol("serialize-a");
+  const ownerB = Symbol("serialize-b");
+  const disposeA = registry.registerHostHookCallbacks({
+    owner: ownerA,
+    serializeHost,
+    beforeSerialize: (context) => events.push(["a", context.thisArg, context.args]),
+  });
+  const installed = serializeHost.serialize;
+  const disposeDuplicate = registry.registerHostHookCallbacks({
+    owner: ownerA,
+    serializeHost,
+    beforeSerialize: () => events.push(["duplicate"]),
+  });
+  const disposeB = registry.registerHostHookCallbacks({
+    owner: ownerB,
+    serializeHost,
+    beforeSerialize: (context) => events.push(["b", context.thisArg, context.args]),
+  });
+
+  assert.equal(serializeHost.serialize, installed);
+  assert.equal(disposeDuplicate(), false, "duplicate setup must not own the existing callback");
+  assert.equal(serializeHost.serialize.call(receiver, firstArg, secondArg), returnValue);
+  assert.deepEqual(events, [
+    ["b", receiver, [firstArg, secondArg]],
+    ["a", receiver, [firstArg, secondArg]],
+    ["original", receiver, [firstArg, secondArg]],
+  ]);
+
+  assert.equal(disposeB(), true);
+  assert.equal(serializeHost.serialize, installed);
+  events.length = 0;
+  serializeHost.serialize.call(receiver, firstArg);
+  assert.deepEqual(events.map(([name]) => name), ["a", "original"]);
+  assert.equal(disposeA(), true);
+  assert.equal(serializeHost.serialize, original, "last callback must restore the original hook");
+  assert.equal(disposeA(), false);
+
+  const callbackError = new Error("before serialize failed");
+  let originalCalls = 0;
+  serializeHost.serialize = function () {
+    originalCalls += 1;
+  };
+  const failingOriginal = serializeHost.serialize;
+  const disposeFailure = registry.registerHostHookCallbacks({
+    owner: Symbol("serialize-failure"),
+    serializeHost,
+    beforeSerialize() {
+      throw callbackError;
+    },
+  });
+  assert.throws(() => serializeHost.serialize(), (error) => error === callbackError);
+  assert.equal(originalCalls, 0, "a legacy before-hook failure must still prevent serialize");
+  disposeFailure();
+  assert.equal(serializeHost.serialize, failingOriginal);
+}
+
+{
+  const events = [];
+  const returnValue = Symbol("clear-result");
+  const clearError = new Error("clear failed");
+  let fail = false;
+  const graph = {
+    clear(...args) {
+      events.push(["original", this, args]);
+      if (fail) {
+        throw clearError;
+      }
+      return returnValue;
+    },
+  };
+  const original = graph.clear;
+  const disposeA = registry.registerHostHookCallbacks({
+    owner: Symbol("clear-a"),
+    graphHost: graph,
+    onGraphClear: () => events.push(["a"]),
+  });
+  const installed = graph.clear;
+  const disposeB = registry.registerHostHookCallbacks({
+    owner: Symbol("clear-b"),
+    graphHost: graph,
+    onGraphClear: () => events.push(["b"]),
+  });
+  const receiver = { graph: true };
+  const arg = { clear: true };
+  assert.equal(graph.clear.call(receiver, arg), returnValue);
+  assert.deepEqual(events, [
+    ["original", receiver, [arg]],
+    ["a"],
+    ["b"],
+  ]);
+
+  events.length = 0;
+  fail = true;
+  assert.throws(() => graph.clear.call(receiver, arg), (error) => error === clearError);
+  assert.deepEqual(events, [["original", receiver, [arg]]]);
+  disposeB();
+  assert.equal(graph.clear, installed);
+  disposeA();
+  assert.equal(graph.clear, original);
+}
+
+{
+  const events = [];
+  const returnValue = { queued: true };
+  const receiver = { queue: true };
+  const firstArg = { first: true };
+  const secondArg = { second: true };
+  const queueHost = {
+    queuePrompt(...args) {
+      events.push(["original", this, args]);
+      return returnValue;
+    },
+  };
+  const original = queueHost.queuePrompt;
+  const disposeA = registry.registerHostHookCallbacks({
+    owner: Symbol("queue-sync-a"),
+    queueHost,
+    beforeQueue: (context) => events.push(["a", context.thisArg, context.args]),
+  });
+  const disposeB = registry.registerHostHookCallbacks({
+    owner: Symbol("queue-sync-b"),
+    queueHost,
+    beforeQueue: (context) => events.push(["b", context.thisArg, context.args]),
+  });
+  const result = queueHost.queuePrompt.call(receiver, firstArg, secondArg);
+  assert.equal(result, returnValue);
+  assert.equal(typeof result?.then, "undefined", "before-only queue hooks must stay synchronous");
+  assert.deepEqual(events, [
+    ["b", receiver, [firstArg, secondArg]],
+    ["a", receiver, [firstArg, secondArg]],
+    ["original", receiver, [firstArg, secondArg]],
+  ]);
+  disposeB();
+  disposeA();
+  assert.equal(queueHost.queuePrompt, original);
+}
+
+{
+  const events = [];
+  const resolved = { prompt_id: "resolved" };
+  const rejected = new Error("queue rejected");
+  const thrown = new Error("queue threw");
+  let mode = "resolve";
+  const queueHost = {
+    queuePrompt(...args) {
+      events.push(["original", this, args]);
+      if (mode === "reject") {
+        return Promise.reject(rejected);
+      }
+      if (mode === "throw") {
+        throw thrown;
+      }
+      return resolved;
+    },
+  };
+  const receiver = { queue: true };
+  const arg = { prompt: true };
+  const registerOwner = (name) => registry.registerHostHookCallbacks({
+    owner: Symbol(name),
+    queueHost,
+    beforeQueue(context) {
+      events.push([`${name}:before`, context.thisArg, context.args]);
+      return `${name}:state`;
+    },
+    afterQueue(context) {
+      events.push([
+        `${name}:after`,
+        context.ok,
+        context.callbackState,
+        context.ok ? context.result : context.error,
+      ]);
+    },
+  });
+  const disposeA = registerOwner("a");
+  const disposeB = registerOwner("b");
+
+  const pending = queueHost.queuePrompt.call(receiver, arg);
+  assert.equal(typeof pending.then, "function", "afterQueue ownership must preserve async wrapping");
+  assert.equal(await pending, resolved);
+  assert.deepEqual(events, [
+    ["b:before", receiver, [arg]],
+    ["a:before", receiver, [arg]],
+    ["original", receiver, [arg]],
+    ["a:after", true, "a:state", resolved],
+    ["b:after", true, "b:state", resolved],
+  ]);
+
+  events.length = 0;
+  mode = "reject";
+  await assert.rejects(queueHost.queuePrompt.call(receiver, arg), (error) => error === rejected);
+  assert.deepEqual(events.map(([name]) => name), [
+    "b:before", "a:before", "original", "a:after", "b:after",
+  ]);
+  assert.equal(events[3][3], rejected);
+  assert.equal(events[4][3], rejected);
+
+  events.length = 0;
+  mode = "throw";
+  await assert.rejects(queueHost.queuePrompt.call(receiver, arg), (error) => error === thrown);
+  assert.deepEqual(events.map(([name]) => name), [
+    "b:before", "a:before", "original", "a:after", "b:after",
+  ]);
+  disposeB();
+  disposeA();
+}
+
+{
+  const beforeError = new Error("before queue failed");
+  const afterError = new Error("after queue failed");
+  let originalCalls = 0;
+  const host = {
+    queuePrompt() {
+      originalCalls += 1;
+      return "queued";
+    },
+  };
+  const disposeBeforeFailure = registry.registerHostHookCallbacks({
+    owner: Symbol("queue-before-failure"),
+    queueHost: host,
+    beforeQueue() {
+      throw beforeError;
+    },
+    afterQueue() {
+      throw new Error("afterQueue must not run when its own beforeQueue fails");
+    },
+  });
+  await assert.rejects(host.queuePrompt(), (error) => error === beforeError);
+  assert.equal(originalCalls, 0);
+  disposeBeforeFailure();
+
+  const disposeAfterFailure = registry.registerHostHookCallbacks({
+    owner: Symbol("queue-after-failure"),
+    queueHost: host,
+    afterQueue() {
+      throw afterError;
+    },
+  });
+  await assert.rejects(host.queuePrompt(), (error) => error === afterError);
+  assert.equal(originalCalls, 1, "afterQueue failure must occur after the original resolves");
+  disposeAfterFailure();
+}
+
+{
+  let callbackCalls = 0;
+  let originalCalls = 0;
+  const host = {
+    queuePrompt() {
+      originalCalls += 1;
+      return originalCalls;
+    },
+  };
+  const original = host.queuePrompt;
+  const dispose = registry.registerHostHookCallbacks({
+    owner: Symbol("identity-guard"),
+    queueHost: host,
+    beforeQueue: () => { callbackCalls += 1; },
+  });
+  const registryWrapper = host.queuePrompt;
+  host.queuePrompt = function (...args) {
+    return registryWrapper.apply(this, args);
+  };
+  const foreignWrapper = host.queuePrompt;
+  assert.equal(dispose(), true);
+  assert.equal(host.queuePrompt, foreignWrapper, "dispose must not overwrite a foreign outer wrapper");
+  assert.equal(host.queuePrompt(), 1);
+  assert.equal(callbackCalls, 0, "disposed callbacks must not survive in a hidden wrapper");
+
+  host.queuePrompt = registryWrapper;
+  const disposeRevived = registry.registerHostHookCallbacks({
+    owner: Symbol("revived-stale-wrapper"),
+    queueHost: host,
+    beforeQueue: () => { callbackCalls += 1; },
+  });
+  assert.equal(host.queuePrompt, registryWrapper, "a stale current wrapper must be reused, not stacked");
+  assert.equal(host.queuePrompt(), 2);
+  assert.equal(callbackCalls, 1);
+  disposeRevived();
+  assert.equal(host.queuePrompt, original);
+}
+
+function exerciseLoraLegacyLoadOrder(registryFirst) {
+  const events = [];
+  class Graph {
+    constructor() {
+      this._nodes = [{ comfyClass: "EasyUseAnimaLoraPreset" }];
+    }
+
+    serialize(value) {
+      events.push("original:serialize");
+      return value;
+    }
+  }
+  const app = {
+    graph: new Graph(),
+    queuePrompt(value) {
+      events.push("original:queue");
+      return value;
+    },
+  };
+  const legacy = loraSaveSync.createLoraPresetSaveSync({
+    app,
+    nodeTypeName: "EasyUseAnimaLoraPreset",
+    saveCurrentProfile: () => events.push("legacy"),
+    getGraphPrototype: () => Graph.prototype,
+  });
+  const installRegistry = () => registry.registerHostHookCallbacks({
+    owner: Symbol(`lora-registry-${registryFirst}`),
+    serializeHost: Graph.prototype,
+    queueHost: app,
+    beforeSerialize: () => events.push("registry"),
+    beforeQueue: () => events.push("registry"),
+  });
+
+  let disposeRegistry;
+  let legacySerialize;
+  let legacyQueue;
+  if (registryFirst) {
+    disposeRegistry = installRegistry();
+    legacy.install();
+    legacySerialize = Graph.prototype.serialize;
+    legacyQueue = app.queuePrompt;
+  } else {
+    legacy.install();
+    legacySerialize = Graph.prototype.serialize;
+    legacyQueue = app.queuePrompt;
+    disposeRegistry = installRegistry();
+  }
+  Graph.prototype.serialize.call(app.graph, "serialize");
+  app.queuePrompt.call(app, "queue");
+  const expectedCall = registryFirst
+    ? ["legacy", "registry", "original:serialize", "legacy", "registry", "original:queue"]
+    : ["registry", "legacy", "original:serialize", "registry", "legacy", "original:queue"];
+  assert.deepEqual(events, expectedCall);
+
+  events.length = 0;
+  disposeRegistry();
+  assert.equal(Graph.prototype.serialize, legacySerialize);
+  assert.equal(app.queuePrompt, legacyQueue);
+  Graph.prototype.serialize.call(app.graph, "serialize");
+  app.queuePrompt.call(app, "queue");
+  assert.deepEqual(events, ["legacy", "original:serialize", "legacy", "original:queue"]);
+}
+
+exerciseLoraLegacyLoadOrder(false);
+exerciseLoraLegacyLoadOrder(true);
+
+function exerciseAioLegacyLoadOrder(registryFirst) {
+  const events = [];
+  const host = {
+    queuePrompt(value) {
+      events.push("original");
+      return value;
+    },
+  };
+  const runtime = {
+    wrapQueuePrompt(queuePrompt) {
+      return function (...args) {
+        events.push("legacy");
+        return queuePrompt.apply(this, args);
+      };
+    },
+  };
+  const installRegistry = () => registry.registerHostHookCallbacks({
+    owner: Symbol(`aio-registry-${registryFirst}`),
+    queueHost: host,
+    beforeQueue: () => events.push("registry"),
+  });
+  let disposeRegistry;
+  let legacyWrapper;
+  if (registryFirst) {
+    disposeRegistry = installRegistry();
+    aioQueueRuntime.aioInstallGeneratorQueuePromptHook(host, runtime);
+    legacyWrapper = host.queuePrompt;
+  } else {
+    aioQueueRuntime.aioInstallGeneratorQueuePromptHook(host, runtime);
+    legacyWrapper = host.queuePrompt;
+    disposeRegistry = installRegistry();
+  }
+  assert.equal(host.queuePrompt("queued"), "queued");
+  assert.deepEqual(
+    events,
+    registryFirst ? ["legacy", "registry", "original"] : ["registry", "legacy", "original"],
+  );
+
+  events.length = 0;
+  disposeRegistry();
+  assert.equal(host.queuePrompt, legacyWrapper);
+  assert.equal(host.queuePrompt("queued"), "queued");
+  assert.deepEqual(events, ["legacy", "original"]);
+}
+
+exerciseAioLegacyLoadOrder(false);
+exerciseAioLegacyLoadOrder(true);
+
+console.log("Host hook registry smoke passed.");

--- a/tests/frontend_host_hook_registry_smoke.mjs
+++ b/tests/frontend_host_hook_registry_smoke.mjs
@@ -16,7 +16,10 @@ const aioQueueRuntime = await import(dataModule(
   "../web/js/aio/generator_queue_runtime.js",
 ));
 
-assert.deepEqual(Object.keys(registry), ["registerHostHookCallbacks"]);
+assert.deepEqual(Object.keys(registry).sort(), [
+  "createHostHookRuntimeLifecycle",
+  "registerHostHookCallbacks",
+]);
 
 {
   const events = [];
@@ -308,6 +311,223 @@ assert.deepEqual(Object.keys(registry), ["registerHostHookCallbacks"]);
   assert.equal(host.queuePrompt(), 2);
   assert.equal(callbackCalls, 1);
   disposeRevived();
+  assert.equal(host.queuePrompt, original);
+}
+
+{
+  const events = [];
+  const host = {
+    serialize(value) {
+      events.push("original");
+      return value;
+    },
+  };
+  const original = host.serialize;
+  const disposeA = registry.registerHostHookCallbacks({
+    owner: Symbol("interleaved-serialize-a"),
+    serializeHost: host,
+    beforeSerialize: () => events.push("a"),
+  });
+  const registryA = host.serialize;
+  host.serialize = function (...args) {
+    events.push("legacy");
+    return registryA.apply(this, args);
+  };
+  const legacy = host.serialize;
+  const disposeB = registry.registerHostHookCallbacks({
+    owner: Symbol("interleaved-serialize-b"),
+    serializeHost: host,
+    beforeSerialize: () => events.push("b"),
+  });
+
+  assert.notEqual(host.serialize, legacy, "a new owner must be reachable above a foreign wrapper");
+  assert.equal(host.serialize("value"), "value");
+  assert.deepEqual(events, ["b", "legacy", "a", "original"]);
+  assert.equal(disposeB(), true);
+  assert.equal(host.serialize, legacy, "the outer segment must restore the foreign wrapper");
+  assert.equal(disposeA(), true);
+  assert.equal(host.serialize, legacy, "an inner disposer must not overwrite a foreign wrapper");
+  events.length = 0;
+  assert.equal(host.serialize("after-dispose"), "after-dispose");
+  assert.deepEqual(events, ["legacy", "original"], "a stale inner wrapper kept its callback");
+  assert.notEqual(host.serialize, original);
+}
+
+{
+  const events = [];
+  const resolved = { prompt_id: "interleaved" };
+  const host = {
+    queuePrompt() {
+      events.push("original");
+      return Promise.resolve(resolved);
+    },
+  };
+  const disposeA = registry.registerHostHookCallbacks({
+    owner: Symbol("interleaved-queue-a"),
+    queueHost: host,
+    beforeQueue: () => { events.push("a:before"); return "a"; },
+    afterQueue: () => events.push("a:after"),
+  });
+  const registryA = host.queuePrompt;
+  host.queuePrompt = async function (...args) {
+    events.push("legacy:before");
+    const result = await registryA.apply(this, args);
+    events.push("legacy:after");
+    return result;
+  };
+  const legacy = host.queuePrompt;
+  const disposeB = registry.registerHostHookCallbacks({
+    owner: Symbol("interleaved-queue-b"),
+    queueHost: host,
+    beforeQueue: () => { events.push("b:before"); return "b"; },
+    afterQueue: () => events.push("b:after"),
+  });
+
+  assert.equal(await host.queuePrompt(), resolved);
+  assert.deepEqual(events, [
+    "b:before",
+    "legacy:before",
+    "a:before",
+    "original",
+    "a:after",
+    "legacy:after",
+    "b:after",
+  ]);
+
+  events.length = 0;
+  assert.equal(disposeA(), true, "an inner segment must be independently disposable");
+  assert.equal(await host.queuePrompt(), resolved);
+  assert.deepEqual(events, [
+    "b:before", "legacy:before", "original", "legacy:after", "b:after",
+  ]);
+  assert.equal(disposeB(), true);
+  assert.equal(host.queuePrompt, legacy);
+}
+
+{
+  const events = [];
+  const graph = {
+    clear() {
+      events.push("original");
+      return "cleared";
+    },
+  };
+  const disposeA = registry.registerHostHookCallbacks({
+    owner: Symbol("interleaved-clear-a"),
+    graphHost: graph,
+    onGraphClear: () => events.push("a"),
+  });
+  const registryA = graph.clear;
+  graph.clear = function (...args) {
+    events.push("legacy:before");
+    const result = registryA.apply(this, args);
+    events.push("legacy:after");
+    return result;
+  };
+  const legacy = graph.clear;
+  const disposeB = registry.registerHostHookCallbacks({
+    owner: Symbol("interleaved-clear-b"),
+    graphHost: graph,
+    onGraphClear: () => events.push("b"),
+  });
+
+  assert.equal(graph.clear(), "cleared");
+  assert.deepEqual(events, ["legacy:before", "original", "a", "legacy:after", "b"]);
+  assert.equal(disposeA(), true);
+  events.length = 0;
+  assert.equal(graph.clear(), "cleared");
+  assert.deepEqual(events, ["legacy:before", "original", "legacy:after", "b"]);
+  assert.equal(disposeB(), true);
+  assert.equal(graph.clear, legacy);
+}
+
+{
+  const events = [];
+  const host = {
+    queuePrompt(value) {
+      events.push("original");
+      return value;
+    },
+  };
+  const disposeA = registry.registerHostHookCallbacks({
+    owner: Symbol("non-delegating-a"),
+    queueHost: host,
+    beforeQueue: () => events.push("a"),
+  });
+  const hiddenRegistryA = host.queuePrompt;
+  host.queuePrompt = function (value) {
+    events.push("foreign");
+    return value;
+  };
+  const foreign = host.queuePrompt;
+  const disposeB = registry.registerHostHookCallbacks({
+    owner: Symbol("non-delegating-b"),
+    queueHost: host,
+    beforeQueue: () => events.push("b"),
+  });
+
+  assert.equal(host.queuePrompt("reachable"), "reachable");
+  assert.deepEqual(events, ["b", "foreign"], "the new owner was hidden below a replacement");
+  assert.equal(disposeB(), true);
+  assert.equal(host.queuePrompt, foreign);
+  assert.equal(disposeA(), true);
+  events.length = 0;
+  assert.equal(hiddenRegistryA("stale"), "stale");
+  assert.deepEqual(events, ["original"], "an inactive hidden segment retained callbacks");
+}
+
+{
+  const events = [];
+  const runtimeOwner = Symbol("runtime-owner");
+  const callbackOwner = Symbol("runtime-callback");
+  const host = {
+    queuePrompt(value) {
+      events.push("original");
+      return value;
+    },
+  };
+  const original = host.queuePrompt;
+  const install = (lifecycle, label, options) => lifecycle.install(
+    "queue",
+    () => registry.registerHostHookCallbacks({
+      owner: callbackOwner,
+      queueHost: host,
+      beforeQueue: () => events.push(label),
+    }),
+    options,
+  );
+
+  const firstRuntime = registry.createHostHookRuntimeLifecycle(host, runtimeOwner);
+  assert.equal(install(firstRuntime, "first"), true);
+  const firstWrapper = host.queuePrompt;
+  assert.equal(install(firstRuntime, "ignored"), false, "setup twice must reuse its lease");
+  assert.equal(host.queuePrompt, firstWrapper);
+  host.queuePrompt("first-call");
+  assert.deepEqual(events, ["first", "original"]);
+
+  events.length = 0;
+  assert.equal(install(firstRuntime, "first-replaced", { replace: true }), true);
+  host.queuePrompt("first-replaced-call");
+  assert.deepEqual(
+    events,
+    ["first-replaced", "original"],
+    "an explicit lease replacement kept the prior callback closure",
+  );
+
+  events.length = 0;
+  const secondRuntime = registry.createHostHookRuntimeLifecycle(host, runtimeOwner);
+  assert.equal(install(secondRuntime, "second"), true);
+  host.queuePrompt("second-call");
+  assert.deepEqual(events, ["second", "original"], "runtime replacement kept the stale closure");
+  assert.equal(firstRuntime.dispose(), false, "a superseded runtime must not release the new lease");
+  assert.equal(secondRuntime.dispose(), true);
+  assert.equal(host.queuePrompt, original);
+
+  events.length = 0;
+  assert.equal(install(secondRuntime, "second-reinstalled"), true);
+  host.queuePrompt("reinstalled-call");
+  assert.deepEqual(events, ["second-reinstalled", "original"]);
+  assert.equal(secondRuntime.dispose(), true);
   assert.equal(host.queuePrompt, original);
 }
 

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -17,10 +17,15 @@ function clone(value) {
 const seedContractUrl = dataModule(
   "../web/js/prompt_studio/wildcard_seed_contract.js",
 );
+const hostHookRegistryUrl = dataModule(
+  "../web/js/lifecycle/host_hook_registry.js",
+);
 const queueSource = readFileSync(
   new URL("../web/js/prompt_studio/advanced_queue_seed_runtime.js", import.meta.url),
   "utf8",
-).replace('from "./wildcard_seed_contract.js"', `from "${seedContractUrl}"`);
+)
+  .replace('from "./wildcard_seed_contract.js"', `from "${seedContractUrl}"`)
+  .replace('from "../lifecycle/host_hook_registry.js"', `from "${hostHookRegistryUrl}"`);
 const queueModule = await import(sourceModule(queueSource));
 const seedContract = await import(seedContractUrl);
 assert.deepEqual(
@@ -189,7 +194,9 @@ const nodeHookConstants = sourceModule(`
 const nodeHooksSource = readFileSync(
   new URL("../web/js/prompt_studio/node_hooks.js", import.meta.url),
   "utf8",
-).replace('from "./constants.js"', `from "${nodeHookConstants}"`);
+)
+  .replace('from "./constants.js"', `from "${nodeHookConstants}"`)
+  .replace('from "../lifecycle/host_hook_registry.js"', `from "${hostHookRegistryUrl}"`);
 const nodeHooksModule = await import(sourceModule(nodeHooksSource));
 const wildcardWidgetHelpers = sourceModule(`
   export function findWidget(node, name) {
@@ -662,15 +669,20 @@ function reservedSeedState(prompt, nodeId) {
       events.push(["cleanup"]);
     },
   };
-  assert.equal(queueModule.installAdvancedQueueSeedGraphCleanup(graph, runtime), true);
+  const originalClear = graph.clear;
+  const disposeCleanup = queueModule.installAdvancedQueueSeedGraphCleanup(graph, runtime);
+  assert.equal(typeof disposeCleanup, "function");
   const installed = graph.clear;
-  assert.equal(queueModule.installAdvancedQueueSeedGraphCleanup(graph, runtime), false);
+  const disposeDuplicate = queueModule.installAdvancedQueueSeedGraphCleanup(graph, runtime);
+  assert.equal(disposeDuplicate(), false);
   assert.equal(graph.clear, installed, "graph cleanup wrapper must install only once");
   assert.equal(graph.clear.call(owner, firstArg, secondArg), clearResult);
   assert.deepEqual(events, [
     ["clear", owner, [firstArg, secondArg]],
     ["cleanup"],
   ]);
+  assert.equal(disposeCleanup(), true);
+  assert.equal(graph.clear, originalClear);
 
   const clearError = new Error("graph clear failed");
   let failedCleanupCalls = 0;
@@ -1953,19 +1965,27 @@ function reservedSeedState(prompt, nodeId) {
       return { prompt_id: "installed", node_errors: {} };
     },
   };
-  assert.equal(queueModule.installAdvancedQueueSeedQueueHook(host, fixture.runtime), true);
+  const disposeQueueHook = queueModule.installAdvancedQueueSeedQueueHook(host, fixture.runtime);
+  assert.equal(typeof disposeQueueHook, "function");
   const installed = host.queuePrompt;
-  assert.equal(queueModule.installAdvancedQueueSeedQueueHook(host, fixture.runtime), false);
+  const disposeDuplicate = queueModule.installAdvancedQueueSeedQueueHook(host, fixture.runtime);
+  assert.equal(disposeDuplicate(), false);
   assert.equal(host.queuePrompt, installed, "repeated setup must not stack wrappers");
   host.queuePrompt = async function (...args) {
     return installed.apply(this, args);
   };
   const foreignWrapper = host.queuePrompt;
-  assert.equal(queueModule.installAdvancedQueueSeedQueueHook(host, fixture.runtime), false);
+  const disposeForeignDuplicate = queueModule.installAdvancedQueueSeedQueueHook(
+    host,
+    fixture.runtime,
+  );
+  assert.equal(disposeForeignDuplicate(), false);
   assert.equal(host.queuePrompt, foreignWrapper, "the host marker survives foreign wrapper composition");
   const result = await host.queuePrompt(0, promptFor(fixture.nodes));
   assert.equal(result.prompt_id, "installed");
   assert.equal(host.calls, 1);
+  assert.equal(disposeQueueHook(), true);
+  assert.equal(host.queuePrompt, foreignWrapper, "dispose must preserve a foreign outer wrapper");
 }
 
 {

--- a/tests/frontend_regional_runtime_smoke.mjs
+++ b/tests/frontend_regional_runtime_smoke.mjs
@@ -475,18 +475,36 @@ assert(app.queuePrompt === originalQueuePrompt, "Last queue owner did not restor
   const lifecycleOriginalSerialize = Graph.prototype.serialize;
   const lifecycleOriginalQueue = lifecycleApp.queuePrompt;
   const createRuntime = (label) => ({
+    ensureRegionalWidgetValues() {},
+    hideRegionalInternalWidgets() {},
     isRegionalNode: (node) => node === regionalNode,
+    removeRegionalInternalInputSockets() {},
+    setRegionalWidgetValue: () => true,
     syncRegionalValues: () => lifecycleOrder.push(label),
   });
   const createExtension = (label) => extension.createRegionalExtensionRuntime(
     lifecycleApp,
     createRuntime(label),
     {},
-    { collectRegionalEditorFields: () => [] },
-    { installRegionalAdapter() {} },
+    {
+      collectRegionalEditorFields: () => [],
+      renderRegionalEditor() {},
+    },
+    {
+      ensureRegionalStyle() {},
+      installRegionalAdapter() {},
+    },
   );
 
   const firstExtension = createExtension("first");
+  function FirstRuntimeRegionalNodeType() {}
+  await firstExtension.beforeRegisterNodeDef(FirstRuntimeRegionalNodeType, {
+    name: "EasyUseAnimaPromptStudioRegional",
+  });
+  const oldWrappedNode = Object.assign(new FirstRuntimeRegionalNodeType(), {
+    graph: lifecycleApp.graph,
+    __easyuseAnimaRegionalEditorEl: {},
+  });
   await firstExtension.setup();
   const firstSerializeWrapper = Graph.prototype.serialize;
   const firstQueueWrapper = lifecycleApp.queuePrompt;
@@ -500,6 +518,9 @@ assert(app.queuePrompt === originalQueuePrompt, "Last queue owner did not restor
   lifecycleOrder.length = 0;
   const secondExtension = createExtension("second");
   await secondExtension.setup();
+  await secondExtension.beforeRegisterNodeDef(FirstRuntimeRegionalNodeType, {
+    name: "EasyUseAnimaPromptStudioRegional",
+  });
   lifecycleApp.graph.serialize("second");
   lifecycleApp.queuePrompt("second");
   assert(
@@ -507,9 +528,14 @@ assert(app.queuePrompt === originalQueuePrompt, "Last queue owner did not restor
     `Regional runtime replacement kept a stale closure: ${lifecycleOrder.join(",")}`,
   );
   assert(firstExtension.dispose() === false, "A stale Regional runtime released the new hooks");
+  oldWrappedNode.onNodeCreated();
+  flushFrames();
   lifecycleOrder.length = 0;
-  lifecycleApp.queuePrompt("second-still-owned");
-  assert(lifecycleOrder.join(",") === "second", "Stale dispose removed the current Regional callback");
+  lifecycleApp.queuePrompt("second-after-old-node-hook");
+  assert(
+    lifecycleOrder.join(",") === "second",
+    "An old Regional node wrapper reclaimed the superseded runtime hook lease",
+  );
   assert(secondExtension.dispose() === true, "Current Regional runtime did not release its hooks");
   assert(Graph.prototype.serialize === lifecycleOriginalSerialize, "Regional dispose kept serialize wrapped");
   assert(lifecycleApp.queuePrompt === lifecycleOriginalQueue, "Regional dispose kept queuePrompt wrapped");

--- a/tests/frontend_regional_runtime_smoke.mjs
+++ b/tests/frontend_regional_runtime_smoke.mjs
@@ -463,6 +463,71 @@ assert(disposeAdvanced() === true, "Advanced disposer did not release its callba
 assert(Graph.prototype.serialize === originalSerialize, "Last serialize owner did not restore the original");
 assert(app.queuePrompt === originalQueuePrompt, "Last queue owner did not restore the original");
 
+{
+  const lifecycleOrder = [];
+  const regionalNode = { type: "EasyUseAnimaPromptStudioRegional" };
+  const lifecycleApp = {
+    graph: Object.assign(new Graph(), { _nodes: [regionalNode] }),
+    queuePrompt(value) {
+      return value;
+    },
+  };
+  const lifecycleOriginalSerialize = Graph.prototype.serialize;
+  const lifecycleOriginalQueue = lifecycleApp.queuePrompt;
+  const createRuntime = (label) => ({
+    isRegionalNode: (node) => node === regionalNode,
+    syncRegionalValues: () => lifecycleOrder.push(label),
+  });
+  const createExtension = (label) => extension.createRegionalExtensionRuntime(
+    lifecycleApp,
+    createRuntime(label),
+    {},
+    { collectRegionalEditorFields: () => [] },
+    { installRegionalAdapter() {} },
+  );
+
+  const firstExtension = createExtension("first");
+  await firstExtension.setup();
+  const firstSerializeWrapper = Graph.prototype.serialize;
+  const firstQueueWrapper = lifecycleApp.queuePrompt;
+  await firstExtension.setup();
+  assert(Graph.prototype.serialize === firstSerializeWrapper, "Regional setup twice stacked serialize");
+  assert(lifecycleApp.queuePrompt === firstQueueWrapper, "Regional setup twice stacked queuePrompt");
+  lifecycleApp.graph.serialize("first");
+  lifecycleApp.queuePrompt("first");
+  assert(lifecycleOrder.join(",") === "first,first", "Regional setup twice duplicated callbacks");
+
+  lifecycleOrder.length = 0;
+  const secondExtension = createExtension("second");
+  await secondExtension.setup();
+  lifecycleApp.graph.serialize("second");
+  lifecycleApp.queuePrompt("second");
+  assert(
+    lifecycleOrder.join(",") === "second,second",
+    `Regional runtime replacement kept a stale closure: ${lifecycleOrder.join(",")}`,
+  );
+  assert(firstExtension.dispose() === false, "A stale Regional runtime released the new hooks");
+  lifecycleOrder.length = 0;
+  lifecycleApp.queuePrompt("second-still-owned");
+  assert(lifecycleOrder.join(",") === "second", "Stale dispose removed the current Regional callback");
+  assert(secondExtension.dispose() === true, "Current Regional runtime did not release its hooks");
+  assert(Graph.prototype.serialize === lifecycleOriginalSerialize, "Regional dispose kept serialize wrapped");
+  assert(lifecycleApp.queuePrompt === lifecycleOriginalQueue, "Regional dispose kept queuePrompt wrapped");
+
+  lifecycleOrder.length = 0;
+  const thirdExtension = createExtension("third");
+  await thirdExtension.setup();
+  lifecycleApp.graph.serialize("third");
+  lifecycleApp.queuePrompt("third");
+  assert(
+    lifecycleOrder.join(",") === "third,third",
+    "A fresh Regional runtime did not install its new callback closure",
+  );
+  assert(thirdExtension.dispose() === true);
+  assert(Graph.prototype.serialize === lifecycleOriginalSerialize);
+  assert(lifecycleApp.queuePrompt === lifecycleOriginalQueue);
+}
+
 delete globalThis.LGraph;
 let prematureGraphReads = 0;
 const setupApp = {

--- a/tests/frontend_regional_runtime_smoke.mjs
+++ b/tests/frontend_regional_runtime_smoke.mjs
@@ -56,6 +56,9 @@ const queueSeedBridgeUrl = dataModule("../web/js/prompt_studio/queue_seed_bridge
 const autocompleteEntryLifecycleUrl = dataModule(
   "../web/js/autocomplete/entry_lifecycle.js",
 );
+const hostHookRegistryUrl = dataModule(
+  "../web/js/lifecycle/host_hook_registry.js",
+);
 const lifecycleUrl = dataModule("../web/js/prompt_studio/regional/lifecycle.js");
 const layoutUrl = dataModule("../web/js/prompt_studio/regional/layout.js", {
   "./lifecycle.js": lifecycleUrl,
@@ -66,6 +69,18 @@ const extensionUrl = dataModule("../web/js/prompt_studio/regional/extension.js",
   "./layout.js": layoutUrl,
   "../queue_seed_bridge.js": queueSeedBridgeUrl,
   "../../autocomplete/entry_lifecycle.js": autocompleteEntryLifecycleUrl,
+  "../../lifecycle/host_hook_registry.js": hostHookRegistryUrl,
+});
+const nodeHookConstantsUrl = `data:text/javascript;base64,${Buffer.from(`
+  export const NODE_TYPE = "EasyUseAnimaPromptStudio";
+  export const ADVANCED_NODE_TYPE = "EasyUseAnimaPromptStudioAdvanced";
+  export const ADVANCED_V2_NODE_TYPE = "EasyUseAnimaPromptStudioAdvancedV2";
+  export const EXTEND_NODE_TYPE = "EasyUseAnimaPromptStudioExtend";
+  export const WILDCARD_NODE_TYPE = "EasyUseAnimaWildcard";
+`).toString("base64")}`;
+const nodeHooksUrl = dataModule("../web/js/prompt_studio/node_hooks.js", {
+  "./constants.js": nodeHookConstantsUrl,
+  "../lifecycle/host_hook_registry.js": hostHookRegistryUrl,
 });
 const regionalRuntimeUrl = dataModule("../web/js/prompt_studio/regional/runtime.js", {
   "./constants.js": constantsUrl,
@@ -84,6 +99,7 @@ const fieldEditorUrl = dataModule("../web/js/prompt_studio/regional/field_editor
 
 const lifecycle = await import(lifecycleUrl);
 const extension = await import(extensionUrl);
+const nodeHooks = await import(nodeHooksUrl);
 const fieldEditor = await import(fieldEditorUrl);
 const queueSeedBridgeModule = await import(queueSeedBridgeUrl);
 const regionalRuntimeModule = await import(regionalRuntimeUrl);
@@ -402,14 +418,50 @@ const app = {
     return { owner: this, value };
   },
 };
-let syncRuns = 0;
-extension.installRegionalSaveSync(app, () => { syncRuns += 1; });
-extension.installRegionalSaveSync(app, () => { syncRuns += 100; });
+const originalSerialize = Graph.prototype.serialize;
+const originalQueuePrompt = app.queuePrompt;
+const syncOrder = [];
+const disposeAdvanced = nodeHooks.installAdvancedSaveSync(
+  app,
+  () => { syncOrder.push("advanced"); },
+);
+const installedSerialize = Graph.prototype.serialize;
+const installedQueuePrompt = app.queuePrompt;
+const disposeAdvancedDuplicate = nodeHooks.installAdvancedSaveSync(
+  app,
+  () => { syncOrder.push("advanced-duplicate"); },
+);
+const disposeRegional = extension.installRegionalSaveSync(
+  app,
+  () => { syncOrder.push("regional"); },
+);
+const disposeRegionalDuplicate = extension.installRegionalSaveSync(
+  app,
+  () => { syncOrder.push("regional-duplicate"); },
+);
+assert(disposeAdvancedDuplicate() === false, "Advanced duplicate setup owned a callback");
+assert(disposeRegionalDuplicate() === false, "Regional duplicate setup owned a callback");
+assert(Graph.prototype.serialize === installedSerialize, "Prompt Studio stacked serialize wrappers");
+assert(app.queuePrompt === installedQueuePrompt, "Prompt Studio stacked queue wrappers");
 const graphResult = app.graph.serialize("save");
 const queueResult = app.queuePrompt("queue");
 assert(graphResult.owner === app.graph && graphResult.value === "save", "Graph serialize context or return changed");
 assert(queueResult.owner === app && queueResult.value === "queue", "queuePrompt context or return changed");
-assert(syncRuns === 2, "Save/queue sync wrapper installed more than once");
+assert(
+  syncOrder.join(",") === "regional,advanced,regional,advanced",
+  `Prompt Studio callback order changed: ${syncOrder.join(",")}`,
+);
+
+syncOrder.length = 0;
+assert(disposeRegional() === true, "Regional disposer did not release its callbacks");
+app.graph.serialize("advanced-only");
+app.queuePrompt("advanced-only");
+assert(syncOrder.join(",") === "advanced,advanced", "Regional disposer removed another owner");
+assert(Graph.prototype.serialize === installedSerialize, "Serialize restored before the last owner left");
+assert(app.queuePrompt === installedQueuePrompt, "Queue restored before the last owner left");
+assert(disposeAdvanced() === true, "Advanced disposer did not release its callbacks");
+assert(Graph.prototype.serialize === originalSerialize, "Last serialize owner did not restore the original");
+assert(app.queuePrompt === originalQueuePrompt, "Last queue owner did not restore the original");
 
 delete globalThis.LGraph;
 let prematureGraphReads = 0;
@@ -422,8 +474,9 @@ const setupApp = {
     return "queued";
   },
 };
-extension.installRegionalSaveSync(setupApp, () => {});
+const disposeSetup = extension.installRegionalSaveSync(setupApp, () => {});
 assert(prematureGraphReads === 0, "Save sync read app.graph during extension setup");
 assert(setupApp.queuePrompt() === "queued", "Setup queue wrapper changed return value");
+assert(disposeSetup() === true, "Setup queue callback was not disposable");
 
 console.log("Regional runtime lifecycle smoke passed.");

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -120,6 +120,9 @@ class FrontendModuleStructureTests(unittest.TestCase):
         node_hooks_source = (
             PROMPT_STUDIO_MODULES / "node_hooks.js"
         ).read_text(encoding="utf-8")
+        extension_runtime_source = (
+            PROMPT_STUDIO_MODULES / "extension_runtime.js"
+        ).read_text(encoding="utf-8")
         regional_extension_source = (
             PROMPT_STUDIO_REGIONAL_MODULES / "extension.js"
         ).read_text(encoding="utf-8")
@@ -136,9 +139,31 @@ class FrontendModuleStructureTests(unittest.TestCase):
             frontend_check_source,
         )
         self.assertIn("export function registerHostHookCallbacks", registry_source)
+        self.assertIn("export function createHostHookRuntimeLifecycle", registry_source)
+        self.assertIn("segments: new Set()", registry_source)
+        self.assertIn("current === record.topState.wrapper", registry_source)
+        self.assertIn("target[methodName] = state.wrapper", registry_source)
         for source in (node_hooks_source, queue_seed_source):
             self.assertIn('../lifecycle/host_hook_registry.js"', source)
         self.assertIn('../../lifecycle/host_hook_registry.js"', regional_extension_source)
+        self.assertIn('../lifecycle/host_hook_registry.js"', extension_runtime_source)
+
+        for source, owner, lease in (
+            (
+                extension_runtime_source,
+                "PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER",
+                '"advanced-save-sync"',
+            ),
+            (
+                regional_extension_source,
+                "REGIONAL_GLOBAL_HOOK_RUNTIME_OWNER",
+                '"regional-save-sync"',
+            ),
+        ):
+            self.assertIn("createHostHookRuntimeLifecycle(", source)
+            self.assertIn(owner, source)
+            self.assertIn(lease, source)
+            self.assertIn("dispose: disposeGlobalHooks", source)
 
         for source in (node_hooks_source, regional_extension_source, queue_seed_source):
             self.assertIn("registerHostHookCallbacks({", source)

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -9,10 +9,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 JSCONFIG = ROOT / "jsconfig.json"
 FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
+HOST_HOOK_REGISTRY_SMOKE = ROOT / "tests" / "frontend_host_hook_registry_smoke.mjs"
 PROMPT_STUDIO_ADVANCED_QUEUE_SEED_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs"
 )
 WEB_JS = ROOT / "web" / "js"
+HOST_HOOK_REGISTRY_JS = WEB_JS / "lifecycle" / "host_hook_registry.js"
 API_JS = WEB_JS / "easyuse_anima_api.js"
 AIO_JS = WEB_JS / "easyuse_anima_aio.js"
 AIO_MODULES = WEB_JS / "aio"
@@ -113,6 +115,46 @@ STATIC_IMPORT_RE = re.compile(
 
 
 class FrontendModuleStructureTests(unittest.TestCase):
+    def test_host_hook_registry_phase_1_is_owned_and_focused(self):
+        registry_source = HOST_HOOK_REGISTRY_JS.read_text(encoding="utf-8")
+        node_hooks_source = (
+            PROMPT_STUDIO_MODULES / "node_hooks.js"
+        ).read_text(encoding="utf-8")
+        regional_extension_source = (
+            PROMPT_STUDIO_REGIONAL_MODULES / "extension.js"
+        ).read_text(encoding="utf-8")
+        queue_seed_source = (
+            PROMPT_STUDIO_MODULES / "advanced_queue_seed_runtime.js"
+        ).read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+
+        self.assertTrue(HOST_HOOK_REGISTRY_SMOKE.is_file())
+        self.assertIn("web/js/lifecycle/**/*.js", config["include"])
+        self.assertIn(
+            r'node "tests\frontend_host_hook_registry_smoke.mjs"',
+            frontend_check_source,
+        )
+        self.assertIn("export function registerHostHookCallbacks", registry_source)
+        for source in (node_hooks_source, queue_seed_source):
+            self.assertIn('../lifecycle/host_hook_registry.js"', source)
+        self.assertIn('../../lifecycle/host_hook_registry.js"', regional_extension_source)
+
+        for source in (node_hooks_source, regional_extension_source, queue_seed_source):
+            self.assertIn("registerHostHookCallbacks({", source)
+        self.assertNotIn("__easyuseAnimaAdvancedWrapped", node_hooks_source)
+        self.assertNotIn("serialize.__easyuseAnimaRegionalWrapped", regional_extension_source)
+        self.assertNotIn("AdvancedQueueSeedInstalled", queue_seed_source)
+
+        self.assertNotIn(
+            "host_hook_registry",
+            AIO_GENERATOR_QUEUE_RUNTIME_JS.read_text(encoding="utf-8"),
+        )
+        self.assertNotIn(
+            "host_hook_registry",
+            (WEB_JS / "lora_preset" / "save_sync.js").read_text(encoding="utf-8"),
+        )
+
     def test_shared_api_module_exports_runtime_helpers(self):
         source = API_JS.read_text(encoding="utf-8")
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -149,6 +149,11 @@ try {
         throw "Frontend Regional runtime lifecycle smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_host_hook_registry_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend host hook registry smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend Prompt Studio Advanced queue seed runtime smoke failed with exit code $LASTEXITCODE."

--- a/web/js/lifecycle/host_hook_registry.js
+++ b/web/js/lifecycle/host_hook_registry.js
@@ -1,0 +1,413 @@
+// @ts-check
+
+const HOST_HOOK_REGISTRY = Symbol.for(
+  "easyuse-anima.lifecycle.host-hook-registry.v1",
+);
+const HOST_HOOK_WRAPPER = Symbol.for(
+  "easyuse-anima.lifecycle.host-hook-wrapper.v1",
+);
+const REGISTRY_VERSION = 1;
+
+/** @returns {false} */
+function noOpDispose() {
+  return false;
+}
+
+/** @param {any} target */
+function targetRegistry(target) {
+  const existing = target?.[HOST_HOOK_REGISTRY];
+  if (existing?.version === REGISTRY_VERSION && existing.methods instanceof Map) {
+    return existing;
+  }
+  const registry = {
+    version: REGISTRY_VERSION,
+    methods: new Map(),
+  };
+  Object.defineProperty(target, HOST_HOOK_REGISTRY, {
+    configurable: true,
+    value: registry,
+  });
+  return registry;
+}
+
+/** @param {any} state */
+function callbackEntries(state) {
+  return [...state.callbacks.values()];
+}
+
+/** @param {any} state */
+function callbacksOuterToInner(state) {
+  return callbackEntries(state).reverse();
+}
+
+/**
+ * @param {any} state
+ * @param {any} thisArg
+ * @param {any[]} args
+ */
+function invokeSerialize(state, thisArg, args) {
+  const originalArgs = args;
+  let callArgs = args;
+  for (const entry of callbacksOuterToInner(state)) {
+    const callback = entry.callbacks.beforeSerialize;
+    if (typeof callback !== "function") {
+      continue;
+    }
+    const context = {
+      host: state.target,
+      thisArg,
+      args: callArgs,
+      originalArgs,
+    };
+    callback(context);
+    callArgs = Array.isArray(context.args) ? context.args : callArgs;
+  }
+  return state.original.apply(thisArg, callArgs);
+}
+
+/**
+ * @param {any} state
+ * @param {any} thisArg
+ * @param {any[]} args
+ */
+function invokeQueueSync(state, thisArg, args) {
+  const originalArgs = args;
+  let callArgs = args;
+  for (const entry of callbacksOuterToInner(state)) {
+    const callback = entry.callbacks.beforeQueue;
+    if (typeof callback !== "function") {
+      continue;
+    }
+    const context = {
+      host: state.target,
+      thisArg,
+      args: callArgs,
+      originalArgs,
+    };
+    callback(context);
+    callArgs = Array.isArray(context.args) ? context.args : callArgs;
+  }
+  return state.original.apply(thisArg, callArgs);
+}
+
+/**
+ * Recursively model nested queue wrappers. Each entry's afterQueue callback
+ * observes the resolve/reject result of the entries registered before it,
+ * which preserves the unwind order of the legacy wrapper chain.
+ *
+ * @param {any} state
+ * @param {any[]} entries
+ * @param {number} index
+ * @param {any} thisArg
+ * @param {any[]} args
+ * @param {any[]} originalArgs
+ */
+function invokeQueueLayer(state, entries, index, thisArg, args, originalArgs) {
+  if (index >= entries.length) {
+    return state.original.apply(thisArg, args);
+  }
+
+  const entry = entries[index];
+  const beforeQueue = entry.callbacks.beforeQueue;
+  const afterQueue = entry.callbacks.afterQueue;
+  const context = {
+    host: state.target,
+    thisArg,
+    args,
+    originalArgs,
+  };
+  const callbackState = typeof beforeQueue === "function"
+    ? beforeQueue(context)
+    : undefined;
+  const callArgs = Array.isArray(context.args) ? context.args : args;
+
+  let result;
+  try {
+    result = invokeQueueLayer(
+      state,
+      entries,
+      index + 1,
+      thisArg,
+      callArgs,
+      originalArgs,
+    );
+  } catch (error) {
+    if (typeof afterQueue === "function") {
+      afterQueue({
+        host: state.target,
+        thisArg,
+        args: callArgs,
+        originalArgs,
+        callbackState,
+        ok: false,
+        error,
+      });
+    }
+    throw error;
+  }
+
+  if (typeof afterQueue !== "function") {
+    return result;
+  }
+  return Promise.resolve(result).then(
+    (value) => {
+      afterQueue({
+        host: state.target,
+        thisArg,
+        args: callArgs,
+        originalArgs,
+        callbackState,
+        ok: true,
+        result: value,
+      });
+      return value;
+    },
+    (error) => {
+      afterQueue({
+        host: state.target,
+        thisArg,
+        args: callArgs,
+        originalArgs,
+        callbackState,
+        ok: false,
+        error,
+      });
+      throw error;
+    },
+  );
+}
+
+/**
+ * @param {any} state
+ * @param {any} thisArg
+ * @param {any[]} args
+ */
+async function invokeQueueAsync(state, thisArg, args) {
+  return invokeQueueLayer(
+    state,
+    callbacksOuterToInner(state),
+    0,
+    thisArg,
+    args,
+    args,
+  );
+}
+
+/**
+ * @param {any} state
+ * @param {any} thisArg
+ * @param {any[]} args
+ */
+function invokeQueue(state, thisArg, args) {
+  const hasAfterQueue = callbackEntries(state).some(
+    (entry) => typeof entry.callbacks.afterQueue === "function",
+  );
+  return hasAfterQueue
+    ? invokeQueueAsync(state, thisArg, args)
+    : invokeQueueSync(state, thisArg, args);
+}
+
+/**
+ * @param {any} state
+ * @param {any} thisArg
+ * @param {any[]} args
+ */
+function invokeGraphClear(state, thisArg, args) {
+  const result = state.original.apply(thisArg, args);
+  for (const entry of callbackEntries(state)) {
+    const callback = entry.callbacks.onGraphClear;
+    if (typeof callback === "function") {
+      callback({
+        host: state.target,
+        thisArg,
+        args,
+        originalArgs: args,
+        result,
+      });
+    }
+  }
+  return result;
+}
+
+/** @param {any} state */
+function createWrapper(state) {
+  const wrapper = function (...args) {
+    if (!state.active || state.callbacks.size === 0) {
+      return state.original.apply(this, args);
+    }
+    if (state.kind === "serialize") {
+      return invokeSerialize(state, this, args);
+    }
+    if (state.kind === "queue") {
+      return invokeQueue(state, this, args);
+    }
+    return invokeGraphClear(state, this, args);
+  };
+  Object.defineProperty(wrapper, HOST_HOOK_WRAPPER, {
+    value: state,
+  });
+  return wrapper;
+}
+
+/**
+ * @param {any} target
+ * @param {string} methodName
+ * @param {"serialize" | "queue" | "graph-clear"} kind
+ */
+function ensureMethodState(target, methodName, kind) {
+  if (!target || typeof target[methodName] !== "function") {
+    return null;
+  }
+  const registry = targetRegistry(target);
+  const registered = registry.methods.get(methodName);
+  if (registered?.active) {
+    return registered;
+  }
+
+  const current = target[methodName];
+  const staleState = current?.[HOST_HOOK_WRAPPER];
+  if (
+    staleState?.version === REGISTRY_VERSION
+    && staleState.target === target
+    && staleState.methodName === methodName
+    && staleState.kind === kind
+  ) {
+    staleState.active = true;
+    registry.methods.set(methodName, staleState);
+    return staleState;
+  }
+
+  const state = {
+    version: REGISTRY_VERSION,
+    target,
+    methodName,
+    kind,
+    original: current,
+    wrapper: null,
+    callbacks: new Map(),
+    active: true,
+  };
+  state.wrapper = createWrapper(state);
+  target[methodName] = state.wrapper;
+  registry.methods.set(methodName, state);
+  return state;
+}
+
+/** @param {any} state */
+function releaseMethodState(state) {
+  state.active = false;
+  state.callbacks.clear();
+  if (state.target[state.methodName] === state.wrapper) {
+    state.target[state.methodName] = state.original;
+  }
+  const registry = state.target[HOST_HOOK_REGISTRY];
+  if (registry?.methods?.get(state.methodName) === state) {
+    registry.methods.delete(state.methodName);
+  }
+  if (
+    registry?.methods?.size === 0
+    && state.target[HOST_HOOK_REGISTRY] === registry
+  ) {
+    delete state.target[HOST_HOOK_REGISTRY];
+  }
+}
+
+/**
+ * @param {any} target
+ * @param {string} methodName
+ * @param {"serialize" | "queue" | "graph-clear"} kind
+ * @param {any} owner
+ * @param {Record<string, any>} callbacks
+ */
+function registerMethodCallbacks(target, methodName, kind, owner, callbacks) {
+  const state = ensureMethodState(target, methodName, kind);
+  if (!state || state.callbacks.has(owner)) {
+    return noOpDispose;
+  }
+  const entry = { owner, callbacks };
+  state.callbacks.set(owner, entry);
+  let disposed = false;
+  return () => {
+    if (disposed || state.callbacks.get(owner) !== entry) {
+      return false;
+    }
+    disposed = true;
+    state.callbacks.delete(owner);
+    if (state.callbacks.size === 0) {
+      releaseMethodState(state);
+    }
+    return true;
+  };
+}
+
+/**
+ * Register one logical owner's global lifecycle callbacks. Later owners run
+ * first for before hooks, matching nested wrapper installation. afterQueue and
+ * onGraphClear unwind in the corresponding inner-to-outer order.
+ *
+ * Re-registering the same owner/target/method is an idempotent no-op. The
+ * returned disposer removes only callbacks created by this registration call.
+ *
+ * @param {{
+ *   owner: any,
+ *   serializeHost?: any,
+ *   queueHost?: any,
+ *   graphHost?: any,
+ *   beforeSerialize?: (context: any) => any,
+ *   beforeQueue?: (context: any) => any,
+ *   afterQueue?: (context: any) => any,
+ *   onGraphClear?: (context: any) => any,
+ * }} options
+ */
+export function registerHostHookCallbacks(options) {
+  if (!options || options.owner == null) {
+    throw new TypeError("A lifecycle hook owner is required.");
+  }
+  const disposers = [];
+  if (typeof options.beforeSerialize === "function") {
+    disposers.push(registerMethodCallbacks(
+      options.serializeHost,
+      "serialize",
+      "serialize",
+      options.owner,
+      { beforeSerialize: options.beforeSerialize },
+    ));
+  }
+  if (
+    typeof options.beforeQueue === "function"
+    || typeof options.afterQueue === "function"
+  ) {
+    disposers.push(registerMethodCallbacks(
+      options.queueHost,
+      "queuePrompt",
+      "queue",
+      options.owner,
+      {
+        beforeQueue: options.beforeQueue,
+        afterQueue: options.afterQueue,
+      },
+    ));
+  }
+  if (typeof options.onGraphClear === "function") {
+    disposers.push(registerMethodCallbacks(
+      options.graphHost,
+      "clear",
+      "graph-clear",
+      options.owner,
+      { onGraphClear: options.onGraphClear },
+    ));
+  }
+
+  let disposed = false;
+  return () => {
+    if (disposed) {
+      return false;
+    }
+    disposed = true;
+    let changed = false;
+    for (const dispose of [...disposers].reverse()) {
+      changed = dispose() || changed;
+    }
+    return changed;
+  };
+}

--- a/web/js/lifecycle/host_hook_registry.js
+++ b/web/js/lifecycle/host_hook_registry.js
@@ -6,6 +6,9 @@ const HOST_HOOK_REGISTRY = Symbol.for(
 const HOST_HOOK_WRAPPER = Symbol.for(
   "easyuse-anima.lifecycle.host-hook-wrapper.v1",
 );
+const HOST_HOOK_RUNTIME_RETIRE = Symbol.for(
+  "easyuse-anima.lifecycle.host-hook-runtime-retire.v1",
+);
 const REGISTRY_VERSION = 1;
 
 /** @returns {false} */
@@ -460,10 +463,12 @@ export function registerHostHookCallbacks(options) {
 
 /**
  * Own a composition root's current global-hook leases on a collision-safe host
- * Symbol. A newer runtime claims the host by disposing the previous runtime's
- * hook leases first. Only leases installed through this lifecycle are owned;
- * listeners, locale watchers, DOM state, and node-local resources remain out
- * of scope.
+ * Symbol. A newer runtime claims the host by terminally retiring the previous
+ * runtime and releasing its hook leases first. A lifecycle that ordinary
+ * `dispose()` releases may reinstall while the owner slot remains available;
+ * a superseded lifecycle can never reclaim a newer owner. Only leases installed
+ * through this lifecycle are owned; listeners, locale watchers, DOM state, and
+ * node-local resources remain out of scope.
  *
  * @param {any} host
  * @param {symbol} owner
@@ -473,18 +478,32 @@ export function createHostHookRuntimeLifecycle(host, owner) {
     throw new TypeError("A host object and Symbol runtime owner are required.");
   }
   const leases = new Map();
+  let status = "fresh";
 
   function isOwner() {
     return host[owner] === lifecycle;
   }
 
   function claim() {
+    if (status === "retired") {
+      return false;
+    }
     if (isOwner()) {
       return false;
     }
     const previous = host[owner];
-    previous?.dispose?.();
+    if (status !== "fresh" && previous && previous !== lifecycle) {
+      retire();
+      return false;
+    }
+    const retirePrevious = previous?.[HOST_HOOK_RUNTIME_RETIRE];
+    if (typeof retirePrevious === "function") {
+      retirePrevious.call(previous);
+    } else {
+      previous?.dispose?.();
+    }
     host[owner] = lifecycle;
+    status = "active";
     return true;
   }
 
@@ -494,7 +513,12 @@ export function createHostHookRuntimeLifecycle(host, owner) {
    * @param {{ replace?: boolean }} [options]
    */
   function install(key, installer, options = {}) {
-    claim();
+    if (status === "retired") {
+      return false;
+    }
+    if (!isOwner() && !claim()) {
+      return false;
+    }
     const previous = leases.get(key);
     if (previous && options.replace !== true) {
       return false;
@@ -511,7 +535,7 @@ export function createHostHookRuntimeLifecycle(host, owner) {
     return true;
   }
 
-  function dispose() {
+  function releaseLeases() {
     let changed = false;
     let cleanupError = null;
     for (const release of [...leases.values()].reverse()) {
@@ -531,11 +555,28 @@ export function createHostHookRuntimeLifecycle(host, owner) {
     return changed;
   }
 
+  function dispose() {
+    const changed = releaseLeases();
+    if (status !== "retired") {
+      status = "disposed";
+    }
+    return changed;
+  }
+
+  function retire() {
+    if (status === "retired") {
+      return false;
+    }
+    status = "retired";
+    return releaseLeases();
+  }
+
   const lifecycle = {
     claim,
     dispose,
     install,
     isOwner,
+    [HOST_HOOK_RUNTIME_RETIRE]: retire,
   };
   return lifecycle;
 }

--- a/web/js/lifecycle/host_hook_registry.js
+++ b/web/js/lifecycle/host_hook_registry.js
@@ -254,26 +254,44 @@ function createWrapper(state) {
  * @param {string} methodName
  * @param {"serialize" | "queue" | "graph-clear"} kind
  */
-function ensureMethodState(target, methodName, kind) {
-  if (!target || typeof target[methodName] !== "function") {
-    return null;
-  }
+function methodRecordFor(target, methodName, kind) {
   const registry = targetRegistry(target);
-  const registered = registry.methods.get(methodName);
-  if (registered?.active) {
-    return registered;
+  let record = registry.methods.get(methodName);
+  if (!record) {
+    record = {
+      registry,
+      target,
+      methodName,
+      kind,
+      segments: new Set(),
+      owners: new Map(),
+      topState: null,
+    };
+    registry.methods.set(methodName, record);
+  }
+  return record;
+}
+
+/** @param {any} record */
+function ensureMethodState(record) {
+  const { target, methodName, kind } = record;
+  const current = target[methodName];
+  if (record.topState?.active && current === record.topState.wrapper) {
+    return record.topState;
   }
 
-  const current = target[methodName];
   const staleState = current?.[HOST_HOOK_WRAPPER];
   if (
     staleState?.version === REGISTRY_VERSION
     && staleState.target === target
     && staleState.methodName === methodName
     && staleState.kind === kind
+    && staleState.callbacks.size === 0
   ) {
     staleState.active = true;
-    registry.methods.set(methodName, staleState);
+    staleState.methodRecord = record;
+    record.segments.add(staleState);
+    record.topState = staleState;
     return staleState;
   }
 
@@ -282,6 +300,7 @@ function ensureMethodState(target, methodName, kind) {
     target,
     methodName,
     kind,
+    methodRecord: record,
     original: current,
     wrapper: null,
     callbacks: new Map(),
@@ -289,7 +308,8 @@ function ensureMethodState(target, methodName, kind) {
   };
   state.wrapper = createWrapper(state);
   target[methodName] = state.wrapper;
-  registry.methods.set(methodName, state);
+  record.segments.add(state);
+  record.topState = state;
   return state;
 }
 
@@ -300,16 +320,47 @@ function releaseMethodState(state) {
   if (state.target[state.methodName] === state.wrapper) {
     state.target[state.methodName] = state.original;
   }
-  const registry = state.target[HOST_HOOK_REGISTRY];
-  if (registry?.methods?.get(state.methodName) === state) {
-    registry.methods.delete(state.methodName);
+  const record = state.methodRecord;
+  record?.segments?.delete(state);
+  if (record?.topState === state) {
+    const currentState = state.target[state.methodName]?.[HOST_HOOK_WRAPPER];
+    record.topState = currentState?.active && record.segments.has(currentState)
+      ? currentState
+      : null;
   }
+  if (record?.segments?.size === 0) {
+    record.registry.methods.delete(state.methodName);
+  }
+  const registry = record?.registry;
   if (
     registry?.methods?.size === 0
     && state.target[HOST_HOOK_REGISTRY] === registry
   ) {
     delete state.target[HOST_HOOK_REGISTRY];
   }
+}
+
+/** @param {any} record @param {any} state @param {any} owner @param {any} entry */
+function createCallbackDisposer(record, state, owner, entry) {
+  let disposed = false;
+  return () => {
+    const current = record.owners.get(owner);
+    if (
+      disposed
+      || current?.state !== state
+      || current?.entry !== entry
+      || state.callbacks.get(owner) !== entry
+    ) {
+      return false;
+    }
+    disposed = true;
+    record.owners.delete(owner);
+    state.callbacks.delete(owner);
+    if (state.callbacks.size === 0) {
+      releaseMethodState(state);
+    }
+    return true;
+  };
 }
 
 /**
@@ -320,24 +371,19 @@ function releaseMethodState(state) {
  * @param {Record<string, any>} callbacks
  */
 function registerMethodCallbacks(target, methodName, kind, owner, callbacks) {
-  const state = ensureMethodState(target, methodName, kind);
-  if (!state || state.callbacks.has(owner)) {
+  if (!target || typeof target[methodName] !== "function") {
     return noOpDispose;
   }
+  const record = methodRecordFor(target, methodName, kind);
+  if (record.owners.has(owner)) {
+    return noOpDispose;
+  }
+
+  const state = ensureMethodState(record);
   const entry = { owner, callbacks };
   state.callbacks.set(owner, entry);
-  let disposed = false;
-  return () => {
-    if (disposed || state.callbacks.get(owner) !== entry) {
-      return false;
-    }
-    disposed = true;
-    state.callbacks.delete(owner);
-    if (state.callbacks.size === 0) {
-      releaseMethodState(state);
-    }
-    return true;
-  };
+  record.owners.set(owner, { state, entry });
+  return createCallbackDisposer(record, state, owner, entry);
 }
 
 /**
@@ -410,4 +456,86 @@ export function registerHostHookCallbacks(options) {
     }
     return changed;
   };
+}
+
+/**
+ * Own a composition root's current global-hook leases on a collision-safe host
+ * Symbol. A newer runtime claims the host by disposing the previous runtime's
+ * hook leases first. Only leases installed through this lifecycle are owned;
+ * listeners, locale watchers, DOM state, and node-local resources remain out
+ * of scope.
+ *
+ * @param {any} host
+ * @param {symbol} owner
+ */
+export function createHostHookRuntimeLifecycle(host, owner) {
+  if (!host || typeof owner !== "symbol") {
+    throw new TypeError("A host object and Symbol runtime owner are required.");
+  }
+  const leases = new Map();
+
+  function isOwner() {
+    return host[owner] === lifecycle;
+  }
+
+  function claim() {
+    if (isOwner()) {
+      return false;
+    }
+    const previous = host[owner];
+    previous?.dispose?.();
+    host[owner] = lifecycle;
+    return true;
+  }
+
+  /**
+   * @param {any} key
+   * @param {() => (() => boolean)} installer
+   * @param {{ replace?: boolean }} [options]
+   */
+  function install(key, installer, options = {}) {
+    claim();
+    const previous = leases.get(key);
+    if (previous && options.replace !== true) {
+      return false;
+    }
+    if (previous) {
+      leases.delete(key);
+      previous();
+    }
+    const dispose = installer();
+    if (typeof dispose !== "function") {
+      throw new TypeError("A host hook installer must return a disposer.");
+    }
+    leases.set(key, dispose);
+    return true;
+  }
+
+  function dispose() {
+    let changed = false;
+    let cleanupError = null;
+    for (const release of [...leases.values()].reverse()) {
+      try {
+        changed = release() || changed;
+      } catch (error) {
+        cleanupError ||= error;
+      }
+    }
+    leases.clear();
+    if (isOwner()) {
+      delete host[owner];
+    }
+    if (cleanupError) {
+      throw cleanupError;
+    }
+    return changed;
+  }
+
+  const lifecycle = {
+    claim,
+    dispose,
+    install,
+    isOwner,
+  };
+  return lifecycle;
 }

--- a/web/js/prompt_studio/advanced_queue_seed_runtime.js
+++ b/web/js/prompt_studio/advanced_queue_seed_runtime.js
@@ -5,6 +5,9 @@ import {
   normalizeWildcardSeed as normalizeSeed,
   optionalWildcardSeed as optionalSeed,
 } from "./wildcard_seed_contract.js";
+import {
+  registerHostHookCallbacks,
+} from "../lifecycle/host_hook_registry.js";
 
 const ACTIVE_WILDCARD_MODES = new Set(["populate", "fixed", "sequential"]);
 const WILDCARD_MODE_ALIASES = new Map([
@@ -21,9 +24,12 @@ const WILDCARD_MODE_ALIASES = new Map([
   ["재현", "reproduce"],
 ]);
 const SEED_CONTROLS = new Set(["fixed", "randomize", "increment", "decrement"]);
-const QUEUE_HOOK_MARKER = "__easyuseAnimaAdvancedQueueSeedWrapped";
-const QUEUE_HOST_MARKER = "__easyuseAnimaAdvancedQueueSeedInstalled";
-const GRAPH_CLEANUP_MARKER = "__easyuseAnimaAdvancedQueueSeedCleanup";
+const ADVANCED_QUEUE_SEED_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.advanced-queue-seed",
+);
+const ADVANCED_QUEUE_SEED_CLEAR_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.advanced-queue-seed-clear",
+);
 const RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed";
 
 function isRecord(value) {
@@ -699,25 +705,40 @@ function createAdvancedQueueSeedRuntime(dependencies) {
     }
   }
 
+  function beforeQueue(context) {
+    const transaction = preparePrompt(context.args[1], context.args[2]);
+    if (transaction) {
+      const queueArgs = [...context.args];
+      queueArgs[1] = transaction.prompt;
+      context.args = queueArgs;
+    }
+    return transaction;
+  }
+
+  function afterQueue(context) {
+    const transaction = context.callbackState;
+    if (!transaction) {
+      return;
+    }
+    if (context.ok) {
+      settleTransaction(transaction, context.result);
+    } else {
+      rejectTransaction(transaction);
+    }
+  }
+
   function wrapQueuePrompt(queuePrompt) {
     return async function (...args) {
-      const transaction = preparePrompt(args[1], args[2]);
-      const queueArgs = transaction ? [...args] : args;
-      if (transaction) {
-        queueArgs[1] = transaction.prompt;
-      }
+      const context = { args };
+      const transaction = beforeQueue(context);
       let result;
       try {
-        result = await queuePrompt.apply(this, queueArgs);
+        result = await queuePrompt.apply(this, context.args);
       } catch (error) {
-        if (transaction) {
-          rejectTransaction(transaction);
-        }
+        afterQueue({ callbackState: transaction, ok: false, error });
         throw error;
       }
-      if (transaction) {
-        settleTransaction(transaction, result);
-      }
+      afterQueue({ callbackState: transaction, ok: true, result });
       return result;
     };
   }
@@ -814,7 +835,9 @@ function createAdvancedQueueSeedRuntime(dependencies) {
   }
 
   return {
+    afterQueue,
     attachNode,
+    beforeQueue,
     clearGraphNodes,
     detachNode,
     preparePrompt,
@@ -825,38 +848,20 @@ function createAdvancedQueueSeedRuntime(dependencies) {
 }
 
 function installAdvancedQueueSeedGraphCleanup(graph, runtime) {
-  if (
-    !graph
-    || typeof graph.clear !== "function"
-    || graph.clear[GRAPH_CLEANUP_MARKER]
-  ) {
-    return false;
-  }
-  const clear = graph.clear;
-  const wrappedClear = function () {
-    const result = clear.apply(this, arguments);
-    runtime.clearGraphNodes();
-    return result;
-  };
-  wrappedClear[GRAPH_CLEANUP_MARKER] = true;
-  graph.clear = wrappedClear;
-  return true;
+  return registerHostHookCallbacks({
+    owner: ADVANCED_QUEUE_SEED_CLEAR_OWNER,
+    graphHost: graph,
+    onGraphClear: runtime.clearGraphNodes,
+  });
 }
 
 function installAdvancedQueueSeedQueueHook(queueHost, runtime) {
-  if (
-    !queueHost
-    || typeof queueHost.queuePrompt !== "function"
-    || queueHost[QUEUE_HOST_MARKER]
-    || queueHost.queuePrompt[QUEUE_HOOK_MARKER]
-  ) {
-    return false;
-  }
-  const wrappedQueuePrompt = runtime.wrapQueuePrompt(queueHost.queuePrompt);
-  wrappedQueuePrompt[QUEUE_HOOK_MARKER] = true;
-  queueHost.queuePrompt = wrappedQueuePrompt;
-  queueHost[QUEUE_HOST_MARKER] = true;
-  return true;
+  return registerHostHookCallbacks({
+    owner: ADVANCED_QUEUE_SEED_OWNER,
+    queueHost,
+    beforeQueue: runtime.beforeQueue,
+    afterQueue: runtime.afterQueue,
+  });
 }
 
 export {

--- a/web/js/prompt_studio/extension_runtime.js
+++ b/web/js/prompt_studio/extension_runtime.js
@@ -134,6 +134,13 @@ import {
   markNodeDirty as markNodeDirtyWithApp,
   refreshNodeSize as refreshNodeSizeWithApp,
 } from "./runtime_canvas.js";
+import {
+  createHostHookRuntimeLifecycle,
+} from "../lifecycle/host_hook_registry.js";
+
+const PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.global-hook-runtime-owner",
+);
 
 const ADVANCED_QUEUE_SEED_CONTRACT = Object.freeze({
   modeInputName: "wildcard_mode",
@@ -162,6 +169,11 @@ function isRegionalQueueSeedNode(node) {
 
 function createPromptStudioExtensionRuntime(app, api = null) {
   const queueSeedBridge = promptStudioQueueSeedBridge(app);
+  const globalHookLifecycle = createHostHookRuntimeLifecycle(
+    app,
+    PROMPT_STUDIO_GLOBAL_HOOK_RUNTIME_OWNER,
+  );
+  let advancedSaveSyncSerializeHost;
 
   function markNodeDirty(node) {
     markNodeDirtyWithApp(app, node);
@@ -427,7 +439,36 @@ function createPromptStudioExtensionRuntime(app, api = null) {
   }
 
   function installAdvancedSaveSyncForApp() {
-    installAdvancedSaveSync(app, syncAllAdvancedNodes);
+    const serializeHost = globalThis.LGraph?.prototype || app?.graph?.constructor?.prototype || null;
+    const replace = advancedSaveSyncSerializeHost !== undefined
+      && serializeHost != null
+      && serializeHost !== advancedSaveSyncSerializeHost;
+    const installed = globalHookLifecycle.install(
+      "advanced-save-sync",
+      () => installAdvancedSaveSync(app, syncAllAdvancedNodes),
+      { replace },
+    );
+    if (installed) {
+      advancedSaveSyncSerializeHost = serializeHost;
+    }
+    return installed;
+  }
+
+  function installGlobalHooks() {
+    installAdvancedSaveSyncForApp();
+    globalHookLifecycle.install(
+      "advanced-queue-seed-graph-clear",
+      () => installAdvancedQueueSeedGraphCleanup(app.graph, advancedQueueSeedRuntime),
+    );
+    globalHookLifecycle.install(
+      "advanced-queue-seed-queue",
+      () => installAdvancedQueueSeedQueueHook(api, advancedQueueSeedRuntime),
+    );
+  }
+
+  function disposeGlobalHooks() {
+    advancedSaveSyncSerializeHost = undefined;
+    return globalHookLifecycle.dispose();
   }
 
   function advancedNodeUiHooks() {
@@ -465,12 +506,11 @@ function createPromptStudioExtensionRuntime(app, api = null) {
   }
 
   return {
+    dispose: disposeGlobalHooks,
     async setup() {
       installAdvancedWheelForwarder();
       installMiddlePanForwarder();
-      installAdvancedSaveSync(app, syncAllAdvancedNodes);
-      installAdvancedQueueSeedGraphCleanup(app.graph, advancedQueueSeedRuntime);
-      installAdvancedQueueSeedQueueHook(api, advancedQueueSeedRuntime);
+      installGlobalHooks();
       installPromptHighlightOverlayRefresh(app, applyPromptStudioTextStyle);
       await loadPromptStudioSettings({
         hideTrainedTagTooltip,

--- a/web/js/prompt_studio/node_hooks.js
+++ b/web/js/prompt_studio/node_hooks.js
@@ -7,6 +7,13 @@ import {
   NODE_TYPE,
   WILDCARD_NODE_TYPE,
 } from "./constants.js";
+import {
+  registerHostHookCallbacks,
+} from "../lifecycle/host_hook_registry.js";
+
+const ADVANCED_SAVE_SYNC_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.advanced-save-sync",
+);
 
 function isAdvancedNodeName(name) {
   return name === ADVANCED_NODE_TYPE || name === ADVANCED_V2_NODE_TYPE;
@@ -198,23 +205,13 @@ function syncAdvancedNodes(app, syncAdvancedValues) {
 
 function installAdvancedSaveSync(app, syncAllAdvancedNodes) {
   const graphProto = globalThis.LGraph?.prototype || app?.graph?.constructor?.prototype;
-  if (graphProto?.serialize && !graphProto.serialize.__easyuseAnimaAdvancedWrapped) {
-    const serialize = graphProto.serialize;
-    graphProto.serialize = function () {
-      syncAllAdvancedNodes();
-      return serialize.apply(this, arguments);
-    };
-    graphProto.serialize.__easyuseAnimaAdvancedWrapped = true;
-  }
-
-  if (app?.queuePrompt && !app.queuePrompt.__easyuseAnimaAdvancedWrapped) {
-    const queuePrompt = app.queuePrompt;
-    app.queuePrompt = function () {
-      syncAllAdvancedNodes();
-      return queuePrompt.apply(this, arguments);
-    };
-    app.queuePrompt.__easyuseAnimaAdvancedWrapped = true;
-  }
+  return registerHostHookCallbacks({
+    owner: ADVANCED_SAVE_SYNC_OWNER,
+    serializeHost: graphProto,
+    queueHost: app,
+    beforeSerialize: syncAllAdvancedNodes,
+    beforeQueue: syncAllAdvancedNodes,
+  });
 }
 
 export {

--- a/web/js/prompt_studio/regional/extension.js
+++ b/web/js/prompt_studio/regional/extension.js
@@ -19,11 +19,15 @@ import {
 } from "../queue_seed_bridge.js";
 import { disposeExternalAutocompleteInputs } from "../../autocomplete/entry_lifecycle.js";
 import {
+  createHostHookRuntimeLifecycle,
   registerHostHookCallbacks,
 } from "../../lifecycle/host_hook_registry.js";
 
 const REGIONAL_SAVE_SYNC_OWNER = Symbol.for(
   "easyuse-anima.prompt-studio.regional-save-sync",
+);
+const REGIONAL_GLOBAL_HOOK_RUNTIME_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.regional-global-hook-runtime-owner",
 );
 
 /**
@@ -179,6 +183,11 @@ function registerRegionalNodeHooks(nodeType, hooks) {
  */
 function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks) {
   const queueSeedBridge = promptStudioQueueSeedBridge(app);
+  const globalHookLifecycle = createHostHookRuntimeLifecycle(
+    app,
+    REGIONAL_GLOBAL_HOOK_RUNTIME_OWNER,
+  );
+  let saveSyncSerializeHost;
   queueSeedBridge.bindRegionalSeedPublisher((node, seed) => {
     if (!runtime.isRegionalNode(node)) {
       return false;
@@ -255,7 +264,24 @@ function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks
 
   /** @param {any} [graph] */
   function installSaveSync(graph = null) {
-    installRegionalSaveSync(app, syncAllRegionalNodes, graph);
+    const serializeHost = globalThis.LGraph?.prototype || graph?.constructor?.prototype || null;
+    const replace = saveSyncSerializeHost !== undefined
+      && serializeHost != null
+      && serializeHost !== saveSyncSerializeHost;
+    const installed = globalHookLifecycle.install(
+      "regional-save-sync",
+      () => installRegionalSaveSync(app, syncAllRegionalNodes, graph),
+      { replace },
+    );
+    if (installed) {
+      saveSyncSerializeHost = serializeHost;
+    }
+    return installed;
+  }
+
+  function disposeGlobalHooks() {
+    saveSyncSerializeHost = undefined;
+    return globalHookLifecycle.dispose();
   }
 
   /** @param {any} node */
@@ -325,6 +351,7 @@ function createRegionalExtensionRuntime(app, runtime, layout, fieldEditor, hooks
   }
 
   return {
+    dispose: disposeGlobalHooks,
     async setup() {
       hooks.installRegionalAdapter();
       installSaveSync();

--- a/web/js/prompt_studio/regional/extension.js
+++ b/web/js/prompt_studio/regional/extension.js
@@ -18,6 +18,13 @@ import {
   promptStudioQueueSeedBridge,
 } from "../queue_seed_bridge.js";
 import { disposeExternalAutocompleteInputs } from "../../autocomplete/entry_lifecycle.js";
+import {
+  registerHostHookCallbacks,
+} from "../../lifecycle/host_hook_registry.js";
+
+const REGIONAL_SAVE_SYNC_OWNER = Symbol.for(
+  "easyuse-anima.prompt-studio.regional-save-sync",
+);
 
 /**
  * @param {any} nodeType
@@ -60,24 +67,13 @@ function registerRegionalConditioningNodeHooks(nodeType, repairWidgets) {
  */
 function installRegionalSaveSync(app, syncAllRegionalNodes, graph = null) {
   const graphProto = globalThis.LGraph?.prototype || graph?.constructor?.prototype;
-  if (graphProto?.serialize && !graphProto.serialize.__easyuseAnimaRegionalWrapped) {
-    const serialize = graphProto.serialize;
-    const wrappedSerialize = function () {
-      syncAllRegionalNodes();
-      return serialize.apply(this, arguments);
-    };
-    wrappedSerialize.__easyuseAnimaRegionalWrapped = true;
-    graphProto.serialize = wrappedSerialize;
-  }
-  if (app.queuePrompt && !app.queuePrompt.__easyuseAnimaRegionalWrapped) {
-    const queuePrompt = app.queuePrompt;
-    const wrappedQueuePrompt = function () {
-      syncAllRegionalNodes();
-      return queuePrompt.apply(this, arguments);
-    };
-    wrappedQueuePrompt.__easyuseAnimaRegionalWrapped = true;
-    app.queuePrompt = wrappedQueuePrompt;
-  }
+  return registerHostHookCallbacks({
+    owner: REGIONAL_SAVE_SYNC_OWNER,
+    serializeHost: graphProto,
+    queueHost: app,
+    beforeSerialize: syncAllRegionalNodes,
+    beforeQueue: syncAllRegionalNodes,
+  });
 }
 
 /**


### PR DESCRIPTION
## 변경 요약

- Issue #166 Phase 1로 app/graph 전역 hook을 대상별 중앙 lifecycle registry에서 관리합니다.
- callback 표면은 `beforeSerialize`, `beforeQueue`, `afterQueue`, `onGraphClear`이며 기존 wrapper 순서, 동기/비동기 반환, queue resolve/reject/throw, `this`/인자/반환값을 보존합니다.
- Prompt Studio Advanced save-sync, Regional save-sync, Advanced queue-seed/graph-clear 전역 wrapper를 Symbol owner 기반 registry callback으로 이관했습니다.
- composition root가 실제 hook disposer를 보관하고 `dispose()`를 노출합니다. 같은 runtime의 setup 2회는 idempotent하고, 새 runtime은 app Symbol lease를 claim하면서 이전 runtime의 migrated hook만 해제한 뒤 새 callback closure를 설치합니다.
- 새 runtime이 이전 lifecycle을 교체할 때 이전 lifecycle을 terminal `retired` 상태로 전환합니다. superseded lifecycle의 `claim()`/`install()`은 현재 owner를 해제하거나 탈취하지 않으며 safe no-op으로 종료됩니다. 반면 자기 `dispose()`로 ordinary release한 lifecycle은 owner slot이 비어 있을 때 재설치할 수 있습니다.
- registry active segment 밖에 foreign wrapper가 끼어든 경우 새 registry segment를 현재 method 위에 설치합니다. delegating/non-delegating replacement 모두 새 owner 도달성을 보존하며, 각 disposer는 identity guard로 자기 segment/callback만 해제합니다.
- AiO `generator_queue_runtime.js`와 LoRA `save_sync.js`는 migration하지 않았고 기존 wrapper와 registry의 양방향 load-order 공존을 회귀 테스트로 유지했습니다.

## 기준

- base: `dev` @ `da05d19c215e360b8cc674fecbbd595c6b42cb5d`
- head: `codex/issue-166-hook-registry-phase1` @ `344294512d37bb712ce006de512437c2565b8144`

## 주요 파일

- `web/js/lifecycle/host_hook_registry.js`
- `web/js/prompt_studio/node_hooks.js`
- `web/js/prompt_studio/regional/extension.js`
- `web/js/prompt_studio/advanced_queue_seed_runtime.js`
- `web/js/prompt_studio/extension_runtime.js`
- `tests/frontend_host_hook_registry_smoke.mjs`
- `tests/frontend_regional_runtime_smoke.mjs`
- `tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs`
- `tests/test_frontend_modules.py`
- `tools/check_frontend.ps1`, `jsconfig.json`

## 회귀 근거

- second runtime이 first lifecycle을 claim한 뒤 first `dispose()`와 `install()` 모두 새 lease에 영향을 주지 않음을 검증했습니다.
- ordinary `dispose()` 후 owner slot이 비어 있으면 같은 lifecycle이 재설치되는 계약을 검증했습니다.
- 첫 Regional runtime closure를 보관한 node prototype wrapper를 두 번째 runtime 생성 후 다시 실행해도 첫 lifecycle이 reclaim되지 않고 두 번째 callback만 실행됨을 검증했습니다.
- 기존 interleaved multi-segment, non-delegating foreign replacement, LIFO/unwind, queue resolve/reject/throw, graph clear 및 AiO/LoRA load-order 회귀를 유지했습니다.

## 검증

- `node tests\frontend_host_hook_registry_smoke.mjs` — 통과
- `node tests\frontend_regional_runtime_smoke.mjs` — 통과
- `node tests\frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs` — 통과
- `python -m unittest tests.test_frontend_modules` — 47 tests 통과
- `powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile quick` — 통과
  - Python compile
  - frontend `node --check`
  - 등록된 frontend smoke
  - Frontend 111 JavaScript files / TypeScript 6.0.3
  - Git diff check
- `git diff --check origin/dev...HEAD` — 통과

## 최종 통합 검증

메인 owner가 exact HEAD `344294512d37bb712ce006de512437c2565b8144`에서 수행했습니다.

- 공식 `full` — 통과
  - Python unittest: 625 passed
  - frontend: 111 JavaScript files passed
  - TypeScript 6.0.3 passed
  - Python compile 및 git diff check passed
- 독립 actual diff 재리뷰 — P0–P2 차단점 없음
- ComfyUI v0.27.0 Codex test instance live browser
  - Classic canvas → Nodes 2.0 → Classic canvas 전환 후 Advanced UI 1개와 Regional UI 2개가 계속 렌더링됨
  - 각 모드/재전환 후 workflow Save 성공, 새 console 오류 없음
  - Nodes 2.0의 queue가 실제 execution path까지 진입함
  - queue 후 실행 실패는 테스트 checkpoint의 SAM3 text projection shape mismatch이며 hook registry 변경과 무관함

## 남은 위험 / 범위 밖

- Phase 1 범위 밖인 AiO/LoRA migration, DOM/canvas/widget/resize 변경, broad `web/js` checkJs 확대는 포함하지 않았습니다.
- GPU model execution 성공 자체는 SAM3 테스트 checkpoint 불일치로 확인하지 못했지만, queue hook과 backend execution 진입은 확인했습니다.

Refs #166
