### PR TITLE
chore: AiO generation settings v1 manifest 계약 고정

### DIFF
--- a/docs/architecture/aio-settings-contract.md
+++ b/docs/architecture/aio-settings-contract.md
@@ -51,10 +51,16 @@ execution은 기존 코드다.
 
 ### Coercion
 
-- Backend boolean은 첫 list/tuple 값을 사용하고 `true`, `1`, `yes`, `on`, `enable`, `enabled` 문자열을 true로
-  처리한다. 다른 문자열은 false다.
+- Backend boolean은 첫 list/tuple 값을 사용하고 빈 list/tuple은 field default를 쓴다. `true`, `1`, `yes`,
+  `on`, `enable`, `enabled` 문자열은 true이며 다른 문자열은 false다.
 - Backend integer/number는 각각 Python `int()`/`float()` 변환을 사용하고 실패하면 해당 default를 쓴다.
-- Choice는 첫 list/tuple 값을 trimmed string으로 만든 뒤 exact membership을 확인하고 실패하면 default를 쓴다.
+- Generic `choice`는 첫 list/tuple 값을 trimmed string으로 만든 뒤 exact membership을 확인하고 실패하면 default를
+  쓴다. 다음 field는 generic pipeline을 사용하지 않으므로 전용 coercion을 갖는다.
+  - `mod_guidance.profile`: whole value를 `str(value or default)`로 바꾼 뒤 trim/case 변환 없이 exact membership을
+    확인한다. list/tuple은 첫 요소가 아니라 container 전체 문자열이 되어 invalid fallback한다.
+  - `upscale.usdu.prompt_mode`, Detailer target `alignment`: whole value를 먼저 `str(value or default)`로 바꾸고
+    그 scalar string을 generic choice에 전달한다. 따라서 whitespace는 trim되지만 list/tuple은 첫 요소로
+    취급되지 않는다. `prompt_mode`의 `quality_tags_only` alias는 string 변환 후 choice 전에만 적용한다.
 - 단, runtime capability를 쓰는 dynamic choice는 preferred default가 현재 capability 목록에 있을 때만 default를
   쓴다. 없으면 첫 capability, capability가 비었으면 preferred default를 쓴다. 이는 static enum의 invalid 정책과
   다른 `default-if-present-else-first` 정책이다.
@@ -67,6 +73,10 @@ execution은 기존 코드다.
   보존한다. backend normalizer가 schema constant를 canonical 값으로 강제하는 동작과 혼동하지 않는다.
 - Static enum과 bound는 manifest가 소유한다. sampler/scheduler 목록과 Comfy max resolution처럼 실행 환경에
   따라 달라지는 값은 `dynamic_enum`/`maximum_source`로만 참조한다.
+- Static enum golden gate는 manifest의 각 member가 해당 backend field에서 round-trip되는지 확인한다. 또한 모든
+  field에 sentinel을 주입해 실제 `_choice` accepted set을 캡처하고, `_choice`를 거치지 않는 profile은 runtime
+  constant를 직접 사용해 manifest/명시 fixture/runtime source의 3자 equality를 검증한다. 따라서 manifest extra
+  member와 runtime accepted member 누락을 모두 차단한다.
 
 ## Dynamic Comfy capability 비소유
 
@@ -128,7 +138,8 @@ write-on-read는 금지한다. 후속 version migration은 명시적인 순수 �
 ## Golden gate
 
 `tests/test_aio_schema_contract.py`는 manifest default와 현재 Python default의 deep equality, 전체 default leaf와
-field contract coverage, coercion 참조 완결성, empty container item 및 pattern/ref coverage, static enum/min/max,
+field contract coverage, coercion 참조 완결성, empty container item 및 pattern/ref coverage, static enum 양방향
+accepted-set/member round-trip과 min/max,
 legacy/unknown 정책, dynamic capability 비소유와 fallback 양쪽 분기를 검증한다.
 `tests/frontend_aio_settings_core_smoke.mjs`는 manifest default와 현재 JavaScript default의 deep equality 및
 frontend coercion/unknown-field 정책과 manifest 내부 coercion/item 정의 완결성을 검증한다.

