### PR TITLE
fix: profile v2 additive contract and migration (#163 Part 3A)

### DIFF
--- a/api.py
+++ b/api.py
@@ -53,8 +53,35 @@ from .api_contract import (
     json_integer,
     json_object,
     json_string,
+    json_uuid_string,
     parse_json_object,
 )
+try:
+    from .easyuse_anima.profiles.contract import (
+        PROFILE_KIND_AIO,
+        PROFILE_KIND_LORA,
+        ProfileContractError,
+        build_profile_document,
+        create_profile_document,
+        interpret_profile_document,
+        legacy_profile_id,
+        normalize_profile_filename_identity,
+        rename_profile_document,
+        update_profile_document,
+    )
+except ImportError:
+    from easyuse_anima.profiles.contract import (
+        PROFILE_KIND_AIO,
+        PROFILE_KIND_LORA,
+        ProfileContractError,
+        build_profile_document,
+        create_profile_document,
+        interpret_profile_document,
+        legacy_profile_id,
+        normalize_profile_filename_identity,
+        rename_profile_document,
+        update_profile_document,
+    )
 try:
     from .storage import AtomicJsonStore, USER_DATA_DIR
 except ImportError:
@@ -276,7 +303,7 @@ async def _run_file_io(function, /, *args, **kwargs):
 
 
 def _windows_profile_filename_identity(name: str) -> str:
-    return str(name or "").rstrip(" .").casefold()
+    return normalize_profile_filename_identity(name)
 
 
 def _sanitize_profile_name(name: str) -> str:
@@ -378,12 +405,7 @@ def _list_lora_profiles() -> list[dict]:
     for path in sorted(LORA_PROFILE_DIR.glob("*.json"), key=lambda item: item.stem.lower()):
         if path.name == ".gitignore":
             continue
-        profiles.append(
-            {
-                "name": path.stem,
-                "modified": int(path.stat().st_mtime),
-            }
-        )
+        profiles.append(_profile_list_item(PROFILE_KIND_LORA, path))
     return profiles
 
 
@@ -574,7 +596,40 @@ def _read_profile_json(path: Path):
             raise
 
 
-def _save_lora_profile(name: str, data: dict, *, overwrite: bool = False) -> dict:
+def _profile_list_item(profile_kind: str, path: Path) -> dict:
+    try:
+        data = _read_profile_json(path)
+        if not isinstance(data, dict):
+            raise ProfileContractError("Profile data is invalid")
+        interpreted = interpret_profile_document(profile_kind, path.stem, data)
+        profile_id = interpreted["profile_id"]
+        revision = interpreted["revision"]
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        ProfileContractError,
+    ):
+        profile_id = legacy_profile_id(profile_kind, path.stem)
+        revision = 0
+    return {
+        "name": path.stem,
+        "modified": int(path.stat().st_mtime),
+        "profile_id": profile_id,
+        "revision": revision,
+    }
+
+
+def _save_lora_profile(
+    name: str,
+    data: dict,
+    *,
+    overwrite: bool = False,
+    profile_id: str | None = None,
+    revision: int | None = None,
+) -> dict:
+    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
+    _ = profile_id, revision
     safe_name = _sanitize_lora_profile_name(name)
     payload = _normalize_lora_profile_payload(data)
     LORA_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
@@ -584,9 +639,27 @@ def _save_lora_profile(name: str, data: dict, *, overwrite: bool = False) -> dic
         if existing is not None and not overwrite:
             raise FileExistsError("Profile already exists")
         path = existing or requested_path
-        payload["name"] = path.stem
-        AtomicJsonStore(path).write(payload)
-    return payload
+        try:
+            if existing is None:
+                document = create_profile_document(
+                    PROFILE_KIND_LORA,
+                    path.stem,
+                    payload,
+                )
+            else:
+                current = _read_profile_json(path)
+                if not isinstance(current, dict):
+                    raise ProfileContractError("Profile data is invalid")
+                document = update_profile_document(
+                    PROFILE_KIND_LORA,
+                    path.stem,
+                    current,
+                    payload,
+                )
+        except ProfileContractError as exc:
+            raise InvalidProfileDataError(str(exc)) from exc
+        AtomicJsonStore(path).write(document)
+    return document
 
 
 def _load_lora_profile(name: str) -> dict:
@@ -607,8 +680,16 @@ def _load_lora_profile(name: str) -> dict:
     elif not isinstance(profile_data, dict):
         raise InvalidProfileDataError("Profile data is invalid")
     payload = _normalize_lora_profile_payload(data)
-    payload["name"] = path.stem
-    return payload
+    try:
+        interpreted = interpret_profile_document(PROFILE_KIND_LORA, path.stem, data)
+        return build_profile_document(
+            name=path.stem,
+            profile_id=interpreted["profile_id"],
+            revision=interpreted["revision"],
+            payload=payload,
+        )
+    except ProfileContractError as exc:
+        raise InvalidProfileDataError(str(exc)) from exc
 
 
 def _sanitize_aio_profile_name(name: str) -> str:
@@ -664,15 +745,27 @@ def _list_aio_profiles(profile_dir: Path | None = None) -> list[dict]:
     if not root.is_dir():
         return []
     return [
-        {
-            "name": path.stem,
-            "modified": int(path.stat().st_mtime),
-        }
+        _profile_list_item(PROFILE_KIND_AIO, path)
         for path in sorted(root.glob("*.json"), key=lambda item: item.stem.casefold())
     ]
 
 
-def _save_aio_profile(name: str, data: dict, *, overwrite: bool = False) -> dict:
+def _validate_aio_profile_size(document: dict) -> None:
+    encoded = json.dumps(document, ensure_ascii=False, indent=2)
+    if len(encoded.encode("utf-8")) > MAX_AIO_PROFILE_BYTES:
+        raise ValueError("Profile settings are too large")
+
+
+def _save_aio_profile(
+    name: str,
+    data: dict,
+    *,
+    overwrite: bool = False,
+    profile_id: str | None = None,
+    revision: int | None = None,
+) -> dict:
+    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
+    _ = profile_id, revision
     payload = _normalize_aio_profile_payload(name, data)
     AIO_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
     requested_path = _aio_profile_path(payload["name"])
@@ -683,17 +776,44 @@ def _save_aio_profile(name: str, data: dict, *, overwrite: bool = False) -> dict
         if existing is None and len(_list_aio_profiles()) >= MAX_AIO_PROFILES:
             raise ValueError(f"A maximum of {MAX_AIO_PROFILES} profiles can be saved")
         path = existing or requested_path
-        payload["name"] = path.stem
-        AtomicJsonStore(path).write(payload)
-    return payload
+        try:
+            if existing is None:
+                document = create_profile_document(
+                    PROFILE_KIND_AIO,
+                    path.stem,
+                    payload,
+                )
+            else:
+                current = _read_profile_json(path)
+                if not isinstance(current, dict):
+                    raise ProfileContractError("Profile data is invalid")
+                document = update_profile_document(
+                    PROFILE_KIND_AIO,
+                    path.stem,
+                    current,
+                    payload,
+                )
+        except ProfileContractError as exc:
+            raise InvalidProfileDataError(str(exc)) from exc
+        _validate_aio_profile_size(document)
+        AtomicJsonStore(path).write(document)
+    return document
 
 
 def _normalize_stored_aio_profile_payload(name: str, data) -> dict:
     if not isinstance(data, dict):
         raise InvalidProfileDataError("Profile data is invalid")
     try:
-        return _normalize_aio_profile_payload(name, data)
-    except ValueError as exc:
+        payload = _normalize_aio_profile_payload(name, data)
+        interpreted = interpret_profile_document(PROFILE_KIND_AIO, name, data)
+        document = build_profile_document(
+            name=name,
+            profile_id=interpreted["profile_id"],
+            revision=interpreted["revision"],
+            payload=payload,
+        )
+        return document
+    except (ProfileContractError, ValueError) as exc:
         raise InvalidProfileDataError(str(exc)) from exc
 
 
@@ -708,40 +828,105 @@ def _load_aio_profile(name: str) -> dict:
     return _normalize_stored_aio_profile_payload(path.stem, data)
 
 
-def _delete_aio_profile(name: str) -> dict:
+def _delete_aio_profile(
+    name: str,
+    *,
+    profile_id: str | None = None,
+    revision: int | None = None,
+) -> dict:
+    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
+    _ = profile_id, revision
     path = _find_aio_profile_path(name)
     if path is None or not path.is_file():
         raise FileNotFoundError("Profile not found")
-    deleted_name = path.stem
+    try:
+        data = _read_profile_json(path)
+        if not isinstance(data, dict):
+            raise ProfileContractError("Profile data is invalid")
+        interpreted = interpret_profile_document(PROFILE_KIND_AIO, path.stem, data)
+        deleted_profile_id = interpreted["profile_id"]
+        deleted_revision = interpreted["revision"]
+    except (OSError, UnicodeError, json.JSONDecodeError, ProfileContractError):
+        deleted_profile_id = legacy_profile_id(PROFILE_KIND_AIO, path.stem)
+        deleted_revision = 0
     try:
         AtomicJsonStore(path).delete()
     except FileNotFoundError as exc:
         raise FileNotFoundError("Profile not found") from exc
-    return {"name": deleted_name}
+    return {
+        "name": path.stem,
+        "profile_id": deleted_profile_id,
+        "revision": deleted_revision,
+    }
 
 
-def _rename_aio_profile(old_name: str, new_name: str, *, overwrite: bool = False) -> dict:
+def _rename_aio_profile(
+    old_name: str,
+    new_name: str,
+    *,
+    overwrite: bool = False,
+    profile_id: str | None = None,
+    revision: int | None = None,
+    target_profile_id: str | None = None,
+    target_revision: int | None = None,
+) -> dict:
+    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
+    _ = profile_id, revision, target_profile_id, target_revision
     source = _find_aio_profile_path(old_name)
     if source is None or not source.is_file():
         raise FileNotFoundError("Profile not found")
     safe_new_name = _sanitize_aio_profile_name(new_name)
     if source.stem.casefold() == safe_new_name.casefold():
-        return _load_aio_profile(source.stem)
+        data = _read_profile_json(source)
+        normalized = _normalize_stored_aio_profile_payload(source.stem, data)
+        try:
+            renamed = rename_profile_document(
+                PROFILE_KIND_AIO,
+                source.stem,
+                source.stem,
+                data,
+                normalized,
+            )
+        except ProfileContractError as exc:
+            raise InvalidProfileDataError(str(exc)) from exc
+        _validate_aio_profile_size(renamed)
+        if data != renamed:
+            AtomicJsonStore(source, backup=False).write(renamed)
+        return renamed
 
     target = _find_aio_profile_path(safe_new_name)
     if target is not None and not overwrite:
         raise FileExistsError("Profile already exists")
 
     target_path = target or _aio_profile_path(safe_new_name)
-    return AtomicJsonStore(target_path).replace_from(
+    renamed = AtomicJsonStore(target_path).replace_from(
         AtomicJsonStore(source),
         overwrite=overwrite,
         backup_target=True,
-        transform=lambda data: _normalize_stored_aio_profile_payload(
+        transform=lambda data: _rename_aio_profile_payload(
+            source.stem,
             target_path.stem,
             data,
         ),
     )
+    AtomicJsonStore(target_path, backup=False).write(renamed)
+    return renamed
+
+
+def _rename_aio_profile_payload(source_name: str, target_name: str, data) -> dict:
+    normalized = _normalize_stored_aio_profile_payload(source_name, data)
+    try:
+        document = rename_profile_document(
+            PROFILE_KIND_AIO,
+            source_name,
+            target_name,
+            data,
+            normalized,
+        )
+    except ProfileContractError as exc:
+        raise InvalidProfileDataError(str(exc)) from exc
+    _validate_aio_profile_size(document)
+    return document
 
 
 def _resolve_lora_preview_path(lora_name: str):
@@ -1063,6 +1248,17 @@ if web is not None and routes is not None:
             overwrite = json_boolean(data, "overwrite")
             if "profile_data" in data:
                 json_object(data, "profile_data")
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
         except ApiContractError as exc:
             return _contract_error_response(exc)
         try:
@@ -1071,6 +1267,8 @@ if web is not None and routes is not None:
                 name,
                 data,
                 overwrite=overwrite,
+                profile_id=profile_id,
+                revision=revision,
             )
         except (FileExistsError, ValueError) as exc:
             return _profile_error_response(exc)
@@ -1108,6 +1306,17 @@ if web is not None and routes is not None:
             name = json_string(data, "name", allow_empty=False)
             json_object(data, "settings")
             overwrite = json_boolean(data, "overwrite")
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
         except ApiContractError as exc:
             return _contract_error_response(exc)
         try:
@@ -1116,6 +1325,8 @@ if web is not None and routes is not None:
                 name,
                 data,
                 overwrite=overwrite,
+                profile_id=profile_id,
+                revision=revision,
             )
         except (FileExistsError, ValueError) as exc:
             return _profile_error_response(exc)
@@ -1139,10 +1350,26 @@ if web is not None and routes is not None:
         try:
             data = await parse_json_object(request)
             name = json_string(data, "name", allow_empty=False)
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
         except ApiContractError as exc:
             return _contract_error_response(exc)
         try:
-            payload = await _run_file_io(_delete_aio_profile, name)
+            payload = await _run_file_io(
+                _delete_aio_profile,
+                name,
+                profile_id=profile_id,
+                revision=revision,
+            )
         except (FileNotFoundError, ValueError) as exc:
             return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
@@ -1155,6 +1382,28 @@ if web is not None and routes is not None:
             old_name = json_string(data, "old_name", allow_empty=False)
             new_name = json_string(data, "new_name", allow_empty=False)
             overwrite = json_boolean(data, "overwrite")
+            profile_id = json_uuid_string(
+                data,
+                "profile_id",
+                required=False,
+            )
+            revision = json_integer(
+                data,
+                "revision",
+                default=None,
+                minimum=0,
+            )
+            target_profile_id = json_uuid_string(
+                data,
+                "target_profile_id",
+                required=False,
+            )
+            target_revision = json_integer(
+                data,
+                "target_revision",
+                default=None,
+                minimum=0,
+            )
         except ApiContractError as exc:
             return _contract_error_response(exc)
         try:
@@ -1163,6 +1412,10 @@ if web is not None and routes is not None:
                 old_name,
                 new_name,
                 overwrite=overwrite,
+                profile_id=profile_id,
+                revision=revision,
+                target_profile_id=target_profile_id,
+                target_revision=target_revision,
             )
         except (FileExistsError, FileNotFoundError, ValueError) as exc:
             return _profile_error_response(exc)

--- a/api.py
+++ b/api.py
@@ -604,11 +604,12 @@ def _profile_list_item(profile_kind: str, path: Path) -> dict:
         interpreted = interpret_profile_document(profile_kind, path.stem, data)
         profile_id = interpreted["profile_id"]
         revision = interpreted["revision"]
