### PR TITLE
fix: 프로필 ID/revision frontend token adoption (Part 3B)

### DIFF
--- a/tests/frontend_aio_profile_api_client_smoke.mjs
+++ b/tests/frontend_aio_profile_api_client_smoke.mjs
@@ -162,6 +162,33 @@ assert.deepEqual(calls.at(-1), {
   argumentCount: 2,
 });
 assert.equal(JSON.stringify(settings), settingsBefore, "save must not mutate settings");
+const legacySaveBody = JSON.parse(calls.at(-1).options.body);
+assert.equal(Object.hasOwn(legacySaveBody, "profile_id"), false);
+assert.equal(Object.hasOwn(legacySaveBody, "revision"), false);
+
+const sourceToken = {
+  profile_id: "11111111-1111-4111-8111-111111111111",
+  revision: 7,
+};
+const targetToken = {
+  profile_id: "22222222-2222-4222-8222-222222222222",
+  revision: 4,
+};
+responses.push(saveResponse);
+assert.equal(await client.saveProfile("New Portrait", false, settings, sourceToken), saveResponse);
+const createBody = JSON.parse(calls.at(-1).options.body);
+assert.equal(Object.hasOwn(createBody, "profile_id"), false);
+assert.equal(Object.hasOwn(createBody, "revision"), false);
+
+responses.push(saveResponse);
+assert.equal(await client.saveProfile("Portrait", true, settings, sourceToken), saveResponse);
+assert.deepEqual(JSON.parse(calls.at(-1).options.body), {
+  name: "Portrait",
+  overwrite: true,
+  settings,
+  profile_id: sourceToken.profile_id,
+  revision: sourceToken.revision,
+});
 
 const renameResponse = { profile: { name: "Portrait 2" } };
 responses.push(renameResponse);
@@ -180,6 +207,32 @@ assert.deepEqual(calls.at(-1), {
   argumentCount: 2,
 });
 
+responses.push(renameResponse);
+assert.equal(
+  await client.renameProfile("Portrait", "portrait", false, sourceToken, targetToken),
+  renameResponse,
+);
+const sameProfileRenameBody = JSON.parse(calls.at(-1).options.body);
+assert.equal(sameProfileRenameBody.profile_id, sourceToken.profile_id);
+assert.equal(sameProfileRenameBody.revision, sourceToken.revision);
+assert.equal(Object.hasOwn(sameProfileRenameBody, "target_profile_id"), false);
+assert.equal(Object.hasOwn(sameProfileRenameBody, "target_revision"), false);
+
+responses.push(renameResponse);
+assert.equal(
+  await client.renameProfile("Portrait", "Portrait 2", true, sourceToken, targetToken),
+  renameResponse,
+);
+assert.deepEqual(JSON.parse(calls.at(-1).options.body), {
+  old_name: "Portrait",
+  new_name: "Portrait 2",
+  overwrite: true,
+  profile_id: sourceToken.profile_id,
+  revision: sourceToken.revision,
+  target_profile_id: targetToken.profile_id,
+  target_revision: targetToken.revision,
+});
+
 const deleteResponse = { profile: { name: "Portrait 2" } };
 responses.push(deleteResponse);
 assert.equal(await client.deleteProfile("Portrait 2"), deleteResponse);
@@ -191,6 +244,14 @@ assert.deepEqual(calls.at(-1), {
     body: JSON.stringify({ name: "Portrait 2" }),
   },
   argumentCount: 2,
+});
+
+responses.push(deleteResponse);
+assert.equal(await client.deleteProfile("Portrait 2", sourceToken), deleteResponse);
+assert.deepEqual(JSON.parse(calls.at(-1).options.body), {
+  name: "Portrait 2",
+  profile_id: sourceToken.profile_id,
+  revision: sourceToken.revision,
 });
 
 const requestError = new Error("backend unavailable");

--- a/tests/frontend_aio_profile_settings_runtime_smoke.mjs
+++ b/tests/frontend_aio_profile_settings_runtime_smoke.mjs
@@ -136,14 +136,20 @@ function createFixture() {
     loadProfile(name) {
       return queuedResult("loadProfile", [name]);
     },
-    saveProfile(name, overwrite, settings) {
-      return queuedResult("saveProfile", [name, overwrite, clone(settings)]);
+    saveProfile(name, overwrite, settings, profile) {
+      return queuedResult("saveProfile", [name, overwrite, clone(settings), clone(profile)]);
     },
-    renameProfile(oldName, newName, overwrite) {
-      return queuedResult("renameProfile", [oldName, newName, overwrite]);
+    renameProfile(oldName, newName, overwrite, profile, targetProfile) {
+      return queuedResult("renameProfile", [
+        oldName,
+        newName,
+        overwrite,
+        clone(profile),
+        clone(targetProfile),
+      ]);
     },
-    deleteProfile(name) {
-      return queuedResult("deleteProfile", [name]);
+    deleteProfile(name, profile) {
+      return queuedResult("deleteProfile", [name, clone(profile)]);
     },
   };
 
@@ -585,6 +591,7 @@ assert.deepEqual(fixture.apiCalls.saveProfile.at(-1), [
   "Landscape",
   true,
   { sampler: { steps: 55 }, save_snapshot: true },
+  { name: "Landscape" },
 ]);
 assert.equal(saveNode.__easyuseAnimaGeneratorProfileValue, "user:Landscape");
 assert.match(saveNode.__easyuseAnimaGeneratorProfileFingerprint, /^fingerprint:/);
@@ -651,7 +658,13 @@ assert.ok(
   fixture.trace.indexOf("resolve") < fixture.trace.indexOf("prompt"),
   "rename must sync the current selection before prompting",
 );
-assert.deepEqual(fixture.apiCalls.renameProfile.at(-1), ["Landscape", "Cinematic", false]);
+assert.deepEqual(fixture.apiCalls.renameProfile.at(-1), [
+  "Landscape",
+  "Cinematic",
+  false,
+  { name: "Landscape" },
+  null,
+]);
 assert.equal(saveNode.__easyuseAnimaGeneratorProfileValue, "user:Cinematic");
 assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeRename + 1);
 assert.equal(fixture.trace.includes("refresh-panels"), true);
@@ -689,7 +702,7 @@ const dialogsBeforeDelete = fixture.dialogs.length;
 const listCallsBeforeDelete = fixture.apiCalls.listProfiles.length;
 fixture.trace.length = 0;
 await buttons.delete.dispatch("click");
-assert.deepEqual(fixture.apiCalls.deleteProfile.at(-1), ["Cinematic"]);
+assert.deepEqual(fixture.apiCalls.deleteProfile.at(-1), ["Cinematic", { name: "Cinematic" }]);
 assert.equal(saveNode.__easyuseAnimaGeneratorProfileValue, "custom");
 assert.equal(Object.hasOwn(saveNode, "__easyuseAnimaGeneratorProfileFingerprint"), false);
 assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeDelete + 1);
@@ -766,6 +779,7 @@ assert.deepEqual(fixture.apiCalls.saveProfile.at(-1), [
   "Refresh Failure",
   false,
   { sampler: { steps: 55 }, save_snapshot: true },
+  null,
 ]);
 assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeRefreshError + 1);
 assert.equal(dialog.backdrop.isConnected, true, "refresh failure must retain its dialog");