--- a/docs/architecture/aio-settings-contract.md
+++ b/docs/architecture/aio-settings-contract.md
@@ -1,0 +1,118 @@
+# AiO generation settings v1 계약
+
+이 문서는 `easyuse_anima_aio_generation_settings` v1의 정적 계약과 소유 경계를 설명한다. 기준 manifest는
+`easyuse_anima/aio/schemas/generation_settings.v1.json`이다.
+
+이번 단계는 [#168](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/168)의 C168-01 Contract PR이다.
+manifest와 golden test만 추가하며 Python/JavaScript runtime은 manifest를 import하지 않는다. generator, codegen,
+typed model, version migration, normalizer 교체도 이 단계에 포함하지 않는다.
+
+## 소유권
+
+| 계약 | owner | 비고 |
+| --- | --- | --- |
+| v1 정적 field shape와 default | `easyuse_anima.aio.generation_settings` manifest | Python/JavaScript default와 golden equality |
+| 정적 enum, min/max, coercion 분류 | manifest | 현재 backend normalizer 동작으로 검증 |
+| legacy alias와 unknown-field 정책 | manifest | surface별 현재 차이도 명시 |
+| Python 실행 시 정규화 | 현재 `nodes.py` | 이번 PR에서 이동하거나 변경하지 않음 |
+| frontend default merge/visible merge | 현재 `web/js/aio/settings.js`, `web/js/easyuse_anima_aio.js` | 이번 PR에서 변경하지 않음 |
+| Comfy/Impact sampler, scheduler, max resolution 목록 | Comfy capability adapter/runtime | manifest가 값 목록을 소유하지 않음 |
+| profile envelope, ID, revision, CAS | [#163](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/163) | nested `settings` payload 내부만 #168 소유 |
+
+manifest의 `default`는 완전한 normalized v1 기본 object다. `shape`는 field type, coercion, static enum 및
+bound를 제공하고 반복되는 Spectrum/DiT correction/Detailer target은 `definitions`와 `$ref`로 표현한다.
+이 구조는 후속 codegen이나 typed model이 소비할 수 있지만, 현재 runtime source of execution은 기존 코드다.
+
+## 정적 field 정책
+
+정규화 이후의 root는 object이며 다음 section을 갖는다.
+
+| section | 핵심 정적 계약 |
+| --- | --- |
+| `schema`, `version`, `mode` | schema name 고정, current version 1, mode enum |
+| `sampler` | backend/seed control enum, steps/cfg/denoise bound, Spectrum/SPD/DiT correction |
+| `model_patches` | AuraFlow, DAVE, Safe PAG, KJ/torch compile |
+| `mod_guidance`, `artist_mix` | mode/profile enum과 weight/layer/count bound |
+| `highres`, `upscale`, `postprocess` | stage switch, method/backend enum, size/sampling bound |
+| `detailer` | ordered `face`/`eye`와 `custom_<n>` target contract |
+| `save`, `preview` | save backend/format/metadata와 preview feed contract |
+
+각 normalized object는 known field를 채우면서 unknown field를 기본적으로 보존한다. 빈 extension object인
+`sampler.spectrum_extra`와 `sampler.spd_extra`도 v1의 공개 확장 지점으로 유지한다.
+
+### Coercion
+
+- Backend boolean은 첫 list/tuple 값을 사용하고 `true`, `1`, `yes`, `on`, `enable`, `enabled` 문자열을 true로
+  처리한다. 다른 문자열은 false다.
+- Backend integer/number는 각각 Python `int()`/`float()` 변환을 사용하고 실패하면 해당 default를 쓴다.
+- Choice는 첫 list/tuple 값을 trimmed string으로 만든 뒤 exact membership을 확인하고 실패하면 default를 쓴다.
+- Frontend boolean과 number coercion은 JavaScript 규칙을 사용한다. backend와 동일하다고 가정하지 않으며
+  정확한 token/operation은 manifest의 `coercions`에 surface별로 기록한다.
+- Static enum과 bound는 manifest가 소유한다. sampler/scheduler 목록과 Comfy max resolution처럼 실행 환경에
+  따라 달라지는 값은 `dynamic_enum`/`maximum_source`로만 참조한다.
+
+## Dynamic Comfy capability 비소유
+
+다음 값은 설치된 ComfyUI 및 custom node capability에 따라 달라지므로 manifest가 snapshot하지 않는다.
+
+- `comfy.samplers`: sampler name
+- `comfy.schedulers`: Comfy scheduler name
+- `impact.schedulers`: Detailer scheduler name
+- `comfy.max_resolution`: USDU tile 및 postprocess size 상한
+
+manifest는 이 값들의 type과 capability source만 지정한다. 현재 목록을 static enum으로 복사하거나 default를
+환경 탐색 결과로 다시 쓰지 않는다.
+
+## Legacy alias와 migration
+
+| legacy | 현재 in-memory 처리 | canonical |
+| --- | --- | --- |
+| `upscale.fit` | 명시적 non-default `postprocess.fit` 값을 우선하고 나머지를 복사한 뒤 제거 | `postprocess.fit` |
+| `upscale.fit.enabled` | true면 postprocess를 활성화 | `postprocess.enabled` |
+| `upscale.usdu.prompt_mode = quality_tags_only` | value alias 변환 | `no_general` |
+| `sampler.dave` | 제거 | `model_patches.dave` |
+| `model_patches.aura_flow.enabled` | 제거 | 없음 |
+| `save.filename_prefix` | 제거 | `save.image_saver.path` + `filename` |
+| `save.image_saver.show_preview` | 제거 | `preview` section |
+
+v1에는 version migration이 없다. 위 처리는 기존 legacy alias 정규화이며 저장 파일을 자동으로 다시 쓰는
+migration이 아니다. Read/list/load는 원본 profile/workflow bytes, mtime, revision을 바꾸지 않아야 한다.
+write-on-read는 금지한다. 후속 version migration은 명시적인 순수 함수로 추가하고, 실제 persist는 사용자가
+요청한 save/update 같은 mutation에서만 수행한다.
+
+## Unknown-field 정책과 현재 drift
+
+확인된 현재 동작은 다음과 같다.
+
+- Python `_merge_versioned_settings()`와 backend normalizer는 nested unknown key를 재귀적으로 보존한다. 위 표의
+  known legacy path만 명시적으로 제거한다.
+- Frontend `aioMergeDefaults()`도 unknown key를 보존한다.
+- Frontend visible merge와 optional-dependency sanitize는 `highres.backend`를 제거한다. Python은 이 key를
+  unknown field로 보존한다. 이 차이는 현재 drift이며 이번 Contract PR에서 동작을 맞추지 않는다.
+- Seed 최소값은 양쪽 모두 `-3`이지만 backend 상한은 uint64
+  `18446744073709551615`, frontend 상한은 현재 `1125899906842624`다.
+- Backend와 frontend의 boolean/integer coercion token 및 변환 규칙도 완전히 같지 않다.
+
+이 drift는 manifest의 `policies.known_surface_drift`와 surface-specific coercion/bound에 기록한다. 후속 동작
+변경은 별도 Behavior/Migration PR에서 호환성 판단과 fixture를 갖춘 뒤 수행한다.
+
+## 관련 이슈 경계
+
+- [#163](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/163): profile envelope, stable identity,
+  revision/CAS, AtomicJsonStore를 소유한다. profile 내부 nested generation settings shape는 이 계약이 소유한다.
+- [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184): `nodes.py`의 동작 보존형 package/module 이동과
+  Comfy adapter 추출을 소유한다. 이 PR은 파일 이동이나 root alias 변경을 하지 않는다.
+- [#169](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/169): `GenerationRequest`/stage pipeline,
+  cleanup, byte-budgeted cache 같은 실행 동작을 소유한다. 이 PR은 queue, stage, cache, result를 변경하지 않는다.
+- [#168](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/168)의 후속 단계가 typed config, generator/codegen,
+  pure version migration 및 normalizer facade 축소를 소유한다.
+
+## Golden gate
+
+`tests/test_aio_schema_contract.py`는 manifest default와 현재 Python default의 deep equality, 전체 default leaf와
+field contract coverage, static enum/min/max/coercion, legacy/unknown 정책, dynamic capability 비소유를 검증한다.
+`tests/frontend_aio_settings_core_smoke.mjs`는 manifest default와 현재 JavaScript default의 deep equality 및
+frontend coercion/unknown-field 정책을 검증한다.
+
+manifest는 runtime package에 포함되어야 하므로 tracked 상태, `.comfyignore` 비제외, `git archive HEAD` 포함도
+dedicated schema test에서 검증한다. 문서와 테스트는 Registry archive에서 제외되어도 된다.

--- a/docs/architecture/aio-settings-contract.md
+++ b/docs/architecture/aio-settings-contract.md
@@ -21,7 +21,10 @@ typed model, version migration, normalizer 교체도 이 단계에 포함하지 
 
 manifest의 `default`는 완전한 normalized v1 기본 object다. `shape`는 field type, coercion, static enum 및
 bound를 제공하고 반복되는 Spectrum/DiT correction/Detailer target은 `definitions`와 `$ref`로 표현한다.
-이 구조는 후속 codegen이나 typed model이 소비할 수 있지만, 현재 runtime source of execution은 기존 코드다.
+모든 coercion 참조, array item, open JSON object value, `custom_<n>` pattern field가 manifest 내부 정의로
+해결되므로 후속 consumer가 별도의 암묵 token 표 없이 계약을 해석할 수 있다. 다만 이번 PR은 실제
+generator/codegen/typed model을 추가하거나 특정 generator와의 호환성을 주장하지 않는다. 현재 runtime source of
+execution은 기존 코드다.
 
 ## 정적 field 정책
 
@@ -40,14 +43,28 @@ bound를 제공하고 반복되는 Spectrum/DiT correction/Detailer target은 `d
 각 normalized object는 known field를 채우면서 unknown field를 기본적으로 보존한다. 빈 extension object인
 `sampler.spectrum_extra`와 `sampler.spd_extra`도 v1의 공개 확장 지점으로 유지한다.
 
+빈 default container도 shape가 비어 있다는 뜻이 아니다. `save.image_saver.additional_hash_bundles`는 정규화된
+문자열 item, `civitai_hash_fetchers`는 `enabled`, `username`, `model_name`, `version`을 갖는 item object를 소유한다.
+후자는 non-object row와 identity 문자열 세 개가 모두 빈 row를 버리고 unknown item field를 보존하지 않는다.
+`detailer.order` item은 `face`, `eye`, `custom_<n>`만 허용하며 중복을 제거하고 현재 backend가 `face`, `eye`를
+항상 보장한다. `sampler.spectrum_extra`와 `sampler.spd_extra`의 추가 값은 JSON value contract를 따른다.
+
 ### Coercion
 
 - Backend boolean은 첫 list/tuple 값을 사용하고 `true`, `1`, `yes`, `on`, `enable`, `enabled` 문자열을 true로
   처리한다. 다른 문자열은 false다.
 - Backend integer/number는 각각 Python `int()`/`float()` 변환을 사용하고 실패하면 해당 default를 쓴다.
 - Choice는 첫 list/tuple 값을 trimmed string으로 만든 뒤 exact membership을 확인하고 실패하면 default를 쓴다.
+- 단, runtime capability를 쓰는 dynamic choice는 preferred default가 현재 capability 목록에 있을 때만 default를
+  쓴다. 없으면 첫 capability, capability가 비었으면 preferred default를 쓴다. 이는 static enum의 invalid 정책과
+  다른 `default-if-present-else-first` 정책이다.
+- `string-or-default`, empty-string string, trimmed string, hash bundle string/list, Civitai fetcher list,
+  Detailer order, open JSON object, seed, constant token은 모두 manifest `coercions`에 정의한다. container item의
+  별도 coercion 참조도 같은 registry에서 해결한다.
 - Frontend boolean과 number coercion은 JavaScript 규칙을 사용한다. backend와 동일하다고 가정하지 않으며
   정확한 token/operation은 manifest의 `coercions`에 surface별로 기록한다.
+- Frontend default merge는 일반 field coercion이나 schema constant 강제를 수행하지 않고 incoming value를
+  보존한다. backend normalizer가 schema constant를 canonical 값으로 강제하는 동작과 혼동하지 않는다.
 - Static enum과 bound는 manifest가 소유한다. sampler/scheduler 목록과 Comfy max resolution처럼 실행 환경에
   따라 달라지는 값은 `dynamic_enum`/`maximum_source`로만 참조한다.
 
@@ -60,8 +77,9 @@ bound를 제공하고 반복되는 Spectrum/DiT correction/Detailer target은 `d
 - `impact.schedulers`: Detailer scheduler name
 - `comfy.max_resolution`: USDU tile 및 postprocess size 상한
 
-manifest는 이 값들의 type과 capability source만 지정한다. 현재 목록을 static enum으로 복사하거나 default를
-환경 탐색 결과로 다시 쓰지 않는다.
+manifest는 이 값들의 type, capability source, invalid fallback 구조만 지정한다. 현재 목록을 static enum으로
+복사하거나 default를 환경 탐색 결과로 다시 쓰지 않는다. golden test는 preferred default가 deterministic
+capability에 존재하는 경우와 존재하지 않아 첫 capability로 fallback하는 경우를 분리해 검증한다.
 
 ## Legacy alias와 migration
 
@@ -110,9 +128,10 @@ write-on-read는 금지한다. 후속 version migration은 명시적인 순수 �
 ## Golden gate
 
 `tests/test_aio_schema_contract.py`는 manifest default와 현재 Python default의 deep equality, 전체 default leaf와
-field contract coverage, static enum/min/max/coercion, legacy/unknown 정책, dynamic capability 비소유를 검증한다.
+field contract coverage, coercion 참조 완결성, empty container item 및 pattern/ref coverage, static enum/min/max,
+legacy/unknown 정책, dynamic capability 비소유와 fallback 양쪽 분기를 검증한다.
 `tests/frontend_aio_settings_core_smoke.mjs`는 manifest default와 현재 JavaScript default의 deep equality 및
-frontend coercion/unknown-field 정책을 검증한다.
+frontend coercion/unknown-field 정책과 manifest 내부 coercion/item 정의 완결성을 검증한다.
 
 manifest는 runtime package에 포함되어야 하므로 tracked 상태, `.comfyignore` 비제외, `git archive HEAD` 포함도
 dedicated schema test에서 검증한다. 문서와 테스트는 Registry archive에서 제외되어도 된다.

--- a/easyuse_anima/aio/schemas/generation_settings.v1.json
+++ b/easyuse_anima/aio/schemas/generation_settings.v1.json
@@ -1,0 +1,492 @@
+{
+  "manifest_version": 1,
+  "settings": {
+    "schema": "easyuse_anima_aio_generation_settings",
+    "version": 1
+  },
+  "owner": "easyuse_anima.aio.generation_settings",
+  "contract_kind": "normalized-settings-manifest",
+  "description": "Golden v1 contract for the normalized AiO generation settings shape. Runtime code does not import this file.",
+  "coercions": {
+    "backend_boolean": {
+      "true_strings": ["true", "1", "yes", "on", "enable", "enabled"],
+      "other_strings": false,
+      "null": "default",
+      "non_strings": "python-bool"
+    },
+    "frontend_boolean": {
+      "true_strings": ["true", "1", "yes", "on"],
+      "false_strings": ["false", "0", "no", "off"],
+      "other_strings": "javascript-truthiness",
+      "null": "default",
+      "non_strings": "javascript-truthiness"
+    },
+    "backend_integer": {
+      "operation": "python-int",
+      "invalid": "default",
+      "list_or_tuple": "first-value"
+    },
+    "backend_number": {
+      "operation": "python-float",
+      "invalid": "default",
+      "list_or_tuple": "first-value"
+    },
+    "frontend_number": {
+      "operation": "javascript-number-then-trunc-when-integer",
+      "invalid": "default"
+    },
+    "choice": {
+      "operation": "trimmed-string-exact-membership",
+      "invalid": "default",
+      "list_or_tuple": "first-value"
+    }
+  },
+  "policies": {
+    "unknown_fields": {
+      "backend": {
+        "mode": "preserve-recursively",
+        "removed_known_legacy_paths": [
+          "/sampler/dave",
+          "/model_patches/aura_flow/enabled",
+          "/upscale/fit",
+          "/save/filename_prefix",
+          "/save/image_saver/show_preview"
+        ]
+      },
+      "frontend_default_merge": {
+        "mode": "preserve-recursively"
+      },
+      "frontend_visible_merge": {
+        "mode": "preserve-recursively-with-known-removals",
+        "removed_paths": [
+          "/sampler/dave",
+          "/model_patches/aura_flow/enabled",
+          "/highres/backend",
+          "/save/filename_prefix",
+          "/save/image_saver/show_preview"
+        ]
+      }
+    },
+    "deprecated_aliases": [
+      {
+        "path": "/upscale/fit",
+        "replacement": "/postprocess/fit",
+        "mode": "in-memory-copy-then-remove",
+        "precedence": "explicit-non-default-postprocess-wins",
+        "enabled_replacement": "/postprocess/enabled"
+      },
+      {
+        "path": "/upscale/usdu/prompt_mode",
+        "value": "quality_tags_only",
+        "replacement_value": "no_general",
+        "mode": "in-memory-value-alias"
+      },
+      {
+        "path": "/sampler/dave",
+        "replacement": "/model_patches/dave",
+        "mode": "remove-obsolete-path"
+      },
+      {
+        "path": "/model_patches/aura_flow/enabled",
+        "replacement": null,
+        "mode": "remove-obsolete-path"
+      },
+      {
+        "path": "/save/filename_prefix",
+        "replacement": "/save/image_saver/path + /save/image_saver/filename",
+        "mode": "remove-obsolete-path"
+      },
+      {
+        "path": "/save/image_saver/show_preview",
+        "replacement": "/preview",
+        "mode": "remove-obsolete-path"
+      }
+    ],
+    "version_migrations": [],
+    "persistence": {
+      "write_on_read": false,
+      "runtime_normalization": "in-memory-only",
+      "future_version_migrations": "explicit-pure-functions"
+    },
+    "dynamic_capabilities": {
+      "owned_by_manifest": false,
+      "sources": {
+        "comfy.samplers": "_comfy_sampler_names",
+        "comfy.schedulers": "_comfy_scheduler_names",
+        "impact.schedulers": "_impact_scheduler_names",
+        "comfy.max_resolution": "_comfy_max_resolution"
+      }
+    },
+    "known_surface_drift": [
+      {
+        "path": "/highres/backend",
+        "backend": "preserved-as-unknown",
+        "frontend_visible_merge": "removed"
+      },
+      {
+        "path": "/sampler/seed",
+        "backend_maximum": "18446744073709551615",
+        "frontend_maximum": 1125899906842624
+      },
+      {
+        "path": "boolean-coercion",
+        "backend": "backend_boolean",
+        "frontend": "frontend_boolean"
+      },
+      {
+        "path": "integer-coercion",
+        "backend": "backend_integer",
+        "frontend": "frontend_number"
+      }
+    ]
+  },
+  "definitions": {
+    "spectrum": {
+      "type": "object",
+      "unknown_fields": "preserve",
+      "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "window_size": {"type": "number", "coercion": "backend_number", "minimum": 1.0, "maximum": 10.0},
+        "flex_window": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 2.0},
+        "warmup_steps": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 10000},
+        "tail_actual_steps": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 10000},
+        "blend_w": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "cheby_degree": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 10},
+        "ridge_lambda": {"type": "number", "coercion": "backend_number", "minimum": 0.001, "maximum": 10.0},
+        "history_size": {"type": "integer", "coercion": "backend_integer", "minimum": 5, "maximum": 10000},
+        "one_sampler_only": {"type": "boolean", "coercion": "backend_boolean"},
+        "verbose": {"type": "boolean", "coercion": "backend_boolean"},
+        "compat_policy": {"type": "string", "coercion": "choice", "enum": ["legacy", "conservative", "strict"]}
+      }
+    },
+    "dit_corrections": {
+      "type": "object",
+      "unknown_fields": "preserve",
+      "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "dcw_mode": {"type": "string", "coercion": "choice", "enum": ["off", "manual", "auto"]},
+        "dcw_lambda": {"type": "number", "coercion": "backend_number", "minimum": -1.0, "maximum": 1.0},
+        "dcw_band_mask": {"type": "string", "coercion": "choice", "enum": ["LL", "all", "HH", "LH+HL+HH"]},
+        "dcw_calibrator": {"type": "string", "coercion": "string-or-default"},
+        "smc_cfg": {"type": "boolean", "coercion": "backend_boolean"},
+        "adaptive_smc_alpha": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "smc_cfg_lambda": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 20.0},
+        "cfgpp": {"type": "boolean", "coercion": "backend_boolean"},
+        "cfgpp_lambda": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 8.0},
+        "fsg": {"type": "boolean", "coercion": "backend_boolean"},
+        "fsg_band_lo": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "fsg_band_hi": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "fsg_k": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 32},
+        "fsg_d_sigma": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "fsg_gamma": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 10.0},
+        "replace_existing_cfg": {"type": "boolean", "coercion": "backend_boolean"}
+      }
+    },
+    "detailer_target": {
+      "type": "object",
+      "unknown_fields": "preserve",
+      "fields": {
+        "label": {"type": "string", "coercion": "string-or-default"},
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "detect_prompt": {"type": "string", "coercion": "string-or-default"},
+        "detect_count": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 20},
+        "threshold": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "refine_iterations": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 16},
+        "individual_masks": {"type": "boolean", "coercion": "backend_boolean"},
+        "combined": {"type": "boolean", "coercion": "backend_boolean"},
+        "crop_factor": {"type": "number", "coercion": "backend_number", "minimum": 1.0, "maximum": 16.0},
+        "bbox_fill": {"type": "boolean", "coercion": "backend_boolean"},
+        "drop_size": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 4096},
+        "contour_fill": {"type": "boolean", "coercion": "backend_boolean"},
+        "guide_size": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum": 4096},
+        "guide_size_for": {"type": "boolean", "coercion": "backend_boolean"},
+        "max_size": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum": 8192},
+        "steps": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 75},
+        "inherit_sampler_settings": {"type": "boolean", "coercion": "backend_boolean"},
+        "cfg": {"type": "number", "coercion": "backend_number", "minimum": 1.0, "maximum": 10.0},
+        "sampler_name": {"type": "string", "coercion": "choice", "dynamic_enum": "comfy.samplers"},
+        "scheduler": {"type": "string", "coercion": "choice", "dynamic_enum": "impact.schedulers"},
+        "denoise": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "feather": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 256},
+        "noise_mask": {"type": "boolean", "coercion": "backend_boolean"},
+        "force_inpaint": {"type": "boolean", "coercion": "backend_boolean"},
+        "wildcard": {"type": "string", "coercion": "string"},
+        "cycle": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 16},
+        "alignment": {"type": "string", "coercion": "choice", "enum": ["impact", "none", "32", "64"]},
+        "inpaint_model": {"type": "boolean", "coercion": "backend_boolean"},
+        "noise_mask_feather": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 256},
+        "tiled_encode": {"type": "boolean", "coercion": "backend_boolean"},
+        "tiled_decode": {"type": "boolean", "coercion": "backend_boolean"},
+        "spectrum": {"$ref": "#/definitions/spectrum"},
+        "dit_corrections": {"$ref": "#/definitions/dit_corrections"}
+      }
+    }
+  },
+  "shape": {
+    "type": "object",
+    "unknown_fields": "preserve",
+    "fields": {
+      "schema": {"type": "string", "coercion": "constant", "const": "easyuse_anima_aio_generation_settings"},
+      "version": {"type": "integer", "coercion": "backend_integer", "current": 1},
+      "mode": {"type": "string", "coercion": "choice", "enum": ["txt2img", "img2img", "inpaint"]},
+      "sampler": {
+        "type": "object",
+        "unknown_fields": "preserve",
+        "fields": {
+          "backend": {"type": "string", "coercion": "choice", "enum": ["comfy_ksampler", "spectrum_mod_guidance_advanced", "spectrum_spd_speed"]},
+          "seed": {"type": "integer", "coercion": "surface-specific-seed", "minimum": -3, "maximum_by_surface": {"backend": "18446744073709551615", "frontend": 1125899906842624}},
+          "seed_after_generate": {"type": "string", "coercion": "choice", "enum": ["fixed", "randomize", "increment", "decrement"]},
+          "steps": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 75},
+          "cfg": {"type": "number", "coercion": "backend_number", "minimum": 1.0, "maximum": 10.0},
+          "sampler_name": {"type": "string", "coercion": "choice", "dynamic_enum": "comfy.samplers"},
+          "scheduler": {"type": "string", "coercion": "choice", "dynamic_enum": "comfy.schedulers"},
+          "denoise": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+          "spectrum": {"$ref": "#/definitions/spectrum"},
+          "spd": {
+            "type": "object",
+            "unknown_fields": "preserve",
+            "fields": {
+              "split_mode": {"type": "string", "coercion": "choice", "enum": ["single"]},
+              "scale": {"type": "number", "coercion": "backend_number", "minimum": 0.25, "maximum": 1.0},
+              "sigma": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+              "adaptive_smc_alpha": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0}
+            }
+          },
+          "spectrum_extra": {"type": "object", "coercion": "json-object-or-empty", "open_content": true},
+          "spd_extra": {"type": "object", "coercion": "json-object-or-empty", "open_content": true},
+          "dit_corrections": {"$ref": "#/definitions/dit_corrections"}
+        }
+      },
+      "model_patches": {
+        "type": "object",
+        "unknown_fields": "preserve",
+        "fields": {
+          "aura_flow": {"type": "object", "unknown_fields": "preserve", "fields": {"shift": {"type": "number", "coercion": "backend_number", "minimum": 1.0, "maximum": 10.0}}},
+          "dave": {"type": "object", "unknown_fields": "preserve", "fields": {
+            "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+            "mask": {"type": "string", "coercion": "string-or-default"},
+            "strength": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+            "tau": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0}
+          }},
+          "safe_pag": {"type": "object", "unknown_fields": "preserve", "fields": {
+            "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+            "scale": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 100.0},
+            "block_indices": {"type": "string", "coercion": "string-or-default"},
+            "perturbation_strength": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+            "head_indices": {"type": "string", "coercion": "string-or-default"},
+            "start_percent": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+            "end_percent": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+            "rescale": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+            "rescale_mode": {"type": "string", "coercion": "choice", "enum": ["full", "partial"]}
+          }},
+          "kj": {"type": "object", "unknown_fields": "preserve", "fields": {
+            "fp16_accumulation": {"type": "boolean", "coercion": "backend_boolean"},
+            "sage_attention": {"type": "string", "coercion": "choice", "enum": ["disabled", "auto", "sageattn_qk_int8_pv_fp16_cuda", "sageattn_qk_int8_pv_fp16_triton", "sageattn_qk_int8_pv_fp8_cuda", "sageattn_qk_int8_pv_fp8_cuda++", "sageattn3", "sageattn3_per_block_mean"]},
+            "sage_allow_compile": {"type": "boolean", "coercion": "backend_boolean"},
+            "torch_compile": {"type": "object", "unknown_fields": "preserve", "fields": {
+              "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+              "backend": {"type": "string", "coercion": "choice", "enum": ["inductor", "cudagraphs"]},
+              "fullgraph": {"type": "boolean", "coercion": "backend_boolean"},
+              "mode": {"type": "string", "coercion": "choice", "enum": ["default", "max-autotune", "max-autotune-no-cudagraphs", "reduce-overhead"]},
+              "dynamic": {"type": "string", "coercion": "choice", "enum": ["auto", "true", "false"]},
+              "compile_transformer_blocks_only": {"type": "boolean", "coercion": "backend_boolean"},
+              "dynamo_cache_size_limit": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 1024},
+              "debug_compile_keys": {"type": "boolean", "coercion": "backend_boolean"},
+              "disable_dynamic_vram": {"type": "boolean", "coercion": "backend_boolean"}
+            }}
+          }}
+        }
+      },
+      "mod_guidance": {"type": "object", "unknown_fields": "preserve", "fields": {
+        "mode": {"type": "string", "coercion": "choice", "enum": ["prompt_data", "enabled", "disabled"]},
+        "profile": {"type": "string", "coercion": "choice", "enum": ["off", "step_i8_skip27", "step_i14", "uniform_w3"]},
+        "advanced": {"type": "object", "unknown_fields": "preserve", "fields": {
+          "adapter": {"type": "string", "coercion": "string-or-default"},
+          "quality_tags": {"type": "string", "coercion": "string-or-default"},
+          "quality_neg": {"type": "string", "coercion": "string-or-default"},
+          "mod_w": {"type": "number", "coercion": "backend_number", "minimum": -20.0, "maximum": 20.0},
+          "mod_start_layer": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 999},
+          "mod_end_layer": {"type": "integer", "coercion": "backend_integer", "minimum": -1, "maximum": 999},
+          "mod_taper": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 999},
+          "mod_taper_scale": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+          "mod_final_w": {"type": "number", "coercion": "backend_number", "minimum": -20.0, "maximum": 20.0}
+        }}
+      }},
+      "artist_mix": {"type": "object", "unknown_fields": "preserve", "fields": {
+        "mode": {"type": "string", "coercion": "choice", "enum": ["prompt_data", "off", "prompt", "average", "delta_rms", "hybrid", "clustered", "exact", "composite_exact", "late_exact", "average_late_exact", "scheduled_average"]},
+        "start_percent": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "strength_scale": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 5.0},
+        "style_gain": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 3.0},
+        "rms_scale_cap": {"type": "number", "coercion": "backend_number", "minimum": 1.0, "maximum": 5.0},
+        "exact_top_k": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 64},
+        "cluster_count": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 32},
+        "dominant_isolation": {"type": "boolean", "coercion": "backend_boolean"},
+        "dominant_threshold": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0}
+      }},
+      "highres": {"type": "object", "unknown_fields": "preserve", "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "scale_by": {"type": "number", "coercion": "backend_number", "minimum": 0.01, "maximum": 8.0},
+        "upscale_method": {"type": "string", "coercion": "choice", "enum": ["nearest-exact", "bilinear", "area", "bicubic", "lanczos"]},
+        "multiple": {"type": "string", "coercion": "choice", "enum": ["8", "16", "32", "64"]},
+        "max_long_edge": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 16384},
+        "steps": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 75},
+        "inherit_sampler_settings": {"type": "boolean", "coercion": "backend_boolean"},
+        "cfg": {"type": "number", "coercion": "backend_number", "minimum": 1.0, "maximum": 10.0},
+        "sampler_name": {"type": "string", "coercion": "choice", "dynamic_enum": "comfy.samplers"},
+        "scheduler": {"type": "string", "coercion": "choice", "dynamic_enum": "comfy.schedulers"},
+        "denoise": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "spectrum": {"$ref": "#/definitions/spectrum"},
+        "dit_corrections": {"$ref": "#/definitions/dit_corrections"}
+      }},
+      "upscale": {"type": "object", "unknown_fields": "preserve", "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "backend": {"type": "string", "coercion": "choice", "enum": ["usdu", "resshift"]},
+        "scale_by": {"type": "number", "coercion": "backend_number", "minimum": 0.05, "maximum": 4.0},
+        "steps": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 1000},
+        "inherit_sampler_settings": {"type": "boolean", "coercion": "backend_boolean"},
+        "cfg": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 100.0},
+        "sampler_name": {"type": "string", "coercion": "choice", "dynamic_enum": "comfy.samplers"},
+        "scheduler": {"type": "string", "coercion": "choice", "dynamic_enum": "comfy.schedulers"},
+        "denoise": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+        "spectrum": {"$ref": "#/definitions/spectrum"},
+        "dit_corrections": {"$ref": "#/definitions/dit_corrections"},
+        "usdu": {"type": "object", "unknown_fields": "preserve", "fields": {
+          "upscale_model_name": {"type": "string", "coercion": "string-or-default"},
+          "auto_tile_size": {"type": "boolean", "coercion": "backend_boolean"},
+          "prompt_mode": {"type": "string", "coercion": "choice", "enum": ["full", "no_general"]},
+          "mode_type": {"type": "string", "coercion": "choice", "enum": ["Linear", "Chess", "None"]},
+          "auto_tile_target": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum_source": "comfy.max_resolution"},
+          "auto_tile_min": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum_source": "comfy.max_resolution"},
+          "auto_tile_max": {"type": "integer", "coercion": "backend_integer", "minimum_source": "../auto_tile_min", "maximum_source": "comfy.max_resolution"},
+          "tile_width": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum_source": "comfy.max_resolution"},
+          "tile_height": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum_source": "comfy.max_resolution"},
+          "mask_blur": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 64},
+          "tile_padding": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum_source": "comfy.max_resolution"},
+          "seam_fix_mode": {"type": "string", "coercion": "choice", "enum": ["None", "Band Pass", "Half Tile", "Half Tile + Intersections"]},
+          "seam_fix_denoise": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0},
+          "seam_fix_width": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum_source": "comfy.max_resolution"},
+          "seam_fix_mask_blur": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 64},
+          "seam_fix_padding": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum_source": "comfy.max_resolution"},
+          "force_uniform_tiles": {"type": "boolean", "coercion": "backend_boolean"},
+          "tiled_decode": {"type": "boolean", "coercion": "backend_boolean"},
+          "batch_size": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 4096}
+        }},
+        "resshift": {"type": "object", "unknown_fields": "preserve", "fields": {
+          "scale": {"type": "string", "coercion": "choice", "enum": ["x2", "x4"]},
+          "student_name": {"type": "string", "coercion": "string-or-default"},
+          "dtype": {"type": "string", "coercion": "choice", "enum": ["bf16", "fp32"]},
+          "chop": {"type": "integer", "coercion": "backend_integer", "minimum": 256, "maximum": 4096},
+          "overlap": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 512},
+          "tile_batch": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 32}
+        }}
+      }},
+      "postprocess": {"type": "object", "unknown_fields": "preserve", "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "fit": {"type": "object", "unknown_fields": "preserve", "fields": {
+          "mode": {"type": "string", "coercion": "choice", "enum": ["max_long_edge", "megapixels"]},
+          "max_long_edge": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum_source": "comfy.max_resolution"},
+          "max_megapixels": {"type": "number", "coercion": "backend_number", "minimum": 0.1, "maximum": 256.0},
+          "method": {"type": "string", "coercion": "choice", "enum": ["nearest-exact", "bilinear", "area", "bicubic", "lanczos"]}
+        }}
+      }},
+      "detailer": {"type": "object", "unknown_fields": "preserve", "pattern_fields": {"^custom_[0-9]+$": {"$ref": "#/definitions/detailer_target"}}, "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "order": {"type": "array", "coercion": "detailer-order", "items": "detailer-target-name"},
+        "sam3": {"type": "object", "unknown_fields": "preserve", "fields": {
+          "context": {"type": "string", "coercion": "choice", "enum": ["load_checkpoint"]},
+          "checkpoint": {"type": "string", "coercion": "string-or-default"}
+        }},
+        "face": {"$ref": "#/definitions/detailer_target"},
+        "eye": {"$ref": "#/definitions/detailer_target"}
+      }},
+      "save": {"type": "object", "unknown_fields": "preserve", "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean"},
+        "backend": {"type": "string", "coercion": "choice", "enum": ["image_saver", "comfy_save_image"]},
+        "image_saver": {"type": "object", "unknown_fields": "preserve", "fields": {
+          "filename": {"type": "string", "coercion": "string-or-default"},
+          "path": {"type": "string", "coercion": "string-or-default"},
+          "extension": {"type": "string", "coercion": "choice", "enum": ["png", "jpeg", "jpg", "webp"]},
+          "lossless_webp": {"type": "boolean", "coercion": "backend_boolean"},
+          "quality_jpeg_or_webp": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 100},
+          "optimize_png": {"type": "boolean", "coercion": "backend_boolean"},
+          "counter": {"type": "integer", "coercion": "backend_integer", "minimum": 0},
+          "clip_skip": {"type": "integer", "coercion": "backend_integer", "minimum": -24, "maximum": 24},
+          "time_format": {"type": "string", "coercion": "string-or-default"},
+          "save_workflow_as_json": {"type": "boolean", "coercion": "backend_boolean"},
+          "embed_workflow": {"type": "boolean", "coercion": "backend_boolean"},
+          "save_prompt_metadata": {"type": "boolean", "coercion": "backend_boolean"},
+          "additional_hashes": {"type": "string", "coercion": "string"},
+          "additional_hash_bundles": {"type": "array", "coercion": "string-list"},
+          "civitai_hash_fetchers": {"type": "array", "coercion": "civitai-fetcher-list"},
+          "download_civitai_data": {"type": "boolean", "coercion": "backend_boolean"},
+          "easy_remix": {"type": "boolean", "coercion": "backend_boolean"},
+          "custom": {"type": "string", "coercion": "string"}
+        }}
+      }},
+      "preview": {"type": "object", "unknown_fields": "preserve", "fields": {
+        "intermediate_images": {"type": "boolean", "coercion": "backend_boolean"},
+        "compare_previous": {"type": "boolean", "coercion": "backend_boolean"},
+        "image_feed": {"type": "boolean", "coercion": "backend_boolean"},
+        "feed_count": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 100}
+      }}
+    }
+  },
+  "default": {
+    "schema": "easyuse_anima_aio_generation_settings",
+    "version": 1,
+    "mode": "txt2img",
+    "sampler": {
+      "backend": "comfy_ksampler",
+      "seed": -1,
+      "seed_after_generate": "fixed",
+      "steps": 32,
+      "cfg": 5.0,
+      "sampler_name": "er_sde",
+      "scheduler": "simple",
+      "denoise": 1.0,
+      "spectrum": {"enabled": false, "window_size": 2.0, "flex_window": 0.25, "warmup_steps": 6, "tail_actual_steps": 3, "blend_w": 0.3, "cheby_degree": 3, "ridge_lambda": 0.1, "history_size": 100, "one_sampler_only": false, "verbose": false, "compat_policy": "conservative"},
+      "spd": {"split_mode": "single", "scale": 0.5, "sigma": 0.7, "adaptive_smc_alpha": 0.0},
+      "spectrum_extra": {},
+      "spd_extra": {},
+      "dit_corrections": {"enabled": false, "dcw_mode": "off", "dcw_lambda": 0.01, "dcw_band_mask": "LL", "dcw_calibrator": "(auto-download default)", "smc_cfg": false, "adaptive_smc_alpha": 0.0, "smc_cfg_lambda": 6.0, "cfgpp": false, "cfgpp_lambda": 0.0, "fsg": false, "fsg_band_lo": 0.59, "fsg_band_hi": 0.75, "fsg_k": 3, "fsg_d_sigma": 0.1, "fsg_gamma": 0.0, "replace_existing_cfg": false}
+    },
+    "model_patches": {
+      "aura_flow": {"shift": 3.0},
+      "dave": {"enabled": false, "mask": "dave_alpha.npz", "strength": 0.3, "tau": 0.1},
+      "safe_pag": {"enabled": false, "scale": 4.0, "block_indices": "18", "perturbation_strength": 0.75, "head_indices": "", "start_percent": 0.0, "end_percent": 0.7, "rescale": 0.2, "rescale_mode": "full"},
+      "kj": {"fp16_accumulation": false, "sage_attention": "disabled", "sage_allow_compile": false, "torch_compile": {"enabled": false, "backend": "inductor", "fullgraph": false, "mode": "max-autotune-no-cudagraphs", "dynamic": "false", "compile_transformer_blocks_only": true, "dynamo_cache_size_limit": 64, "debug_compile_keys": false, "disable_dynamic_vram": true}}
+    },
+    "mod_guidance": {"mode": "prompt_data", "profile": "step_i8_skip27", "advanced": {"adapter": "(auto-download default)", "quality_tags": "highres, best quality, score_7", "quality_neg": "score_1, score_2, score_3, worst quality, lowres, old, bad hands, bad anatomy", "mod_w": 3.0, "mod_start_layer": 8, "mod_end_layer": 27, "mod_taper": 0, "mod_taper_scale": 0.25, "mod_final_w": 0.0}},
+    "artist_mix": {"mode": "prompt_data", "start_percent": 0.5, "strength_scale": 1.0, "style_gain": 1.35, "rms_scale_cap": 2.0, "exact_top_k": 4, "cluster_count": 4, "dominant_isolation": true, "dominant_threshold": 0.25},
+    "highres": {
+      "enabled": false, "scale_by": 1.5, "upscale_method": "bicubic", "multiple": "32", "max_long_edge": 2560, "steps": 20, "inherit_sampler_settings": true, "cfg": 8.0, "sampler_name": "euler", "scheduler": "simple", "denoise": 0.25,
+      "spectrum": {"enabled": false, "window_size": 2.0, "flex_window": 0.2, "warmup_steps": 7, "tail_actual_steps": 4, "blend_w": 0.3, "cheby_degree": 3, "ridge_lambda": 0.1, "history_size": 100, "one_sampler_only": false, "verbose": false, "compat_policy": "conservative"},
+      "dit_corrections": {"enabled": false, "dcw_mode": "off", "dcw_lambda": 0.02, "dcw_band_mask": "LL", "dcw_calibrator": "(auto-download default)", "smc_cfg": false, "adaptive_smc_alpha": 0.0, "smc_cfg_lambda": 6.0, "cfgpp": false, "cfgpp_lambda": 0.0, "fsg": false, "fsg_band_lo": 0.59, "fsg_band_hi": 0.75, "fsg_k": 3, "fsg_d_sigma": 0.1, "fsg_gamma": 0.0, "replace_existing_cfg": false}
+    },
+    "upscale": {
+      "enabled": false, "backend": "usdu", "scale_by": 2.0, "steps": 20, "inherit_sampler_settings": true, "cfg": 8.0, "sampler_name": "euler", "scheduler": "simple", "denoise": 0.2,
+      "spectrum": {"enabled": false, "window_size": 2.0, "flex_window": 0.2, "warmup_steps": 7, "tail_actual_steps": 4, "blend_w": 0.3, "cheby_degree": 3, "ridge_lambda": 0.1, "history_size": 100, "one_sampler_only": false, "verbose": false, "compat_policy": "conservative"},
+      "dit_corrections": {"enabled": false, "dcw_mode": "off", "dcw_lambda": 0.02, "dcw_band_mask": "LL", "dcw_calibrator": "(auto-download default)", "smc_cfg": false, "adaptive_smc_alpha": 0.0, "smc_cfg_lambda": 6.0, "cfgpp": false, "cfgpp_lambda": 0.0, "fsg": false, "fsg_band_lo": 0.59, "fsg_band_hi": 0.75, "fsg_k": 3, "fsg_d_sigma": 0.1, "fsg_gamma": 0.0, "replace_existing_cfg": false},
+      "usdu": {"upscale_model_name": "2x-AnimeSharpV4_Fast_RCAN_PU.safetensors", "auto_tile_size": true, "prompt_mode": "full", "mode_type": "Linear", "auto_tile_target": 1024, "auto_tile_min": 512, "auto_tile_max": 2048, "tile_width": 512, "tile_height": 512, "mask_blur": 8, "tile_padding": 32, "seam_fix_mode": "None", "seam_fix_denoise": 1.0, "seam_fix_width": 64, "seam_fix_mask_blur": 8, "seam_fix_padding": 16, "force_uniform_tiles": true, "tiled_decode": false, "batch_size": 1},
+      "resshift": {"scale": "x2", "student_name": "(auto-download)", "dtype": "bf16", "chop": 512, "overlap": 64, "tile_batch": 4}
+    },
+    "postprocess": {"enabled": false, "fit": {"mode": "max_long_edge", "max_long_edge": 2048, "max_megapixels": 4.0, "method": "bicubic"}},
+    "detailer": {
+      "enabled": false,
+      "order": ["face", "eye"],
+      "sam3": {"context": "load_checkpoint", "checkpoint": "sam3.1_multiplex_fp16.safetensors"},
+      "face": {
+        "label": "Face Detailer", "enabled": false, "detect_prompt": "face", "detect_count": 1, "threshold": 0.52, "refine_iterations": 2, "individual_masks": true, "combined": false, "crop_factor": 4.0, "bbox_fill": false, "drop_size": 100, "contour_fill": true, "guide_size": 1024, "guide_size_for": false, "max_size": 2048, "steps": 20, "inherit_sampler_settings": true, "cfg": 8.0, "sampler_name": "euler", "scheduler": "sgm_uniform", "denoise": 0.33, "feather": 5, "noise_mask": true, "force_inpaint": true, "wildcard": "", "cycle": 1, "alignment": "32", "inpaint_model": false, "noise_mask_feather": 10, "tiled_encode": false, "tiled_decode": false,
+        "spectrum": {"enabled": true, "window_size": 2.0, "flex_window": 0.15, "warmup_steps": 6, "tail_actual_steps": 3, "blend_w": 0.3, "cheby_degree": 3, "ridge_lambda": 0.1, "history_size": 100, "one_sampler_only": false, "verbose": false, "compat_policy": "conservative"},
+        "dit_corrections": {"enabled": false, "dcw_mode": "off", "dcw_lambda": 0.02, "dcw_band_mask": "LL", "dcw_calibrator": "(auto-download default)", "smc_cfg": false, "adaptive_smc_alpha": 0.0, "smc_cfg_lambda": 6.0, "cfgpp": false, "cfgpp_lambda": 0.0, "fsg": false, "fsg_band_lo": 0.59, "fsg_band_hi": 0.75, "fsg_k": 3, "fsg_d_sigma": 0.1, "fsg_gamma": 0.0, "replace_existing_cfg": false}
+      },
+      "eye": {
+        "label": "Eye Detailer", "enabled": false, "detect_prompt": "eyes", "detect_count": 1, "threshold": 0.5, "refine_iterations": 2, "individual_masks": true, "combined": false, "crop_factor": 6.0, "bbox_fill": false, "drop_size": 40, "contour_fill": true, "guide_size": 1024, "guide_size_for": false, "max_size": 2048, "steps": 20, "inherit_sampler_settings": true, "cfg": 8.0, "sampler_name": "euler", "scheduler": "sgm_uniform", "denoise": 0.29, "feather": 6, "noise_mask": true, "force_inpaint": true, "wildcard": "", "cycle": 1, "alignment": "32", "inpaint_model": false, "noise_mask_feather": 20, "tiled_encode": false, "tiled_decode": false,
+        "spectrum": {"enabled": true, "window_size": 2.0, "flex_window": 0.15, "warmup_steps": 6, "tail_actual_steps": 3, "blend_w": 0.3, "cheby_degree": 3, "ridge_lambda": 0.1, "history_size": 100, "one_sampler_only": false, "verbose": false, "compat_policy": "conservative"},
+        "dit_corrections": {"enabled": false, "dcw_mode": "off", "dcw_lambda": 0.02, "dcw_band_mask": "LL", "dcw_calibrator": "(auto-download default)", "smc_cfg": false, "adaptive_smc_alpha": 0.0, "smc_cfg_lambda": 6.0, "cfgpp": false, "cfgpp_lambda": 0.0, "fsg": false, "fsg_band_lo": 0.59, "fsg_band_hi": 0.75, "fsg_k": 3, "fsg_d_sigma": 0.1, "fsg_gamma": 0.0, "replace_existing_cfg": false}
+      }
+    },
+    "save": {"enabled": true, "backend": "image_saver", "image_saver": {"filename": "%time_%basemodelname", "path": "EasyUseAnima/AiO", "extension": "webp", "lossless_webp": false, "quality_jpeg_or_webp": 97, "optimize_png": true, "counter": 0, "clip_skip": 0, "time_format": "%Y-%m-%d-%H%M%S", "save_workflow_as_json": false, "embed_workflow": true, "save_prompt_metadata": true, "additional_hashes": "", "additional_hash_bundles": [], "civitai_hash_fetchers": [], "download_civitai_data": true, "easy_remix": true, "custom": ""}},
+    "preview": {"intermediate_images": false, "compare_previous": false, "image_feed": true, "feed_count": 12}
+  }
+}