+    except ProfileContractError as exc:
+        raise InvalidProfileDataError(str(exc)) from exc
     except (
         OSError,
         UnicodeError,
         json.JSONDecodeError,
-        ProfileContractError,
     ):
         profile_id = legacy_profile_id(profile_kind, path.stem)
         revision = 0
@@ -839,20 +840,24 @@ def _delete_aio_profile(
     path = _find_aio_profile_path(name)
     if path is None or not path.is_file():
         raise FileNotFoundError("Profile not found")
-    try:
-        data = _read_profile_json(path)
-        if not isinstance(data, dict):
-            raise ProfileContractError("Profile data is invalid")
-        interpreted = interpret_profile_document(PROFILE_KIND_AIO, path.stem, data)
-        deleted_profile_id = interpreted["profile_id"]
-        deleted_revision = interpreted["revision"]
-    except (OSError, UnicodeError, json.JSONDecodeError, ProfileContractError):
-        deleted_profile_id = legacy_profile_id(PROFILE_KIND_AIO, path.stem)
-        deleted_revision = 0
-    try:
-        AtomicJsonStore(path).delete()
-    except FileNotFoundError as exc:
-        raise FileNotFoundError("Profile not found") from exc
+    store = AtomicJsonStore(path)
+    with store.locked():
+        try:
+            data = _read_profile_json(path)
+            if not isinstance(data, dict):
+                raise ProfileContractError("Profile data is invalid")
+            interpreted = interpret_profile_document(PROFILE_KIND_AIO, path.stem, data)
+            deleted_profile_id = interpreted["profile_id"]
+            deleted_revision = interpreted["revision"]
+        except ProfileContractError as exc:
+            raise InvalidProfileDataError(str(exc)) from exc
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            deleted_profile_id = legacy_profile_id(PROFILE_KIND_AIO, path.stem)
+            deleted_revision = 0
+        try:
+            store.delete()
+        except FileNotFoundError as exc:
+            raise FileNotFoundError("Profile not found") from exc
     return {
         "name": path.stem,
         "profile_id": deleted_profile_id,
@@ -877,22 +882,17 @@ def _rename_aio_profile(
         raise FileNotFoundError("Profile not found")
     safe_new_name = _sanitize_aio_profile_name(new_name)
     if source.stem.casefold() == safe_new_name.casefold():
-        data = _read_profile_json(source)
-        normalized = _normalize_stored_aio_profile_payload(source.stem, data)
-        try:
-            renamed = rename_profile_document(
-                PROFILE_KIND_AIO,
+        store = AtomicJsonStore(source, backup=False)
+        with store.locked():
+            data = _read_profile_json(source)
+            renamed = _rename_aio_profile_payload(
                 source.stem,
                 source.stem,
                 data,
-                normalized,
             )
-        except ProfileContractError as exc:
-            raise InvalidProfileDataError(str(exc)) from exc
-        _validate_aio_profile_size(renamed)
-        if data != renamed:
-            AtomicJsonStore(source, backup=False).write(renamed)
-        return renamed
+            if data != renamed:
+                store.write(renamed)
+            return renamed
 
     target = _find_aio_profile_path(safe_new_name)
     if target is not None and not overwrite:
@@ -909,7 +909,6 @@ def _rename_aio_profile(
             data,
         ),
     )
-    AtomicJsonStore(target_path, backup=False).write(renamed)
     return renamed
 
 
@@ -1237,7 +1236,11 @@ if web is not None and routes is not None:
     @routes.get("/easyuse_anima/lora_profiles")
     @_request_correlated
     async def lora_profiles_handler(request):
-        return web.json_response({"profiles": await _run_file_io(_list_lora_profiles)})
+        try:
+            payload = await _run_file_io(_list_lora_profiles)
+        except InvalidProfileDataError as exc:
+            return _profile_error_response(exc)
+        return web.json_response({"profiles": payload})
 
     @routes.post("/easyuse_anima/lora_profiles/save")
     @_request_correlated
@@ -1294,9 +1297,11 @@ if web is not None and routes is not None:
     @routes.get("/easyuse_anima/aio_profiles")
     @_request_correlated
     async def aio_profiles_handler(request):
-        return web.json_response(
-            {"status": "ok", "profiles": await _run_file_io(_list_aio_profiles)}
-        )
+        try:
+            payload = await _run_file_io(_list_aio_profiles)
+        except InvalidProfileDataError as exc:
+            return _profile_error_response(exc)
+        return web.json_response({"status": "ok", "profiles": payload})
 
     @routes.post("/easyuse_anima/aio_profiles/save")
     @_request_correlated

--- a/api_contract.py
+++ b/api_contract.py
@@ -163,10 +163,10 @@ def json_integer(
     data: Mapping[str, Any],
     field: str,
     *,
-    default: int,
+    default: int | None,
     minimum: int | None = None,
     maximum: int | None = None,
-) -> int:
+) -> int | None:
     if field not in data:
         return default
     value = data[field]
@@ -177,3 +177,23 @@ def json_integer(
     if maximum is not None and value > maximum:
         raise _field_error(field, f"an integer less than or equal to {maximum}")
     return value
+
+
+def json_uuid_string(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    required: bool = True,
+    default: str | None = None,
+) -> str | None:
+    if field not in data:
+        if required:
+            raise _field_error(field, "a UUID string")
+        return default
+    value = data[field]
+    if not isinstance(value, str):
+        raise _field_error(field, "a UUID string")
+    try:
+        return str(uuid.UUID(value))
+    except (AttributeError, ValueError) as exc:
+        raise _field_error(field, "a UUID string") from exc

--- a/easyuse_anima/profiles/__init__.py
+++ b/easyuse_anima/profiles/__init__.py
@@ -1,0 +1,3 @@
+"""Side-effect-free profile contracts and migrations."""
+
+__all__ = ()

--- a/easyuse_anima/profiles/contract.py
+++ b/easyuse_anima/profiles/contract.py
@@ -46,17 +46,12 @@ def read_profile_metadata(
     version = document.get("version")
     if version is not None and type(version) is not int:
         raise ProfileContractError("Profile version is invalid")
-    has_v2_envelope = all(
-        field in document
-        for field in ("profile_id", "revision", "name")
-    )
-    if version in (None, 1) or (
-        version == PROFILE_ENVELOPE_VERSION
-        and not has_v2_envelope
-    ):
+    if version in (None, 1):
         return legacy_profile_id(profile_kind, filename), 0
     if version != PROFILE_ENVELOPE_VERSION:
         raise ProfileContractError("Profile version is invalid")
+    if not all(field in document for field in ("profile_id", "revision", "name")):
+        raise ProfileContractError("Profile envelope is invalid")
     if not isinstance(document["name"], str) or not document["name"].strip():
         raise ProfileContractError("Profile name is invalid")
 

--- a/easyuse_anima/profiles/contract.py
+++ b/easyuse_anima/profiles/contract.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from typing import Any
+
+
+PROFILE_ENVELOPE_VERSION = 2
+PROFILE_KIND_AIO = "aio"
+PROFILE_KIND_LORA = "lora"
+PROFILE_ID_NAMESPACE = uuid.UUID("7d89dd90-6095-4dca-a80f-8e0b10868aaf")
+
+_PROFILE_KINDS = frozenset({PROFILE_KIND_AIO, PROFILE_KIND_LORA})
+_ENVELOPE_FIELDS = frozenset({"version", "profile_id", "revision", "name"})
+
+
+class ProfileContractError(ValueError):
+    """A stored profile does not satisfy the supported envelope taxonomy."""
+
+
+def normalize_profile_filename_identity(name: str) -> str:
+    """Return the Windows-compatible identity used by legacy profile files."""
+
+    return str(name or "").rstrip(" .").casefold()
+
+
+def legacy_profile_id(profile_kind: str, filename: str) -> str:
+    """Derive the stable identity for a legacy profile without mutating it."""
+
+    _validate_profile_kind(profile_kind)
+    identity = normalize_profile_filename_identity(filename)
+    return str(uuid.uuid5(PROFILE_ID_NAMESPACE, f"{profile_kind}:{identity}"))
+
+
+def read_profile_metadata(
+    profile_kind: str,
+    filename: str,
+    document: Mapping[str, Any],
+) -> tuple[str, int]:
+    """Interpret v2 metadata or derive the pure legacy migration identity."""
+
+    _validate_profile_kind(profile_kind)
+    if not isinstance(document, Mapping):
+        raise ProfileContractError("Profile data is invalid")
+
+    version = document.get("version")
+    if version is not None and type(version) is not int:
+        raise ProfileContractError("Profile version is invalid")
+    has_v2_envelope = all(
+        field in document
+        for field in ("profile_id", "revision", "name")
+    )
+    if version in (None, 1) or (
+        version == PROFILE_ENVELOPE_VERSION
+        and not has_v2_envelope
+    ):
+        return legacy_profile_id(profile_kind, filename), 0
+    if version != PROFILE_ENVELOPE_VERSION:
+        raise ProfileContractError("Profile version is invalid")
+    if not isinstance(document["name"], str) or not document["name"].strip():
+        raise ProfileContractError("Profile name is invalid")
+
+    return _parse_profile_id(document["profile_id"]), _parse_revision(document["revision"])
+
+
+def build_profile_document(
+    *,
+    name: str,
+    profile_id: str,
+    revision: int,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compose a v2 envelope while preventing payload metadata overrides."""
+
+    if not isinstance(payload, Mapping):
+        raise ProfileContractError("Profile payload is invalid")
+    document = {
+        key: value
+        for key, value in payload.items()
+        if key not in _ENVELOPE_FIELDS
+    }
+    return {
+        "version": PROFILE_ENVELOPE_VERSION,
+        "profile_id": _parse_profile_id(profile_id),
+        "revision": _parse_revision(revision),
+        "name": _parse_profile_name(name),
+        **document,
+    }
+
+
+def interpret_profile_document(
+    profile_kind: str,
+    filename: str,
+    document: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the additive v2 view of stored bytes without writing migration state."""
+
+    profile_id, revision = read_profile_metadata(profile_kind, filename, document)
+    return build_profile_document(
+        name=filename,
+        profile_id=profile_id,
+        revision=revision,
+        payload=document,
+    )
+
+
+def create_profile_document(
+    profile_kind: str,
+    name: str,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Create a server-owned UUID4 profile at content revision one."""
+
+    _validate_profile_kind(profile_kind)
+    return build_profile_document(
+        name=name,
+        profile_id=str(uuid.uuid4()),
+        revision=1,
+        payload=payload,
+    )
+
+
+def update_profile_document(
+    profile_kind: str,
+    filename: str,
+    current_document: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Preserve identity and advance content revision for a normal overwrite."""
+
+    profile_id, revision = read_profile_metadata(
+        profile_kind,
+        filename,
+        current_document,
+    )
+    return build_profile_document(
+        name=filename,
+        profile_id=profile_id,
+        revision=revision + 1,
+        payload=payload,
+    )
+
+
+def rename_profile_document(
+    profile_kind: str,
+    source_filename: str,
+    target_filename: str,
+    current_document: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Preserve source identity and content revision across a display rename."""
+
+    profile_id, revision = read_profile_metadata(
+        profile_kind,
+        source_filename,
+        current_document,
+    )
+    return build_profile_document(
+        name=target_filename,
+        profile_id=profile_id,
+        revision=revision,
+        payload=payload,
+    )
+
+
+def _validate_profile_kind(profile_kind: str) -> None:
+    if profile_kind not in _PROFILE_KINDS:
+        raise ValueError(f"Unknown profile kind: {profile_kind}")
+
+
+def _parse_profile_id(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ProfileContractError("Profile ID is invalid")
+    try:
+        return str(uuid.UUID(value))
+    except (AttributeError, ValueError) as exc:
+        raise ProfileContractError("Profile ID is invalid") from exc
+
+
+def _parse_revision(value: Any) -> int:
+    if type(value) is not int or value < 0:
+        raise ProfileContractError("Profile revision is invalid")
+    return value
+
+
+def _parse_profile_name(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ProfileContractError("Profile name is invalid")
+    return value
+
+
+__all__ = ()

--- a/storage.py
+++ b/storage.py
@@ -295,7 +295,10 @@ class AtomicJsonStore:
         A transformed value is encoded before either primary is changed. The
         source is then moved onto the target and the transformed bytes are
         published before the joint lock is released. If that second
-        publication fails, both primaries are restored byte-for-byte.
+        publication fails, both primaries are restored byte-for-byte. A source
+        backup is consumed by a successful move and restored after any failure
+        before primary publication completes. A failed overwrite also restores
+        the target backup's prior existence and exact bytes.
         """
 
         if source.path.parent != self.path.parent:
@@ -306,46 +309,104 @@ class AtomicJsonStore:
                 raise FileExistsError("Profile already exists")
             self.path.parent.mkdir(parents=True, exist_ok=True)
 
-            if transform is None:
-                if backup_target and self.path.is_file():
-                    self._backup_primary_unlocked()
-                os.replace(source.path, self.path)
-                _fsync_directory(self.path.parent)
-                return value
-
-            value = transform(value)
-            encoded = self._encode(value, indent=2, trailing_newline=False)
-            transformed_temp: Path | None = self._write_temp(self.path, encoded)
+            transformed_temp: Path | None = None
             target_restore_temp: Path | None = None
+            target_backup_restore_temp: Path | None = None
+            source_backup_restore_temp: Path | None = None
+            target_backup_restore_needed = False
+            source_backup_removed = False
             target_was_file = self.path.is_file()
+            target_backup_existed = (
+                self.backup_path is not None and self.backup_path.is_file()
+            )
+            if transform is not None:
+                value = transform(value)
+                encoded = self._encode(value, indent=2, trailing_newline=False)
+                transformed_temp = self._write_temp(self.path, encoded)
             try:
-                if target_was_file:
+                if transform is not None and target_was_file:
                     target_restore_temp = self._write_temp(
                         self.path,
                         self.path.read_bytes(),
                     )
-                if backup_target and target_was_file:
+                if backup_target and target_was_file and target_backup_existed:
+                    target_backup_restore_temp = self._write_temp(
+                        self.backup_path,
+                        self.backup_path.read_bytes(),
+                    )
+                if source.backup_path is not None and source.backup_path.is_file():
+                    source_backup_restore_temp = source._write_temp(
+                        source.backup_path,
+                        source.backup_path.read_bytes(),
+                    )
+                    try:
+                        source.backup_path.unlink()
+                    except FileNotFoundError:
+                        pass
+                    source_backup_removed = True
+                    _fsync_directory(self.path.parent)
+                if (
+                    backup_target
+                    and target_was_file
+                    and self.backup_path is not None
+                ):
+                    target_backup_restore_needed = True
                     self._backup_primary_unlocked()
 
                 os.replace(source.path, self.path)
-                try:
-                    os.replace(transformed_temp, self.path)
-                    transformed_temp = None
-                except BaseException as publication_error:
+                if transformed_temp is not None:
                     try:
-                        os.replace(self.path, source.path)
-                        if target_restore_temp is not None:
-                            os.replace(target_restore_temp, self.path)
-                            target_restore_temp = None
-                        _fsync_directory(self.path.parent)
-                    except BaseException as rollback_error:
-                        raise rollback_error from publication_error
-                    raise
+                        os.replace(transformed_temp, self.path)
+                        transformed_temp = None
+                    except BaseException as publication_error:
+                        try:
+                            os.replace(self.path, source.path)
+                            if target_restore_temp is not None:
+                                os.replace(target_restore_temp, self.path)
+                                target_restore_temp = None
+                            _fsync_directory(self.path.parent)
+                        except BaseException as rollback_error:
+                            raise rollback_error from publication_error
+                        raise
 
+                source_backup_removed = False
+                target_backup_restore_needed = False
                 _fsync_directory(self.path.parent)
                 return value
+            except BaseException as transaction_error:
+                rollback_error = None
+                if source_backup_removed and source_backup_restore_temp is not None:
+                    try:
+                        os.replace(source_backup_restore_temp, source.backup_path)
+                        source_backup_restore_temp = None
+                        source_backup_removed = False
+                        _fsync_directory(self.path.parent)
+                    except BaseException as exc:
+                        rollback_error = exc
+                if target_backup_restore_needed and self.backup_path is not None:
+                    try:
+                        if target_backup_existed:
+                            os.replace(
+                                target_backup_restore_temp,
+                                self.backup_path,
+                            )
+                            target_backup_restore_temp = None
+                        else:
+                            _unlink_if_present(self.backup_path)
+                        target_backup_restore_needed = False
+                        _fsync_directory(self.path.parent)
+                    except BaseException as exc:
+                        if rollback_error is None:
+                            rollback_error = exc
+                if rollback_error is not None:
+                    raise rollback_error from transaction_error
+                raise
             finally:
                 if transformed_temp is not None:
                     _unlink_if_present(transformed_temp)
                 if target_restore_temp is not None:
                     _unlink_if_present(target_restore_temp)
+                if target_backup_restore_temp is not None:
+                    _unlink_if_present(target_backup_restore_temp)
+                if source_backup_restore_temp is not None:
+                    _unlink_if_present(source_backup_restore_temp)

--- a/storage.py
+++ b/storage.py
@@ -290,7 +290,13 @@ class AtomicJsonStore:
         backup_target: bool = True,
         transform: Callable[[object], _T] | None = None,
     ) -> object | _T:
-        """Validate/transform under both locks, then atomically move the primary."""
+        """Validate and move a primary while holding both path locks.
+
+        A transformed value is encoded before either primary is changed. The
+        source is then moved onto the target and the transformed bytes are
+        published before the joint lock is released. If that second
+        publication fails, both primaries are restored byte-for-byte.
+        """
 
         if source.path.parent != self.path.parent:
             raise ValueError("Atomic JSON moves require the same directory")
@@ -298,11 +304,48 @@ class AtomicJsonStore:
             value = source._read_path(source.path)
             if self.path.exists() and not overwrite:
                 raise FileExistsError("Profile already exists")
-            if transform is not None:
-                value = transform(value)
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            if backup_target and self.path.is_file():
-                self._backup_primary_unlocked()
-            os.replace(source.path, self.path)
-            _fsync_directory(self.path.parent)
-            return value
+
+            if transform is None:
+                if backup_target and self.path.is_file():
+                    self._backup_primary_unlocked()
+                os.replace(source.path, self.path)
+                _fsync_directory(self.path.parent)
+                return value
+
+            value = transform(value)
+            encoded = self._encode(value, indent=2, trailing_newline=False)
+            transformed_temp: Path | None = self._write_temp(self.path, encoded)
+            target_restore_temp: Path | None = None
+            target_was_file = self.path.is_file()
+            try:
+                if target_was_file:
+                    target_restore_temp = self._write_temp(
+                        self.path,
+                        self.path.read_bytes(),
+                    )
+                if backup_target and target_was_file:
+                    self._backup_primary_unlocked()
+
+                os.replace(source.path, self.path)
+                try:
+                    os.replace(transformed_temp, self.path)
+                    transformed_temp = None
+                except BaseException as publication_error:
+                    try:
+                        os.replace(self.path, source.path)
+                        if target_restore_temp is not None:
+                            os.replace(target_restore_temp, self.path)
+                            target_restore_temp = None
+                        _fsync_directory(self.path.parent)
+                    except BaseException as rollback_error:
+                        raise rollback_error from publication_error
+                    raise
+
+                _fsync_directory(self.path.parent)
+                return value
+            finally:
+                if transformed_temp is not None:
+                    _unlink_if_present(transformed_temp)
+                if target_restore_temp is not None:
+                    _unlink_if_present(target_restore_temp)

--- a/storage.py
+++ b/storage.py
@@ -202,23 +202,27 @@ class AtomicJsonStore:
         except _RECOVERABLE_READ_ERRORS:
             return False
 
-        backup_temp = self._write_temp(self.backup_path, raw)
+        backup_temp: Path | None = self._write_temp(self.backup_path, raw)
         try:
             os.replace(backup_temp, self.backup_path)
+            backup_temp = None
             _fsync_directory(self.path.parent)
         finally:
-            _unlink_if_present(backup_temp)
+            if backup_temp is not None:
+                _unlink_if_present(backup_temp)
         return True
 
     def _write_bytes_unlocked(self, encoded: bytes) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        primary_temp = self._write_temp(self.path, encoded)
+        primary_temp: Path | None = self._write_temp(self.path, encoded)
         try:
             self._backup_primary_unlocked()
             os.replace(primary_temp, self.path)
+            primary_temp = None
             _fsync_directory(self.path.parent)
         finally:
-            _unlink_if_present(primary_temp)
+            if primary_temp is not None:
+                _unlink_if_present(primary_temp)
 
     @staticmethod
     def _encode(value, *, indent: int | None, trailing_newline: bool) -> bytes:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -12548,9 +12548,9 @@
       },
       {
         "is_package": false,
-        "loc": 351,
+        "loc": 412,
         "module": "storage",
-        "normalized_git_blob_sha1": "4193cab56e50634eae7fd9064097a4e6c6def417",
+        "normalized_git_blob_sha1": "4119e4b41259196dd8440cbdd072b0f44f98a463",
         "path": "storage.py",
         "top_level": {
           "class_count": 1,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -1923,6 +1923,24 @@
       },
       {
         "alias": null,
+        "bound_name": "json_uuid_string",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".api_contract:json_uuid_string",
+        "kind": "static_from",
+        "line": 46,
+        "name": "json_uuid_string",
+        "optional": false,
+        "requested": ".api_contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "api_contract.py"
+      },
+      {
+        "alias": null,
         "bound_name": "parse_json_object",
         "branch_context": [],
         "classification": "internal",
@@ -1941,6 +1959,656 @@
       },
       {
         "alias": null,
+        "bound_name": "PROFILE_KIND_AIO",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROFILE_KIND_AIO",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
+        "kind": "static_from",
+        "line": 60,
+        "name": "PROFILE_KIND_AIO",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROFILE_KIND_LORA",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROFILE_KIND_LORA",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
+        "kind": "static_from",
+        "line": 60,
+        "name": "PROFILE_KIND_LORA",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ProfileContractError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ProfileContractError",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:ProfileContractError",
+        "kind": "static_from",
+        "line": 60,
+        "name": "ProfileContractError",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "build_profile_document",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "build_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:build_profile_document",
+        "kind": "static_from",
+        "line": 60,
+        "name": "build_profile_document",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "create_profile_document",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "create_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:create_profile_document",
+        "kind": "static_from",
+        "line": 60,
+        "name": "create_profile_document",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "interpret_profile_document",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "interpret_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:interpret_profile_document",
+        "kind": "static_from",
+        "line": 60,
+        "name": "interpret_profile_document",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "legacy_profile_id",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "legacy_profile_id",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:legacy_profile_id",
+        "kind": "static_from",
+        "line": 60,
+        "name": "legacy_profile_id",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_profile_filename_identity",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_profile_filename_identity",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:normalize_profile_filename_identity",
+        "kind": "static_from",
+        "line": 60,
+        "name": "normalize_profile_filename_identity",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "rename_profile_document",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "rename_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:rename_profile_document",
+        "kind": "static_from",
+        "line": 60,
+        "name": "rename_profile_document",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "update_profile_document",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "update_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.contract:update_profile_document",
+        "kind": "static_from",
+        "line": 60,
+        "name": "update_profile_document",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.contract",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROFILE_KIND_AIO",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROFILE_KIND_AIO",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
+        "kind": "static_from",
+        "line": 73,
+        "name": "PROFILE_KIND_AIO",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PROFILE_KIND_LORA",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROFILE_KIND_LORA",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
+        "kind": "static_from",
+        "line": 73,
+        "name": "PROFILE_KIND_LORA",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ProfileContractError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ProfileContractError",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:ProfileContractError",
+        "kind": "static_from",
+        "line": 73,
+        "name": "ProfileContractError",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "build_profile_document",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "build_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:build_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "name": "build_profile_document",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "create_profile_document",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "create_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:create_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "name": "create_profile_document",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "interpret_profile_document",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "interpret_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:interpret_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "name": "interpret_profile_document",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "legacy_profile_id",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "legacy_profile_id",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:legacy_profile_id",
+        "kind": "static_from",
+        "line": 73,
+        "name": "legacy_profile_id",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_profile_filename_identity",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_profile_filename_identity",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:normalize_profile_filename_identity",
+        "kind": "static_from",
+        "line": 73,
+        "name": "normalize_profile_filename_identity",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "rename_profile_document",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "rename_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:rename_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "name": "rename_profile_document",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "update_profile_document",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "update_profile_document",
+          "target": "easyuse_anima/profiles/contract.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:update_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "name": "update_profile_document",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.contract",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
         "bound_name": "AtomicJsonStore",
         "branch_context": [
           {
@@ -1948,7 +2616,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 58
+            "line": 85
           }
         ],
         "classification": "internal",
@@ -1956,12 +2624,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 58
+          "try_line": 85
         },
         "conditional": true,
         "imported": ".storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 59,
+        "line": 86,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": ".storage",
@@ -1979,7 +2647,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 58
+            "line": 85
           }
         ],
         "classification": "internal",
@@ -1987,12 +2655,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 58
+          "try_line": 85
         },
         "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 59,
+        "line": 86,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -2011,9 +2679,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 60,
+            "handler_line": 87,
             "kind": "try",
-            "line": 58
+            "line": 85
           }
         ],
         "classification": "compatibility_fallback",
@@ -2021,12 +2689,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 58
+          "try_line": 85
         },
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 61,
+        "line": 88,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "storage",
@@ -2045,9 +2713,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 60,
+            "handler_line": 87,
             "kind": "try",