@@ -777,6 +791,115 @@ fixture.apiQueues.listProfiles.push({ profiles: [{ name: "Recovered After Refres
 assert.deepEqual(await fixture.runtime.loadProfiles({ force: true }), [
   { name: "Recovered After Refresh" },
 ]);
+
+const tokenFixture = createFixture();
+const sourceV1 = {
+  name: "Source",
+  profile_id: "11111111-1111-4111-8111-111111111111",
+  revision: 1,
+};
+const targetV4 = {
+  name: "Target",
+  profile_id: "22222222-2222-4222-8222-222222222222",
+  revision: 4,
+};
+tokenFixture.apiQueues.listProfiles.push({ profiles: [sourceV1, targetV4] });
+await tokenFixture.runtime.loadProfiles();
+const tokenNode = {
+  settings: { sampler: { steps: 61 } },
+  __easyuseAnimaGeneratorProfileValue: "user:Source",
+  __easyuseAnimaGeneratorProfileFingerprint: "source-fingerprint",
+};
+tokenFixture.runtime.open(tokenNode);
+let tokenDialog = tokenFixture.dialogs.at(-1);
+let tokenButtons = dialogButtons(tokenDialog);
+tokenButtons.select.value = "user:Source";
+
+const targetV5 = { ...targetV4, revision: 5 };
+tokenFixture.prompts.push("Target");
+tokenFixture.confirms.push(true);
+tokenFixture.apiQueues.saveProfile.push({ profile: targetV5 });
+tokenFixture.apiQueues.listProfiles.push(new Error("save refresh failed"));
+await tokenButtons.save.dispatch("click");
+assert.deepEqual(tokenFixture.apiCalls.saveProfile.at(-1), [
+  "Target",
+  true,
+  { sampler: { steps: 61 } },
+  targetV4,
+]);
+assert.deepEqual(
+  (await tokenFixture.runtime.loadProfiles()).find((profile) => profile.name === "Target"),
+  targetV5,
+  "save response metadata must survive a failed list refresh",
+);
+
+const targetV6 = { ...targetV4, revision: 6 };
+tokenFixture.prompts.push("Target");
+tokenFixture.confirms.push(true);
+tokenFixture.apiQueues.saveProfile.push({ profile: targetV6 });
+tokenFixture.apiQueues.listProfiles.push(new Error("second save refresh failed"));
+await tokenButtons.save.dispatch("click");
+assert.deepEqual(tokenFixture.apiCalls.saveProfile.at(-1).at(-1), targetV5);
+
+tokenButtons.select.value = "user:Source";
+tokenFixture.prompts.push("Target");
+tokenFixture.confirms.push(true);
+const renamedTarget = { ...sourceV1, name: "Target" };
+tokenFixture.apiQueues.renameProfile.push({ profile: renamedTarget });
+tokenFixture.apiQueues.listProfiles.push(new Error("rename refresh failed"));
+await tokenButtons.rename.dispatch("click");
+assert.deepEqual(tokenFixture.apiCalls.renameProfile.at(-1), [
+  "Source",
+  "Target",
+  true,
+  sourceV1,
+  targetV6,
+]);
+
+tokenButtons.select.value = "user:Target";
+tokenFixture.confirms.push(true);
+tokenFixture.apiQueues.deleteProfile.push({ profile: renamedTarget });
+tokenFixture.apiQueues.listProfiles.push(new Error("delete refresh failed"));
+await tokenButtons.delete.dispatch("click");
+assert.deepEqual(tokenFixture.apiCalls.deleteProfile.at(-1), ["Target", renamedTarget]);
+assert.equal(
+  (await tokenFixture.runtime.loadProfiles()).some((profile) => profile.name === "Target"),
+  false,
+  "delete success must remove cached metadata even when refresh fails",
+);
+
+const caseFixture = createFixture();
+const caseProfile = {
+  name: "Case Name",
+  profile_id: "33333333-3333-4333-8333-333333333333",
+  revision: 2,
+};
+caseFixture.apiQueues.listProfiles.push({ profiles: [caseProfile] });
+await caseFixture.runtime.loadProfiles();
+const caseNode = {
+  settings: { keep: true },
+  __easyuseAnimaGeneratorProfileValue: "user:Case Name",
+  __easyuseAnimaGeneratorProfileFingerprint: "case-fingerprint",
+};
+caseFixture.runtime.open(caseNode);
+const caseButtons = dialogButtons(caseFixture.dialogs.at(-1));
+caseButtons.select.value = "user:Case Name";
+caseFixture.prompts.push("case name");
+caseFixture.apiQueues.renameProfile.push({
+  profile: { ...caseProfile, name: "case name" },
+});
+caseFixture.apiQueues.listProfiles.push({
+  profiles: [{ ...caseProfile, name: "case name" }],
+});
+await caseButtons.rename.dispatch("click");
+assert.deepEqual(caseFixture.apiCalls.renameProfile.at(-1), [
+  "Case Name",
+  "case name",
+  false,
+  caseProfile,
+  null,
+]);
+assert.deepEqual(caseFixture.confirmCalls, [], "case-only rename must not confirm overwrite");
 
 const preserveFixture = createFixture();
 preserveFixture.apiQueues.listProfiles.push({

--- a/tests/frontend_aio_profile_settings_runtime_smoke.mjs
+++ b/tests/frontend_aio_profile_settings_runtime_smoke.mjs
@@ -20,6 +20,12 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
+function profileExistsError(message = "Profile already exists") {
+  const error = new Error(message);
+  error.code = "profile_exists";
+  return error;
+}
+
 class FakeClassList {
   constructor() {
     this.values = new Set();
@@ -900,6 +906,153 @@ assert.deepEqual(caseFixture.apiCalls.renameProfile.at(-1), [
   null,
 ]);
 assert.deepEqual(caseFixture.confirmCalls, [], "case-only rename must not confirm overwrite");
+
+const sanitizedSaveFixture = createFixture();
+sanitizedSaveFixture.apiQueues.listProfiles.push({ profiles: [] });
+await sanitizedSaveFixture.runtime.loadProfiles();
+const sanitizedSaveNode = {
+  settings: { sampler: { steps: 71 }, sanitized: true },
+  __easyuseAnimaGeneratorProfileValue: "custom",
+};
+sanitizedSaveFixture.runtime.open(sanitizedSaveNode);
+const sanitizedSaveButtons = dialogButtons(sanitizedSaveFixture.dialogs.at(-1));
+const sanitizedTarget = {
+  name: "foo_bar",
+  profile_id: "44444444-4444-4444-8444-444444444444",
+  revision: 7,
+};
+const sanitizedSaved = { ...sanitizedTarget, revision: 8 };
+sanitizedSaveFixture.prompts.push("foo?bar");
+sanitizedSaveFixture.apiQueues.saveProfile.push(profileExistsError("localized conflict"));
+sanitizedSaveFixture.apiQueues.loadProfile.push({ profile: sanitizedTarget });
+sanitizedSaveFixture.confirms.push(true);
+sanitizedSaveFixture.apiQueues.saveProfile.push({ profile: sanitizedSaved });
+sanitizedSaveFixture.apiQueues.listProfiles.push(new Error("sanitized refresh failed"));
+await sanitizedSaveButtons.save.dispatch("click");
+assert.deepEqual(sanitizedSaveFixture.apiCalls.saveProfile, [
+  ["foo?bar", false, { sampler: { steps: 71 }, sanitized: true }, null],
+  ["foo?bar", true, { sampler: { steps: 71 }, sanitized: true }, sanitizedTarget],
+]);
+assert.deepEqual(sanitizedSaveFixture.apiCalls.loadProfile, [["foo?bar"]]);
+assert.match(sanitizedSaveFixture.confirmCalls.at(-1), /foo_bar/);
+assert.deepEqual(
+  (await sanitizedSaveFixture.runtime.loadProfiles()).find((profile) => profile.name === "foo_bar"),
+  sanitizedSaved,
+  "conflict save response metadata must survive a failed list refresh",
+);
+
+const declineFixture = createFixture();
+declineFixture.apiQueues.listProfiles.push({ profiles: [] });
+await declineFixture.runtime.loadProfiles();
+declineFixture.runtime.open({ settings: { decline: true }, __easyuseAnimaGeneratorProfileValue: "custom" });
+const declineButtons = dialogButtons(declineFixture.dialogs.at(-1));
+const declineTarget = {
+  name: "decline_canonical",
+  profile_id: "55555555-5555-4555-8555-555555555555",
+  revision: 3,
+};
+declineFixture.prompts.push("decline?alias");
+declineFixture.apiQueues.saveProfile.push(profileExistsError());
+declineFixture.apiQueues.loadProfile.push({ profile: declineTarget });
+declineFixture.confirms.push(false);
+await declineButtons.save.dispatch("click");
+assert.equal(declineFixture.apiCalls.saveProfile.length, 1);
+assert.deepEqual(declineFixture.apiCalls.loadProfile, [["decline?alias"]]);
+assert.match(declineFixture.confirmCalls.at(-1), /decline_canonical/);
+assert.deepEqual(await declineFixture.runtime.loadProfiles(), [declineTarget]);
+
+const messageFixture = createFixture();
+messageFixture.apiQueues.listProfiles.push({ profiles: [] });
+await messageFixture.runtime.loadProfiles();
+messageFixture.runtime.open({ settings: { message: true }, __easyuseAnimaGeneratorProfileValue: "custom" });
+const messageButtons = dialogButtons(messageFixture.dialogs.at(-1));
+messageFixture.prompts.push("Message Conflict");
+messageFixture.apiQueues.saveProfile.push(new Error("Profile already exists"));
+await messageButtons.save.dispatch("click");
+assert.equal(messageFixture.apiCalls.saveProfile.length, 1);
+assert.equal(messageFixture.apiCalls.loadProfile.length, 0);
+assert.equal(messageFixture.confirmCalls.length, 0);
+assert.match(messageFixture.alerts.at(-1), /Profile already exists/);
+
+const overwriteErrorFixture = createFixture();
+const overwriteExisting = {
+  name: "Existing",
+  profile_id: "66666666-6666-4666-8666-666666666666",
+  revision: 4,
+};
+overwriteErrorFixture.apiQueues.listProfiles.push({ profiles: [overwriteExisting] });
+await overwriteErrorFixture.runtime.loadProfiles();
+overwriteErrorFixture.runtime.open({ settings: { overwrite: true }, __easyuseAnimaGeneratorProfileValue: "custom" });
+const overwriteErrorButtons = dialogButtons(overwriteErrorFixture.dialogs.at(-1));
+overwriteErrorFixture.prompts.push("Existing");
+overwriteErrorFixture.confirms.push(true);
+overwriteErrorFixture.apiQueues.saveProfile.push(profileExistsError("stale overwrite"));
+await overwriteErrorButtons.save.dispatch("click");
+assert.deepEqual(overwriteErrorFixture.apiCalls.saveProfile, [
+  ["Existing", true, { overwrite: true }, overwriteExisting],
+]);
+assert.equal(overwriteErrorFixture.apiCalls.loadProfile.length, 0);
+assert.equal(overwriteErrorFixture.confirmCalls.length, 1);
+
+const tokenlessFixture = createFixture();
+tokenlessFixture.apiQueues.listProfiles.push({ profiles: [] });
+await tokenlessFixture.runtime.loadProfiles();
+tokenlessFixture.runtime.open({ settings: { legacy: true }, __easyuseAnimaGeneratorProfileValue: "custom" });
+const tokenlessButtons = dialogButtons(tokenlessFixture.dialogs.at(-1));
+const tokenlessTarget = { name: "legacy_name" };
+tokenlessFixture.prompts.push("legacy?name");
+tokenlessFixture.apiQueues.saveProfile.push(
+  profileExistsError(),
+  profileExistsError("retry conflict"),
+);
+tokenlessFixture.apiQueues.loadProfile.push({ profile: tokenlessTarget });
+tokenlessFixture.confirms.push(true);
+await tokenlessButtons.save.dispatch("click");
+assert.deepEqual(tokenlessFixture.apiCalls.saveProfile, [
+  ["legacy?name", false, { legacy: true }, null],
+  ["legacy?name", true, { legacy: true }, tokenlessTarget],
+]);
+assert.equal(Object.hasOwn(tokenlessFixture.apiCalls.saveProfile[1][3], "profile_id"), false);
+assert.equal(Object.hasOwn(tokenlessFixture.apiCalls.saveProfile[1][3], "revision"), false);
+assert.equal(tokenlessFixture.apiCalls.loadProfile.length, 1);
+assert.equal(tokenlessFixture.confirmCalls.length, 1);
+
+const staleRenameFixture = createFixture();
+const renameSource = {
+  name: "Source",
+  profile_id: "77777777-7777-4777-8777-777777777777",
+  revision: 2,
+};
+const renameTarget = {
+  name: "foo_bar",
+  profile_id: "88888888-8888-4888-8888-888888888888",
+  revision: 5,
+};
+staleRenameFixture.apiQueues.listProfiles.push({ profiles: [renameSource] });
+await staleRenameFixture.runtime.loadProfiles();
+const staleRenameNode = {
+  settings: { rename: true },
+  __easyuseAnimaGeneratorProfileValue: "user:Source",
+  __easyuseAnimaGeneratorProfileFingerprint: "source-fingerprint",
+};
+staleRenameFixture.runtime.open(staleRenameNode);
+const staleRenameButtons = dialogButtons(staleRenameFixture.dialogs.at(-1));
+staleRenameButtons.select.value = "user:Source";
+staleRenameFixture.prompts.push("foo?bar");
+staleRenameFixture.apiQueues.renameProfile.push(profileExistsError());
+staleRenameFixture.apiQueues.loadProfile.push({ profile: renameTarget });
+staleRenameFixture.confirms.push(true);
+const renamedSource = { ...renameSource, name: "foo_bar" };
+staleRenameFixture.apiQueues.renameProfile.push({ profile: renamedSource });
+staleRenameFixture.apiQueues.listProfiles.push({ profiles: [renamedSource] });
+await staleRenameButtons.rename.dispatch("click");
+assert.deepEqual(staleRenameFixture.apiCalls.renameProfile, [
+  ["Source", "foo?bar", false, renameSource, null],
+  ["Source", "foo?bar", true, renameSource, renameTarget],
+]);
+assert.deepEqual(staleRenameFixture.apiCalls.loadProfile, [["foo?bar"]]);
+assert.match(staleRenameFixture.confirmCalls.at(-1), /foo_bar/);
+assert.equal(staleRenameNode.__easyuseAnimaGeneratorProfileValue, "user:foo_bar");
 
 const preserveFixture = createFixture();
 preserveFixture.apiQueues.listProfiles.push({

--- a/tests/frontend_lora_preset_api_client_smoke.mjs
+++ b/tests/frontend_lora_preset_api_client_smoke.mjs
@@ -101,6 +101,35 @@ assert.deepEqual(calls.at(-1), {
   argumentCount: 2,
 });
 assert.equal(JSON.stringify(savePayload), savePayloadBefore, "overwrite save must not mutate the payload");
+const legacyOverwriteBody = JSON.parse(calls.at(-1).options.body);
+assert.equal(Object.hasOwn(legacyOverwriteBody, "profile_id"), false);
+assert.equal(Object.hasOwn(legacyOverwriteBody, "revision"), false);
+
+const profileToken = {
+  profile_id: "11111111-1111-4111-8111-111111111111",
+  revision: 0,
+};
+responses.push(saveResponse);
+assert.equal(
+  await client.saveProfile("New Demo", savePayload, false, profileToken),
+  saveResponse,
+);
+const createBody = JSON.parse(calls.at(-1).options.body);
+assert.equal(Object.hasOwn(createBody, "profile_id"), false);
+assert.equal(Object.hasOwn(createBody, "revision"), false);
+
+responses.push(saveResponse);
+assert.equal(
+  await client.saveProfile("Demo", savePayload, true, profileToken),
+  saveResponse,
+);
+assert.deepEqual(JSON.parse(calls.at(-1).options.body), {
+  name: "Demo",
+  ...savePayload,
+  overwrite: true,
+  profile_id: profileToken.profile_id,
+  revision: profileToken.revision,
+});
 
 const fixPayload = {
   profile_count: 2,

--- a/tests/frontend_lora_preset_api_client_smoke.mjs
+++ b/tests/frontend_lora_preset_api_client_smoke.mjs
@@ -118,6 +118,40 @@ const createBody = JSON.parse(calls.at(-1).options.body);
 assert.equal(Object.hasOwn(createBody, "profile_id"), false);
 assert.equal(Object.hasOwn(createBody, "revision"), false);
 
+const reservedPayload = {
+  ...savePayload,
+  name: "payload name",
+  overwrite: true,
+  profile_id: "payload-profile-id",
+  revision: 99,
+};
+const reservedPayloadBefore = JSON.stringify(reservedPayload);
+responses.push(saveResponse);
+assert.equal(
+  await client.saveProfile("Endpoint Create", reservedPayload, false, profileToken),
+  saveResponse,
+);
+assert.deepEqual(JSON.parse(calls.at(-1).options.body), {
+  ...savePayload,
+  name: "Endpoint Create",
+  overwrite: false,
+});
+assert.equal(JSON.stringify(reservedPayload), reservedPayloadBefore);
+
+responses.push(saveResponse);
+assert.equal(
+  await client.saveProfile("Endpoint Overwrite", reservedPayload, true, profileToken),
+  saveResponse,
+);
+assert.deepEqual(JSON.parse(calls.at(-1).options.body), {
+  ...savePayload,
+  name: "Endpoint Overwrite",
+  overwrite: true,
+  profile_id: profileToken.profile_id,
+  revision: profileToken.revision,
+});
+assert.equal(JSON.stringify(reservedPayload), reservedPayloadBefore);
+
 responses.push(saveResponse);
 assert.equal(
   await client.saveProfile("Demo", savePayload, true, profileToken),

--- a/tests/frontend_lora_preset_profile_mutations_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_mutations_smoke.mjs
@@ -87,9 +87,9 @@ const apiMutations = createLoraPresetProfileMutations({
   text: (key) => key,
   formatText: (key) => key,
   apiClient: {
-    async saveProfile(name, payload, overwrite) {
-      apiCalls.save.push({ name, payload, overwrite });
-      return { profile: { name } };
+    async saveProfile(name, payload, overwrite, profile) {
+      apiCalls.save.push({ name, payload, overwrite, profile });
+      return { profile: { name, profile_id: "00000000-0000-4000-8000-000000000001", revision: 1 } };
     },
     async loadProfile(name) {
       apiCalls.load.push(name);
@@ -119,9 +119,16 @@ assert.equal(apiMutations.profileCount(node), 3);
 assert.equal(apiMutations.activeProfileIndex(node), 3);
 assert.equal(widgetValue(findWidget(node, "style_prompt")), "loaded second");
 
-function createSaveScenario(responses, confirmResult) {
+function profileExistsError(message = "Profile already exists") {
+  const error = new Error(message);
+  error.code = "profile_exists";
+  return error;
+}
+
+function createSaveScenario(responses, confirmResult, loadResponses = [], promptName = " existing profile ") {
   const scenarioNode = createProfileNode();
   const calls = [];
+  const loads = [];
   const confirmations = [];
   const alerts = [];
   const scenarioMutations = createLoraPresetProfileMutations({
@@ -134,9 +141,17 @@ function createSaveScenario(responses, confirmResult) {
     text: (key) => key,
     formatText: (key, values = {}) => `${key}:${values.name ?? values.message ?? ""}`,
     apiClient: {
-      async saveProfile(name, payload, overwrite) {
-        calls.push({ name, payload, overwrite });
+      async saveProfile(name, payload, overwrite, profile) {
+        calls.push({ name, payload, overwrite, profile });
         const response = responses.shift();
+        if (response instanceof Error) {
+          throw response;
+        }
+        return response;
+      },
+      async loadProfile(name) {
+        loads.push(name);
+        const response = loadResponses.shift();
         if (response instanceof Error) {
           throw response;
         }
@@ -144,7 +159,7 @@ function createSaveScenario(responses, confirmResult) {
       },
     },
     host: {
-      prompt: () => " existing profile ",
+      prompt: () => promptName,
       confirm(message) {
         confirmations.push(message);
         return confirmResult;
@@ -154,29 +169,63 @@ function createSaveScenario(responses, confirmResult) {
       },
     },
   });
-  return { alerts, calls, confirmations, mutations: scenarioMutations, node: scenarioNode };
+  return { alerts, calls, confirmations, loads, mutations: scenarioMutations, node: scenarioNode };
 }
 
 {
   const scenario = createSaveScenario([
-    new Error("Profile already exists"),
-    { profile: { name: "existing profile" } },
-  ], true);
+    profileExistsError(),
+    {
+      profile: {
+        name: "existing profile",
+        profile_id: "11111111-1111-4111-8111-111111111111",
+        revision: 8,
+      },
+    },
+    profileExistsError("localized conflict"),
+    {
+      profile: {
+        name: "existing profile",
+        profile_id: "11111111-1111-4111-8111-111111111111",
+        revision: 9,
+      },
+    },
+  ], true, [{
+    profile: {
+      name: "existing profile",
+      profile_id: "11111111-1111-4111-8111-111111111111",
+      revision: 7,
+    },
+  }]);
   await scenario.mutations.saveProfileSet(scenario.node);
   assert.deepEqual(scenario.calls.map((call) => call.overwrite), [false, true]);
   assert.strictEqual(scenario.calls[1].payload, scenario.calls[0].payload);
+  assert.deepEqual(scenario.calls[1].profile, {
+    profile_id: "11111111-1111-4111-8111-111111111111",
+    revision: 7,
+  });
+  assert.deepEqual(scenario.loads, ["existing profile"]);
   assert.deepEqual(scenario.confirmations, ["profile.overwriteConfirm:existing profile"]);
   assert.deepEqual(scenario.alerts, []);
   assert.equal(scenario.mutations.profileSaveStatus(scenario.node, 1).state, "saved");
+
+  await scenario.mutations.saveProfileSet(scenario.node);
+  assert.deepEqual(scenario.calls.map((call) => call.overwrite), [false, true, false, true]);
+  assert.deepEqual(scenario.calls[3].profile, {
+    profile_id: "11111111-1111-4111-8111-111111111111",
+    revision: 8,
+  });
+  assert.deepEqual(scenario.loads, ["existing profile"], "save response must refresh the token cache");
 }
 
 {
-  const scenario = createSaveScenario([new Error("Profile already exists")], false);
+  const scenario = createSaveScenario([profileExistsError()], false);
   const beforeData = scenario.mutations.parseProfileData(findWidget(scenario.node, "profile_data"));
   const beforeStatus = scenario.mutations.profileSaveStatus(scenario.node, 1);
   const beforeDirty = scenario.node.dirty;
   await scenario.mutations.saveProfileSet(scenario.node);
   assert.deepEqual(scenario.calls.map((call) => call.overwrite), [false]);
+  assert.deepEqual(scenario.loads, [], "declined overwrite must not load target metadata");
   assert.deepEqual(scenario.confirmations, ["profile.overwriteConfirm:existing profile"]);
   assert.deepEqual(scenario.alerts, []);
   assert.deepEqual(
@@ -188,11 +237,52 @@ function createSaveScenario(responses, confirmResult) {
 }
 
 {
-  const scenario = createSaveScenario([new Error("Profile already exists.")], true);
+  const scenario = createSaveScenario([new Error("Profile already exists")], true);
   await scenario.mutations.saveProfileSet(scenario.node);
   assert.deepEqual(scenario.calls.map((call) => call.overwrite), [false]);
   assert.deepEqual(scenario.confirmations, []);
-  assert.deepEqual(scenario.alerts, ["profile.saveFailed:Profile already exists."]);
+  assert.deepEqual(scenario.alerts, ["profile.saveFailed:Profile already exists"]);
+}
+
+{
+  const scenario = createSaveScenario([
+    profileExistsError(),
+    { profile: { name: "foo_bar", profile_id: "44444444-4444-4444-8444-444444444444", revision: 4 } },
+  ], true, [{
+    profile: { name: "foo_bar", profile_id: "44444444-4444-4444-8444-444444444444", revision: 3 },
+  }], " foo?bar ");
+  await scenario.mutations.saveProfileSet(scenario.node);
+  assert.deepEqual(scenario.loads, ["foo?bar"]);
+  assert.deepEqual(scenario.calls[1].profile, {
+    profile_id: "44444444-4444-4444-8444-444444444444",
+    revision: 3,
+  });
+}
+
+{
+  const scenario = createSaveScenario([
+    profileExistsError(),
+    { profile: { name: "existing profile" } },
+  ], true, [{ profile: { name: "existing profile" } }]);
+  await scenario.mutations.saveProfileSet(scenario.node);
+  assert.equal(scenario.calls[1].profile, null);
+  assert.deepEqual(scenario.alerts, []);
+}
+
+{
+  const scenario = createSaveScenario([
+    profileExistsError(),
+    { profile: { name: "existing profile", profile_id: "55555555-5555-4555-8555-555555555555", revision: 6 } },
+  ], true);
+  scenario.mutations.rememberProfileTokens([
+    { name: "existing profile", profile_id: "55555555-5555-4555-8555-555555555555", revision: 5 },
+  ]);
+  await scenario.mutations.saveProfileSet(scenario.node);
+  assert.deepEqual(scenario.loads, []);
+  assert.deepEqual(scenario.calls[1].profile, {
+    profile_id: "55555555-5555-4555-8555-555555555555",
+    revision: 5,
+  });
 }
 
 const partialNode = createProfileNode();

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -288,7 +288,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
             ["aioCreateProfileSettingsRuntime"],
         )
-        self.assertLessEqual(len(source.splitlines()), 430)
+        self.assertLessEqual(len(source.splitlines()), 480)
         self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
         self.assertNotRegex(source, r"\b(?:window|app|api)\b")
         self.assertNotIn("fetch(", source)

--- a/web/js/aio/profile_api_client.js
+++ b/web/js/aio/profile_api_client.js
@@ -26,6 +26,13 @@ export function createAioProfileApiClient(dependencies) {
     });
   }
 
+  function profileToken(profile, prefix = "") {
+    if (typeof profile?.profile_id !== "string" || !profile.profile_id || !Number.isInteger(profile?.revision) || profile.revision < 0) {
+      return {};
+    }
+    return { [`${prefix}profile_id`]: profile.profile_id, [`${prefix}revision`]: profile.revision };
+  }
+
   function listProfiles() {
     return fetchJson("/easyuse_anima/aio_profiles");
   }
@@ -36,24 +43,30 @@ export function createAioProfileApiClient(dependencies) {
     );
   }
 
-  function saveProfile(name, overwrite, settings) {
+  function saveProfile(name, overwrite, settings, profile = null) {
     return postJson("/easyuse_anima/aio_profiles/save", {
       name,
       overwrite,
       settings,
+      ...profileToken(overwrite ? profile : null),
     });
   }
 
-  function renameProfile(oldName, newName, overwrite) {
+  function renameProfile(oldName, newName, overwrite, profile = null, targetProfile = null) {
     return postJson("/easyuse_anima/aio_profiles/rename", {
       old_name: oldName,
       new_name: newName,
       overwrite,
+      ...profileToken(profile),
+      ...profileToken(overwrite ? targetProfile : null, "target_"),
     });
   }
 
-  function deleteProfile(name) {
-    return postJson("/easyuse_anima/aio_profiles/delete", { name });
+  function deleteProfile(name, profile = null) {
+    return postJson("/easyuse_anima/aio_profiles/delete", {
+      name,
+      ...profileToken(profile),
+    });
   }
 
   return {

--- a/web/js/aio/profile_settings_runtime.js
+++ b/web/js/aio/profile_settings_runtime.js
@@ -4,9 +4,9 @@
  * @typedef {object} AioProfileApi
  * @property {() => Promise<any>} listProfiles
  * @property {(name: string) => Promise<any>} loadProfile
- * @property {(name: string, overwrite: boolean, settings: any) => Promise<any>} saveProfile
- * @property {(oldName: string, newName: string, overwrite: boolean) => Promise<any>} renameProfile
- * @property {(name: string) => Promise<any>} deleteProfile
+ * @property {(name: string, overwrite: boolean, settings: any, profile?: any) => Promise<any>} saveProfile
+ * @property {(oldName: string, newName: string, overwrite: boolean, profile?: any, targetProfile?: any) => Promise<any>} renameProfile
+ * @property {(name: string, profile?: any) => Promise<any>} deleteProfile
  */
 
 /**
@@ -117,6 +117,25 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
     return findUser(state.profiles, name);
   }
 
+  function rememberProfile(profile, ...replacedNames) {
+    const name = String(profile?.name || "").trim();
+    if (!name) {
+      return;
+    }
+    const replaced = new Set([...replacedNames, name].map((value) => String(value || "").toLowerCase()));
+    state.profiles = state.profiles.filter(
+      (current) => !replaced.has(String(current?.name || "").toLowerCase()),
+    );
+    state.profiles.push(profile);
+  }
+
+  function forgetProfile(name) {
+    const expected = String(name || "").toLowerCase();
+    state.profiles = state.profiles.filter(
+      (profile) => String(profile?.name || "").toLowerCase() !== expected,
+    );
+  }
+
   async function loadProfiles({ force = false } = {}) {
     if (state.loaded && !force) {
       return state.profiles;
@@ -164,6 +183,7 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
     const name = userName(textValue);
     const data = await profileApi.loadProfile(name);
     const profile = data?.profile || null;
+    rememberProfile(profile ? { ...profile, name } : null, name);
     if (!profile?.settings || typeof profile.settings !== "object") {
       throw new Error("Profile settings are missing");
     }
@@ -187,7 +207,8 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
       return;
     }
     const settings = getSettings(node);
-    const data = await profileApi.saveProfile(name, overwrite, settings);
+    const data = await profileApi.saveProfile(name, overwrite, settings, existing);
+    rememberProfile(data?.profile, name);
     await loadProfiles({ force: true });
     node.__easyuseAnimaGeneratorProfileValue = userValue(data?.profile?.name || name);
     node.__easyuseAnimaGeneratorProfileFingerprint = fingerprint(settings);
@@ -214,7 +235,15 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
     if (overwrite && !dialogs.confirm(format("profile.overwriteConfirm", { name: existing.name }))) {
       return;
     }
-    const data = await profileApi.renameProfile(oldName, newName, overwrite);
+    const current = userProfileByName(oldName);
+    const data = await profileApi.renameProfile(
+      oldName,
+      newName,
+      overwrite,
+      current,
+      overwrite ? existing : null,
+    );
+    rememberProfile(data?.profile, oldName, newName);
     await loadProfiles({ force: true });
     if (currentName.toLowerCase() === oldName.toLowerCase()) {
       node.__easyuseAnimaGeneratorProfileValue = userValue(data?.profile?.name || newName);
@@ -228,7 +257,9 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
       return;
     }
     const currentName = userName(syncValue(node));
-    await profileApi.deleteProfile(name);
+    const current = userProfileByName(name);
+    await profileApi.deleteProfile(name, current);
+    forgetProfile(name);
     await loadProfiles({ force: true });
     if (currentName.toLowerCase() === name.toLowerCase()) {
       node.__easyuseAnimaGeneratorProfileValue = customValue;

--- a/web/js/aio/profile_settings_runtime.js
+++ b/web/js/aio/profile_settings_runtime.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const PROFILE_EXISTS_CODE = "profile_exists";
+
 /**
  * @typedef {object} AioProfileApi
  * @property {() => Promise<any>} listProfiles
@@ -117,6 +119,10 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
     return findUser(state.profiles, name);
   }
 
+  function isProfileExistsError(error) {
+    return error?.code === PROFILE_EXISTS_CODE;
+  }
+
   function rememberProfile(profile, ...replacedNames) {
     const name = String(profile?.name || "").trim();
     if (!name) {
@@ -134,6 +140,13 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
     state.profiles = state.profiles.filter(
       (profile) => String(profile?.name || "").toLowerCase() !== expected,
     );
+  }
+
+  async function loadConflictProfile(name) {
+    const data = await profileApi.loadProfile(name);
+    const profile = data?.profile || null;
+    rememberProfile(profile, name);
+    return profile;
   }
 
   async function loadProfiles({ force = false } = {}) {
@@ -207,7 +220,24 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
       return;
     }
     const settings = getSettings(node);
-    const data = await profileApi.saveProfile(name, overwrite, settings, existing);
+    let data;
+    if (overwrite) {
+      data = await profileApi.saveProfile(name, true, settings, existing);
+    } else {
+      try {
+        data = await profileApi.saveProfile(name, false, settings, null);
+      } catch (error) {
+        if (!isProfileExistsError(error)) {
+          throw error;
+        }
+        const target = await loadConflictProfile(name);
+        const targetName = String(target?.name || name);
+        if (!dialogs.confirm(format("profile.overwriteConfirm", { name: targetName }))) {
+          return;
+        }
+        data = await profileApi.saveProfile(name, true, settings, target);
+      }
+    }
     rememberProfile(data?.profile, name);
     await loadProfiles({ force: true });
     node.__easyuseAnimaGeneratorProfileValue = userValue(data?.profile?.name || name);
@@ -236,13 +266,24 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
       return;
     }
     const current = userProfileByName(oldName);
-    const data = await profileApi.renameProfile(
-      oldName,
-      newName,
-      overwrite,
-      current,
-      overwrite ? existing : null,
-    );
+    let data;
+    if (overwrite) {
+      data = await profileApi.renameProfile(oldName, newName, true, current, existing);
+    } else {
+      try {
+        data = await profileApi.renameProfile(oldName, newName, false, current, null);
+      } catch (error) {
+        if (!isProfileExistsError(error)) {
+          throw error;
+        }
+        const target = await loadConflictProfile(newName);
+        const targetName = String(target?.name || newName);
+        if (!dialogs.confirm(format("profile.overwriteConfirm", { name: targetName }))) {
+          return;
+        }
+        data = await profileApi.renameProfile(oldName, newName, true, current, target);
+      }
+    }
     rememberProfile(data?.profile, oldName, newName);
     await loadProfiles({ force: true });
     if (currentName.toLowerCase() === oldName.toLowerCase()) {

--- a/web/js/easyuse_anima_lora_preset.js
+++ b/web/js/easyuse_anima_lora_preset.js
@@ -344,6 +344,7 @@ const {
   deleteProfile,
   selectedProfilePayload,
   profileSaveStatus,
+  rememberProfileTokens,
   appendProfilePayload,
   saveProfileSet,
   loadProfileSet,
@@ -534,6 +535,7 @@ async function openProfileLoadMenu(node, event, pos) {
   try {
     const data = await loraPresetApi.listProfiles();
     profiles = Array.isArray(data?.profiles) ? data.profiles : [];
+    rememberProfileTokens(profiles);
   } catch (error) {
     window.alert(lpFormat("profile.listFailed", { message: errorMessage(error) }));
     return;
@@ -552,7 +554,10 @@ async function openProfileLoadMenu(node, event, pos) {
     callback: (value) => {
       const name = String(value?.content ?? value ?? "").trim();
       if (name) {
-        loadProfileSet(node, name);
+        loadProfileSet(
+          node,
+          profiles.find((profile) => String(profile?.name || "") === name) || name,
+        );
       }
     },
   });

--- a/web/js/lora_preset/api_client.js
+++ b/web/js/lora_preset/api_client.js
@@ -33,6 +33,14 @@ export function createLoraPresetApiClient(dependencies) {
     return { profile_id: profile.profile_id, revision: profile.revision };
   }
 
+  function profilePayload(payload) {
+    const sanitized = { ...(payload || {}) };
+    for (const field of ["name", "overwrite", "profile_id", "revision"]) {
+      delete sanitized[field];
+    }
+    return sanitized;
+  }
+
   function listProfiles() {
     return fetchJson("/easyuse_anima/lora_profiles");
   }
@@ -46,7 +54,7 @@ export function createLoraPresetApiClient(dependencies) {
   function saveProfile(name, payload, overwrite = false, profile = null) {
     return postJson("/easyuse_anima/lora_profiles/save", {
       name,
-      ...payload,
+      ...profilePayload(payload),
       overwrite,
       ...profileToken(overwrite ? profile : null),
     });

--- a/web/js/lora_preset/api_client.js
+++ b/web/js/lora_preset/api_client.js
@@ -26,6 +26,13 @@ export function createLoraPresetApiClient(dependencies) {
     });
   }
 
+  function profileToken(profile) {
+    if (typeof profile?.profile_id !== "string" || !profile.profile_id || !Number.isInteger(profile?.revision) || profile.revision < 0) {
+      return {};
+    }
+    return { profile_id: profile.profile_id, revision: profile.revision };
+  }
+
   function listProfiles() {
     return fetchJson("/easyuse_anima/lora_profiles");
   }
@@ -36,11 +43,12 @@ export function createLoraPresetApiClient(dependencies) {
     );
   }
 
-  function saveProfile(name, payload, overwrite = false) {
+  function saveProfile(name, payload, overwrite = false, profile = null) {
     return postJson("/easyuse_anima/lora_profiles/save", {
       name,
       ...payload,
       overwrite,
+      ...profileToken(overwrite ? profile : null),
     });
   }
 

--- a/web/js/lora_preset/profile_mutations.js
+++ b/web/js/lora_preset/profile_mutations.js
@@ -12,7 +12,7 @@ import {
   wrapProfileIndex,
 } from "./profile_data.js";
 
-const PROFILE_ALREADY_EXISTS_MESSAGE = "Profile already exists";
+const PROFILE_EXISTS_CODE = "profile_exists";
 
 /**
  * Owns profile and LoRA-row mutations while leaving canvas rendering and node
@@ -31,6 +31,32 @@ export function createLoraPresetProfileMutations({
   errorMessage = (error) => error?.message || String(error),
   host = globalThis.window,
 }) {
+  const profileTokens = new Map();
+
+  function rememberProfileTokens(profiles) {
+    if (Array.isArray(profiles)) {
+      profileTokens.clear();
+    }
+    for (const profile of Array.isArray(profiles) ? profiles : [profiles]) {
+      const name = String(profile?.name || "").trim().toLowerCase();
+      if (!name) {
+        continue;
+      }
+      if (typeof profile?.profile_id === "string" && profile.profile_id && Number.isInteger(profile?.revision) && profile.revision >= 0) {
+        profileTokens.set(name, {
+          profile_id: profile.profile_id,
+          revision: profile.revision,
+        });
+      } else {
+        profileTokens.delete(name);
+      }
+    }
+  }
+
+  function profileToken(name) {
+    return profileTokens.get(String(name || "").trim().toLowerCase()) || null;
+  }
+
   function renderProfileBar(node) {
     getCanvasWidgets()?.renderProfileBar(node);
   }
@@ -299,7 +325,7 @@ export function createLoraPresetProfileMutations({
       try {
         data = await apiClient.saveProfile(trimmedName, payload, false);
       } catch (error) {
-        if (errorMessage(error) !== PROFILE_ALREADY_EXISTS_MESSAGE) {
+        if (error?.code !== PROFILE_EXISTS_CODE) {
           throw error;
         }
         const confirmed = host.confirm?.(
@@ -308,8 +334,20 @@ export function createLoraPresetProfileMutations({
         if (!confirmed) {
           return;
         }
-        data = await apiClient.saveProfile(trimmedName, payload, true);
+        let overwriteToken = profileToken(trimmedName);
+        if (!overwriteToken) {
+          const current = await apiClient.loadProfile(trimmedName);
+          rememberProfileTokens(current?.profile);
+          overwriteToken = profileToken(current?.profile?.name);
+        }
+        data = await apiClient.saveProfile(
+          trimmedName,
+          payload,
+          true,
+          overwriteToken,
+        );
       }
+      rememberProfileTokens(data?.profile);
       markSelectedProfileSaved(node, data?.profile?.name || trimmedName);
       renderProfileBar(node);
       node.setDirtyCanvas?.(true, true);
@@ -318,9 +356,12 @@ export function createLoraPresetProfileMutations({
     }
   }
 
-  async function loadProfileSet(node, name) {
+  async function loadProfileSet(node, profileOrName) {
     try {
+      rememberProfileTokens(profileOrName);
+      const name = String(profileOrName?.name || profileOrName || "").trim();
       const data = await apiClient.loadProfile(name);
+      rememberProfileTokens(data?.profile);
       appendProfilePayload(node, data.profile);
     } catch (error) {
       host.alert?.(formatText("profile.loadFailed", { message: errorMessage(error) }));
@@ -407,6 +448,7 @@ export function createLoraPresetProfileMutations({
     deleteProfile,
     selectedProfilePayload,
     profileSaveStatus,
+    rememberProfileTokens,
     appendProfilePayload,
     saveProfileSet,
     loadProfileSet,


### PR DESCRIPTION
## 변경 요약

Issue #163 Part 3B(frontend token adoption)를 구현하고 메인+독립 리뷰 차단점을 반영합니다.

- LoRA/AiO frontend API client가 additive `profile_id`/`revision`을 optional precondition으로 전송합니다.
- AiO runtime이 list/load/save/rename 응답 metadata를 보존하고 overwrite save, rename source/target, delete 요청에 전달합니다.
- sanitized/stale target이 local list에 없더라도 coded `profile_exists`에서 target을 load하고 canonical name으로 확인한 뒤 정확히 한 번 overwrite retry합니다.
- message-only 오류, 이미 알고 있던 overwrite 오류, retry 오류는 자동 재시도하지 않습니다.
- LoRA runtime은 list/load/save token을 비직렬화 cache에 보존하고 cold conflict에서 load metadata를 보충합니다.
- LoRA API client는 caller payload의 reserved `name`/`overwrite`/`profile_id`/`revision`을 제거하고 endpoint-owned 값과 별도 token만 사용합니다.
- 구형 tokenless 응답에서는 token 필드를 생략하며, 신규 create와 non-overwrite rename target에는 token을 넣지 않습니다.

공개 workflow의 `user:<name>` 선택값과 hidden widget 순서/직렬화 계약은 변경하지 않습니다.

Refs #163

## 주요 파일

- `web/js/aio/profile_api_client.js`
- `web/js/aio/profile_settings_runtime.js`
- `web/js/lora_preset/api_client.js`
- `web/js/lora_preset/profile_mutations.js`
- `web/js/easyuse_anima_lora_preset.js`
- deterministic frontend smoke 4개와 `tests/test_frontend_modules.py`

## 검증

Delegated focused validation:

- 영향 Node smoke 4개 통과
- `node --check` 통과
- frontend modules: 47 tests OK
- LoRA frontend: 19 tests OK
- TypeScript 6.0.3 / `jsconfig.json` 통과
- repository-owned `tools/check_project.ps1 -Profile quick` 통과

메인 병합 전 검증, exact HEAD `f2f3c6d24c799b660651bab0dbc5097cca2bb4a2`:

- `powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project D:\ComfyUI\custom_nodes_workplace\worktrees\ComfyUI-EasyUseAnima\codex\issue-163-frontend-token-adoption -Profile full`
- Python unittest: 657 tests OK
- Frontend: 111 JavaScript files
- TypeScript: 6.0.3
- Python compile / Git diff check 통과
- 메인 actual diff 리뷰 및 독립 focused review 차단점 수정 확인

## 테스트 표면

- Repository deterministic frontend smoke 및 공식 full validation
- Live ComfyUI/API/browser smoke: 이 PR에서는 미실행

이 변경은 DOM, canvas, widget order, workflow serialization을 수정하지 않습니다. 토큰의 실제 stale-conflict 효력이 활성화되는 Part 3C strict CAS에서 end-to-end API/browser 검증을 함께 수행합니다.

## 남은 위험 / 미확인

- strict CAS enforcement 및 신규 409 taxonomy는 Part 3C 범위입니다.
- tokenless 구형 서버에서는 기존 동작을 유지하며 strict CAS 효력은 없습니다.
- frontend 변경이므로 수동 확인 시 브라우저 hard refresh가 필요할 수 있습니다.