--- a/easyuse_anima/aio/schemas/generation_settings.v1.json
+++ b/easyuse_anima/aio/schemas/generation_settings.v1.json
@@ -12,7 +12,9 @@
       "true_strings": ["true", "1", "yes", "on", "enable", "enabled"],
       "other_strings": false,
       "null": "default",
-      "non_strings": "python-bool"
+      "non_strings": "python-bool",
+      "list_or_tuple": "first-value",
+      "empty_list_or_tuple": "default"
     },
     "frontend_boolean": {
       "true_strings": ["true", "1", "yes", "on"],
@@ -47,6 +49,34 @@
         }
       },
       "list_or_tuple": "first-value"
+    },
+    "string-then-choice": {
+      "backend": {
+        "operation": [
+          "python-str-of-value-or-field-default",
+          "trimmed-string-exact-membership"
+        ],
+        "null_or_falsy": "field-default",
+        "list_or_tuple": "python-str-whole-value",
+        "whitespace": "trim-before-membership",
+        "invalid": "default"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "mod-guidance-profile": {
+      "backend": {
+        "operation": "python-str-of-value-or-field-default-then-exact-membership",
+        "null_or_falsy": "field-default",
+        "list_or_tuple": "python-str-whole-value",
+        "whitespace": "preserve",
+        "case": "preserve",
+        "invalid": "default"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
     },
     "constant": {
       "backend": {
@@ -360,7 +390,7 @@
         "force_inpaint": {"type": "boolean", "coercion": "backend_boolean"},
         "wildcard": {"type": "string", "coercion": "string"},
         "cycle": {"type": "integer", "coercion": "backend_integer", "minimum": 1, "maximum": 16},
-        "alignment": {"type": "string", "coercion": "choice", "enum": ["impact", "none", "32", "64"]},
+        "alignment": {"type": "string", "coercion": "string-then-choice", "enum": ["impact", "none", "32", "64"]},
         "inpaint_model": {"type": "boolean", "coercion": "backend_boolean"},
         "noise_mask_feather": {"type": "integer", "coercion": "backend_integer", "minimum": 0, "maximum": 256},
         "tiled_encode": {"type": "boolean", "coercion": "backend_boolean"},
@@ -447,7 +477,7 @@
       },
       "mod_guidance": {"type": "object", "unknown_fields": "preserve", "fields": {
         "mode": {"type": "string", "coercion": "choice", "enum": ["prompt_data", "enabled", "disabled"]},
-        "profile": {"type": "string", "coercion": "choice", "enum": ["off", "step_i8_skip27", "step_i14", "uniform_w3"]},
+        "profile": {"type": "string", "coercion": "mod-guidance-profile", "enum": ["off", "step_i8_skip27", "step_i14", "uniform_w3"]},
         "advanced": {"type": "object", "unknown_fields": "preserve", "fields": {
           "adapter": {"type": "string", "coercion": "string-or-default"},
           "quality_tags": {"type": "string", "coercion": "string-or-default"},
@@ -501,7 +531,7 @@
         "usdu": {"type": "object", "unknown_fields": "preserve", "fields": {
           "upscale_model_name": {"type": "string", "coercion": "string-or-default"},
           "auto_tile_size": {"type": "boolean", "coercion": "backend_boolean"},
-          "prompt_mode": {"type": "string", "coercion": "choice", "enum": ["full", "no_general"]},
+          "prompt_mode": {"type": "string", "coercion": "string-then-choice", "enum": ["full", "no_general"], "pre_choice_aliases": {"quality_tags_only": "no_general"}},
           "mode_type": {"type": "string", "coercion": "choice", "enum": ["Linear", "Chess", "None"]},
           "auto_tile_target": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum_source": "comfy.max_resolution"},
           "auto_tile_min": {"type": "integer", "coercion": "backend_integer", "minimum": 64, "maximum_source": "comfy.max_resolution"},

--- a/easyuse_anima/aio/schemas/generation_settings.v1.json
+++ b/easyuse_anima/aio/schemas/generation_settings.v1.json
@@ -37,8 +37,126 @@
     },
     "choice": {
       "operation": "trimmed-string-exact-membership",
-      "invalid": "default",
+      "invalid": {
+        "static_enum": "default",
+        "dynamic_enum": {
+          "policy": "default-if-present-else-first",
+          "preferred_default_present": "default",
+          "preferred_default_absent": "first-capability",
+          "empty_capabilities": "default"
+        }
+      },
       "list_or_tuple": "first-value"
+    },
+    "constant": {
+      "backend": {
+        "operation": "replace-with-contract-const"
+      },
+      "frontend": {
+        "operation": "not-coerced-by-default-merge",
+        "incoming_value": "preserve"
+      }
+    },
+    "string-or-default": {
+      "backend": {
+        "operation": "python-str-of-value-or-field-default",
+        "null_or_falsy": "field-default",
+        "list_or_tuple": "python-str-whole-value"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "string": {
+      "backend": {
+        "operation": "python-str-of-value-or-empty",
+        "null_or_falsy": "empty-string",
+        "list_or_tuple": "python-str-whole-value"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "trimmed-string": {
+      "backend": {
+        "operation": "python-str-of-value-or-empty-then-strip",
+        "null_or_falsy": "empty-string"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "hash-bundle-string": {
+      "backend": {
+        "operation": "python-str-of-value-or-empty-then-strip-character-set",
+        "strip_characters": [" ", ",", "\n", "\r", "\t"],
+        "empty_after_strip": "omit-item"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "string-list": {
+      "backend": {
+        "string_input": {
+          "operation": "json-decode",
+          "decode_error": "single-original-string-item"
+        },
+        "non_list": "empty-list",
+        "item_coercion": "hash-bundle-string",
+        "empty_items": "omit"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "civitai-fetcher-list": {
+      "backend": {
+        "string_input": {
+          "operation": "json-decode",
+          "decode_error": "empty-list"
+        },
+        "non_list": "empty-list",
+        "non_object_items": "omit",
+        "unknown_item_fields": "discard",
+        "empty_identity_items": "omit"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "detailer-order": {
+      "backend": {
+        "input_container": "list-only",
+        "items": "trim-deduplicate-and-keep-valid-target-names",
+        "object_target_fields": "append-valid-dict-valued-target-names",
+        "required_tail": ["face", "eye"]
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "json-object-or-empty": {
+      "backend": {
+        "object": "json-clone",
+        "non_object": "empty-object"
+      },
+      "frontend": {
+        "operation": "not-normalized-by-default-merge"
+      }
+    },
+    "surface-specific-seed": {
+      "backend": {
+        "operation": "backend_integer-then-clamp",
+        "minimum": -3,
+        "maximum": "18446744073709551615"
+      },
+      "frontend": {
+        "operation": "javascript-number-then-trunc-and-clamp",
+        "invalid": "supplied-fallback",
+        "minimum": -3,
+        "maximum": 1125899906842624
+      }
     }
   },
   "policies": {
@@ -141,6 +259,36 @@
     ]
   },
   "definitions": {
+    "json_value": {
+      "one_of": [
+        {"type": "null"},
+        {"type": "boolean"},
+        {"type": "number"},
+        {"type": "string"},
+        {"type": "array", "items": {"$ref": "#/definitions/json_value"}},
+        {"type": "object", "additional_properties": {"$ref": "#/definitions/json_value"}}
+      ]
+    },
+    "detailer_target_name": {
+      "type": "string",
+      "coercion": "trimmed-string",
+      "any_of": [
+        {"enum": ["face", "eye"]},
+        {"pattern": "^custom_[0-9]+$"}
+      ]
+    },
+    "civitai_hash_fetcher": {
+      "type": "object",
+      "unknown_fields": "discard",
+      "required": ["enabled", "username", "model_name", "version"],
+      "omit_if": "username-model_name-version-all-empty",
+      "fields": {
+        "enabled": {"type": "boolean", "coercion": "backend_boolean", "default": true},
+        "username": {"type": "string", "coercion": "trimmed-string", "default": ""},
+        "model_name": {"type": "string", "coercion": "trimmed-string", "default": ""},
+        "version": {"type": "string", "coercion": "trimmed-string", "default": ""}
+      }
+    },
     "spectrum": {
       "type": "object",
       "unknown_fields": "preserve",
@@ -252,8 +400,8 @@
               "adaptive_smc_alpha": {"type": "number", "coercion": "backend_number", "minimum": 0.0, "maximum": 1.0}
             }
           },
-          "spectrum_extra": {"type": "object", "coercion": "json-object-or-empty", "open_content": true},
-          "spd_extra": {"type": "object", "coercion": "json-object-or-empty", "open_content": true},
+          "spectrum_extra": {"type": "object", "coercion": "json-object-or-empty", "open_content": true, "additional_properties": {"$ref": "#/definitions/json_value"}},
+          "spd_extra": {"type": "object", "coercion": "json-object-or-empty", "open_content": true, "additional_properties": {"$ref": "#/definitions/json_value"}},
           "dit_corrections": {"$ref": "#/definitions/dit_corrections"}
         }
       },
@@ -391,7 +539,7 @@
       }},
       "detailer": {"type": "object", "unknown_fields": "preserve", "pattern_fields": {"^custom_[0-9]+$": {"$ref": "#/definitions/detailer_target"}}, "fields": {
         "enabled": {"type": "boolean", "coercion": "backend_boolean"},
-        "order": {"type": "array", "coercion": "detailer-order", "items": "detailer-target-name"},
+        "order": {"type": "array", "coercion": "detailer-order", "items": {"$ref": "#/definitions/detailer_target_name"}},
         "sam3": {"type": "object", "unknown_fields": "preserve", "fields": {
           "context": {"type": "string", "coercion": "choice", "enum": ["load_checkpoint"]},
           "checkpoint": {"type": "string", "coercion": "string-or-default"}
@@ -416,8 +564,8 @@
           "embed_workflow": {"type": "boolean", "coercion": "backend_boolean"},
           "save_prompt_metadata": {"type": "boolean", "coercion": "backend_boolean"},
           "additional_hashes": {"type": "string", "coercion": "string"},
-          "additional_hash_bundles": {"type": "array", "coercion": "string-list"},
-          "civitai_hash_fetchers": {"type": "array", "coercion": "civitai-fetcher-list"},
+          "additional_hash_bundles": {"type": "array", "coercion": "string-list", "items": {"type": "string", "coercion": "hash-bundle-string"}},
+          "civitai_hash_fetchers": {"type": "array", "coercion": "civitai-fetcher-list", "items": {"$ref": "#/definitions/civitai_hash_fetcher"}},
           "download_civitai_data": {"type": "boolean", "coercion": "backend_boolean"},
           "easy_remix": {"type": "boolean", "coercion": "backend_boolean"},
           "custom": {"type": "string", "coercion": "string"}

--- a/tests/frontend_aio_settings_core_smoke.mjs
+++ b/tests/frontend_aio_settings_core_smoke.mjs
@@ -128,6 +128,17 @@ assertJsonEqual(
   "Dynamic capability choices must not use the static-enum fallback claim",
 );
 assert(
+  generationManifest.coercions.backend_boolean.list_or_tuple === "first-value"
+    && generationManifest.coercions.backend_boolean.empty_list_or_tuple === "default",
+  "Backend boolean coercion must record first-value and empty-container fallback behavior",
+);
+assert(
+  generationManifest.shape.fields.mod_guidance.fields.profile.coercion === "mod-guidance-profile"
+    && generationManifest.shape.fields.upscale.fields.usdu.fields.prompt_mode.coercion === "string-then-choice"
+    && generationManifest.definitions.detailer_target.fields.alignment.coercion === "string-then-choice",
+  "Field-specific backend choice pipelines must not claim the generic choice coercion",
+);
+assert(
   AIO_DEFAULT_GENERATION_SETTINGS.sampler.seed === AIO_GENERATOR_SPECIAL_SEED_RANDOM
     && AIO_DEFAULT_GENERATION_SETTINGS.sampler.steps === 32
     && AIO_DEFAULT_GENERATION_SETTINGS.sampler.cfg === 5

--- a/tests/frontend_aio_settings_core_smoke.mjs
+++ b/tests/frontend_aio_settings_core_smoke.mjs
@@ -15,6 +15,25 @@ function assertJsonEqual(actual, expected, message) {
   assert(JSON.stringify(actual) === JSON.stringify(expected), message);
 }
 
+function collectCoercionReferences(value, output = new Set()) {
+  if (Array.isArray(value)) {
+    for (const child of value) {
+      collectCoercionReferences(child, output);
+    }
+    return output;
+  }
+  if (!value || typeof value !== "object") {
+    return output;
+  }
+  for (const [name, child] of Object.entries(value)) {
+    if ((name === "coercion" || name === "item_coercion") && typeof child === "string") {
+      output.add(child);
+    }
+    collectCoercionReferences(child, output);
+  }
+  return output;
+}
+
 const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
 const generationManifest = JSON.parse(readFileSync(
   new URL("../easyuse_anima/aio/schemas/generation_settings.v1.json", import.meta.url),
@@ -73,6 +92,40 @@ assertJsonEqual(
   AIO_DEFAULT_GENERATION_SETTINGS,
   generationManifest.default,
   "AiO manifest defaults must deep-equal the frontend generation defaults",
+);
+const coercionReferences = collectCoercionReferences({
+  shape: generationManifest.shape,
+  definitions: generationManifest.definitions,
+  coercions: generationManifest.coercions,
+});
+const undefinedCoercions = [...coercionReferences]
+  .filter((name) => !Object.prototype.hasOwnProperty.call(generationManifest.coercions, name));
+assertJsonEqual(
+  undefinedCoercions,
+  [],
+  "Every manifest coercion reference must have a self-contained definition",
+);
+const imageSaverContract = generationManifest.shape.fields.save.fields.image_saver.fields;
+assert(
+  imageSaverContract.additional_hash_bundles.items?.type === "string"
+    && imageSaverContract.civitai_hash_fetchers.items?.$ref === "#/definitions/civitai_hash_fetcher"
+    && generationManifest.shape.fields.detailer.fields.order.items?.$ref === "#/definitions/detailer_target_name",
+  "Empty-default arrays must retain explicit item contracts",
+);
+assertJsonEqual(
+  Object.keys(generationManifest.definitions.civitai_hash_fetcher.fields),
+  ["enabled", "username", "model_name", "version"],
+  "The Civitai fetcher item contract must retain its normalized backend fields",
+);
+assertJsonEqual(
+  generationManifest.coercions.choice.invalid.dynamic_enum,
+  {
+    policy: "default-if-present-else-first",
+    preferred_default_present: "default",
+    preferred_default_absent: "first-capability",
+    empty_capabilities: "default",
+  },
+  "Dynamic capability choices must not use the static-enum fallback claim",
 );
 assert(
   AIO_DEFAULT_GENERATION_SETTINGS.sampler.seed === AIO_GENERATOR_SPECIAL_SEED_RANDOM

--- a/tests/frontend_aio_settings_core_smoke.mjs
+++ b/tests/frontend_aio_settings_core_smoke.mjs
@@ -16,6 +16,14 @@ function assertJsonEqual(actual, expected, message) {
 }
 
 const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
+const generationManifest = JSON.parse(readFileSync(
+  new URL("../easyuse_anima/aio/schemas/generation_settings.v1.json", import.meta.url),
+  "utf8",
+));
+const aioRuntimeSource = readFileSync(
+  new URL("../web/js/easyuse_anima_aio.js", import.meta.url),
+  "utf8",
+);
 const {
   AIO_DEFAULT_GENERATION_SETTINGS,
   AIO_DEFAULT_INPUT_SETTINGS,
@@ -55,6 +63,16 @@ assert(
     && AIO_DEFAULT_GENERATION_SETTINGS.version === 1
     && AIO_DEFAULT_GENERATION_SETTINGS.mode === "txt2img",
   "AiO generation settings must keep their versioned schema",
+);
+assert(
+  generationManifest.settings.schema === AIO_DEFAULT_GENERATION_SETTINGS.schema
+    && generationManifest.settings.version === AIO_DEFAULT_GENERATION_SETTINGS.version,
+  "AiO manifest identity must match the frontend v1 settings identity",
+);
+assertJsonEqual(
+  AIO_DEFAULT_GENERATION_SETTINGS,
+  generationManifest.default,
+  "AiO manifest defaults must deep-equal the frontend generation defaults",
 );
 assert(
   AIO_DEFAULT_GENERATION_SETTINGS.sampler.seed === AIO_GENERATOR_SPECIAL_SEED_RANDOM
@@ -278,10 +296,20 @@ assert(
   "The legacy enabled flag must keep enabling postprocess during migration",
 );
 
-for (const value of [true, "true", "1", "yes", "on", " TRUE "]) {
+assertJsonEqual(
+  generationManifest.coercions.frontend_boolean.true_strings,
+  ["true", "1", "yes", "on"],
+  "Manifest frontend true-string coercion tokens must remain stable",
+);
+assertJsonEqual(
+  generationManifest.coercions.frontend_boolean.false_strings,
+  ["false", "0", "no", "off"],
+  "Manifest frontend false-string coercion tokens must remain stable",
+);
+for (const value of [true, ...generationManifest.coercions.frontend_boolean.true_strings, " TRUE "]) {
   assert(aioAsBool(value, false) === true, `Boolean value ${String(value)} must normalize true`);
 }
-for (const value of [false, "false", "0", "no", "off", " FALSE "]) {
+for (const value of [false, ...generationManifest.coercions.frontend_boolean.false_strings, " FALSE "]) {
   assert(aioAsBool(value, true) === false, `Boolean value ${String(value)} must normalize false`);
 }
 assert(aioAsBool(null, true) === true, "Null booleans must use their fallback");
@@ -297,6 +325,11 @@ assert(
     && AIO_GENERATOR_SPECIAL_SEED_INCREMENT === -2
     && AIO_GENERATOR_SPECIAL_SEED_DECREMENT === -3,
   "rgthree-compatible special seed values must remain stable",
+);
+assert(
+  generationManifest.shape.fields.sampler.fields.seed.minimum === AIO_GENERATOR_SPECIAL_SEED_DECREMENT
+    && generationManifest.shape.fields.sampler.fields.seed.maximum_by_surface.frontend === AIO_GENERATOR_MAX_SEED,
+  "Manifest frontend seed bounds must match the current settings core",
 );
 assert(
   aioNormalizeSeedControl(" increment ") === "increment"
@@ -396,6 +429,27 @@ assert(
 assert(
   JSON.stringify(compactSource) === compactSourceSnapshot,
   "Compact generation serialization must not mutate the caller's settings object",
+);
+
+const unknownFieldPolicy = generationManifest.policies.unknown_fields;
+assert(
+  unknownFieldPolicy.frontend_default_merge.mode === "preserve-recursively"
+    && unknownFieldPolicy.frontend_visible_merge.removed_paths.includes("/highres/backend")
+    && !unknownFieldPolicy.backend.removed_known_legacy_paths.includes("/highres/backend"),
+  "Manifest must record the current highres.backend surface drift without changing it",
+);
+const visibleMergeSource = aioRuntimeSource.slice(
+  aioRuntimeSource.indexOf("function mergeVisibleGeneratorSettings"),
+  aioRuntimeSource.indexOf("function applyVisibleGeneratorSettings"),
+);
+assert(
+  visibleMergeSource.includes("delete next.highres?.backend;"),
+  "Frontend visible merge must keep removing highres.backend while the manifest records the drift",
+);
+assert(
+  generationManifest.policies.persistence.write_on_read === false
+    && generationManifest.policies.version_migrations.length === 0,
+  "The v1 contract must not introduce write-on-read or a version migration",
 );
 
 console.log("AiO settings core smoke passed.");

--- a/tests/test_aio_schema_contract.py
+++ b/tests/test_aio_schema_contract.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import io
+import json
+import re
+import subprocess
+import tarfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import nodes
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "easyuse_anima" / "aio" / "schemas" / "generation_settings.v1.json"
+MANIFEST_REPOSITORY_PATH = MANIFEST_PATH.relative_to(ROOT).as_posix()
+FRONTEND_SETTINGS_PATH = ROOT / "web" / "js" / "aio" / "settings.js"
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _resolve_contract(manifest: dict, contract: dict) -> dict:
+    while "$ref" in contract:
+        reference = contract["$ref"]
+        if not reference.startswith("#/"):
+            raise AssertionError(f"Unsupported manifest reference: {reference}")
+        resolved = manifest
+        for part in reference[2:].split("/"):
+            resolved = resolved[part]
+        contract = resolved
+    return contract
+
+
+def _leaf_contracts(manifest: dict, contract: dict, path: tuple[str, ...] = ()):
+    contract = _resolve_contract(manifest, contract)
+    fields = contract.get("fields")
+    if isinstance(fields, dict) and fields:
+        for name, child in fields.items():
+            yield from _leaf_contracts(manifest, child, (*path, name))
+        return
+    yield path, contract
+
+
+def _default_leaves(value, path: tuple[str, ...] = ()):
+    if isinstance(value, dict) and value:
+        for name, child in value.items():
+            yield from _default_leaves(child, (*path, name))
+        return
+    yield path, value
+
+
+def _get_path(value: dict, path: tuple[str, ...]):
+    current = value
+    for name in path:
+        current = current[name]
+    return current
+
+
+def _payload_with(path: tuple[str, ...], value) -> dict:
+    payload: dict = {}
+    current = payload
+    for name in path[:-1]:
+        current[name] = {}
+        current = current[name]
+    current[path[-1]] = value
+    return payload
+
+
+def _git(*args: str, binary: bool = False):
+    return subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=not binary,
+        encoding=None if binary else "utf-8",
+        timeout=30,
+    )
+
+
+@contextmanager
+def _deterministic_capabilities():
+    with patch.multiple(
+        nodes,
+        _comfy_sampler_names=lambda: ["er_sde", "euler"],
+        _comfy_scheduler_names=lambda: ["simple"],
+        _impact_scheduler_names=lambda: ["sgm_uniform"],
+        _comfy_max_resolution=lambda: 16384,
+    ):
+        yield
+
+
+class AIOGenerationSettingsManifestTests(unittest.TestCase):
+    def test_manifest_default_matches_python_runtime_default(self):
+        manifest = _manifest()
+
+        self.assertEqual(manifest["settings"]["schema"], nodes.AIO_GENERATION_SETTINGS_SCHEMA)
+        self.assertEqual(manifest["settings"]["version"], nodes.AIO_GENERATION_SETTINGS_VERSION)
+        self.assertEqual(manifest["default"], nodes.AIO_GENERATION_DEFAULT_SETTINGS)
+
+    def test_manifest_shape_covers_every_default_leaf_with_matching_types(self):
+        manifest = _manifest()
+        contracts = dict(_leaf_contracts(manifest, manifest["shape"]))
+        defaults = dict(_default_leaves(manifest["default"]))
+
+        self.assertEqual(set(contracts), set(defaults))
+        for path, value in defaults.items():
+            contract = contracts[path]
+            field_type = contract["type"]
+            with self.subTest(path="/" + "/".join(path), field_type=field_type):
+                if field_type == "boolean":
+                    self.assertIs(type(value), bool)
+                elif field_type == "integer":
+                    self.assertIs(type(value), int)
+                elif field_type == "number":
+                    self.assertIsInstance(value, (int, float))
+                    self.assertIsNot(type(value), bool)
+                elif field_type == "string":
+                    self.assertIsInstance(value, str)
+                elif field_type == "array":
+                    self.assertIsInstance(value, list)
+                elif field_type == "object":
+                    self.assertIsInstance(value, dict)
+                else:
+                    self.fail(f"Unsupported manifest field type at {path}: {field_type}")
+
+                if "const" in contract:
+                    self.assertEqual(value, contract["const"])
+                if "enum" in contract:
+                    self.assertIn(value, contract["enum"])
+                if "minimum" in contract:
+                    self.assertGreaterEqual(value, contract["minimum"])
+                if "maximum" in contract:
+                    self.assertLessEqual(value, contract["maximum"])
+
+    def test_static_enum_and_bounds_match_backend_normalization(self):
+        manifest = _manifest()
+        defaults = manifest["default"]
+        contracts = dict(_leaf_contracts(manifest, manifest["shape"]))
+
+        with _deterministic_capabilities():
+            for path, contract in contracts.items():
+                default = _get_path(defaults, path)
+                if "enum" in contract:
+                    with self.subTest(path="/" + "/".join(path), rule="enum"):
+                        normalized = nodes._normalize_aio_generation_settings(
+                            _payload_with(path, "__invalid_manifest_choice__")
+                        )
+                        self.assertEqual(_get_path(normalized, path), default)
+
+                if "dynamic_enum" in contract:
+                    with self.subTest(path="/" + "/".join(path), rule="dynamic-enum"):
+                        normalized = nodes._normalize_aio_generation_settings(
+                            _payload_with(path, "__invalid_dynamic_choice__")
+                        )
+                        self.assertEqual(_get_path(normalized, path), default)
+
+                if "minimum" in contract:
+                    with self.subTest(path="/" + "/".join(path), rule="minimum"):
+                        minimum = contract["minimum"]
+                        normalized = nodes._normalize_aio_generation_settings(
+                            _payload_with(path, minimum - 1)
+                        )
+                        self.assertEqual(_get_path(normalized, path), minimum)
+
+                if "maximum" in contract:
+                    with self.subTest(path="/" + "/".join(path), rule="maximum"):
+                        maximum = contract["maximum"]
+                        normalized = nodes._normalize_aio_generation_settings(
+                            _payload_with(path, maximum + 1)
+                        )
+                        self.assertEqual(_get_path(normalized, path), maximum)
+
+    def test_coercion_profiles_match_current_backend_helpers(self):
+        manifest = _manifest()
+        coercions = manifest["coercions"]
+
+        for value in coercions["backend_boolean"]["true_strings"]:
+            with self.subTest(value=value):
+                self.assertTrue(nodes._as_bool(value, False))
+        for value in ("false", "0", "no", "off", "disabled", "unknown"):
+            with self.subTest(value=value):
+                self.assertFalse(nodes._as_bool(value, True))
+
+        self.assertEqual(nodes._as_int("12", 7), 12)
+        self.assertEqual(nodes._as_int("12.9", 7), 7)
+        self.assertEqual(nodes._as_float("12.9", 7.0), 12.9)
+        self.assertEqual(nodes._choice(" two ", ("one", "two"), "one"), "two")
+        self.assertEqual(nodes._choice("missing", ("one", "two"), "one"), "one")
+
+    def test_alias_unknown_field_and_surface_drift_policies_match_current_code(self):
+        manifest = _manifest()
+        policies = manifest["policies"]
+        normalized = nodes._normalize_aio_generation_settings({
+            "sampler": {"dave": {"enabled": True}, "future_sampler": "kept"},
+            "model_patches": {"aura_flow": {"enabled": True}},
+            "highres": {"backend": "future_backend"},
+            "upscale": {
+                "fit": {
+                    "enabled": True,
+                    "mode": "megapixels",
+                    "max_megapixels": 9,
+                },
+                "usdu": {"prompt_mode": "quality_tags_only"},
+            },
+            "save": {
+                "filename_prefix": "legacy/prefix",
+                "image_saver": {"show_preview": True},
+            },
+            "future_section": {"value": 42},
+        })
+
+        self.assertNotIn("dave", normalized["sampler"])
+        self.assertNotIn("enabled", normalized["model_patches"]["aura_flow"])
+        self.assertNotIn("fit", normalized["upscale"])
+        self.assertEqual(normalized["upscale"]["usdu"]["prompt_mode"], "no_general")
+        self.assertTrue(normalized["postprocess"]["enabled"])
+        self.assertEqual(normalized["postprocess"]["fit"]["mode"], "megapixels")
+        self.assertEqual(normalized["postprocess"]["fit"]["max_megapixels"], 9.0)
+        self.assertNotIn("filename_prefix", normalized["save"])
+        self.assertNotIn("show_preview", normalized["save"]["image_saver"])
+        self.assertEqual(normalized["future_section"], {"value": 42})
+        self.assertEqual(normalized["sampler"]["future_sampler"], "kept")
+        self.assertEqual(normalized["highres"]["backend"], "future_backend")
+
+        backend_policy = policies["unknown_fields"]["backend"]
+        visible_policy = policies["unknown_fields"]["frontend_visible_merge"]
+        self.assertEqual(backend_policy["mode"], "preserve-recursively")
+        self.assertNotIn("/highres/backend", backend_policy["removed_known_legacy_paths"])
+        self.assertIn("/highres/backend", visible_policy["removed_paths"])
+        self.assertFalse(policies["persistence"]["write_on_read"])
+        self.assertEqual(policies["version_migrations"], [])
+
+    def test_schema_version_dynamic_owners_and_seed_surface_bounds_do_not_drift(self):
+        manifest = _manifest()
+        shape_fields = manifest["shape"]["fields"]
+        capabilities = manifest["policies"]["dynamic_capabilities"]
+        seed_contract = shape_fields["sampler"]["fields"]["seed"]
+        frontend_source = FRONTEND_SETTINGS_PATH.read_text(encoding="utf-8")
+        frontend_seed_match = re.search(
+            r"export const AIO_GENERATOR_MAX_SEED = (?P<value>\d+);",
+            frontend_source,
+        )
+
+        self.assertEqual(shape_fields["schema"]["const"], nodes.AIO_GENERATION_SETTINGS_SCHEMA)
+        self.assertEqual(shape_fields["version"]["current"], nodes.AIO_GENERATION_SETTINGS_VERSION)
+        self.assertFalse(capabilities["owned_by_manifest"])
+        self.assertEqual(
+            set(capabilities["sources"]),
+            {"comfy.samplers", "comfy.schedulers", "impact.schedulers", "comfy.max_resolution"},
+        )
+        self.assertEqual(seed_contract["maximum_by_surface"]["backend"], str(nodes.MAX_SEED))
+        self.assertIsNotNone(frontend_seed_match)
+        self.assertEqual(
+            seed_contract["maximum_by_surface"]["frontend"],
+            int(frontend_seed_match.group("value")),
+        )
+
+    def test_manifest_is_tracked_registry_included_and_present_in_head_archive(self):
+        tracked = _git("ls-files", "--error-unmatch", "--", MANIFEST_REPOSITORY_PATH)
+        self.assertEqual(tracked.stdout.strip(), MANIFEST_REPOSITORY_PATH)
+
+        ignored = _git(
+            "ls-files",
+            "-ci",
+            "--exclude-from=.comfyignore",
+            "--",
+            MANIFEST_REPOSITORY_PATH,
+        )
+        self.assertEqual(ignored.stdout.strip(), "")
+
+        archive = _git(
+            "archive",
+            "--format=tar",
+            "HEAD",
+            "--",
+            MANIFEST_REPOSITORY_PATH,
+            binary=True,
+        )
+        with tarfile.open(fileobj=io.BytesIO(archive.stdout), mode="r:") as tar:
+            self.assertIn(MANIFEST_REPOSITORY_PATH, tar.getnames())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aio_schema_contract.py
+++ b/tests/test_aio_schema_contract.py
@@ -45,6 +45,43 @@ def _leaf_contracts(manifest: dict, contract: dict, path: tuple[str, ...] = ()):
     yield path, contract
 
 
+def _contract_nodes(contract: dict, path: tuple[str, ...] = ()):
+    yield path, contract
+    for group_name in ("fields", "pattern_fields"):
+        children = contract.get(group_name)
+        if isinstance(children, dict):
+            for name, child in children.items():
+                if isinstance(child, dict):
+                    yield from _contract_nodes(child, (*path, group_name, name))
+    for child_name in ("items", "additional_properties"):
+        child = contract.get(child_name)
+        if isinstance(child, dict):
+            yield from _contract_nodes(child, (*path, child_name))
+    for group_name in ("one_of", "any_of"):
+        children = contract.get(group_name)
+        if isinstance(children, list):
+            for index, child in enumerate(children):
+                if isinstance(child, dict):
+                    yield from _contract_nodes(child, (*path, group_name, str(index)))
+
+
+def _all_contract_nodes(manifest: dict):
+    yield from _contract_nodes(manifest["shape"], ("shape",))
+    for name, definition in manifest["definitions"].items():
+        yield from _contract_nodes(definition, ("definitions", name))
+
+
+def _coercion_references(value):
+    if isinstance(value, dict):
+        for name, child in value.items():
+            if name in {"coercion", "item_coercion"} and isinstance(child, str):
+                yield child
+            yield from _coercion_references(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _coercion_references(child)
+
+
 def _default_leaves(value, path: tuple[str, ...] = ()):
     if isinstance(value, dict) and value:
         for name, child in value.items():
@@ -83,12 +120,17 @@ def _git(*args: str, binary: bool = False):
 
 
 @contextmanager
-def _deterministic_capabilities():
+def _deterministic_capabilities(
+    *,
+    samplers=("er_sde", "euler"),
+    schedulers=("simple",),
+    impact_schedulers=("sgm_uniform",),
+):
     with patch.multiple(
         nodes,
-        _comfy_sampler_names=lambda: ["er_sde", "euler"],
-        _comfy_scheduler_names=lambda: ["simple"],
-        _impact_scheduler_names=lambda: ["sgm_uniform"],
+        _comfy_sampler_names=lambda: list(samplers),
+        _comfy_scheduler_names=lambda: list(schedulers),
+        _impact_scheduler_names=lambda: list(impact_schedulers),
         _comfy_max_resolution=lambda: 16384,
     ):
         yield
@@ -152,13 +194,6 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
                         )
                         self.assertEqual(_get_path(normalized, path), default)
 
-                if "dynamic_enum" in contract:
-                    with self.subTest(path="/" + "/".join(path), rule="dynamic-enum"):
-                        normalized = nodes._normalize_aio_generation_settings(
-                            _payload_with(path, "__invalid_dynamic_choice__")
-                        )
-                        self.assertEqual(_get_path(normalized, path), default)
-
                 if "minimum" in contract:
                     with self.subTest(path="/" + "/".join(path), rule="minimum"):
                         minimum = contract["minimum"]
@@ -191,6 +226,182 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
         self.assertEqual(nodes._as_float("12.9", 7.0), 12.9)
         self.assertEqual(nodes._choice(" two ", ("one", "two"), "one"), "two")
         self.assertEqual(nodes._choice("missing", ("one", "two"), "one"), "one")
+        self.assertEqual(coercions["choice"]["invalid"]["static_enum"], "default")
+
+    def test_every_referenced_coercion_has_a_self_contained_definition(self):
+        manifest = _manifest()
+        defined = set(manifest["coercions"])
+        referenced = set(_coercion_references({
+            "shape": manifest["shape"],
+            "definitions": manifest["definitions"],
+            "coercions": manifest["coercions"],
+        }))
+
+        self.assertEqual(referenced - defined, set())
+        self.assertTrue({
+            "constant",
+            "string-or-default",
+            "string",
+            "string-list",
+            "civitai-fetcher-list",
+            "detailer-order",
+            "json-object-or-empty",
+            "surface-specific-seed",
+        }.issubset(referenced))
+
+    def test_container_item_contracts_match_current_backend_normalizers(self):
+        manifest = _manifest()
+        image_saver = manifest["shape"]["fields"]["save"]["fields"]["image_saver"]["fields"]
+
+        for path, contract in _all_contract_nodes(manifest):
+            if contract.get("type") == "array":
+                with self.subTest(path="/".join(path), container="array"):
+                    self.assertIsInstance(contract.get("items"), dict)
+                    item_contract = _resolve_contract(manifest, contract["items"])
+                    self.assertTrue(
+                        any(name in item_contract for name in ("type", "one_of", "any_of")),
+                        f"Missing item type contract at {'/'.join(path)}",
+                    )
+            if contract.get("type") == "object" and contract.get("open_content"):
+                with self.subTest(path="/".join(path), container="open-object"):
+                    self.assertIsInstance(contract.get("additional_properties"), dict)
+                    _resolve_contract(manifest, contract["additional_properties"])
+
+        fetcher_contract = _resolve_contract(manifest, image_saver["civitai_hash_fetchers"]["items"])
+        self.assertEqual(
+            set(fetcher_contract["fields"]),
+            {"enabled", "username", "model_name", "version"},
+        )
+        self.assertEqual(fetcher_contract["unknown_fields"], "discard")
+        self.assertEqual(
+            set(fetcher_contract["required"]),
+            {"enabled", "username", "model_name", "version"},
+        )
+
+        normalized = nodes._normalize_aio_generation_settings({
+            "save": {
+                "image_saver": {
+                    "additional_hash_bundles": '[" alpha, ", null, " beta "]',
+                    "civitai_hash_fetchers": json.dumps([
+                        {
+                            "enabled": "off",
+                            "username": " user ",
+                            "model_name": " model ",
+                            "version": " v1 ",
+                            "future": "discarded",
+                        },
+                        {"enabled": True, "username": " ", "model_name": "", "version": ""},
+                        "not-an-object",
+                    ]),
+                }
+            }
+        })
+        self.assertEqual(
+            normalized["save"]["image_saver"]["additional_hash_bundles"],
+            ["alpha", "beta"],
+        )
+        self.assertEqual(
+            normalized["save"]["image_saver"]["civitai_hash_fetchers"],
+            [{"enabled": False, "username": "user", "model_name": "model", "version": "v1"}],
+        )
+        self.assertEqual(nodes._normalize_aio_hash_bundles(" raw, "), ["raw"])
+        self.assertEqual(nodes._normalize_aio_hash_bundles('"json-string"'), [])
+        self.assertEqual(nodes._normalize_aio_civitai_hash_fetchers("not-json"), [])
+        self.assertEqual(
+            nodes._aio_detailer_target_order({
+                "order": [" custom_2 ", "face", "custom_2", "invalid"],
+                "custom_3": {},
+                "custom_4": "not-an-object",
+            }),
+            ["custom_2", "face", "custom_3", "eye"],
+        )
+
+    def test_refs_and_detailer_pattern_fields_cover_non_default_targets(self):
+        manifest = _manifest()
+        for path, contract in _all_contract_nodes(manifest):
+            if "$ref" in contract:
+                with self.subTest(path="/".join(path), reference=contract["$ref"]):
+                    resolved = _resolve_contract(manifest, contract)
+                    self.assertTrue(any(name in resolved for name in ("type", "one_of", "any_of")))
+
+        detailer_contract = manifest["shape"]["fields"]["detailer"]
+        pattern_fields = detailer_contract["pattern_fields"]
+        self.assertEqual(set(pattern_fields), {"^custom_[0-9]+$"})
+        pattern = next(iter(pattern_fields))
+        self.assertIsNotNone(re.fullmatch(pattern, "custom_7"))
+        self.assertIsNone(re.fullmatch(pattern, "custom_name"))
+        self.assertIs(
+            _resolve_contract(manifest, pattern_fields[pattern]),
+            manifest["definitions"]["detailer_target"],
+        )
+
+        with _deterministic_capabilities():
+            normalized = nodes._normalize_aio_generation_settings({
+                "detailer": {
+                    "order": ["custom_7"],
+                    "custom_7": {
+                        "label": "",
+                        "detect_count": 0,
+                        "threshold": -1,
+                        "sampler_name": "invalid",
+                        "scheduler": "invalid",
+                        "future_target_key": {"kept": True},
+                    },
+                }
+            })
+        target = normalized["detailer"]["custom_7"]
+        self.assertEqual(target["label"], "Detailer Block 7")
+        self.assertEqual(target["detect_count"], 1)
+        self.assertEqual(target["threshold"], 0.0)
+        self.assertEqual(target["sampler_name"], "euler")
+        self.assertEqual(target["scheduler"], "sgm_uniform")
+        self.assertEqual(target["future_target_key"], {"kept": True})
+
+    def test_dynamic_choice_fallback_policy_matches_runtime_capabilities(self):
+        manifest = _manifest()
+        dynamic_contracts = [
+            (path, contract)
+            for path, contract in _leaf_contracts(manifest, manifest["shape"])
+            if "dynamic_enum" in contract
+        ]
+        dynamic_policy = manifest["coercions"]["choice"]["invalid"]["dynamic_enum"]
+        self.assertEqual(dynamic_policy, {
+            "policy": "default-if-present-else-first",
+            "preferred_default_present": "default",
+            "preferred_default_absent": "first-capability",
+            "empty_capabilities": "default",
+        })
+
+        defaults = manifest["default"]
+        with _deterministic_capabilities():
+            for path, contract in dynamic_contracts:
+                with self.subTest(path="/" + "/".join(path), default_present=True):
+                    normalized = nodes._normalize_aio_generation_settings(
+                        _payload_with(path, "__invalid_dynamic_choice__")
+                    )
+                    self.assertEqual(_get_path(normalized, path), _get_path(defaults, path))
+
+        first_by_source = {
+            "comfy.samplers": "cap-sampler-first",
+            "comfy.schedulers": "cap-scheduler-first",
+            "impact.schedulers": "cap-impact-first",
+        }
+        with _deterministic_capabilities(
+            samplers=("cap-sampler-first", "cap-sampler-second"),
+            schedulers=("cap-scheduler-first", "cap-scheduler-second"),
+            impact_schedulers=("cap-impact-first", "cap-impact-second"),
+        ):
+            for path, contract in dynamic_contracts:
+                with self.subTest(path="/" + "/".join(path), default_present=False):
+                    normalized = nodes._normalize_aio_generation_settings(
+                        _payload_with(path, "__invalid_dynamic_choice__")
+                    )
+                    self.assertEqual(
+                        _get_path(normalized, path),
+                        first_by_source[contract["dynamic_enum"]],
+                    )
+
+        self.assertEqual(nodes._choice("missing", (), "preferred"), "preferred")
 
     def test_alias_unknown_field_and_surface_drift_policies_match_current_code(self):
         manifest = _manifest()

--- a/tests/test_aio_schema_contract.py
+++ b/tests/test_aio_schema_contract.py
@@ -136,6 +136,87 @@ def _deterministic_capabilities(
         yield
 
 
+def _authoritative_static_enum_choices() -> dict[tuple[str, ...], tuple[str, ...]]:
+    choices = {
+        ("mode",): ("txt2img", "img2img", "inpaint"),
+        ("sampler", "backend"): (
+            "comfy_ksampler",
+            "spectrum_mod_guidance_advanced",
+            "spectrum_spd_speed",
+        ),
+        ("sampler", "seed_after_generate"): tuple(nodes.SEED_CONTROL_MODES),
+        ("sampler", "spd", "split_mode"): ("single",),
+        ("model_patches", "safe_pag", "rescale_mode"): ("full", "partial"),
+        ("model_patches", "kj", "sage_attention"): (
+            "disabled",
+            "auto",
+            "sageattn_qk_int8_pv_fp16_cuda",
+            "sageattn_qk_int8_pv_fp16_triton",
+            "sageattn_qk_int8_pv_fp8_cuda",
+            "sageattn_qk_int8_pv_fp8_cuda++",
+            "sageattn3",
+            "sageattn3_per_block_mean",
+        ),
+        ("model_patches", "kj", "torch_compile", "backend"): ("inductor", "cudagraphs"),
+        ("model_patches", "kj", "torch_compile", "mode"): (
+            "default",
+            "max-autotune",
+            "max-autotune-no-cudagraphs",
+            "reduce-overhead",
+        ),
+        ("model_patches", "kj", "torch_compile", "dynamic"): ("auto", "true", "false"),
+        ("mod_guidance", "mode"): tuple(nodes.ANIMA_MOD_GUIDANCE_MODES),
+        ("mod_guidance", "profile"): tuple(nodes.ANIMA_MOD_GUIDANCE_PROFILES),
+        ("artist_mix", "mode"): tuple(nodes.ARTIST_MIX_INPUT_MODES),
+        ("highres", "upscale_method"): tuple(nodes.IMAGE_UPSCALE_METHODS),
+        ("highres", "multiple"): tuple(nodes.IMAGE_SCALE_MULTIPLES),
+        ("upscale", "backend"): tuple(nodes.AIO_FINAL_UPSCALE_BACKENDS),
+        ("upscale", "usdu", "prompt_mode"): tuple(nodes.AIO_USDU_PROMPT_MODES),
+        ("upscale", "usdu", "mode_type"): tuple(nodes.AIO_USDU_MODE_TYPES),
+        ("upscale", "usdu", "seam_fix_mode"): tuple(nodes.AIO_USDU_SEAM_FIX_MODES),
+        ("upscale", "resshift", "scale"): tuple(nodes.AIO_RESHIFT_SCALES),
+        ("upscale", "resshift", "dtype"): tuple(nodes.AIO_RESHIFT_DTYPES),
+        ("postprocess", "fit", "mode"): tuple(nodes.AIO_FINAL_FIT_MODES),
+        ("postprocess", "fit", "method"): tuple(nodes.IMAGE_UPSCALE_METHODS),
+        ("detailer", "sam3", "context"): ("load_checkpoint",),
+        ("save", "backend"): ("image_saver", "comfy_save_image"),
+        ("save", "image_saver", "extension"): ("png", "jpeg", "jpg", "webp"),
+    }
+    for prefix in (
+        ("sampler",),
+        ("highres",),
+        ("upscale",),
+        ("detailer", "face"),
+        ("detailer", "eye"),
+    ):
+        choices[(*prefix, "spectrum", "compat_policy")] = ("legacy", "conservative", "strict")
+        choices[(*prefix, "dit_corrections", "dcw_mode")] = ("off", "manual", "auto")
+        choices[(*prefix, "dit_corrections", "dcw_band_mask")] = ("LL", "all", "HH", "LH+HL+HH")
+    for target_name in ("face", "eye"):
+        choices[("detailer", target_name, "alignment")] = ("impact", "none", "32", "64")
+    return choices
+
+
+def _runtime_static_enum_choices(path: tuple[str, ...]) -> tuple[str, ...]:
+    if path == ("mod_guidance", "profile"):
+        return tuple(nodes.ANIMA_MOD_GUIDANCE_PROFILES)
+
+    marker = "__capture_runtime_static_enum_choices__"
+    observed: list[tuple[str, ...]] = []
+    original_choice = nodes._choice
+
+    def capture_choice(value, choices, default):
+        if value == marker:
+            observed.append(tuple(choices or ()))
+        return original_choice(value, choices, default)
+
+    with _deterministic_capabilities(), patch.object(nodes, "_choice", side_effect=capture_choice):
+        nodes._normalize_aio_generation_settings(_payload_with(path, marker))
+    if len(observed) != 1:
+        raise AssertionError(f"Expected one runtime choice source for {path}, got {observed}")
+    return observed[0]
+
+
 class AIOGenerationSettingsManifestTests(unittest.TestCase):
     def test_manifest_default_matches_python_runtime_default(self):
         manifest = _manifest()
@@ -179,21 +260,45 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
                 if "maximum" in contract:
                     self.assertLessEqual(value, contract["maximum"])
 
-    def test_static_enum_and_bounds_match_backend_normalization(self):
+    def test_static_enum_sets_and_members_match_backend_normalization(self):
         manifest = _manifest()
         defaults = manifest["default"]
+        contracts = dict(_leaf_contracts(manifest, manifest["shape"]))
+        enum_contracts = {
+            path: contract
+            for path, contract in contracts.items()
+            if "enum" in contract
+        }
+        authoritative = _authoritative_static_enum_choices()
+
+        self.assertEqual(set(enum_contracts), set(authoritative))
+        for path, contract in enum_contracts.items():
+            with self.subTest(path="/" + "/".join(path), rule="accepted-set"):
+                self.assertEqual(tuple(contract["enum"]), authoritative[path])
+                self.assertEqual(_runtime_static_enum_choices(path), authoritative[path])
+
+        with _deterministic_capabilities():
+            for path, contract in enum_contracts.items():
+                default = _get_path(defaults, path)
+                with self.subTest(path="/" + "/".join(path), rule="invalid"):
+                    normalized = nodes._normalize_aio_generation_settings(
+                        _payload_with(path, "__invalid_manifest_choice__")
+                    )
+                    self.assertEqual(_get_path(normalized, path), default)
+
+                for member in contract["enum"]:
+                    with self.subTest(path="/" + "/".join(path), rule="round-trip", member=member):
+                        normalized = nodes._normalize_aio_generation_settings(
+                            _payload_with(path, member)
+                        )
+                        self.assertEqual(_get_path(normalized, path), member)
+
+    def test_static_bounds_match_backend_normalization(self):
+        manifest = _manifest()
         contracts = dict(_leaf_contracts(manifest, manifest["shape"]))
 
         with _deterministic_capabilities():
             for path, contract in contracts.items():
-                default = _get_path(defaults, path)
-                if "enum" in contract:
-                    with self.subTest(path="/" + "/".join(path), rule="enum"):
-                        normalized = nodes._normalize_aio_generation_settings(
-                            _payload_with(path, "__invalid_manifest_choice__")
-                        )
-                        self.assertEqual(_get_path(normalized, path), default)
-
                 if "minimum" in contract:
                     with self.subTest(path="/" + "/".join(path), rule="minimum"):
                         minimum = contract["minimum"]
@@ -227,6 +332,41 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
         self.assertEqual(nodes._choice(" two ", ("one", "two"), "one"), "two")
         self.assertEqual(nodes._choice("missing", ("one", "two"), "one"), "one")
         self.assertEqual(coercions["choice"]["invalid"]["static_enum"], "default")
+        self.assertEqual(coercions["backend_boolean"]["list_or_tuple"], "first-value")
+        self.assertEqual(coercions["backend_boolean"]["empty_list_or_tuple"], "default")
+        self.assertTrue(nodes._as_bool(["yes"], False))
+        self.assertTrue(nodes._as_bool(("enabled",), False))
+        self.assertFalse(nodes._as_bool(["off"], True))
+        self.assertTrue(nodes._as_bool([], True))
+        self.assertFalse(nodes._as_bool((), False))
+
+    def test_field_specific_choice_coercions_match_current_backend(self):
+        manifest = _manifest()
+        contracts = dict(_leaf_contracts(manifest, manifest["shape"]))
+        self.assertEqual(contracts[("mod_guidance", "profile")]["coercion"], "mod-guidance-profile")
+        self.assertEqual(contracts[("upscale", "usdu", "prompt_mode")]["coercion"], "string-then-choice")
+        self.assertEqual(contracts[("detailer", "face", "alignment")]["coercion"], "string-then-choice")
+
+        cases = (
+            (("mod_guidance", "profile"), "step_i14", "step_i14"),
+            (("mod_guidance", "profile"), " step_i14 ", nodes.ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE),
+            (("mod_guidance", "profile"), "STEP_I14", nodes.ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE),
+            (("mod_guidance", "profile"), ["step_i14"], nodes.ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE),
+            (("mod_guidance", "profile"), ("step_i14",), nodes.ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE),
+            (("upscale", "usdu", "prompt_mode"), " no_general ", "no_general"),
+            (("upscale", "usdu", "prompt_mode"), "quality_tags_only", "no_general"),
+            (("upscale", "usdu", "prompt_mode"), " quality_tags_only ", "full"),
+            (("upscale", "usdu", "prompt_mode"), ["no_general"], "full"),
+            (("upscale", "usdu", "prompt_mode"), ("no_general",), "full"),
+            (("detailer", "face", "alignment"), " none ", "none"),
+            (("detailer", "face", "alignment"), ["none"], "32"),
+            (("detailer", "face", "alignment"), ("none",), "32"),
+        )
+        with _deterministic_capabilities():
+            for path, value, expected in cases:
+                with self.subTest(path="/" + "/".join(path), value=value):
+                    normalized = nodes._normalize_aio_generation_settings(_payload_with(path, value))
+                    self.assertEqual(_get_path(normalized, path), expected)
 
     def test_every_referenced_coercion_has_a_self_contained_definition(self):
         manifest = _manifest()
@@ -240,6 +380,8 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
         self.assertEqual(referenced - defined, set())
         self.assertTrue({
             "constant",
+            "string-then-choice",
+            "mod-guidance-profile",
             "string-or-default",
             "string",
             "string-list",


### PR DESCRIPTION
## 변경 요약

- `easyuse_anima/aio/schemas/generation_settings.v1.json`에 AiO generation settings v1 canonical manifest를 추가했습니다.
- 현재 Python `AIO_GENERATION_DEFAULT_SETTINGS`와 frontend `AIO_DEFAULT_GENERATION_SETTINGS`의 default를 golden deep-equality로 고정했습니다.
- static field/default/enum/min/max/coercion, legacy alias, unknown-field, dynamic capability 비소유, write-on-read 금지 정책을 manifest와 아키텍처 문서에 명시했습니다.
- runtime import, generator/codegen, typed model, migration, default object, normalizer, UI dialog, queue, API/profile envelope 및 production runtime은 변경하지 않았습니다.

Refs #168

## Manifest contract 보완

- `shape`/`definitions`/container item이 참조하는 모든 coercion token을 top-level `coercions`에 자체완결적으로 정의하고, 참조 집합과 정의 집합의 차이가 비어 있음을 deterministic gate로 검증합니다.
- 빈 default가 item shape 누락을 숨기지 않도록 다음 계약을 명시했습니다.
  - `additional_hash_bundles`: normalized string item
  - `civitai_hash_fetchers`: `enabled`, `username`, `model_name`, `version` item object와 row drop/unknown-field 정책
  - `detailer.order`: `face`, `eye`, `custom_<n>` item과 dedupe/required-tail 정책
  - `spectrum_extra`/`spd_extra`: recursive JSON value
- `custom_<n>` Detailer target의 `pattern_fields`와 `$ref` coverage를 golden test로 고정했습니다.
- dynamic choice invalid 정책을 static enum과 분리해 `default-if-present-else-first`로 기록하고, preferred default의 capability 포함/미포함 양쪽을 실제 `_choice` 동작과 대조했습니다.
- 후속 consumer가 암묵 token 표 없이 manifest를 해석할 수 있도록 했지만, 이번 PR에서 generator/codegen/typed model을 추가하거나 특정 generator 호환성을 주장하지 않습니다.

## Post-fix choice / enum 보완

- generic `choice`가 아닌 현재 backend field별 pipeline을 전용 coercion으로 기록했습니다.
  - `mod_guidance.profile`: whole value를 `str(value or default)`로 바꾸고 trim/case 변환 없이 exact membership을 확인합니다. whitespace, 대문자, list/tuple은 invalid/default입니다.
  - `upscale.usdu.prompt_mode`: whole value를 먼저 문자열화한 뒤 choice trim을 적용합니다. list/tuple은 first item이 아니라 whole container 문자열이므로 invalid/default입니다. `quality_tags_only` alias는 문자열화 후 choice 전에만 적용됩니다.
  - Detailer target `alignment`: whole value 문자열화 후 choice trim을 적용하며 list/tuple은 invalid/default입니다.
- backend boolean에 `_single_value`의 list/tuple first-value와 empty container의 field-default 동작을 명시하고 scalar/list/tuple/empty 회귀를 추가했습니다.
- 42개 static enum field에 대해 다음 양방향 gate를 추가했습니다.
  - manifest의 모든 enum member를 해당 backend field에서 round-trip
  - field별 authoritative fixture와 manifest accepted set equality
  - sentinel로 실제 runtime `_choice` accepted set을 캡처하고, profile은 runtime constant를 직접 사용
  - manifest extra member와 runtime accepted member 누락을 모두 차단
- dynamic enum gate는 위 static enum gate와 분리 유지합니다.

## 주요 파일

- `easyuse_anima/aio/schemas/generation_settings.v1.json`
- `docs/architecture/aio-settings-contract.md`
- `tests/test_aio_schema_contract.py`
- `tests/frontend_aio_settings_core_smoke.mjs`

## 현재 drift 기록

동작 변경 없이 다음 현재 차이를 manifest와 문서에 기록했습니다.

- Python backend는 unknown `highres.backend`를 보존하지만 frontend visible merge/optional sanitize는 제거합니다.
- seed 상한은 backend uint64와 frontend 현재 상한이 다릅니다.
- backend/frontend boolean 및 integer/number coercion 규칙이 완전히 같지 않습니다.
- backend schema constant 강제와 달리 frontend default merge는 incoming schema 값을 일반적으로 보존합니다.
- 위 세 choice field는 generic `_single_value` 경로와 다르며, field별 whitespace/list 처리도 서로 다릅니다.

## 기준 / HEAD / 소유 diff

- base: `dev@2e73fb92a4054f011288b50474bd37c70e66dfd9`
- head: `codex/issue-168-c01-schema-manifest@e226e180b85ef89d99db96546cb28b5e0646da86`
- fetch 후 최신 `origin/dev` 및 merge-base가 위 exact base와 일치함을 재확인했습니다.
- `origin/dev...HEAD` diff는 위 4개 contract/test/doc 파일만 포함하며 production runtime 파일은 포함하지 않습니다.

## 검증

최종 커밋 `e226e180b85ef89d99db96546cb28b5e0646da86`과 동일한 tree에서 실행했습니다.

- `python -m unittest discover -s tests -p test_aio_schema_contract.py` — 13 passed
  - Python/frontend default deep equality 계약
  - coercion registry 완결성 및 empty container/item/ref/pattern coverage
  - field-specific choice whitespace/list/alias 동작
  - backend boolean scalar/list/tuple/empty 동작
  - static enum 42-field accepted-set 3-way equality, invalid fallback 및 member round-trip
  - dynamic capability fallback 양쪽 분기
  - legacy/unknown/drift 및 tracked/non-`.comfyignore`/`git archive HEAD` 계약
- `node tests/frontend_aio_settings_core_smoke.mjs` — passed
- `node --check tests/frontend_aio_settings_core_smoke.mjs` — passed
- `tools/check_project.ps1 -Profile quick` — passed
  - Python compile
  - frontend 110 JavaScript files
  - TypeScript 6.0.3
  - project diff checks
- `git diff --check origin/dev...HEAD` — passed
- actual `origin/dev...HEAD` diff 자체검토 — 4-file scope, production runtime 변경 없음

검증 표면: deterministic Python/frontend contract 및 repository quick gate.

## 최종 통합 검증 / 잔여 위험

메인 owner가 exact HEAD `e226e180b85ef89d99db96546cb28b5e0646da86`에서 공식 full을 실행했습니다.

- `tools/check_custom_node.ps1 -Project <PR worktree> -Profile full` — passed
  - Python unittest: 624 passed
  - frontend: 110 JavaScript files passed
  - TypeScript 6.0.3 passed
  - Python compile 및 git diff check passed
- 독립 actual diff 재리뷰: P0–P2 차단점 없음
- integration/live ComfyUI/Legacy canvas/Node 2.0/browser smoke는 runtime production 변경이 없는 Contract PR이므로 실행하지 않았습니다.
- 잔여 위험: manifest는 이번 단계에서 runtime이 import하지 않는 정적 계약이며 codegen/typed model은 후속 단계 범위입니다.