-            "line": 58
+            "line": 85
           }
         ],
         "classification": "compatibility_fallback",
@@ -2055,12 +2723,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 58
+          "try_line": 85
         },
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 61,
+        "line": 88,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -2078,7 +2746,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 402
+            "line": 424
           }
         ],
         "classification": "external",
@@ -2086,7 +2754,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 403,
+        "line": 425,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -2103,7 +2771,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 428
+            "line": 450
           }
         ],
         "classification": "external",
@@ -2111,7 +2779,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 429,
+        "line": 451,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -2128,7 +2796,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 748
+            "line": 933
           }
         ],
         "classification": "external",
@@ -2136,7 +2804,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 749,
+        "line": 934,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -4148,6 +4816,74 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/image_nodes.py",
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "uuid",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "uuid",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 4,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/contract.py"
       },
       {
         "alias": null,
@@ -11025,6 +11761,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "from": "api.py",
         "to": "prompt_translation.py"
       },
       {
@@ -11354,6 +12094,18 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/profiles/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/profiles/contract.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "nodes.py"
         ]
       },
@@ -11384,7 +12136,7 @@
     ]
   },
   "inventory": {
-    "module_count": 34,
+    "module_count": 36,
     "modules": [
       {
         "is_package": true,
@@ -11484,25 +12236,25 @@
       },
       {
         "is_package": false,
-        "loc": 1181,
+        "loc": 1434,
         "module": "api",
-        "normalized_git_blob_sha1": "d92db7ffb0350bb478e4f669b33e9422e517c1cc",
+        "normalized_git_blob_sha1": "b10cde00603bd53f8f803967d8e1f932073af295",
         "path": "api.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 56,
+          "function_count": 59,
           "global_count": 19
         }
       },
       {
         "is_package": false,
-        "loc": 179,
+        "loc": 199,
         "module": "api_contract",
-        "normalized_git_blob_sha1": "d6e98857583f2d1d400bf82a166d739d99861b39",
+        "normalized_git_blob_sha1": "99fdcf3a54bb475e112df0ee663261aa13bb5e91",
         "path": "api_contract.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 10,
+          "function_count": 11,
           "global_count": 1
         }
       },
@@ -11725,6 +12477,30 @@
       {
         "is_package": true,
         "loc": 3,
+        "module": "easyuse_anima.profiles",
+        "normalized_git_blob_sha1": "46d0dbee1d4ec4441a90bf6a674200e22ac90ffd",
+        "path": "easyuse_anima/profiles/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 192,
+        "module": "easyuse_anima.profiles.contract",
+        "normalized_git_blob_sha1": "ab38dd0c4df631d66a4b1ec142ce42a18f183baf",
+        "path": "easyuse_anima/profiles/contract.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 12,
+          "global_count": 7
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
         "module": "easyuse_anima.prompt",
         "normalized_git_blob_sha1": "afa59976058fdbd03ff11463234c7813b532df28",
         "path": "easyuse_anima/prompt/__init__.py",
@@ -11772,9 +12548,9 @@
       },
       {
         "is_package": false,
-        "loc": 304,
+        "loc": 308,
         "module": "storage",
-        "normalized_git_blob_sha1": "7dc248b4665db14cbd907cede619e8e8d5ff2eb6",
+        "normalized_git_blob_sha1": "e30367726feb39fb68ad7dd16c834cac5527d827",
         "path": "storage.py",
         "top_level": {
           "class_count": 1,
@@ -11988,16 +12764,246 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 60,
+            "handler_line": 72,
             "kind": "try",
-            "line": 58
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:ProfileContractError",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:build_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:create_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:interpret_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:legacy_profile_id",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:normalize_profile_filename_identity",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:rename_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 72,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.contract:update_profile_document",
+        "kind": "static_from",
+        "line": 73,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 87,
+            "kind": "try",
+            "line": 85
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 61,
+        "line": 88,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -12011,16 +13017,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 60,
+            "handler_line": 87,
             "kind": "try",
-            "line": 58
+            "line": 85
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 61,
+        "line": 88,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -14367,14 +15373,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 402
+            "line": 424
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 403,
+        "line": 425,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -14386,14 +15392,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 428
+            "line": 450
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 429,
+        "line": 451,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -14405,14 +15411,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 748
+            "line": 933
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 749,
+        "line": 934,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -15094,6 +16100,50 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "uuid",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/contract.py"
       },
       {
         "branch_context": [],
@@ -16543,14 +17593,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 402
+            "line": 424
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 403,
+        "line": 425,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -16562,14 +17612,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 428
+            "line": 450
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 429,
+        "line": 451,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -16581,14 +17631,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 748
+            "line": 933
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 749,
+        "line": 934,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -17522,6 +18572,8 @@
       "easyuse_anima/infrastructure/comfy/resources.py",
       "easyuse_anima/nodes/__init__.py",
       "easyuse_anima/nodes/image_nodes.py",
+      "easyuse_anima/profiles/__init__.py",
+      "easyuse_anima/profiles/contract.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -17557,6 +18609,8 @@
       "easyuse_anima/infrastructure/comfy/resources.py",
       "easyuse_anima/nodes/__init__.py",
       "easyuse_anima/nodes/image_nodes.py",
+      "easyuse_anima/profiles/__init__.py",
+      "easyuse_anima/profiles/contract.py",
       "easyuse_anima/prompt/__init__.py",
       "nodes.py",
       "prompt_translation.py",
@@ -17766,7 +18820,7 @@
         "column": 29,
         "context": "assign:INVALID_PROFILE_NAME_CHARS",
         "kind": "import_time_call",
-        "line": 67,
+        "line": 94,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17775,7 +18829,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 92,
+        "line": 119,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17784,7 +18838,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 93,
+        "line": 120,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17793,7 +18847,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 99,
+        "line": 126,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17802,7 +18856,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 106,
+        "line": 133,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17811,7 +18865,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 107,
+        "line": 134,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17820,7 +18874,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 156,
+        "line": 183,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17829,7 +18883,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 157,
+        "line": 184,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17838,7 +18892,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 775,
+        "line": 960,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17847,7 +18901,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 925,
+        "line": 1110,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17856,7 +18910,7 @@
         "column": 5,
         "context": "decorator:get_settings_handler",
         "kind": "route_registration",
-        "line": 930,
+        "line": 1115,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17865,7 +18919,7 @@
         "column": 5,
         "context": "decorator:set_setting_handler",
         "kind": "route_registration",
-        "line": 935,
+        "line": 1120,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17874,7 +18928,7 @@
         "column": 5,
         "context": "decorator:get_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 953,
+        "line": 1138,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17883,7 +18937,7 @@
         "column": 5,
         "context": "decorator:get_wildcards_handler",
         "kind": "route_registration",
-        "line": 960,
+        "line": 1145,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17892,7 +18946,7 @@
         "column": 5,
         "context": "decorator:save_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 965,
+        "line": 1150,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17901,7 +18955,7 @@
         "column": 5,
         "context": "decorator:autocomplete_status_handler",
         "kind": "route_registration",
-        "line": 977,
+        "line": 1162,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17910,7 +18964,7 @@
         "column": 5,
         "context": "decorator:autocomplete_handler",
         "kind": "route_registration",
-        "line": 982,
+        "line": 1167,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17919,7 +18973,7 @@
         "column": 5,
         "context": "decorator:classify_prompt_handler",
         "kind": "route_registration",
-        "line": 1000,
+        "line": 1185,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17928,7 +18982,7 @@
         "column": 5,
         "context": "decorator:translate_prompt_handler",
         "kind": "route_registration",
-        "line": 1019,
+        "line": 1204,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17937,7 +18991,7 @@
         "column": 5,
         "context": "decorator:lora_preview_handler",
         "kind": "route_registration",
-        "line": 1033,
+        "line": 1218,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17946,7 +19000,7 @@
         "column": 5,
         "context": "decorator:loras_handler",
         "kind": "route_registration",
-        "line": 1047,
+        "line": 1232,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17955,7 +19009,7 @@
         "column": 5,
         "context": "decorator:lora_profiles_handler",
         "kind": "route_registration",
-        "line": 1052,
+        "line": 1237,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17964,7 +19018,7 @@
         "column": 5,
         "context": "decorator:save_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1057,
+        "line": 1242,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17973,7 +19027,7 @@
         "column": 5,
         "context": "decorator:load_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1079,
+        "line": 1277,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17982,7 +19036,7 @@
         "column": 5,
         "context": "decorator:aio_profiles_handler",
         "kind": "route_registration",
-        "line": 1096,
+        "line": 1294,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -17991,7 +19045,7 @@
         "column": 5,
         "context": "decorator:save_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1103,
+        "line": 1301,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18000,7 +19054,7 @@
         "column": 5,
         "context": "decorator:load_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1124,
+        "line": 1335,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18009,7 +19063,7 @@
         "column": 5,
         "context": "decorator:delete_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1136,
+        "line": 1347,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18018,7 +19072,7 @@
         "column": 5,
         "context": "decorator:rename_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1150,
+        "line": 1377,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18027,7 +19081,7 @@
         "column": 5,
         "context": "decorator:fix_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1171,
+        "line": 1424,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18218,6 +19272,33 @@
         "kind": "import_time_call",
         "line": 11,
         "module": "easyuse_anima/image/detailer.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "uuid.UUID",
+        "column": 23,
+        "context": "assign:PROFILE_ID_NAMESPACE",
+        "kind": "import_time_call",
+        "line": 11,
+        "module": "easyuse_anima/profiles/contract.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 17,
+        "context": "assign:_PROFILE_KINDS",
+        "kind": "import_time_call",
+        "line": 13,
+        "module": "easyuse_anima/profiles/contract.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 19,
+        "context": "assign:_ENVELOPE_FIELDS",
+        "kind": "import_time_call",
+        "line": 14,
+        "module": "easyuse_anima/profiles/contract.py",
         "scope": "<module>"
       },
       {
@@ -18631,13 +19712,13 @@
       },
       {
         "kind": "set",
-        "line": 71,
+        "line": 98,
         "module": "api.py",
         "name": "AIO_RESERVED_PROFILE_NAMES"
       },
       {
         "kind": "set",
-        "line": 87,
+        "line": 114,
         "module": "api.py",
         "name": "WINDOWS_RESERVED_FILE_BASENAMES"
       },
@@ -18924,7 +20005,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 106,
+        "line": 133,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -18933,7 +20014,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 156,
+        "line": 183,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -2796,7 +2796,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 933
+            "line": 932
           }
         ],
         "classification": "external",
@@ -2804,7 +2804,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 934,
+        "line": 933,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -12236,9 +12236,9 @@
       },
       {
         "is_package": false,
-        "loc": 1434,
+        "loc": 1439,
         "module": "api",
-        "normalized_git_blob_sha1": "b10cde00603bd53f8f803967d8e1f932073af295",
+        "normalized_git_blob_sha1": "5a6bc68e39ef4b724baf6e55769c8ddcef9babc4",
         "path": "api.py",
         "top_level": {
           "class_count": 2,
@@ -12488,9 +12488,9 @@
       },
       {
         "is_package": false,
-        "loc": 192,
+        "loc": 187,
         "module": "easyuse_anima.profiles.contract",
-        "normalized_git_blob_sha1": "ab38dd0c4df631d66a4b1ec142ce42a18f183baf",
+        "normalized_git_blob_sha1": "133100d192bab58ae126e156e16b01b484b04d4e",
         "path": "easyuse_anima/profiles/contract.py",
         "top_level": {
           "class_count": 1,
@@ -12548,9 +12548,9 @@
       },
       {
         "is_package": false,
-        "loc": 308,
+        "loc": 351,
         "module": "storage",
-        "normalized_git_blob_sha1": "e30367726feb39fb68ad7dd16c834cac5527d827",
+        "normalized_git_blob_sha1": "4193cab56e50634eae7fd9064097a4e6c6def417",
         "path": "storage.py",
         "top_level": {
           "class_count": 1,
@@ -15411,14 +15411,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 933
+            "line": 932
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 934,
+        "line": 933,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -17631,14 +17631,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 933
+            "line": 932
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 934,
+        "line": 933,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -18892,7 +18892,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 960,
+        "line": 959,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18901,7 +18901,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 1110,
+        "line": 1109,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18910,7 +18910,7 @@
         "column": 5,
         "context": "decorator:get_settings_handler",
         "kind": "route_registration",
-        "line": 1115,
+        "line": 1114,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18919,7 +18919,7 @@
         "column": 5,
         "context": "decorator:set_setting_handler",
         "kind": "route_registration",
-        "line": 1120,
+        "line": 1119,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18928,7 +18928,7 @@
         "column": 5,
         "context": "decorator:get_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 1138,
+        "line": 1137,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18937,7 +18937,7 @@
         "column": 5,
         "context": "decorator:get_wildcards_handler",
         "kind": "route_registration",
-        "line": 1145,
+        "line": 1144,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18946,7 +18946,7 @@
         "column": 5,
         "context": "decorator:save_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 1150,
+        "line": 1149,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18955,7 +18955,7 @@
         "column": 5,
         "context": "decorator:autocomplete_status_handler",
         "kind": "route_registration",
-        "line": 1162,
+        "line": 1161,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18964,7 +18964,7 @@
         "column": 5,
         "context": "decorator:autocomplete_handler",
         "kind": "route_registration",
-        "line": 1167,
+        "line": 1166,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18973,7 +18973,7 @@
         "column": 5,
         "context": "decorator:classify_prompt_handler",
         "kind": "route_registration",
-        "line": 1185,
+        "line": 1184,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18982,7 +18982,7 @@
         "column": 5,
         "context": "decorator:translate_prompt_handler",
         "kind": "route_registration",
-        "line": 1204,
+        "line": 1203,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -18991,7 +18991,7 @@
         "column": 5,
         "context": "decorator:lora_preview_handler",
         "kind": "route_registration",
-        "line": 1218,
+        "line": 1217,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19000,7 +19000,7 @@
         "column": 5,
         "context": "decorator:loras_handler",
         "kind": "route_registration",
-        "line": 1232,
+        "line": 1231,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19009,7 +19009,7 @@
         "column": 5,
         "context": "decorator:lora_profiles_handler",
         "kind": "route_registration",
-        "line": 1237,
+        "line": 1236,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19018,7 +19018,7 @@
         "column": 5,
         "context": "decorator:save_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1242,
+        "line": 1245,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19027,7 +19027,7 @@
         "column": 5,
         "context": "decorator:load_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1277,
+        "line": 1280,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19036,7 +19036,7 @@
         "column": 5,
         "context": "decorator:aio_profiles_handler",
         "kind": "route_registration",
-        "line": 1294,
+        "line": 1297,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19045,7 +19045,7 @@
         "column": 5,
         "context": "decorator:save_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1301,
+        "line": 1306,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19054,7 +19054,7 @@
         "column": 5,
         "context": "decorator:load_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1335,
+        "line": 1340,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19063,7 +19063,7 @@
         "column": 5,
         "context": "decorator:delete_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1347,
+        "line": 1352,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19072,7 +19072,7 @@
         "column": 5,
         "context": "decorator:rename_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1377,
+        "line": 1382,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -19081,7 +19081,7 @@
         "column": 5,
         "context": "decorator:fix_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1424,
+        "line": 1429,
         "module": "api.py",
         "scope": "<module>"
       },

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -192,6 +192,34 @@ class AIOProfileStorageTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "Profile data is invalid"):
                     api._load_aio_profile("Recreated")
 
+    def test_rename_removes_source_backup_before_old_name_recreation(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "Source.json"
+            source_backup = root / "Source.json.bak"
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                api._save_aio_profile("Source", {"settings": {"value": "old"}})
+                current = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "current"}},
+                    overwrite=True,
+                )
+                renamed = api._rename_aio_profile("Source", "Renamed")
+
+                self.assertEqual(renamed["profile_id"], current["profile_id"])
+                self.assertFalse(source_backup.exists())
+
+                recreated = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "replacement"}},
+                )
+                source.write_text("{", encoding="utf-8")
+
+                with self.assertRaises(api.InvalidProfileDataError):
+                    api._load_aio_profile("Source")
+                self.assertNotEqual(recreated["profile_id"], renamed["profile_id"])
+
     def test_delete_waits_for_in_progress_write_on_same_profile_path(self):
         api = load_api_module()
         profile_storage = sys.modules[api.AtomicJsonStore.__module__]
@@ -1020,8 +1048,14 @@ class AIOProfileStorageTests(unittest.TestCase):
             real_replace = profile_storage.os.replace
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+                api._save_aio_profile("Source", {"settings": {"value": "old source"}})
+                api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "source"}},
+                    overwrite=True,
+                )
                 api._save_aio_profile("Target", {"settings": {"value": "target"}})
+                source_backup_bytes = (root / "Source.json.bak").read_bytes()
 
                 def fail_move(current, destination):
                     if Path(current) == source and Path(destination) == target:
@@ -1034,8 +1068,11 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 self.assertEqual(api._load_aio_profile("Source")["settings"]["value"], "source")
                 self.assertEqual(api._load_aio_profile("Target")["settings"]["value"], "target")
-                backup = json.loads((root / "Target.json.bak").read_text(encoding="utf-8"))
-                self.assertEqual(backup["settings"]["value"], "target")
+                self.assertEqual(
+                    (root / "Source.json.bak").read_bytes(),
+                    source_backup_bytes,
+                )
+                self.assertFalse((root / "Target.json.bak").exists())
                 self.assertEqual([path for path in root.iterdir() if path.name.endswith(".tmp")], [])
 
     def test_rename_target_backup_failure_preserves_source_and_target(self):

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -256,7 +256,165 @@ class AIOProfileStorageTests(unittest.TestCase):
                 self.assertFalse(profile_path.exists())
                 self.assertFalse((root / "Concurrent Delete.json.bak").exists())
 
-    def test_delete_waits_for_in_progress_rename_on_target_profile_path(self):
+    def test_delete_metadata_snapshot_and_delete_share_one_path_lock(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_path = (root / "Snapshot.json").resolve()
+            metadata_ready = threading.Event()
+            release_metadata = threading.Event()
+            overwrite_started = threading.Event()
+            errors: list[BaseException] = []
+            deleted: list[dict] = []
+            overwritten: list[dict] = []
+            real_interpret = api.interpret_profile_document
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                original = api._save_aio_profile(
+                    "Snapshot",
+                    {"settings": {"value": "original"}},
+                )
+
+                def block_after_metadata_read(profile_kind, filename, document):
+                    result = real_interpret(profile_kind, filename, document)
+                    if filename == "Snapshot":
+                        metadata_ready.set()
+                        if not release_metadata.wait(2):
+                            raise AssertionError("delete metadata read was not released")
+                    return result
+
+                def delete_profile():
+                    try:
+                        deleted.append(api._delete_aio_profile("Snapshot"))
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                def overwrite_profile():
+                    overwrite_started.set()
+                    try:
+                        overwritten.append(
+                            api._save_aio_profile(
+                                "Snapshot",
+                                {"settings": {"value": "replacement"}},
+                                overwrite=True,
+                            )
+                        )
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                with patch.object(
+                    api,
+                    "interpret_profile_document",
+                    side_effect=block_after_metadata_read,
+                ):
+                    deleter = threading.Thread(target=delete_profile)
+                    overwriter = threading.Thread(target=overwrite_profile)
+                    deleter.start()
+                    self.assertTrue(metadata_ready.wait(2))
+                    path_lock = profile_storage._path_lock(profile_path)
+                    lock_was_available = path_lock.acquire(blocking=False)
+                    if lock_was_available:
+                        path_lock.release()
+                    overwriter.start()
+                    self.assertTrue(overwrite_started.wait(2))
+                    release_metadata.set()
+                    deleter.join(2)
+                    overwriter.join(2)
+
+                self.assertFalse(deleter.is_alive())
+                self.assertFalse(overwriter.is_alive())
+                self.assertFalse(lock_was_available)
+                self.assertEqual(errors, [])
+                self.assertEqual(deleted[0]["profile_id"], original["profile_id"])
+                self.assertEqual(deleted[0]["revision"], original["revision"])
+                self.assertNotEqual(overwritten[0]["profile_id"], original["profile_id"])
+                self.assertEqual(overwritten[0]["revision"], 1)
+                self.assertEqual(
+                    api._load_aio_profile("Snapshot")["settings"]["value"],
+                    "replacement",
+                )
+
+    def test_same_name_rename_serializes_transform_and_publish_with_overwrite(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_path = (root / "Same.json").resolve()
+            transform_ready = threading.Event()
+            release_transform = threading.Event()
+            overwrite_started = threading.Event()
+            errors: list[BaseException] = []
+            renamed_profiles: list[dict] = []
+            overwritten_profiles: list[dict] = []
+            real_rename_payload = api._rename_aio_profile_payload
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                profile_path.write_text(
+                    json.dumps({"version": 1, "settings": {"value": "legacy"}}),
+                    encoding="utf-8",
+                )
+                legacy_id = api.legacy_profile_id(api.PROFILE_KIND_AIO, "Same")
+
+                def block_after_transform(source_name, target_name, data):
+                    result = real_rename_payload(source_name, target_name, data)
+                    transform_ready.set()
+                    if not release_transform.wait(2):
+                        raise AssertionError("same-name transform was not released")
+                    return result
+
+                def rename_same_name():
+                    try:
+                        renamed_profiles.append(api._rename_aio_profile("Same", "Same"))
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                def overwrite_profile():
+                    overwrite_started.set()
+                    try:
+                        overwritten_profiles.append(
+                            api._save_aio_profile(
+                                "Same",
+                                {"settings": {"value": "replacement"}},
+                                overwrite=True,
+                            )
+                        )
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                with patch.object(
+                    api,
+                    "_rename_aio_profile_payload",
+                    side_effect=block_after_transform,
+                ):
+                    renamer = threading.Thread(target=rename_same_name)
+                    overwriter = threading.Thread(target=overwrite_profile)
+                    renamer.start()
+                    self.assertTrue(transform_ready.wait(2))
+                    path_lock = profile_storage._path_lock(profile_path)
+                    lock_was_available = path_lock.acquire(blocking=False)
+                    if lock_was_available:
+                        path_lock.release()
+                    overwriter.start()
+                    self.assertTrue(overwrite_started.wait(2))
+                    release_transform.set()
+                    renamer.join(2)
+                    overwriter.join(2)
+
+                self.assertFalse(renamer.is_alive())
+                self.assertFalse(overwriter.is_alive())
+                self.assertFalse(lock_was_available)
+                self.assertEqual(errors, [])
+                self.assertEqual(renamed_profiles[0]["profile_id"], legacy_id)
+                self.assertEqual(renamed_profiles[0]["revision"], 0)
+                self.assertEqual(overwritten_profiles[0]["profile_id"], legacy_id)
+                self.assertEqual(overwritten_profiles[0]["revision"], 1)
+                self.assertEqual(
+                    api._load_aio_profile("Same")["settings"]["value"],
+                    "replacement",
+                )
+
+    def test_reader_observes_transformed_rename_before_joint_lock_release(self):
         api = load_api_module()
         profile_storage = sys.modules[api.AtomicJsonStore.__module__]
         with tempfile.TemporaryDirectory() as tmp:
@@ -265,21 +423,147 @@ class AIOProfileStorageTests(unittest.TestCase):
             target = (root / "Target.json").resolve()
             move_ready = threading.Event()
             release_move = threading.Event()
-            delete_started = threading.Event()
-            delete_done = threading.Event()
+            transaction_done = threading.Event()
+            release_api_return = threading.Event()
+            reader_started = threading.Event()
+            reader_done = threading.Event()
             errors: list[BaseException] = []
+            renamed_profiles: list[dict] = []
+            loaded_profiles: list[dict] = []
+            listed_profiles: list[dict] = []
             real_replace = profile_storage.os.replace
+            real_replace_from = api.AtomicJsonStore.replace_from
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+                source.write_text(
+                    json.dumps({"version": 1, "settings": {"value": "source"}}),
+                    encoding="utf-8",
+                )
+                source_profile_id = api.legacy_profile_id(api.PROFILE_KIND_AIO, "Source")
                 api._save_aio_profile("Target", {"settings": {"value": "target"}})
+                target_bytes = target.read_bytes()
 
-                def block_profile_move(current, destination):
+                def block_after_source_move(current, destination):
+                    result = real_replace(current, destination)
                     if Path(current) == source and Path(destination) == target:
                         move_ready.set()
                         if not release_move.wait(2):
                             raise AssertionError("profile move was not released")
-                    return real_replace(current, destination)
+                    return result
+
+                def pause_after_transaction(store, source_store, *args, **kwargs):
+                    result = real_replace_from(store, source_store, *args, **kwargs)
+                    transaction_done.set()
+                    if not release_api_return.wait(2):
+                        raise AssertionError("rename return was not released")
+                    return result
+
+                def rename_profile():
+                    try:
+                        renamed_profiles.append(
+                            api._rename_aio_profile("Source", "Target", overwrite=True)
+                        )
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                def load_target():
+                    reader_started.set()
+                    try:
+                        loaded_profiles.append(api._load_aio_profile("Target"))
+                        listed_profiles.append(
+                            next(
+                                profile
+                                for profile in api._list_aio_profiles()
+                                if profile["name"] == "Target"
+                            )
+                        )
+                    except BaseException as exc:
+                        errors.append(exc)
+                    finally:
+                        reader_done.set()
+
+                with (
+                    patch.object(
+                        profile_storage.os,
+                        "replace",
+                        side_effect=block_after_source_move,
+                    ),
+                    patch.object(
+                        api.AtomicJsonStore,
+                        "replace_from",
+                        autospec=True,
+                        side_effect=pause_after_transaction,
+                    ),
+                ):
+                    renamer = threading.Thread(target=rename_profile)
+                    reader = threading.Thread(target=load_target)
+                    renamer.start()
+                    self.assertTrue(move_ready.wait(2))
+                    reader.start()
+                    self.assertTrue(reader_started.wait(2))
+                    self.assertFalse(reader_done.wait(0.05))
+                    release_move.set()
+                    self.assertTrue(transaction_done.wait(2))
+                    self.assertTrue(reader_done.wait(2))
+                    release_api_return.set()
+                    renamer.join(2)
+                    reader.join(2)
+
+                self.assertFalse(renamer.is_alive())
+                self.assertFalse(reader.is_alive())
+                self.assertEqual(errors, [])
+                self.assertEqual(loaded_profiles, renamed_profiles)
+                self.assertEqual(loaded_profiles[0]["profile_id"], source_profile_id)
+                self.assertEqual(loaded_profiles[0]["revision"], 0)
+                self.assertEqual(loaded_profiles[0]["name"], "Target")
+                self.assertEqual(listed_profiles[0]["profile_id"], source_profile_id)
+                self.assertEqual(listed_profiles[0]["revision"], 0)
+                self.assertEqual(
+                    json.loads(target.read_text(encoding="utf-8")),
+                    renamed_profiles[0],
+                )
+                self.assertFalse(source.exists())
+                self.assertEqual((root / "Target.json.bak").read_bytes(), target_bytes)
+
+    def test_delete_cannot_enter_rename_transaction_or_be_undone_after_return(self):
+        api = load_api_module()
+        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = (root / "Source.json").resolve()
+            target = (root / "Target.json").resolve()
+            move_ready = threading.Event()
+            release_move = threading.Event()
+            transaction_done = threading.Event()
+            release_api_return = threading.Event()
+            delete_started = threading.Event()
+            delete_done = threading.Event()
+            errors: list[BaseException] = []
+            deleted: list[dict] = []
+            real_replace = profile_storage.os.replace
+            real_replace_from = api.AtomicJsonStore.replace_from
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                source_profile = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "source"}},
+                )
+                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+
+                def block_after_profile_move(current, destination):
+                    result = real_replace(current, destination)
+                    if Path(current) == source and Path(destination) == target:
+                        move_ready.set()
+                        if not release_move.wait(2):
+                            raise AssertionError("profile move was not released")
+                    return result
+
+                def pause_after_transaction(store, source_store, *args, **kwargs):
+                    result = real_replace_from(store, source_store, *args, **kwargs)
+                    transaction_done.set()
+                    if not release_api_return.wait(2):
+                        raise AssertionError("rename return was not released")
+                    return result
 
                 def rename_profile():
                     try:
@@ -290,13 +574,25 @@ class AIOProfileStorageTests(unittest.TestCase):
                 def delete_target():
                     delete_started.set()
                     try:
-                        api._delete_aio_profile("Target")
+                        deleted.append(api._delete_aio_profile("Target"))
                     except BaseException as exc:
                         errors.append(exc)
                     finally:
                         delete_done.set()
 
-                with patch.object(profile_storage.os, "replace", side_effect=block_profile_move):
+                with (
+                    patch.object(
+                        profile_storage.os,
+                        "replace",
+                        side_effect=block_after_profile_move,
+                    ),
+                    patch.object(
+                        api.AtomicJsonStore,
+                        "replace_from",
+                        autospec=True,
+                        side_effect=pause_after_transaction,
+                    ),
+                ):
                     renamer = threading.Thread(target=rename_profile)
                     deleter = threading.Thread(target=delete_target)
                     renamer.start()
@@ -305,12 +601,17 @@ class AIOProfileStorageTests(unittest.TestCase):
                     self.assertTrue(delete_started.wait(2))
                     self.assertFalse(delete_done.wait(0.05))
                     release_move.set()
+                    self.assertTrue(transaction_done.wait(2))
+                    self.assertTrue(delete_done.wait(2))
+                    release_api_return.set()
                     renamer.join(2)
                     deleter.join(2)
 
                 self.assertFalse(renamer.is_alive())
                 self.assertFalse(deleter.is_alive())
                 self.assertEqual(errors, [])
+                self.assertEqual(deleted[0]["profile_id"], source_profile["profile_id"])
+                self.assertEqual(deleted[0]["revision"], source_profile["revision"])
                 self.assertFalse(source.exists())
                 self.assertFalse(target.exists())
                 self.assertFalse((root / "Target.json.bak").exists())
@@ -397,6 +698,29 @@ class AIOProfileStorageTests(unittest.TestCase):
                 self.assertEqual((broken.read_bytes(), broken.stat().st_mtime_ns), before)
                 with self.assertRaisesRegex(ValueError, "Profile data is invalid"):
                     api._load_aio_profile("Broken")
+
+    def test_incomplete_v2_delete_is_rejected_without_mutating_the_file(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile = root / "Incomplete.json"
+            profile.write_text(
+                json.dumps(
+                    {
+                        "version": 2,
+                        "name": "Incomplete",
+                        "settings": {"value": "preserved"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            before = profile.read_bytes()
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                with self.assertRaises(api.InvalidProfileDataError):
+                    api._delete_aio_profile("Incomplete")
+
+            self.assertEqual(profile.read_bytes(), before)
 
     def test_empty_profile_preserves_legacy_payload_validation_contract(self):
         api = load_api_module()

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -11,6 +11,7 @@ import textwrap
 import threading
 import types
 import unittest
+import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -90,22 +91,33 @@ class AIOProfileStorageTests(unittest.TestCase):
                     },
                 )
                 self.assertEqual(saved["name"], "My_ Profile")
+                self.assertEqual(saved["version"], 2)
+                self.assertEqual(saved["revision"], 1)
+                self.assertEqual(uuid.UUID(saved["profile_id"]).version, 4)
                 self.assertTrue((Path(tmp) / "My_ Profile.json").is_file())
-                self.assertEqual(
-                    [profile["name"] for profile in api._list_aio_profiles()],
-                    ["My_ Profile"],
-                )
+                profiles = api._list_aio_profiles()
+                self.assertEqual([profile["name"] for profile in profiles], ["My_ Profile"])
+                self.assertEqual(profiles[0]["profile_id"], saved["profile_id"])
+                self.assertEqual(profiles[0]["revision"], 1)
                 self.assertTrue(
                     api._load_aio_profile("my_ profile")["settings"]["future_section"]["kept"]
                 )
 
                 renamed = api._rename_aio_profile("My_ Profile", "Production")
                 self.assertEqual(renamed["name"], "Production")
+                self.assertEqual(renamed["profile_id"], saved["profile_id"])
+                self.assertEqual(renamed["revision"], 1)
                 self.assertFalse((Path(tmp) / "My_ Profile.json").exists())
                 self.assertTrue((Path(tmp) / "Production.json").is_file())
+                self.assertEqual(
+                    json.loads((Path(tmp) / "Production.json").read_text(encoding="utf-8")),
+                    renamed,
+                )
 
                 deleted = api._delete_aio_profile("production")
                 self.assertEqual(deleted["name"], "Production")
+                self.assertEqual(deleted["profile_id"], saved["profile_id"])
+                self.assertEqual(deleted["revision"], 1)
                 self.assertEqual(api._list_aio_profiles(), [])
 
     def test_delete_removes_profile_primary_and_backup(self):
@@ -238,7 +250,9 @@ class AIOProfileStorageTests(unittest.TestCase):
                 self.assertFalse(writer.is_alive())
                 self.assertFalse(deleter.is_alive())
                 self.assertEqual(errors, [])
-                self.assertEqual(deleted, [{"name": "Concurrent Delete"}])
+                self.assertEqual(deleted[0]["name"], "Concurrent Delete")
+                self.assertIn("profile_id", deleted[0])
+                self.assertEqual(deleted[0]["revision"], 2)
                 self.assertFalse(profile_path.exists())
                 self.assertFalse((root / "Concurrent Delete.json.bak").exists())
 
@@ -373,7 +387,14 @@ class AIOProfileStorageTests(unittest.TestCase):
         api = load_api_module()
         with tempfile.TemporaryDirectory() as tmp:
             with patch.object(api, "AIO_PROFILE_DIR", Path(tmp)):
-                (Path(tmp) / "Broken.json").write_text("{", encoding="utf-8")
+                broken = Path(tmp) / "Broken.json"
+                broken.write_text("{", encoding="utf-8")
+                before = (broken.read_bytes(), broken.stat().st_mtime_ns)
+
+                listed = api._list_aio_profiles()
+                self.assertEqual(listed[0]["name"], "Broken")
+                self.assertEqual(listed[0]["revision"], 0)
+                self.assertEqual((broken.read_bytes(), broken.stat().st_mtime_ns), before)
                 with self.assertRaisesRegex(ValueError, "Profile data is invalid"):
                     api._load_aio_profile("Broken")
 
@@ -386,6 +407,103 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 with self.assertRaisesRegex(ValueError, "Profile settings must be an object"):
                     api._load_aio_profile("Empty")
+
+    def test_legacy_near_limit_profile_remains_loadable_after_additive_view(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stored = {
+                "version": 1,
+                "name": "Near Limit",
+                "settings": {"blob": "x" * 32},
+            }
+            legacy_payload = api._normalize_aio_profile_payload("Near Limit", stored)
+            legacy_size = len(
+                json.dumps(legacy_payload, ensure_ascii=False, indent=2).encode("utf-8")
+            )
+            (root / "Near Limit.json").write_text(
+                json.dumps(stored, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(api, "AIO_PROFILE_DIR", root),
+                patch.object(api, "MAX_AIO_PROFILE_BYTES", legacy_size),
+            ):
+                loaded = api._load_aio_profile("Near Limit")
+
+            additive_size = len(
+                json.dumps(loaded, ensure_ascii=False, indent=2).encode("utf-8")
+            )
+            self.assertGreater(additive_size, legacy_size)
+            self.assertEqual(loaded["settings"]["blob"], "x" * 32)
+            self.assertEqual(loaded["revision"], 0)
+
+    def test_legacy_list_and_load_are_pure_and_overwrite_promotes_to_v2(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            primary = root / "Legacy.json"
+            backup = root / "Legacy.json.bak"
+            primary.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "name": "Legacy",
+                        "settings": {"future_section": {"kept": True}},
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            backup.write_text('{"sentinel":true}', encoding="utf-8")
+            primary_before = (primary.read_bytes(), primary.stat().st_mtime_ns)
+            backup_before = (backup.read_bytes(), backup.stat().st_mtime_ns)
+
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                listed = api._list_aio_profiles()[0]
+                loaded = api._load_aio_profile("legacy")
+
+                self.assertEqual(listed["profile_id"], loaded["profile_id"])
+                self.assertEqual(listed["revision"], 0)
+                self.assertTrue(loaded["settings"]["future_section"]["kept"])
+                self.assertEqual(
+                    (primary.read_bytes(), primary.stat().st_mtime_ns),
+                    primary_before,
+                )
+                self.assertEqual(
+                    (backup.read_bytes(), backup.stat().st_mtime_ns),
+                    backup_before,
+                )
+
+                promoted = api._save_aio_profile(
+                    "Legacy",
+                    {"settings": {"future_section": {"kept": "updated"}}},
+                    overwrite=True,
+                    profile_id="00000000-0000-4000-8000-000000000000",
+                    revision=999,
+                )
+
+            self.assertEqual(promoted["profile_id"], listed["profile_id"])
+            self.assertEqual(promoted["revision"], 1)
+            self.assertEqual(json.loads(primary.read_text(encoding="utf-8")), promoted)
+
+    def test_v2_overwrite_preserves_id_and_advances_revision_without_strict_token(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(api, "AIO_PROFILE_DIR", Path(tmp)):
+                created = api._save_aio_profile("Updated", {"settings": {"value": 1}})
+                updated = api._save_aio_profile(
+                    "Updated",
+                    {"settings": {"value": 2}},
+                    overwrite=True,
+                    profile_id="00000000-0000-4000-8000-000000000000",
+                    revision=0,
+                )
+
+        self.assertEqual(updated["profile_id"], created["profile_id"])
+        self.assertEqual(updated["revision"], 2)
+        self.assertEqual(updated["settings"]["value"], 2)
 
     def test_invalid_primary_recovers_last_valid_backup(self):
         api = load_api_module()
@@ -526,6 +644,48 @@ class AIOProfileStorageTests(unittest.TestCase):
                 self.assertEqual(backup["settings"]["value"], "target")
                 self.assertFalse((root / "Source.json").exists())
 
+    def test_legacy_rename_writes_v2_source_identity_and_discards_target_id(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "Source.json"
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                source.write_text(
+                    json.dumps(
+                        {
+                            "version": 1,
+                            "name": "Source",
+                            "settings": {"future_section": {"kept": True}},
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                source_id = api.legacy_profile_id(api.PROFILE_KIND_AIO, "Source")
+                target = api._save_aio_profile("Target", {"settings": {"value": "target"}})
+
+                renamed = api._rename_aio_profile(
+                    "Source",
+                    "Target",
+                    overwrite=True,
+                    profile_id="00000000-0000-4000-8000-000000000000",
+                    revision=99,
+                    target_profile_id=target["profile_id"],
+                    target_revision=target["revision"],
+                )
+
+            stored = json.loads((root / "Target.json").read_text(encoding="utf-8"))
+            target_backup = json.loads(
+                (root / "Target.json.bak").read_text(encoding="utf-8")
+            )
+            self.assertEqual(renamed["version"], 2)
+            self.assertEqual(renamed["profile_id"], source_id)
+            self.assertNotEqual(renamed["profile_id"], target["profile_id"])
+            self.assertEqual(renamed["revision"], 0)
+            self.assertEqual(renamed["name"], "Target")
+            self.assertTrue(renamed["settings"]["future_section"]["kept"])
+            self.assertEqual(stored, renamed)
+            self.assertEqual(target_backup["profile_id"], target["profile_id"])
+
     def test_rename_move_failure_preserves_source_target_and_backup(self):
         api = load_api_module()
         profile_storage = sys.modules[api.AtomicJsonStore.__module__]
@@ -648,6 +808,115 @@ class AIOProfileApiRouteTests(unittest.TestCase):
                         "overwrite must be a JSON boolean.",
                     )
                     operation.assert_not_called()
+
+    def test_optional_concurrency_tokens_are_typed_and_forwarded_without_enforcement(self):
+        api, routes = load_api_routes()
+        source_id = "12345678-1234-4234-9234-1234567890AB"
+        target_id = "22345678-1234-4234-9234-1234567890AB"
+        cases = (
+            (
+                "/easyuse_anima/aio_profiles/save",
+                {
+                    "name": "Saved",
+                    "settings": {},
+                    "profile_id": source_id,
+                    "revision": 7,
+                },
+                "_save_aio_profile",
+                {
+                    "profile_id": source_id.lower(),
+                    "revision": 7,
+                },
+            ),
+            (
+                "/easyuse_anima/aio_profiles/delete",
+                {"name": "Saved", "profile_id": source_id, "revision": 7},
+                "_delete_aio_profile",
+                {
+                    "profile_id": source_id.lower(),
+                    "revision": 7,
+                },
+            ),
+            (
+                "/easyuse_anima/aio_profiles/rename",
+                {
+                    "old_name": "Old",
+                    "new_name": "Renamed",
+                    "profile_id": source_id,
+                    "revision": 7,
+                    "target_profile_id": target_id,
+                    "target_revision": 11,
+                },
+                "_rename_aio_profile",
+                {
+                    "profile_id": source_id.lower(),
+                    "revision": 7,
+                    "target_profile_id": target_id.lower(),
+                    "target_revision": 11,
+                },
+            ),
+        )
+
+        for path, payload, operation_name, expected in cases:
+            with self.subTest(path=path), patch.object(
+                api,
+                operation_name,
+                return_value={"name": "Saved"},
+            ) as operation:
+                response = asyncio.run(routes.handlers[path](JsonRequest(payload)))
+
+                self.assertEqual(response["status"], 200)
+                for field, value in expected.items():
+                    self.assertEqual(operation.call_args.kwargs[field], value)
+
+    def test_optional_concurrency_tokens_reject_invalid_json_types(self):
+        api, routes = load_api_routes()
+        cases = (
+            (
+                "/easyuse_anima/aio_profiles/save",
+                {"name": "Saved", "settings": {}, "profile_id": "not-a-uuid"},
+                "_save_aio_profile",
+                "profile_id",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/delete",
+                {"name": "Saved", "revision": True},
+                "_delete_aio_profile",
+                "revision",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/rename",
+                {
+                    "old_name": "Old",
+                    "new_name": "Renamed",
+                    "target_profile_id": 3,
+                },
+                "_rename_aio_profile",
+                "target_profile_id",
+            ),
+            (
+                "/easyuse_anima/aio_profiles/rename",
+                {
+                    "old_name": "Old",
+                    "new_name": "Renamed",
+                    "target_revision": -1,
+                },
+                "_rename_aio_profile",
+                "target_revision",
+            ),
+        )
+
+        for path, payload, operation_name, field in cases:
+            with self.subTest(path=path, field=field), patch.object(
+                api,
+                operation_name,
+            ) as operation:
+                response = asyncio.run(routes.handlers[path](JsonRequest(payload)))
+
+                self.assertEqual(response["status"], 422)
+                self.assertEqual(response["payload"]["code"], "invalid_request")
+                self.assertEqual(response["payload"]["details"], {"field": field})
+                operation.assert_not_called()
 
     def test_profile_conflicts_use_existing_error_json_shape_with_409_status(self):
         api, routes = load_api_routes()

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -539,6 +539,45 @@ class ApiRequestContractTests(unittest.TestCase):
                         "Profile data is invalid",
                     )
 
+    def test_invalid_profile_version_taxonomy_keeps_422_and_request_id_contract(self):
+        api, routes = load_api_routes()
+        request_id = "52345678-1234-4567-89ab-1234567890ab"
+        cases = (
+            (
+                "/easyuse_anima/lora_profiles/load",
+                "LORA_PROFILE_DIR",
+                {"version": True, "profile_data": {}},
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                "AIO_PROFILE_DIR",
+                {"version": 2.0, "settings": {}},
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for route, directory_name, stored in cases:
+                with self.subTest(route=route):
+                    (root / "InvalidVersion.json").write_text(
+                        json.dumps(stored),
+                        encoding="utf-8",
+                    )
+                    with (
+                        patch.object(api, directory_name, root),
+                        patch.object(api, "create_request_id", return_value=request_id),
+                    ):
+                        response = asyncio.run(
+                            routes.handlers[route](
+                                JsonRequest(query={"name": "InvalidVersion"})
+                            )
+                        )
+
+                    self.assertEqual(response["status"], 422)
+                    self.assertEqual(response["payload"]["code"], "invalid_profile_data")
+                    self.assertEqual(response["payload"]["request_id"], request_id)
+                    self.assertEqual(response.headers["X-Request-ID"], request_id)
+
     def test_invalid_utf8_profile_files_have_stable_redacted_422_code(self):
         api, routes = load_api_routes()
         cases = (

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -539,7 +539,7 @@ class ApiRequestContractTests(unittest.TestCase):
                         "Profile data is invalid",
                     )
 
-    def test_invalid_profile_version_taxonomy_keeps_422_and_request_id_contract(self):
+    def test_invalid_profile_envelope_taxonomy_keeps_422_and_request_id_contract(self):
         api, routes = load_api_routes()
         request_id = "52345678-1234-4567-89ab-1234567890ab"
         cases = (
@@ -552,6 +552,30 @@ class ApiRequestContractTests(unittest.TestCase):
                 "/easyuse_anima/aio_profiles/load",
                 "AIO_PROFILE_DIR",
                 {"version": 2.0, "settings": {}},
+            ),
+            (
+                "/easyuse_anima/lora_profiles/load",
+                "LORA_PROFILE_DIR",
+                {
+                    "version": 2,
+                    "profile_id": "12345678-1234-4234-9234-1234567890ab",
+                    "profile_data": {},
+                },
+            ),
+            (
+                "/easyuse_anima/aio_profiles/load",
+                "AIO_PROFILE_DIR",
+                {"version": 2, "name": "Incomplete", "settings": {}},
+            ),
+            (
+                "/easyuse_anima/lora_profiles",
+                "LORA_PROFILE_DIR",
+                {"version": 2, "revision": 1, "profile_data": {}},
+            ),
+            (
+                "/easyuse_anima/aio_profiles",
+                "AIO_PROFILE_DIR",
+                {"version": 2, "revision": 1, "settings": {}},
             ),
         )
 
@@ -747,6 +771,30 @@ class ApiRequestContractTests(unittest.TestCase):
             response.headers["X-Request-ID"],
         )
         log_exception.assert_called_once()
+
+    def test_profile_list_does_not_mask_arbitrary_value_error_as_invalid_request(self):
+        api, routes = load_api_routes()
+        cases = (
+            ("/easyuse_anima/lora_profiles", "_list_lora_profiles"),
+            ("/easyuse_anima/aio_profiles", "_list_aio_profiles"),
+        )
+
+        for route, operation_name in cases:
+            with (
+                self.subTest(route=route),
+                patch.object(
+                    api,
+                    operation_name,
+                    side_effect=ValueError("storage programming error"),
+                ),
+                patch.object(api._LOGGER, "exception") as log_exception,
+            ):
+                response = asyncio.run(routes.handlers[route](JsonRequest()))
+
+            self.assertEqual(response["status"], 500)
+            self.assertEqual(response["payload"]["code"], "internal_error")
+            self.assertNotEqual(response["payload"]["code"], "invalid_request")
+            log_exception.assert_called_once()
 
     def test_normal_settings_and_profile_success_payloads_remain_compatible(self):
         api, routes = load_api_routes()

--- a/tests/test_lora_profiles.py
+++ b/tests/test_lora_profiles.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import types
 import unittest
+import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -102,13 +103,20 @@ class LoraProfileStorageTests(unittest.TestCase):
                 self.assertEqual(saved["name"], "style_preset")
                 self.assertEqual(saved["profile_count"], 2)
                 self.assertEqual(saved["profile_index"], 1)
+                self.assertEqual(saved["version"], 2)
+                self.assertEqual(saved["revision"], 1)
+                self.assertEqual(uuid.UUID(saved["profile_id"]).version, 4)
                 self.assertNotIn("name", saved["profile_data"]["1"])
                 self.assertTrue((Path(tmp) / "style_preset.json").is_file())
 
                 profiles = api._list_lora_profiles()
                 self.assertEqual([profile["name"] for profile in profiles], ["style_preset"])
+                self.assertEqual(profiles[0]["profile_id"], saved["profile_id"])
+                self.assertEqual(profiles[0]["revision"], 1)
 
                 loaded = api._load_lora_profile("style_preset")
+                self.assertEqual(loaded["profile_id"], saved["profile_id"])
+                self.assertEqual(loaded["revision"], 1)
                 self.assertEqual(loaded["profile_data"]["2"]["style_prompt"], "@b")
                 self.assertEqual(loaded["profile_data"]["2"]["loras"][0]["name"], "foo.safetensors")
 
@@ -140,6 +148,14 @@ class LoraProfileStorageTests(unittest.TestCase):
             with patch.object(api, "LORA_PROFILE_DIR", root):
                 (root / "Broken.json").write_text("{", encoding="utf-8")
                 (root / "Broken.json.bak").write_text("[", encoding="utf-8")
+                primary_before = (root / "Broken.json").read_bytes()
+                backup_before = (root / "Broken.json.bak").read_bytes()
+
+                listed = api._list_lora_profiles()
+                self.assertEqual(listed[0]["name"], "Broken")
+                self.assertEqual(listed[0]["revision"], 0)
+                self.assertEqual((root / "Broken.json").read_bytes(), primary_before)
+                self.assertEqual((root / "Broken.json.bak").read_bytes(), backup_before)
 
                 with self.assertRaises(json.JSONDecodeError):
                     api._load_lora_profile("Broken")
@@ -156,6 +172,80 @@ class LoraProfileStorageTests(unittest.TestCase):
         self.assertEqual(loaded["name"], "Empty")
         self.assertEqual(loaded["profile_count"], 1)
         self.assertEqual(loaded["profile_data"], {})
+        self.assertEqual(loaded["revision"], 0)
+
+    def test_legacy_list_and_load_are_pure_and_overwrite_promotes_to_v2(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            primary = root / "Legacy.json"
+            backup = root / "Legacy.json.bak"
+            primary.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "profile_count": 1,
+                        "profile_index": 1,
+                        "profile_data": json.dumps(
+                            {"1": {"style_prompt": "legacy", "loras": []}}
+                        ),
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            backup.write_text('{"sentinel":true}', encoding="utf-8")
+            primary_before = (primary.read_bytes(), primary.stat().st_mtime_ns)
+            backup_before = (backup.read_bytes(), backup.stat().st_mtime_ns)
+
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                listed = api._list_lora_profiles()[0]
+                loaded = api._load_lora_profile("legacy")
+
+                self.assertEqual(listed["profile_id"], loaded["profile_id"])
+                self.assertEqual(listed["revision"], 0)
+                self.assertEqual(loaded["profile_data"]["1"]["style_prompt"], "legacy")
+                self.assertEqual(
+                    (primary.read_bytes(), primary.stat().st_mtime_ns),
+                    primary_before,
+                )
+                self.assertEqual(
+                    (backup.read_bytes(), backup.stat().st_mtime_ns),
+                    backup_before,
+                )
+
+                promoted = api._save_lora_profile(
+                    "Legacy",
+                    {"profile_data": {"1": {"style_prompt": "updated"}}},
+                    overwrite=True,
+                    profile_id="00000000-0000-4000-8000-000000000000",
+                    revision=999,
+                )
+
+            stored = json.loads(primary.read_text(encoding="utf-8"))
+            self.assertEqual(promoted["profile_id"], listed["profile_id"])
+            self.assertEqual(promoted["revision"], 1)
+            self.assertEqual(stored, promoted)
+
+    def test_v2_overwrite_preserves_id_and_advances_revision_without_strict_token(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(api, "LORA_PROFILE_DIR", Path(tmp)):
+                created = api._save_lora_profile(
+                    "Updated",
+                    {"profile_data": {"1": {"style_prompt": "first"}}},
+                )
+                updated = api._save_lora_profile(
+                    "Updated",
+                    {"profile_data": {"1": {"style_prompt": "second"}}},
+                    overwrite=True,
+                    profile_id="00000000-0000-4000-8000-000000000000",
+                    revision=0,
+                )
+
+        self.assertEqual(updated["profile_id"], created["profile_id"])
+        self.assertEqual(updated["revision"], 2)
+        self.assertEqual(updated["profile_data"]["1"]["style_prompt"], "second")
 
     def test_filename_identity_collisions_require_explicit_overwrite(self):
         api = load_api_module()
@@ -429,6 +519,42 @@ class LoraProfileApiRouteTests(unittest.TestCase):
                     },
                 )
                 operation.assert_not_called()
+
+    def test_optional_concurrency_tokens_are_typed_and_forwarded(self):
+        api, routes = load_api_routes()
+        handler = routes.handlers[self.PATH]
+        profile_id = "12345678-1234-4234-9234-1234567890AB"
+
+        with patch.object(
+            api,
+            "_save_lora_profile",
+            return_value={"name": "Saved"},
+        ) as operation:
+            response = asyncio.run(
+                handler(
+                    JsonRequest(
+                        {
+                            **self.BASE_PAYLOAD,
+                            "profile_id": profile_id,
+                            "revision": 8,
+                        }
+                    )
+                )
+            )
+
+        self.assertEqual(response["status"], 200)
+        self.assertEqual(operation.call_args.kwargs["profile_id"], profile_id.lower())
+        self.assertEqual(operation.call_args.kwargs["revision"], 8)
+
+        for field, value in (("profile_id", "bad"), ("revision", False)):
+            with self.subTest(field=field), patch.object(api, "_save_lora_profile") as operation:
+                response = asyncio.run(
+                    handler(JsonRequest({**self.BASE_PAYLOAD, field: value}))
+                )
+
+            self.assertEqual(response["status"], 422)
+            self.assertEqual(response["payload"]["details"], {"field": field})
+            operation.assert_not_called()
 
     def test_profile_conflict_uses_existing_error_json_shape_with_409_status(self):
         api, routes = load_api_routes()

--- a/tests/test_profile_contract.py
+++ b/tests/test_profile_contract.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import unittest
+import uuid
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from easyuse_anima.profiles import contract
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProfileContractTests(unittest.TestCase):
+    def test_create_uses_uuid4_revision_one_and_preserves_payload(self):
+        profile_id = uuid.UUID("12345678-1234-4234-9234-1234567890ab")
+
+        with patch.object(contract.uuid, "uuid4", return_value=profile_id):
+            document = contract.create_profile_document(
+                contract.PROFILE_KIND_AIO,
+                "Display",
+                {"settings": {"future": {"kept": True}}},
+            )
+
+        self.assertEqual(
+            document,
+            {
+                "version": 2,
+                "profile_id": str(profile_id),
+                "revision": 1,
+                "name": "Display",
+                "settings": {"future": {"kept": True}},
+            },
+        )
+
+    def test_legacy_uuid5_is_exact_case_normalized_and_kind_scoped(self):
+        self.assertEqual(
+            contract.legacy_profile_id(contract.PROFILE_KIND_LORA, "Portrait"),
+            "776e3a00-f7ea-57fa-b2fe-a608b3807f55",
+        )
+        self.assertEqual(
+            contract.legacy_profile_id(contract.PROFILE_KIND_LORA, "portrait. "),
+            "776e3a00-f7ea-57fa-b2fe-a608b3807f55",
+        )
+        self.assertEqual(
+            contract.legacy_profile_id(contract.PROFILE_KIND_AIO, "Portrait"),
+            "5f105f16-0eae-5d9e-894e-34243e44922b",
+        )
+
+    def test_legacy_uuid5_is_stable_across_fresh_processes(self):
+        script = (
+            f"import sys; sys.path.insert(0, {str(ROOT)!r}); "
+            "from easyuse_anima.profiles.contract import legacy_profile_id; "
+            "print(legacy_profile_id('lora', 'Portrait'))"
+        )
+        outputs = []
+        for _ in range(2):
+            result = subprocess.run(
+                [sys.executable, "-I", "-B", "-c", script],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=10,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            outputs.append(result.stdout.strip())
+
+        self.assertEqual(
+            outputs,
+            [
+                "776e3a00-f7ea-57fa-b2fe-a608b3807f55",
+                "776e3a00-f7ea-57fa-b2fe-a608b3807f55",
+            ],
+        )
+
+    def test_v1_and_missing_v2_fields_are_pure_legacy_views(self):
+        for document in (
+            {"version": 1, "settings": {}},
+            {"settings": {}},
+            {"version": 2, "name": "Legacy", "settings": {}},
+        ):
+            with self.subTest(document=document):
+                interpreted = contract.interpret_profile_document(
+                    contract.PROFILE_KIND_AIO,
+                    "Legacy",
+                    document,
+                )
+
+                self.assertEqual(interpreted["version"], 2)
+                self.assertEqual(interpreted["revision"], 0)
+                self.assertEqual(
+                    interpreted["profile_id"],
+                    contract.legacy_profile_id(contract.PROFILE_KIND_AIO, "Legacy"),
+                )
+                self.assertEqual(interpreted["name"], "Legacy")
+
+    def test_update_preserves_identity_and_advances_current_revision(self):
+        current = {
+            "version": 2,
+            "profile_id": "12345678-1234-4234-9234-1234567890ab",
+            "revision": 7,
+            "name": "Current",
+            "settings": {"value": "old"},
+        }
+
+        updated = contract.update_profile_document(
+            contract.PROFILE_KIND_AIO,
+            "Current",
+            current,
+            {"settings": {"value": "new"}},
+        )
+
+        self.assertEqual(updated["profile_id"], current["profile_id"])
+        self.assertEqual(updated["revision"], 8)
+        self.assertEqual(updated["settings"], {"value": "new"})
+
+    def test_legacy_update_promotes_to_revision_one(self):
+        updated = contract.update_profile_document(
+            contract.PROFILE_KIND_LORA,
+            "Legacy",
+            {"version": 1, "profile_data": {}},
+            {"profile_count": 1, "profile_index": 1, "profile_data": {}},
+        )
+
+        self.assertEqual(updated["revision"], 1)
+        self.assertEqual(
+            updated["profile_id"],
+            contract.legacy_profile_id(contract.PROFILE_KIND_LORA, "Legacy"),
+        )
+
+    def test_rename_preserves_source_identity_and_content_revision(self):
+        current = {
+            "version": 2,
+            "profile_id": "12345678-1234-4234-9234-1234567890ab",
+            "revision": 4,
+            "name": "Source",
+            "settings": {"value": "source"},
+        }
+
+        renamed = contract.rename_profile_document(
+            contract.PROFILE_KIND_AIO,
+            "Source",
+            "Target",
+            current,
+            {"settings": current["settings"]},
+        )
+
+        self.assertEqual(renamed["name"], "Target")
+        self.assertEqual(renamed["profile_id"], current["profile_id"])
+        self.assertEqual(renamed["revision"], 4)
+
+    def test_invalid_complete_v2_taxonomy_is_rejected(self):
+        invalid_documents = (
+            {"version": True, "settings": {}},
+            {"version": 2.0, "settings": {}},
+            {
+                "version": 3,
+                "profile_id": "12345678-1234-4234-9234-1234567890ab",
+                "revision": 1,
+                "name": "Invalid",
+            },
+            {
+                "version": 2,
+                "profile_id": "not-a-uuid",
+                "revision": 1,
+                "name": "Invalid",
+            },
+            {
+                "version": 2,
+                "profile_id": "12345678-1234-4234-9234-1234567890ab",
+                "revision": True,
+                "name": "Invalid",
+            },
+            {
+                "version": 2,
+                "profile_id": "12345678-1234-4234-9234-1234567890ab",
+                "revision": 1,
+                "name": [],
+            },
+        )
+
+        for document in invalid_documents:
+            with self.subTest(document=document), self.assertRaises(
+                contract.ProfileContractError
+            ):
+                contract.interpret_profile_document(
+                    contract.PROFILE_KIND_AIO,
+                    "Invalid",
+                    document,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_profile_contract.py
+++ b/tests/test_profile_contract.py
@@ -77,11 +77,10 @@ class ProfileContractTests(unittest.TestCase):
             ],
         )
 
-    def test_v1_and_missing_v2_fields_are_pure_legacy_views(self):
+    def test_v1_and_version_missing_documents_are_pure_legacy_views(self):
         for document in (
             {"version": 1, "settings": {}},
             {"settings": {}},
-            {"version": 2, "name": "Legacy", "settings": {}},
         ):
             with self.subTest(document=document):
                 interpreted = contract.interpret_profile_document(
@@ -153,10 +152,25 @@ class ProfileContractTests(unittest.TestCase):
         self.assertEqual(renamed["profile_id"], current["profile_id"])
         self.assertEqual(renamed["revision"], 4)
 
-    def test_invalid_complete_v2_taxonomy_is_rejected(self):
+    def test_invalid_v2_taxonomy_is_rejected(self):
         invalid_documents = (
             {"version": True, "settings": {}},
             {"version": 2.0, "settings": {}},
+            {
+                "version": 2,
+                "revision": 1,
+                "name": "Invalid",
+            },
+            {
+                "version": 2,
+                "profile_id": "12345678-1234-4234-9234-1234567890ab",
+                "name": "Invalid",
+            },
+            {
+                "version": 2,
+                "profile_id": "12345678-1234-4234-9234-1234567890ab",
+                "revision": 1,
+            },
             {
                 "version": 3,
                 "profile_id": "12345678-1234-4234-9234-1234567890ab",

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 34)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 34)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 32)
+        self.assertEqual(report["inventory"]["module_count"], 36)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 36)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 34)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
@@ -712,6 +712,8 @@ ignored/
                 "easyuse_anima/infrastructure/comfy/resources.py",
                 "easyuse_anima/nodes/__init__.py",
                 "easyuse_anima/nodes/image_nodes.py",
+                "easyuse_anima/profiles/__init__.py",
+                "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/prompt/__init__.py",
             }.issubset(report["registry"]["shipped_python_modules"])
         )
@@ -728,6 +730,8 @@ ignored/
                 "easyuse_anima/infrastructure/comfy/invocation.py",
                 "easyuse_anima/infrastructure/comfy/resources.py",
                 "easyuse_anima/nodes/image_nodes.py",
+                "easyuse_anima/profiles/__init__.py",
+                "easyuse_anima/profiles/contract.py",
             }.issubset(report["registry"]["runtime_import_closure"])
         )
         self.assertIn(
@@ -750,6 +754,10 @@ ignored/
             {"from": "api.py", "to": "api_contract.py"},
             report["imports"]["module_graph"],
         )
+        self.assertIn(
+            {"from": "api.py", "to": "easyuse_anima/profiles/contract.py"},
+            report["imports"]["module_graph"],
+        )
         self.assertNotIn(
             "tests/test_python_backend_analyzer.py",
             report["registry"]["shipped_python_modules"],
@@ -765,6 +773,7 @@ ignored/
         self.assertTrue(
             {
                 ("api.py", "storage.py"),
+                ("api.py", "easyuse_anima/profiles/contract.py"),
                 ("nodes.py", "prompt_translation.py"),
                 ("nodes.py", "settings.py"),
                 ("nodes.py", "wildcard_engine.py"),

--- a/tests/test_python_import_boundaries.py
+++ b/tests/test_python_import_boundaries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import importlib.util
 import unittest
 from pathlib import Path
@@ -53,6 +54,38 @@ class PythonImportBoundaryTests(unittest.TestCase):
                 self.assertNotIn("ANIMA_", source)
                 self.assertNotIn("from nodes", source)
                 self.assertNotIn("import nodes", source)
+
+    def test_profile_contract_has_no_http_storage_or_outer_layer_imports(self):
+        contract_path = INTERNAL_PACKAGE / "profiles" / "contract.py"
+        source = contract_path.read_text(encoding="utf-8")
+        violations = analyzer.find_import_boundary_violations(
+            source,
+            module_name="easyuse_anima.profiles.contract",
+        )
+        tree = ast.parse(source)
+        imported_roots = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_roots.update(
+                    alias.name.split(".", 1)[0]
+                    for alias in node.names
+                )
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_roots.add(node.module.split(".", 1)[0])
+
+        self.assertEqual(violations, [])
+        self.assertTrue(
+            imported_roots.isdisjoint(
+                {
+                    "aiohttp",
+                    "api_contract",
+                    "folder_paths",
+                    "server",
+                    "storage",
+                }
+            )
+        )
+        self.assertNotIn("AtomicJsonStore", source)
 
     def test_synthetic_allowed_imports_have_no_violations(self):
         sources = {

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -22,6 +22,8 @@ PACKAGE_MODULES = (
     "easyuse_anima.infrastructure.comfy.invocation",
     "easyuse_anima.infrastructure.comfy.resources",
     "easyuse_anima.nodes",
+    "easyuse_anima.profiles",
+    "easyuse_anima.profiles.contract",
     "easyuse_anima.prompt",
 )
 

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -32,6 +32,8 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/infrastructure/comfy/resources.py",
     "easyuse_anima/nodes/__init__.py",
     "easyuse_anima/nodes/image_nodes.py",
+    "easyuse_anima/profiles/__init__.py",
+    "easyuse_anima/profiles/contract.py",
     "easyuse_anima/prompt/__init__.py",
 }
 STATIC_IMPORT_FROM_RE = re.compile(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -232,10 +232,12 @@ class AtomicJsonStoreTests(unittest.TestCase):
     def test_replace_transform_failure_preserves_source_target_and_backup(self):
         source = AtomicJsonStore(self.root / "source.json")
         target = AtomicJsonStore(self.root / "target.json")
+        source.write({"settings": {"value": "old source"}})
         source.write({"settings": {"value": "source"}})
         target.write({"settings": {"value": "old target"}})
         target.write({"settings": {"value": "current target"}})
         source_bytes = source.path.read_bytes()
+        source_backup_bytes = source.backup_path.read_bytes()
         target_bytes = target.path.read_bytes()
         backup_bytes = target.backup_path.read_bytes()
 
@@ -247,6 +249,7 @@ class AtomicJsonStoreTests(unittest.TestCase):
             target.replace_from(source, transform=reject_source)
 
         self.assertEqual(source.path.read_bytes(), source_bytes)
+        self.assertEqual(source.backup_path.read_bytes(), source_backup_bytes)
         self.assertEqual(target.path.read_bytes(), target_bytes)
         self.assertEqual(target.backup_path.read_bytes(), backup_bytes)
         self.assertEqual(self._temp_files(), [])
@@ -254,10 +257,11 @@ class AtomicJsonStoreTests(unittest.TestCase):
     def test_replace_transform_persists_returned_value_and_exact_target_backup(self):
         source = AtomicJsonStore(self.root / "source.json")
         target = AtomicJsonStore(self.root / "target.json")
-        source_bytes = b'{"settings":{"value":"source"}}\n'
-        target_bytes = b'{ "version": 2, "settings": {"value": "target"} }\n'
-        source.path.write_bytes(source_bytes)
-        target.path.write_bytes(target_bytes)
+        source.write({"settings": {"value": "old source"}})
+        source.write({"settings": {"value": "source"}})
+        target.write({"settings": {"value": "old target"}})
+        target.write({"settings": {"value": "target"}})
+        target_bytes = target.path.read_bytes()
 
         transformed = target.replace_from(
             source,
@@ -270,17 +274,55 @@ class AtomicJsonStoreTests(unittest.TestCase):
 
         self.assertEqual(target.read(), transformed)
         self.assertFalse(source.path.exists())
+        self.assertFalse(source.backup_path.exists())
         self.assertEqual(target.backup_path.read_bytes(), target_bytes)
+        self.assertEqual(self._temp_files(), [])
+
+    def test_replace_source_backup_removal_failure_preserves_all_files(self):
+        source = AtomicJsonStore(self.root / "source.json")
+        target = AtomicJsonStore(self.root / "target.json")
+        source.write({"settings": {"value": "old source"}})
+        source.write({"settings": {"value": "source"}})
+        target.write({"settings": {"value": "target"}})
+        source_bytes = source.path.read_bytes()
+        source_backup_bytes = source.backup_path.read_bytes()
+        target_bytes = target.path.read_bytes()
+        real_unlink = Path.unlink
+
+        def fail_source_backup_removal(path, *args, **kwargs):
+            if Path(path) == source.backup_path:
+                raise OSError("source backup removal failed")
+            return real_unlink(path, *args, **kwargs)
+
+        with patch.object(
+            Path,
+            "unlink",
+            autospec=True,
+            side_effect=fail_source_backup_removal,
+        ):
+            with self.assertRaisesRegex(OSError, "source backup removal failed"):
+                target.replace_from(
+                    source,
+                    transform=lambda value: {"version": 2, **value},
+                )
+
+        self.assertEqual(source.path.read_bytes(), source_bytes)
+        self.assertEqual(source.backup_path.read_bytes(), source_backup_bytes)
+        self.assertEqual(target.path.read_bytes(), target_bytes)
+        self.assertFalse(target.backup_path.exists())
         self.assertEqual(self._temp_files(), [])
 
     def test_replace_transform_publication_failure_rolls_back_and_cleans_temps(self):
         source = AtomicJsonStore(self.root / "source.json")
         target = AtomicJsonStore(self.root / "target.json")
+        source.write({"settings": {"value": "old source"}})
         source.write({"settings": {"value": "source"}})
         target.write({"settings": {"value": "old target"}})
         target.write({"settings": {"value": "current target"}})
         source_bytes = source.path.read_bytes()
+        source_backup_bytes = source.backup_path.read_bytes()
         target_bytes = target.path.read_bytes()
+        target_backup_bytes = target.backup_path.read_bytes()
         real_replace = storage.os.replace
         state = {"source_moved": False, "publication_failed": False}
 
@@ -307,8 +349,9 @@ class AtomicJsonStoreTests(unittest.TestCase):
                 )
 
         self.assertEqual(source.path.read_bytes(), source_bytes)
+        self.assertEqual(source.backup_path.read_bytes(), source_backup_bytes)
         self.assertEqual(target.path.read_bytes(), target_bytes)
-        self.assertEqual(target.backup_path.read_bytes(), target_bytes)
+        self.assertEqual(target.backup_path.read_bytes(), target_backup_bytes)
         self.assertEqual(self._temp_files(), [])
 
     def test_invalid_or_missing_primary_reads_valid_backup_without_repair(self):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -251,6 +251,66 @@ class AtomicJsonStoreTests(unittest.TestCase):
         self.assertEqual(target.backup_path.read_bytes(), backup_bytes)
         self.assertEqual(self._temp_files(), [])
 
+    def test_replace_transform_persists_returned_value_and_exact_target_backup(self):
+        source = AtomicJsonStore(self.root / "source.json")
+        target = AtomicJsonStore(self.root / "target.json")
+        source_bytes = b'{"settings":{"value":"source"}}\n'
+        target_bytes = b'{ "version": 2, "settings": {"value": "target"} }\n'
+        source.path.write_bytes(source_bytes)
+        target.path.write_bytes(target_bytes)
+
+        transformed = target.replace_from(
+            source,
+            transform=lambda value: {
+                "version": 2,
+                "name": "target",
+                **value,
+            },
+        )
+
+        self.assertEqual(target.read(), transformed)
+        self.assertFalse(source.path.exists())
+        self.assertEqual(target.backup_path.read_bytes(), target_bytes)
+        self.assertEqual(self._temp_files(), [])
+
+    def test_replace_transform_publication_failure_rolls_back_and_cleans_temps(self):
+        source = AtomicJsonStore(self.root / "source.json")
+        target = AtomicJsonStore(self.root / "target.json")
+        source.write({"settings": {"value": "source"}})
+        target.write({"settings": {"value": "old target"}})
+        target.write({"settings": {"value": "current target"}})
+        source_bytes = source.path.read_bytes()
+        target_bytes = target.path.read_bytes()
+        real_replace = storage.os.replace
+        state = {"source_moved": False, "publication_failed": False}
+
+        def fail_transformed_publication(current, destination):
+            current_path = Path(current)
+            destination_path = Path(destination)
+            if current_path == source.path and destination_path == target.path:
+                state["source_moved"] = True
+                return real_replace(current, destination)
+            if (
+                state["source_moved"]
+                and not state["publication_failed"]
+                and destination_path == target.path
+            ):
+                state["publication_failed"] = True
+                raise OSError("transformed publication failed")
+            return real_replace(current, destination)
+
+        with patch.object(storage.os, "replace", side_effect=fail_transformed_publication):
+            with self.assertRaisesRegex(OSError, "transformed publication failed"):
+                target.replace_from(
+                    source,
+                    transform=lambda value: {"version": 2, **value},
+                )
+
+        self.assertEqual(source.path.read_bytes(), source_bytes)
+        self.assertEqual(target.path.read_bytes(), target_bytes)
+        self.assertEqual(target.backup_path.read_bytes(), target_bytes)
+        self.assertEqual(self._temp_files(), [])
+
     def test_invalid_or_missing_primary_reads_valid_backup_without_repair(self):
         store = self._store()
         store.path.write_text("{", encoding="utf-8")


### PR DESCRIPTION
Refs #163

## 기준

- base: `dev @ 6477eb72d105dbd13d1396cea0ee522a4e9e6d89`
- head: `3d7542bb66d1719c77c4b617fe59ee59060020f1`

## 변경 요약

- side-effect-free canonical `easyuse_anima/profiles` package에 additive profile v2 envelope와 legacy migration 계약을 추가했습니다.
- 신규 LoRA/AiO profile은 UUID4 `profile_id`와 `revision: 1`로 저장합니다.
- version 누락/v1 profile은 profile kind + Windows-normalized filename identity 기반 고정 namespace UUIDv5와 `revision: 0`으로 순수 해석합니다.
- 명시적 `version: 2` 문서는 `profile_id`/`revision`/`name`이 모두 있어야 하며, incomplete/malformed v2는 load/list/save/rename/delete에서 기존 `invalid_profile_data` 422 및 request-ID 형식으로 거부합니다.
- list/load는 legacy bytes, mtime, backup을 변경하지 않으며 write-on-read를 수행하지 않습니다.
- 명시적 overwrite에서 기존 ID를 유지하고 revision을 1 증가시키며, optional concurrency token은 타입만 파싱하고 아직 stale/missing 조건을 거부하지 않습니다.
- AiO rename은 source ID와 content revision을 유지하고 overwrite target ID를 폐기합니다.

## 원자성 수정

- 2-path AiO rename의 raw source move와 transformed v2 publication을 `AtomicJsonStore.replace_from`의 source+target 공동 lock transaction 안에서 완료하고 API의 별도 second write를 제거했습니다.
- transformed publication 실패 시 source/target primary, source backup, 기존 target backup의 존재 여부와 bytes를 복구하며 same-directory temp를 정리합니다.
- 성공한 rename은 overwrite 전 target v2 bytes를 target backup으로 정확히 보존하고, old-name source backup을 제거해 같은 이름 재생성 후 stale identity/data가 복구되지 않게 합니다.
- same-name rename은 read/metadata transform/conditional publish를 하나의 path lock 안에서 수행합니다.
- AiO delete는 실제 삭제한 document의 metadata snapshot과 primary/backup 삭제를 하나의 path lock 안에서 수행해 응답 `profile_id`/`revision`이 삭제된 bytes와 일치합니다.
- list route는 의도된 `InvalidProfileDataError`만 profile 422로 매핑하며 임의 `ValueError`는 기존 safe-500 경계를 통과합니다.

## 주요 파일

- `easyuse_anima/profiles/contract.py`: v2 envelope, UUID4/UUIDv5, read/create/update/rename migration 규칙
- `api.py`: LoRA/AiO filesystem adapter, additive public metadata, atomic same-name/delete adapter
- `api_contract.py`: optional UUID/revision request token typed parser
- `storage.py`: 공동 lock rename publication, source/target backup snapshot/rollback, fsync/temp cleanup
- `tests/test_profile_contract.py`: deterministic identity, revision, explicit incomplete-v2 taxonomy
- `tests/test_lora_profiles.py`, `tests/test_aio_profiles.py`, `tests/test_api_contract.py`, `tests/test_storage.py`: legacy purity, promotion, deterministic interleaving, backup/recovery, error taxonomy 회귀
- `tests/fixtures/python_backend_baseline.json`: 최신 dev 코드 기준 공식 analyzer generator로 재생성

## Additive 응답 예시

신규 LoRA save/load 응답의 `profile`:

```json
{
  "version": 2,
  "profile_id": "UUID4",
  "revision": 1,
  "name": "My Preset",
  "profile_count": 1,
  "profile_index": 1,
  "profile_data": {}
}
```

legacy list item은 기존 필드에 metadata만 추가됩니다:

```json
{
  "name": "Legacy",
  "modified": 1720000000,
  "profile_id": "deterministic UUID5",
  "revision": 0
}
```

기존 consumer는 계속 `name`/`modified`/`settings` 또는 `profile_count`/`profile_index`/`profile_data`만 사용할 수 있습니다.

## 검증

- `python -m unittest tests.test_profile_contract tests.test_lora_profiles tests.test_aio_profiles tests.test_api_contract tests.test_storage` — 115 tests passed
- `python -m unittest tests.test_python_backend_analyzer tests.test_python_import_boundaries tests.test_python_package_skeleton tests.test_registry_scanner_safety` — 36 tests passed
- `tools/check_project.ps1 -Profile quick` — passed (Python compile, 111 JavaScript files, TypeScript 6.0.3, diff check)
- backend analyzer official baseline generation 후 감사 — modules 36, Registry shipped 36, runtime closure 34, missing internal imports 0
- 공식 full: `powershell -ExecutionPolicy Bypass -File D:\\ComfyUI\\custom_nodes_workplace\\tools\\check_custom_node.ps1 -Project <PR worktree> -Profile full` — Python 657 tests passed, frontend 111 JavaScript files, TypeScript 6.0.3, diff check passed
- `git diff --check origin/dev...HEAD` — passed
- actual diff 자체검토 및 독립 정적 재검토 — no findings

## 테스트 표면

- ComfyUI Codex test instance: 공식 full runner (Python unittest + frontend semantic smoke/typecheck)
- live ComfyUI/API/browser integration: 미실행
- deterministic backend unittest 및 기존 frontend Node smoke
- Registry/archive/import closure 정적 검증
- frontend source 변경 없음

## 남은 위험 / 제외 범위

- stale revision 409, 동시 CAS winner, directory/process lock은 Part 3C 범위입니다.
- process-local lock을 따르지 않는 외부 프로세스 경쟁은 검증하지 않았습니다.
- 두 OS publication 사이의 전원 중단과 rollback 자체의 double-fault는 이번 회귀에서 검증하지 않았습니다.
- frontend adoption은 Part 3B 범위이며 이 PR은 frontend JS를 수정하지 않습니다.
- AiO nested settings schema/migration은 #168 범위이며 settings object는 opaque하게 보존합니다.
- integration/live/browser 검증은 실행하지 않았습니다. 이 PR은 backend additive contract이며 frontend source를 변경하지 않습니다.
- `dev` squash merge 완료: `18b0f1caac9c4c8e10a8e68f090be9d5b200d57c`
