### PR TITLE
chore: Wildcard와 NAIA vertical slice를 canonical package로 이동

### DIFF
--- a/easyuse_anima/naia/__init__.py
+++ b/easyuse_anima/naia/__init__.py
@@ -1,0 +1,3 @@
+"""NAIA feature package boundary."""
+
+__all__ = ()

--- a/easyuse_anima/naia/client.py
+++ b/easyuse_anima/naia/client.py
@@ -1,0 +1,134 @@
+"""NAIA Remote API transport and response normalization."""
+
+from __future__ import annotations
+
+import re
+from math import sqrt
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 7243
+NAIA_LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
+NAIA_REQUEST_TIMEOUT = 30.0
+HTTP_TIMEOUT = NAIA_REQUEST_TIMEOUT + 5.0
+NAI_1MP = 1024 * 1024
+LATENT_ALIGN = 8
+NAIA_MAX_RESOLUTION = 8192
+PREPROCESSING_KEYS = [
+    "remove_author",
+    "remove_work_title",
+    "remove_character_name",
+    "remove_character_features",
+    "remove_clothes",
+    "remove_color",
+    "remove_location_and_background_color",
+    "remove_expression",
+    "remove_pose_action",
+    "remove_meta_tags",
+    "remove_object_tags",
+    "remove_noise_tags",
+    "e621_auto_boost",
+    "danbooru_auto_weight",
+    "tag_implication_compression",
+]
+PP_STATE_CHOICES = ["skip", "on", "off"]
+
+_HASH_COMMENT_RE = re.compile(r"^[ \t]*#[^\n]*", re.MULTILINE)
+_MULTI_COMMA_RE = re.compile(r"(\s*,){2,}")
+
+
+def _clean_prompt(value: str) -> str:
+    if not value:
+        return value
+    value = _HASH_COMMENT_RE.sub("", value)
+    value = _MULTI_COMMA_RE.sub(",", value)
+    return value.strip(" ,\n\t")
+
+
+def _fit_to_1mp(width: int, height: int) -> tuple[int, int]:
+    if width <= 0 or height <= 0:
+        return width, height
+    if width * height <= NAI_1MP:
+        return width, height
+
+    scale = sqrt(NAI_1MP / (width * height))
+    new_w = max(LATENT_ALIGN, round(width * scale / LATENT_ALIGN) * LATENT_ALIGN)
+    new_h = max(LATENT_ALIGN, round(height * scale / LATENT_ALIGN) * LATENT_ALIGN)
+    if new_w * new_h > NAI_1MP:
+        if new_w >= new_h:
+            new_w = (NAI_1MP // new_h // LATENT_ALIGN) * LATENT_ALIGN
+        else:
+            new_h = (NAI_1MP // new_w // LATENT_ALIGN) * LATENT_ALIGN
+    return new_w, new_h
+
+
+def _is_local_naia_host(host: str) -> bool:
+    return str(host or "").strip().strip("[]").lower() in NAIA_LOCAL_HOSTS
+
+
+def _build_naia_random_url(host: str, port: int, allow_remote_api: bool = False) -> str:
+    host_value = str(host or DEFAULT_HOST).strip() or DEFAULT_HOST
+    if any(token in host_value for token in ("://", "/", "\\", "?", "#", "@")) or re.search(r"\s", host_value):
+        raise RuntimeError("[EasyUse Anima] NAIA host must be a hostname or IP address, not a URL.")
+    if not allow_remote_api and not _is_local_naia_host(host_value):
+        raise RuntimeError(
+            "[EasyUse Anima] Remote NAIA API access is disabled. "
+            "Enable 'Allow remote API' in EasyUse Anima NAIA settings to use a non-local host."
+        )
+    url_host = host_value
+    if ":" in host_value and not host_value.startswith("["):
+        url_host = f"[{host_value}]"
+    return f"http://{url_host}:{int(port)}/api/comfyui/random"
+
+
+def _post_random(host: str, port: int, body: dict, allow_remote_api: bool = False) -> dict:
+    try:
+        import requests
+    except ImportError:
+        raise RuntimeError("[EasyUse Anima] requests is not installed. Install requirements.txt.")
+
+    url = _build_naia_random_url(host, port, allow_remote_api=allow_remote_api)
+    try:
+        # Explicit user-configured NAIA API call. Default use is localhost-only;
+        # remote hosts require allow_remote_api=True. The response is parsed as
+        # JSON and is never executed as code.
+        response = requests.post(url, json=body, timeout=HTTP_TIMEOUT)
+    except requests.RequestException as exc:
+        raise RuntimeError(f"[EasyUse Anima] NAIA API request failed: {exc}")
+
+    if not response.ok:
+        raise RuntimeError(
+            f"[EasyUse Anima] NAIA API error HTTP {response.status_code}: {response.text[:300]}"
+        )
+    try:
+        data = response.json()
+    except ValueError:
+        raise RuntimeError(f"[EasyUse Anima] NAIA API returned non-JSON: {response.text[:300]}")
+
+    if not data.get("ok", True):
+        raise RuntimeError(f"[EasyUse Anima] NAIA API returned error: {data}")
+    return data
+
+
+def _parse_random_response(resp: dict) -> tuple[str, str, int, int]:
+    prompt = _clean_prompt(resp.get("prompt", "") or "")
+    negative = _clean_prompt(resp.get("negative_prompt", "") or "")
+    w_raw, h_raw = resp.get("width"), resp.get("height")
+    if w_raw is None or h_raw is None:
+        raise RuntimeError("[EasyUse Anima] NAIA response is missing width/height.")
+    try:
+        raw_width, raw_height = int(w_raw), int(h_raw)
+    except (TypeError, ValueError):
+        raise RuntimeError(f"[EasyUse Anima] Invalid NAIA width/height: {w_raw!r}, {h_raw!r}")
+    if not (
+        1 <= raw_width <= NAIA_MAX_RESOLUTION
+        and 1 <= raw_height <= NAIA_MAX_RESOLUTION
+    ):
+        raise RuntimeError(
+            f"[EasyUse Anima] Invalid NAIA width/height: {w_raw!r}, {h_raw!r}; "
+            f"expected values from 1 to {NAIA_MAX_RESOLUTION}."
+        )
+    width, height = _fit_to_1mp(raw_width, raw_height)
+    return prompt, negative, width, height
+
+__all__ = ()

--- a/easyuse_anima/naia/resolution.py
+++ b/easyuse_anima/naia/resolution.py
@@ -1,0 +1,211 @@
+"""Prompt Studio and NAIA resolution selection policy."""
+
+from __future__ import annotations
+
+import re
+from math import gcd, log
+
+from ..common.values import _as_float, _as_int, _single_value
+
+
+ADVANCED_RESOLUTION_BUCKETS = {
+    "512": (
+        (256, 1024), (1024, 256),
+        (288, 896), (896, 288),
+        (384, 672), (672, 384),
+        (512, 512),
+        (448, 576), (576, 448),
+    ),
+    "768": (
+        (384, 1440), (1440, 384),
+        (480, 1152), (1152, 480),
+        (576, 960), (960, 576),
+        (640, 864), (864, 640),
+        (768, 768),
+    ),
+    "896": (
+        (448, 1728), (1728, 448),
+        (480, 1600), (1600, 480),
+        (576, 1344), (1344, 576),
+        (672, 1152), (1152, 672),
+        (800, 960), (960, 800),
+        (896, 896),
+    ),
+    "1024": (
+        (512, 2016), (2016, 512),
+        (576, 1792), (1792, 576),
+        (672, 1536), (1536, 672),
+        (672, 1600), (1600, 672),
+        (768, 1344), (1344, 768),
+        (800, 1344), (1344, 800),
+        (896, 1152), (1152, 896),
+        (960, 1120), (1120, 960),
+        (1024, 1024),
+    ),
+    "1280": (
+        (672, 2400), (2400, 672),
+        (800, 2016), (2016, 800),
+        (1024, 1536), (1536, 1024),
+        (1024, 1600), (1600, 1024),
+        (1120, 1440), (1440, 1120),
+        (1280, 1280),
+    ),
+    "1536": (
+        (1440, 1536), (1536, 1440),
+        (1280, 1728), (1728, 1280),
+        (1152, 1920), (1920, 1152),
+        (1024, 2176), (2176, 1024),
+        (960, 2304), (2304, 960),
+        (864, 2560), (2560, 864),
+        (768, 2880), (2880, 768),
+        (1536, 1536),
+    ),
+}
+CUSTOM_ADVANCED_RESOLUTION_BUCKET = "Custom"
+NAIA_ADVANCED_RESOLUTION_BUCKET = "NAIA"
+DEFAULT_ADVANCED_RESOLUTION_BUCKET = "1024"
+DEFAULT_ADVANCED_RESOLUTION_SIZE = "1024 * 1024 (1:1)"
+NAIA_RESOLUTION_MODE_SCALE = "scale"
+NAIA_RESOLUTION_MODE_BUCKET = "bucket"
+
+_RESOLUTION_LABEL_RE = re.compile(r"(\d+)\s*(?:\*|x|×)\s*(\d+)")
+
+
+def _ratio_label(width: int, height: int) -> str:
+    divisor = gcd(max(1, int(width)), max(1, int(height)))
+    return f"{int(width) // divisor}:{int(height) // divisor}"
+
+
+def _resolution_label(width: int, height: int) -> str:
+    return f"{int(width)} * {int(height)} ({_ratio_label(width, height)})"
+
+
+def _sorted_resolution_options(bucket: str) -> list[tuple[int, int]]:
+    values = ADVANCED_RESOLUTION_BUCKETS.get(bucket) or ADVANCED_RESOLUTION_BUCKETS[DEFAULT_ADVANCED_RESOLUTION_BUCKET]
+    return sorted(values, key=lambda item: (item[0] / item[1], item[0], item[1]))
+
+
+def _normalize_resolution_bucket(value) -> str:
+    value = str(_single_value(value) or "").strip()
+    if value in {CUSTOM_ADVANCED_RESOLUTION_BUCKET, NAIA_ADVANCED_RESOLUTION_BUCKET}:
+        return value
+    return value if value in ADVANCED_RESOLUTION_BUCKETS else DEFAULT_ADVANCED_RESOLUTION_BUCKET
+
+
+def _snap_resolution_32(value, default: int = 1024) -> int:
+    raw = _as_int(value, default)
+    if raw <= 0:
+        raw = default
+    return max(32, int(round(raw / 32)) * 32)
+
+
+def _resolve_naia_resolution_scale(naia_settings: dict | None) -> float:
+    value = _as_float((naia_settings or {}).get("resolution_scale", 1.0), 1.0)
+    return max(0.25, min(4.0, value))
+
+
+def _resolve_naia_resolution_max_long_edge(naia_settings: dict | None) -> int:
+    value = _as_int((naia_settings or {}).get("resolution_max_long_edge", 0), 0)
+    if value <= 0:
+        return 0
+    return max(32, min(16384, value))
+
+
+def _resolve_naia_resolution_mode(naia_settings: dict | None) -> str:
+    value = str(
+        _single_value((naia_settings or {}).get("resolution_mode", NAIA_RESOLUTION_MODE_SCALE)) or ""
+    ).strip().lower()
+    if value == "bucket_fit":
+        return NAIA_RESOLUTION_MODE_BUCKET
+    return value if value in {NAIA_RESOLUTION_MODE_SCALE, NAIA_RESOLUTION_MODE_BUCKET} else NAIA_RESOLUTION_MODE_SCALE
+
+
+def _resolve_naia_resolution_bucket(naia_settings: dict | None) -> str:
+    bucket = _normalize_resolution_bucket((naia_settings or {}).get("resolution_bucket", DEFAULT_ADVANCED_RESOLUTION_BUCKET))
+    return bucket if bucket in ADVANCED_RESOLUTION_BUCKETS else DEFAULT_ADVANCED_RESOLUTION_BUCKET
+
+
+def _snap_scaled_resolution_32(value: float, max_value: int = 0, default: int = 1024) -> int:
+    raw = _as_float(value, float(default))
+    if raw <= 0:
+        raw = float(default)
+    snapped = max(32, int(round(raw / 32)) * 32)
+    if max_value > 0 and snapped > max_value:
+        snapped = max(32, int(max_value // 32) * 32)
+    return snapped
+
+
+def _scale_naia_resolution(
+    width: int,
+    height: int,
+    naia_settings: dict | None,
+) -> tuple[int, int]:
+    scale = _resolve_naia_resolution_scale(naia_settings)
+    max_long_edge = _resolve_naia_resolution_max_long_edge(naia_settings)
+    scaled_width = max(1.0, _as_float(width, 1024.0) * scale)
+    scaled_height = max(1.0, _as_float(height, 1024.0) * scale)
+
+    if max_long_edge > 0:
+        long_edge = max(scaled_width, scaled_height)
+        if long_edge > max_long_edge:
+            ratio = max_long_edge / long_edge
+            scaled_width *= ratio
+            scaled_height *= ratio
+
+    return (
+        _snap_scaled_resolution_32(scaled_width, max_long_edge, 1024),
+        _snap_scaled_resolution_32(scaled_height, max_long_edge, 1024),
+    )
+
+
+def _fit_naia_resolution_to_bucket(
+    width: int,
+    height: int,
+    naia_settings: dict | None,
+) -> tuple[int, int]:
+    bucket = _resolve_naia_resolution_bucket(naia_settings)
+    source_width = max(1.0, _as_float(width, 1024.0))
+    source_height = max(1.0, _as_float(height, 1024.0))
+    source_ratio = source_width / source_height
+    options = ADVANCED_RESOLUTION_BUCKETS.get(bucket) or ADVANCED_RESOLUTION_BUCKETS[DEFAULT_ADVANCED_RESOLUTION_BUCKET]
+
+    return min(
+        options,
+        key=lambda item: abs(log((item[0] / item[1]) / source_ratio)),
+    )
+
+
+def _resolve_naia_resolution(
+    width: int,
+    height: int,
+    naia_settings: dict | None,
+) -> tuple[int, int]:
+    if _resolve_naia_resolution_mode(naia_settings) == NAIA_RESOLUTION_MODE_BUCKET:
+        return _fit_naia_resolution_to_bucket(width, height, naia_settings)
+    return _scale_naia_resolution(width, height, naia_settings)
+
+
+def _advanced_resolution_from_selection(
+    bucket,
+    size,
+    custom_width: int | str = 1024,
+    custom_height: int | str = 1024,
+) -> tuple[int, int]:
+    bucket_name = _normalize_resolution_bucket(bucket)
+    if bucket_name in {CUSTOM_ADVANCED_RESOLUTION_BUCKET, NAIA_ADVANCED_RESOLUTION_BUCKET}:
+        return (
+            _snap_resolution_32(custom_width, 1024),
+            _snap_resolution_32(custom_height, 1024),
+        )
+    raw_size = str(_single_value(size) or "").strip()
+    match = _RESOLUTION_LABEL_RE.search(raw_size)
+    if match:
+        width, height = int(match.group(1)), int(match.group(2))
+        if (width, height) in ADVANCED_RESOLUTION_BUCKETS.get(bucket_name, ()):
+            return width, height
+    default_width, default_height = 1024, 1024
+    if (default_width, default_height) in ADVANCED_RESOLUTION_BUCKETS.get(bucket_name, ()):
+        return default_width, default_height
+    return _sorted_resolution_options(bucket_name)[0]
+
+__all__ = ()

--- a/easyuse_anima/nodes/naia_nodes.py
+++ b/easyuse_anima/nodes/naia_nodes.py
@@ -1,0 +1,594 @@
+"""ComfyUI adapter for the NAIA random prompt client."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from ..common.serialization import _stable_change_key
+from ..common.values import _as_bool, _as_int, _single_value
+from ..naia.client import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    NAIA_MAX_RESOLUTION,
+    NAIA_REQUEST_TIMEOUT,
+    PP_STATE_CHOICES,
+    PREPROCESSING_KEYS,
+    _parse_random_response,
+    _post_random,
+)
+
+
+logger = logging.getLogger("ComfyUI-EasyUseAnima")
+
+
+def _unbound_runtime(*_args, **_kwargs):
+    raise RuntimeError("NAIA node runtime dependencies are not bound.")
+
+
+resolve_naia_settings = _unbound_runtime
+_get_workflow_node = _unbound_runtime
+
+
+def _bind_naia_node_runtime(*, resolve_settings, get_workflow_node, post_random, parse_random_response) -> None:
+    global resolve_naia_settings, _get_workflow_node
+    global _post_random, _parse_random_response
+
+    resolve_naia_settings = resolve_settings
+    _get_workflow_node = get_workflow_node
+    _post_random = post_random
+    _parse_random_response = parse_random_response
+
+
+class EasyUseAnimaNAIARandomPrompt:
+    """NAIA random prompt node with bypass and frozen-output cache."""
+
+    DESCRIPTION = (
+        "Requests a random prompt from NAIA Remote API, supports bypass and frozen output reuse, "
+        "and stores generated values so saved-image workflows can reproduce the same result."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Prompt text from NAIA or the original input when bypassed or not overridden.",
+        "Negative prompt text from NAIA or the original input when bypassed or not overridden.",
+        "Width from NAIA or the original input when bypassed or not overridden.",
+        "Height from NAIA or the original input when bypassed or not overridden.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        required = {
+            "use_naia_bridge": ("BOOLEAN", {
+                "default": True,
+                "tooltip": (
+                    "false: bypass NAIA and return prompt/negative_prompt/width/height as-is. "
+                    "This mode keeps ComfyUI cache stable when inputs are unchanged."
+                ),
+            }),
+            "freeze_naia_output": ("BOOLEAN", {
+                "default": False,
+                "tooltip": (
+                    "true: if cached output is valid, return it without calling NAIA. "
+                    "Saved-image workflows are written with this enabled."
+                ),
+            }),
+            "show_preview": ("BOOLEAN", {
+                "default": True,
+                "tooltip": "Show the large read-only preview widget in the node UI.",
+            }),
+            "cached_prompt": ("STRING", {
+                "multiline": True,
+                "default": "",
+                "tooltip": "Stored prompt used for frozen output and saved-image reproduction.",
+            }),
+            "cached_negative_prompt": ("STRING", {
+                "multiline": True,
+                "default": "",
+                "tooltip": "Stored negative prompt used for frozen output and saved-image reproduction.",
+            }),
+            "cached_width": ("INT", {
+                "default": 0, "min": 0, "max": NAIA_MAX_RESOLUTION, "step": 8,
+                "tooltip": "Stored width used for frozen output and saved-image reproduction.",
+            }),
+            "cached_height": ("INT", {
+                "default": 0, "min": 0, "max": NAIA_MAX_RESOLUTION, "step": 8,
+                "tooltip": "Stored height used for frozen output and saved-image reproduction.",
+            }),
+            "cached_signature": ("STRING", {
+                "multiline": True,
+                "default": "",
+                "tooltip": "Internal signature for validating cached output.",
+            }),
+            "prompt": ("STRING", {
+                "multiline": False,
+                "default": "",
+                "placeholder": "prompt",
+                "tooltip": "Returned as-is when bypassed or when override_prompt is false.",
+            }),
+            "override_prompt": ("BOOLEAN", {
+                "default": True,
+                "tooltip": "true: use NAIA prompt. false: preserve input prompt.",
+            }),
+            "negative_prompt": ("STRING", {
+                "multiline": False,
+                "default": "",
+                "placeholder": "negative_prompt",
+                "tooltip": "Returned as-is when bypassed or when override_negative is false.",
+            }),
+            "override_negative": ("BOOLEAN", {
+                "default": True,
+                "tooltip": "true: use NAIA negative prompt. false: preserve input negative_prompt.",
+            }),
+            "width": ("INT", {
+                "default": 1024, "min": 64, "max": NAIA_MAX_RESOLUTION, "step": 8,
+                "tooltip": "Returned as-is when bypassed or when override_width is false.",
+            }),
+            "override_width": ("BOOLEAN", {
+                "default": True,
+                "tooltip": "true: use NAIA width. false: preserve input width.",
+            }),
+            "height": ("INT", {
+                "default": 1024, "min": 64, "max": NAIA_MAX_RESOLUTION, "step": 8,
+                "tooltip": "Returned as-is when bypassed or when override_height is false.",
+            }),
+            "override_height": ("BOOLEAN", {
+                "default": True,
+                "tooltip": "true: use NAIA height. false: preserve input height.",
+            }),
+            "use_naia_settings": ("BOOLEAN", {
+                "default": True,
+                "tooltip": (
+                    "true: use NAIA desktop Prompt Engineering settings. "
+                    "false: send this node's pre/post/auto_hide and preprocessing options."
+                ),
+            }),
+            "pre_prompt": ("STRING", {
+                "multiline": True,
+                "default": "",
+                "placeholder": "pre_prompt",
+                "tooltip": "Used only when use_naia_settings is false.",
+            }),
+            "post_prompt": ("STRING", {
+                "multiline": True,
+                "default": "",
+                "placeholder": "post_prompt",
+                "tooltip": "Used only when use_naia_settings is false.",
+            }),
+            "auto_hide": ("STRING", {
+                "multiline": True,
+                "default": "",
+                "placeholder": "auto_hide",
+                "tooltip": "Used only when use_naia_settings is false.",
+            }),
+        }
+
+        pp_tooltip = (
+            "Used only when use_naia_settings is false.\n"
+            "skip: do not send this key\n"
+            "on: remove this category\n"
+            "off: explicitly keep this category"
+        )
+        for key in PREPROCESSING_KEYS:
+            required[key] = (PP_STATE_CHOICES, {
+                "default": "skip",
+                "tooltip": pp_tooltip,
+                "advanced": key.startswith("remove_"),
+                "socketless": key.startswith("remove_"),
+            })
+
+        required["host"] = ("STRING", {
+            "default": DEFAULT_HOST,
+            "tooltip": "NAIA Remote API host.",
+        })
+        required["port"] = ("INT", {
+            "default": DEFAULT_PORT, "min": 1, "max": 65535,
+            "tooltip": "NAIA Remote API port.",
+        })
+        return {
+            "required": required,
+            "hidden": {
+                "workflow_prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+                "unique_id": "UNIQUE_ID",
+            },
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "INT", "INT")
+    RETURN_NAMES = ("prompt", "negative_prompt", "width", "height")
+    FUNCTION = "request"
+    CATEGORY = "NAIA Bridge/API"
+
+    def __init__(self):
+        self._cache_signature: Optional[str] = None
+        self._cache_value: Optional[tuple[str, str, int, int]] = None
+
+    @classmethod
+    def IS_CHANGED(
+        cls,
+        use_naia_bridge: bool = True,
+        freeze_naia_output: bool = False,
+        show_preview: bool = True,
+        cached_prompt: str = "",
+        cached_negative_prompt: str = "",
+        cached_width: int = 0,
+        cached_height: int = 0,
+        cached_signature: str = "",
+        prompt: str = "",
+        override_prompt: bool = True,
+        negative_prompt: str = "",
+        override_negative: bool = True,
+        width: int = 1024,
+        override_width: bool = True,
+        height: int = 1024,
+        override_height: bool = True,
+        use_naia_settings: bool = True,
+        pre_prompt: str = "",
+        post_prompt: str = "",
+        auto_hide: str = "",
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+        **kwargs,
+    ):
+        naia_settings = resolve_naia_settings()
+        use_naia_settings = naia_settings["use_naia_settings"]
+        pre_prompt = naia_settings["pre_prompt"]
+        post_prompt = naia_settings["post_prompt"]
+        auto_hide = naia_settings["auto_hide"]
+        host = naia_settings["host"]
+        port = naia_settings["port"]
+        pp_kwargs = naia_settings["preprocessing"]
+
+        if not _as_bool(use_naia_bridge, True):
+            return _stable_change_key({
+                "mode": "disabled",
+                "prompt": str(prompt),
+                "negative_prompt": str(negative_prompt),
+                "width": _as_int(width, 1024),
+                "height": _as_int(height, 1024),
+            })
+
+        signature = cls._make_signature(
+            prompt,
+            override_prompt,
+            negative_prompt,
+            override_negative,
+            width,
+            override_width,
+            height,
+            override_height,
+            use_naia_settings,
+            pre_prompt,
+            post_prompt,
+            auto_hide,
+            host,
+            port,
+            pp_kwargs,
+        )
+
+        if _as_bool(freeze_naia_output, False):
+            cached = cls._cached_tuple(
+                cached_prompt,
+                cached_negative_prompt,
+                cached_width,
+                cached_height,
+            )
+            if cached is not None and str(cached_signature) == signature:
+                return _stable_change_key({
+                    "mode": "frozen",
+                    "signature": signature,
+                    "prompt": cached[0],
+                    "negative_prompt": cached[1],
+                    "width": cached[2],
+                    "height": cached[3],
+                })
+            return float("nan")
+
+        return float("nan")
+
+    @staticmethod
+    def _cached_tuple(
+        cached_prompt: str,
+        cached_negative_prompt: str,
+        cached_width: int,
+        cached_height: int,
+    ) -> Optional[tuple[str, str, int, int]]:
+        width = _as_int(cached_width, 0)
+        height = _as_int(cached_height, 0)
+        if width <= 0 or height <= 0:
+            return None
+        if not cached_prompt and not cached_negative_prompt:
+            return None
+        return (str(cached_prompt), str(cached_negative_prompt), width, height)
+
+    @classmethod
+    def _widget_input_names(cls) -> list[str]:
+        return list(cls.INPUT_TYPES()["required"].keys())
+
+    @staticmethod
+    def _make_signature(
+        prompt: str,
+        override_prompt: bool,
+        negative_prompt: str,
+        override_negative: bool,
+        width: int,
+        override_width: bool,
+        height: int,
+        override_height: bool,
+        use_naia_settings: bool,
+        pre_prompt: str,
+        post_prompt: str,
+        auto_hide: str,
+        host: str,
+        port: int,
+        pp_kwargs: dict,
+    ) -> str:
+        use_settings = _as_bool(use_naia_settings, True)
+        preprocessing = {}
+        if not use_settings:
+            preprocessing = {
+                key: str(pp_kwargs.get(key, "skip"))
+                for key in PREPROCESSING_KEYS
+            }
+        payload = {
+            "prompt": str(prompt),
+            "override_prompt": _as_bool(override_prompt, True),
+            "negative_prompt": str(negative_prompt),
+            "override_negative": _as_bool(override_negative, True),
+            "width": _as_int(width, 1024),
+            "override_width": _as_bool(override_width, True),
+            "height": _as_int(height, 1024),
+            "override_height": _as_bool(override_height, True),
+            "use_naia_settings": use_settings,
+            "pre_prompt": "" if use_settings else str(pre_prompt),
+            "post_prompt": "" if use_settings else str(post_prompt),
+            "auto_hide": "" if use_settings else str(auto_hide),
+            "preprocessing": preprocessing,
+            "host": str(host),
+            "port": _as_int(port, DEFAULT_PORT),
+        }
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _make_request_body(
+        use_naia_settings: bool,
+        pre_prompt: str,
+        post_prompt: str,
+        auto_hide: str,
+        pp_kwargs: dict,
+    ) -> dict:
+        body = {
+            "timeout": NAIA_REQUEST_TIMEOUT,
+            "respect_naia_autogen": True,
+            "force_naia_skip_generate": False,
+        }
+        if not use_naia_settings:
+            preprocessing_options = {}
+            for key in PREPROCESSING_KEYS:
+                state = pp_kwargs.get(key, "skip")
+                if state == "on":
+                    preprocessing_options[key] = True
+                elif state == "off":
+                    preprocessing_options[key] = False
+            body["peng_override"] = {
+                "pre_prompt": pre_prompt,
+                "post_prompt": post_prompt,
+                "auto_hide": auto_hide,
+                "preprocessing_options": preprocessing_options,
+            }
+        return body
+
+    @staticmethod
+    def _apply_overrides(
+        naia_value: tuple[str, str, int, int],
+        prompt: str,
+        override_prompt: bool,
+        negative_prompt: str,
+        override_negative: bool,
+        width: int,
+        override_width: bool,
+        height: int,
+        override_height: bool,
+    ) -> tuple[str, str, int, int]:
+        naia_prompt, naia_negative, naia_width, naia_height = naia_value
+        return (
+            naia_prompt if override_prompt else str(prompt),
+            naia_negative if override_negative else str(negative_prompt),
+            naia_width if override_width else _as_int(width, 1024),
+            naia_height if override_height else _as_int(height, 1024),
+        )
+
+    @classmethod
+    def _update_metadata_cache(
+        cls,
+        workflow_prompt,
+        extra_pnginfo,
+        unique_id,
+        output_value: tuple[str, str, int, int],
+        signature: str,
+    ) -> None:
+        node_id = _single_value(unique_id)
+        if node_id is None:
+            return
+        node_id = str(node_id)
+        out_prompt, out_negative, out_width, out_height = output_value
+        updates = {
+            "use_naia_bridge": True,
+            "freeze_naia_output": True,
+            "cached_prompt": out_prompt,
+            "cached_negative_prompt": out_negative,
+            "cached_width": int(out_width),
+            "cached_height": int(out_height),
+            "cached_signature": signature,
+        }
+
+        if isinstance(workflow_prompt, dict):
+            prompt_node = workflow_prompt.get(node_id)
+            if isinstance(prompt_node, dict):
+                inputs = prompt_node.setdefault("inputs", {})
+                for name, value in updates.items():
+                    inputs[name] = value
+
+        workflow_node = _get_workflow_node(extra_pnginfo, node_id)
+        if workflow_node is None:
+            return
+
+        input_names = cls._widget_input_names()
+        widgets_values = workflow_node.setdefault("widgets_values", [])
+        for name, value in updates.items():
+            if name not in input_names:
+                continue
+            index = input_names.index(name)
+            while len(widgets_values) <= index:
+                widgets_values.append(None)
+            widgets_values[index] = value
+
+    @staticmethod
+    def _ui(prompt: str, negative: str, width: int, height: int, status: str, signature: str):
+        return {
+            "prompt": [prompt],
+            "negative_prompt": [negative],
+            "width": [width],
+            "height": [height],
+            "status": [status],
+            "cached_signature": [signature],
+        }
+
+    def request(
+        self,
+        use_naia_bridge: bool,
+        freeze_naia_output: bool,
+        show_preview: bool,
+        cached_prompt: str,
+        cached_negative_prompt: str,
+        cached_width: int,
+        cached_height: int,
+        cached_signature: str,
+        prompt: str,
+        override_prompt: bool,
+        negative_prompt: str,
+        override_negative: bool,
+        width: int,
+        override_width: bool,
+        height: int,
+        override_height: bool,
+        use_naia_settings: bool,
+        pre_prompt: str,
+        post_prompt: str,
+        auto_hide: str,
+        host: str,
+        port: int,
+        workflow_prompt=None,
+        extra_pnginfo=None,
+        unique_id=None,
+        **pp_kwargs,
+    ):
+        naia_settings = resolve_naia_settings()
+        use_naia_settings = naia_settings["use_naia_settings"]
+        pre_prompt = naia_settings["pre_prompt"]
+        post_prompt = naia_settings["post_prompt"]
+        auto_hide = naia_settings["auto_hide"]
+        host = naia_settings["host"]
+        port = naia_settings["port"]
+        pp_kwargs = naia_settings["preprocessing"]
+
+        bridge_enabled = _as_bool(use_naia_bridge, True)
+        freeze_output = _as_bool(freeze_naia_output, False)
+        use_settings = _as_bool(use_naia_settings, True)
+        override_prompt = _as_bool(override_prompt, True)
+        override_negative = _as_bool(override_negative, True)
+        override_width = _as_bool(override_width, True)
+        override_height = _as_bool(override_height, True)
+
+        signature = self._make_signature(
+            prompt,
+            override_prompt,
+            negative_prompt,
+            override_negative,
+            width,
+            override_width,
+            height,
+            override_height,
+            use_settings,
+            pre_prompt,
+            post_prompt,
+            auto_hide,
+            host,
+            port,
+            pp_kwargs,
+        )
+
+        if not bridge_enabled:
+            out_prompt = str(prompt)
+            out_negative = str(negative_prompt)
+            out_width = _as_int(width, 1024)
+            out_height = _as_int(height, 1024)
+            return {
+                "ui": self._ui(out_prompt, out_negative, out_width, out_height, "disabled", signature),
+                "result": (out_prompt, out_negative, out_width, out_height),
+            }
+
+        saved_cache = self._cached_tuple(
+            cached_prompt,
+            cached_negative_prompt,
+            cached_width,
+            cached_height,
+        )
+        if freeze_output and saved_cache is not None and str(cached_signature) == signature:
+            out_prompt, out_negative, out_width, out_height = saved_cache
+            return {
+                "ui": self._ui(out_prompt, out_negative, out_width, out_height, "frozen", signature),
+                "result": (out_prompt, out_negative, out_width, out_height),
+            }
+
+        if self._cache_signature != signature:
+            self._cache_signature = signature
+            self._cache_value = (
+                saved_cache if saved_cache is not None and str(cached_signature) == signature else None
+            )
+
+        if self._cache_value is None or not freeze_output:
+            body = self._make_request_body(use_settings, pre_prompt, post_prompt, auto_hide, pp_kwargs)
+            resp = _post_random(
+                host,
+                port,
+                body,
+                allow_remote_api=bool(naia_settings.get("allow_remote_api", False)),
+            )
+            naia_value = _parse_random_response(resp)
+            self._cache_value = self._apply_overrides(
+                naia_value,
+                prompt,
+                override_prompt,
+                negative_prompt,
+                override_negative,
+                width,
+                override_width,
+                height,
+                override_height,
+            )
+            logger.debug(
+                "request_id=%s prompt_len=%d size=%dx%d use_naia_settings=%s",
+                resp.get("request_id"),
+                len(self._cache_value[0]),
+                self._cache_value[2],
+                self._cache_value[3],
+                use_settings,
+            )
+
+        if self._cache_value is None:
+            raise RuntimeError("[EasyUse Anima] Internal cache creation failed.")
+
+        out_prompt, out_negative, out_width, out_height = self._cache_value
+        self._update_metadata_cache(
+            workflow_prompt,
+            extra_pnginfo,
+            unique_id,
+            (out_prompt, out_negative, out_width, out_height),
+            signature,
+        )
+        return {
+            "ui": self._ui(out_prompt, out_negative, out_width, out_height, "fresh", signature),
+            "result": (out_prompt, out_negative, out_width, out_height),
+        }
+
+__all__ = ("EasyUseAnimaNAIARandomPrompt",)

--- a/easyuse_anima/nodes/wildcard_nodes.py
+++ b/easyuse_anima/nodes/wildcard_nodes.py
@@ -1,0 +1,303 @@
+"""ComfyUI adapter for wildcard expansion."""
+
+from __future__ import annotations
+
+from ..common.serialization import _stable_change_key
+from ..common.values import _single_value
+
+try:
+    from ...wildcard_engine import (
+        MAX_SEED,
+        PUBLIC_MAX_SEED,
+        SEED_CONTROL_FIXED,
+        SEED_CONTROL_INCREMENT,
+        SEED_CONTROL_MODES,
+        SEED_CONTROL_RANDOMIZE,
+        WILDCARD_MODE_FIXED,
+        WILDCARD_MODE_LABELS,
+        WILDCARD_MODE_POPULATE,
+        WILDCARD_MODE_REPRODUCE,
+        WILDCARD_MODE_SEQUENTIAL,
+        expand_wildcards,
+        has_wildcard_syntax,
+        next_seed,
+        normalize_seed,
+        normalize_wildcard_mode,
+        wildcard_sources_signature,
+    )
+except ImportError:
+    from wildcard_engine import (
+        MAX_SEED,
+        PUBLIC_MAX_SEED,
+        SEED_CONTROL_FIXED,
+        SEED_CONTROL_INCREMENT,
+        SEED_CONTROL_MODES,
+        SEED_CONTROL_RANDOMIZE,
+        WILDCARD_MODE_FIXED,
+        WILDCARD_MODE_LABELS,
+        WILDCARD_MODE_POPULATE,
+        WILDCARD_MODE_REPRODUCE,
+        WILDCARD_MODE_SEQUENTIAL,
+        expand_wildcards,
+        has_wildcard_syntax,
+        next_seed,
+        normalize_seed,
+        normalize_wildcard_mode,
+        wildcard_sources_signature,
+    )
+
+
+WILDCARD_SEED_RANGE_NOTE = (
+    f"Browser/public editing and next-seed range: 0..{PUBLIC_MAX_SEED}. The Python "
+    "backend continues accepting uint64 values for legacy workflow validation, but "
+    "values above the public maximum are best-effort in the browser because JavaScript "
+    "may already have lost integer precision. Fixed does not intentionally advance a "
+    "legacy value; increment, decrement, and randomize return the next seed to the "
+    "public range."
+)
+
+
+class _FlexibleOptionalInputType(dict):
+    def __init__(self, input_type):
+        self.input_type = input_type
+
+    def __getitem__(self, key):
+        return (self.input_type,)
+
+    def __contains__(self, key):
+        return True
+
+
+def _unbound_runtime(*_args, **_kwargs):
+    raise RuntimeError("Wildcard node runtime dependencies are not bound.")
+
+
+_get_workflow_node = _unbound_runtime
+_consume_reserved_wildcard_next_seed = _unbound_runtime
+
+
+def _bind_wildcard_node_runtime(*, get_workflow_node, consume_reserved_next_seed, expand, has_syntax, next_seed_value, normalize_seed_value, normalize_mode, sources_signature) -> None:
+    global _get_workflow_node, _consume_reserved_wildcard_next_seed
+    global expand_wildcards, has_wildcard_syntax, next_seed
+    global normalize_seed, normalize_wildcard_mode, wildcard_sources_signature
+
+    _get_workflow_node = get_workflow_node
+    _consume_reserved_wildcard_next_seed = consume_reserved_next_seed
+    expand_wildcards = expand
+    has_wildcard_syntax = has_syntax
+    next_seed = next_seed_value
+    normalize_seed = normalize_seed_value
+    normalize_wildcard_mode = normalize_mode
+    wildcard_sources_signature = sources_signature
+
+
+class EasyUseAnimaWildcard:
+    """Expand Impact Pack compatible wildcard and dynamic prompt syntax."""
+
+    DESCRIPTION = (
+        "Expands EasyUse Anima wildcard files and dynamic prompt syntax with fixed, sequential, "
+        "and reproducible modes."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Expanded prompt text.",
+        "Seed after applying the seed control option.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Prompt text with wildcard syntax such as __style__ or {2::a|5::b|c}.",
+                }),
+                "populated_text": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Cached expanded prompt used by fixed and reproduce modes.",
+                }),
+                "mode": (WILDCARD_MODE_LABELS, {
+                    "default": WILDCARD_MODE_LABELS[0],
+                    "tooltip": (
+                        "일반 채우기: seed-based random fill. 고정/재현: cached text. "
+                        "순차: seed modulo each wildcard option count."
+                    ),
+                }),
+                "seed": ("INT", {
+                    "default": 0,
+                    "min": 0,
+                    "max": MAX_SEED,
+                    "tooltip": (
+                        "Wildcard seed. Sequential mode uses seed % option_count for each wildcard. "
+                        f"{WILDCARD_SEED_RANGE_NOTE}"
+                    ),
+                }),
+                "seed_after_generate": (SEED_CONTROL_MODES, {
+                    "default": SEED_CONTROL_FIXED,
+                    "tooltip": "Seed control after generation: fixed, randomize, increment, or decrement.",
+                }),
+            },
+            "hidden": {
+                "workflow_prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+                "unique_id": "UNIQUE_ID",
+            },
+            "optional": _FlexibleOptionalInputType("STRING"),
+        }
+
+    RETURN_TYPES = ("STRING", "INT")
+    RETURN_NAMES = ("text", "seed")
+    FUNCTION = "generate"
+    CATEGORY = "EasyUse Anima/Prompt"
+
+    @classmethod
+    def _widget_input_names(cls):
+        return tuple(cls.INPUT_TYPES().get("required", {}).keys())
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        mode = normalize_wildcard_mode(kwargs.get("mode", WILDCARD_MODE_LABELS[0]))
+        seed_control = str(kwargs.get("seed_after_generate", SEED_CONTROL_FIXED) or "")
+        text = str(kwargs.get("text", "") or "")
+        if (
+            mode in {WILDCARD_MODE_POPULATE, WILDCARD_MODE_FIXED, WILDCARD_MODE_SEQUENTIAL}
+            and seed_control == SEED_CONTROL_RANDOMIZE
+            and has_wildcard_syntax(text)
+        ):
+            return float("nan")
+        return _stable_change_key({
+            "mode": "wildcard",
+            "wildcard_sources": wildcard_sources_signature(),
+            **{key: str(value) for key, value in sorted(kwargs.items())},
+        })
+
+    @classmethod
+    def _update_metadata_cache(
+        cls,
+        workflow_prompt,
+        extra_pnginfo,
+        unique_id,
+        populated_text: str,
+        mode: str,
+        seed: int,
+    ) -> None:
+        node_id = _single_value(unique_id)
+        if node_id is None:
+            return
+        node_id = str(node_id)
+        updates = {
+            "populated_text": populated_text,
+            "mode": mode,
+            "seed": int(seed),
+        }
+
+        if isinstance(workflow_prompt, dict):
+            prompt_node = workflow_prompt.get(node_id)
+            if isinstance(prompt_node, dict):
+                inputs = prompt_node.setdefault("inputs", {})
+                for name, value in updates.items():
+                    inputs[name] = value
+
+        workflow_node = _get_workflow_node(extra_pnginfo, node_id)
+        if workflow_node is None:
+            return
+
+        input_names = cls._widget_input_names()
+        widgets_values = workflow_node.setdefault("widgets_values", [])
+        for name, value in updates.items():
+            if name not in input_names:
+                continue
+            index = input_names.index(name)
+            while len(widgets_values) <= index:
+                widgets_values.append(None)
+            widgets_values[index] = value
+
+    @staticmethod
+    def _ui(
+        populated_text: str,
+        mode: str,
+        seed: int,
+        status: str,
+        used_keys: tuple[str, ...],
+        missing_keys: tuple[str, ...],
+    ):
+        return {
+            "wildcard": [{
+                "populated_text": populated_text,
+                "mode": mode,
+                "seed": seed,
+                "status": status,
+                "used_keys": list(used_keys),
+                "missing_keys": list(missing_keys),
+            }]
+        }
+
+    def generate(
+        self,
+        text: str,
+        populated_text: str,
+        mode: str,
+        seed: int,
+        seed_after_generate: str,
+        workflow_prompt=None,
+        extra_pnginfo=None,
+        unique_id=None,
+        **reservation_inputs,
+    ):
+        mode_key = normalize_wildcard_mode(mode)
+        seed_value = normalize_seed(seed)
+        used_keys: tuple[str, ...] = ()
+        missing_keys: tuple[str, ...] = ()
+
+        if mode_key == WILDCARD_MODE_REPRODUCE:
+            output_text = str(populated_text if populated_text else text or "")
+            status = mode_key
+            metadata_mode = str(mode or WILDCARD_MODE_LABELS[3])
+        else:
+            expansion = expand_wildcards(str(text or ""), seed=seed_value, mode=mode_key)
+            output_text = expansion.text
+            used_keys = expansion.used_keys
+            missing_keys = expansion.missing_keys
+            status = WILDCARD_MODE_SEQUENTIAL if mode_key == WILDCARD_MODE_SEQUENTIAL else mode_key
+            metadata_mode = WILDCARD_MODE_LABELS[3]
+
+        effective_seed_control = (
+            SEED_CONTROL_INCREMENT
+            if mode_key == WILDCARD_MODE_SEQUENTIAL
+            else seed_after_generate
+        )
+        reserved_next_seed = _consume_reserved_wildcard_next_seed(
+            reservation_inputs,
+            workflow_prompt,
+            unique_id,
+            seed_value,
+            mode_key,
+            effective_seed_control,
+        )
+        next_seed_value = (
+            reserved_next_seed
+            if reserved_next_seed is not None
+            else next_seed(seed_value, effective_seed_control)
+        )
+        self._update_metadata_cache(
+            workflow_prompt,
+            extra_pnginfo,
+            unique_id,
+            output_text,
+            metadata_mode,
+            seed_value,
+        )
+        return {
+            "ui": self._ui(
+                output_text,
+                str(mode or WILDCARD_MODE_LABELS[0]),
+                next_seed_value,
+                status,
+                used_keys,
+                missing_keys,
+            ),
+            "result": (output_text, next_seed_value),
+        }
+
+__all__ = ("EasyUseAnimaWildcard",)

--- a/nodes.py
+++ b/nodes.py
@@ -8,7 +8,7 @@ import os
 import random
 import re
 import sys
-from math import ceil, gcd, isfinite, log, sqrt
+from math import ceil, isfinite, sqrt
 from typing import Any, Optional
 
 try:
@@ -67,6 +67,55 @@ try:
     from .easyuse_anima.nodes.image_nodes import (
         EasyUseAnimaDetailerAlignHook as EasyUseAnimaDetailerAlignHook,
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
+    )
+    from .easyuse_anima.naia.client import (
+        DEFAULT_HOST as DEFAULT_HOST,
+        DEFAULT_PORT as DEFAULT_PORT,
+        HTTP_TIMEOUT as HTTP_TIMEOUT,
+        LATENT_ALIGN as LATENT_ALIGN,
+        NAI_1MP as NAI_1MP,
+        NAIA_LOCAL_HOSTS as NAIA_LOCAL_HOSTS,
+        NAIA_MAX_RESOLUTION as NAIA_MAX_RESOLUTION,
+        NAIA_REQUEST_TIMEOUT as NAIA_REQUEST_TIMEOUT,
+        PP_STATE_CHOICES as PP_STATE_CHOICES,
+        PREPROCESSING_KEYS as PREPROCESSING_KEYS,
+        _build_naia_random_url as _build_naia_random_url,
+        _fit_to_1mp as _fit_to_1mp,
+        _is_local_naia_host as _is_local_naia_host,
+        _parse_random_response as _parse_random_response,
+        _post_random as _post_random,
+    )
+    from .easyuse_anima.naia.resolution import (
+        ADVANCED_RESOLUTION_BUCKETS as ADVANCED_RESOLUTION_BUCKETS,
+        CUSTOM_ADVANCED_RESOLUTION_BUCKET as CUSTOM_ADVANCED_RESOLUTION_BUCKET,
+        DEFAULT_ADVANCED_RESOLUTION_BUCKET as DEFAULT_ADVANCED_RESOLUTION_BUCKET,
+        DEFAULT_ADVANCED_RESOLUTION_SIZE as DEFAULT_ADVANCED_RESOLUTION_SIZE,
+        NAIA_ADVANCED_RESOLUTION_BUCKET as NAIA_ADVANCED_RESOLUTION_BUCKET,
+        NAIA_RESOLUTION_MODE_BUCKET as NAIA_RESOLUTION_MODE_BUCKET,
+        NAIA_RESOLUTION_MODE_SCALE as NAIA_RESOLUTION_MODE_SCALE,
+        _advanced_resolution_from_selection as _advanced_resolution_from_selection,
+        _fit_naia_resolution_to_bucket as _fit_naia_resolution_to_bucket,
+        _normalize_resolution_bucket as _normalize_resolution_bucket,
+        _ratio_label as _ratio_label,
+        _resolution_label as _resolution_label,
+        _resolve_naia_resolution as _resolve_naia_resolution,
+        _resolve_naia_resolution_bucket as _resolve_naia_resolution_bucket,
+        _resolve_naia_resolution_max_long_edge as _resolve_naia_resolution_max_long_edge,
+        _resolve_naia_resolution_mode as _resolve_naia_resolution_mode,
+        _resolve_naia_resolution_scale as _resolve_naia_resolution_scale,
+        _scale_naia_resolution as _scale_naia_resolution,
+        _snap_resolution_32 as _snap_resolution_32,
+        _snap_scaled_resolution_32 as _snap_scaled_resolution_32,
+        _sorted_resolution_options as _sorted_resolution_options,
+    )
+    from .easyuse_anima.nodes.naia_nodes import (
+        EasyUseAnimaNAIARandomPrompt as EasyUseAnimaNAIARandomPrompt,
+        _bind_naia_node_runtime as _bind_naia_node_runtime,
+    )
+    from .easyuse_anima.nodes.wildcard_nodes import (
+        EasyUseAnimaWildcard as EasyUseAnimaWildcard,
+        WILDCARD_SEED_RANGE_NOTE as WILDCARD_SEED_RANGE_NOTE,
+        _bind_wildcard_node_runtime as _bind_wildcard_node_runtime,
     )
     from .anima_prompt import correct_prompt, load_knowledge_base
     from .anima_prompt.parser import parse_prompt
@@ -153,6 +202,55 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaDetailerAlignHook as EasyUseAnimaDetailerAlignHook,
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
     )
+    from easyuse_anima.naia.client import (
+        DEFAULT_HOST as DEFAULT_HOST,
+        DEFAULT_PORT as DEFAULT_PORT,
+        HTTP_TIMEOUT as HTTP_TIMEOUT,
+        LATENT_ALIGN as LATENT_ALIGN,
+        NAI_1MP as NAI_1MP,
+        NAIA_LOCAL_HOSTS as NAIA_LOCAL_HOSTS,
+        NAIA_MAX_RESOLUTION as NAIA_MAX_RESOLUTION,
+        NAIA_REQUEST_TIMEOUT as NAIA_REQUEST_TIMEOUT,
+        PP_STATE_CHOICES as PP_STATE_CHOICES,
+        PREPROCESSING_KEYS as PREPROCESSING_KEYS,
+        _build_naia_random_url as _build_naia_random_url,
+        _fit_to_1mp as _fit_to_1mp,
+        _is_local_naia_host as _is_local_naia_host,
+        _parse_random_response as _parse_random_response,
+        _post_random as _post_random,
+    )
+    from easyuse_anima.naia.resolution import (
+        ADVANCED_RESOLUTION_BUCKETS as ADVANCED_RESOLUTION_BUCKETS,
+        CUSTOM_ADVANCED_RESOLUTION_BUCKET as CUSTOM_ADVANCED_RESOLUTION_BUCKET,
+        DEFAULT_ADVANCED_RESOLUTION_BUCKET as DEFAULT_ADVANCED_RESOLUTION_BUCKET,
+        DEFAULT_ADVANCED_RESOLUTION_SIZE as DEFAULT_ADVANCED_RESOLUTION_SIZE,
+        NAIA_ADVANCED_RESOLUTION_BUCKET as NAIA_ADVANCED_RESOLUTION_BUCKET,
+        NAIA_RESOLUTION_MODE_BUCKET as NAIA_RESOLUTION_MODE_BUCKET,
+        NAIA_RESOLUTION_MODE_SCALE as NAIA_RESOLUTION_MODE_SCALE,
+        _advanced_resolution_from_selection as _advanced_resolution_from_selection,
+        _fit_naia_resolution_to_bucket as _fit_naia_resolution_to_bucket,
+        _normalize_resolution_bucket as _normalize_resolution_bucket,
+        _ratio_label as _ratio_label,
+        _resolution_label as _resolution_label,
+        _resolve_naia_resolution as _resolve_naia_resolution,
+        _resolve_naia_resolution_bucket as _resolve_naia_resolution_bucket,
+        _resolve_naia_resolution_max_long_edge as _resolve_naia_resolution_max_long_edge,
+        _resolve_naia_resolution_mode as _resolve_naia_resolution_mode,
+        _resolve_naia_resolution_scale as _resolve_naia_resolution_scale,
+        _scale_naia_resolution as _scale_naia_resolution,
+        _snap_resolution_32 as _snap_resolution_32,
+        _snap_scaled_resolution_32 as _snap_scaled_resolution_32,
+        _sorted_resolution_options as _sorted_resolution_options,
+    )
+    from easyuse_anima.nodes.naia_nodes import (
+        EasyUseAnimaNAIARandomPrompt as EasyUseAnimaNAIARandomPrompt,
+        _bind_naia_node_runtime as _bind_naia_node_runtime,
+    )
+    from easyuse_anima.nodes.wildcard_nodes import (
+        EasyUseAnimaWildcard as EasyUseAnimaWildcard,
+        WILDCARD_SEED_RANGE_NOTE as WILDCARD_SEED_RANGE_NOTE,
+        _bind_wildcard_node_runtime as _bind_wildcard_node_runtime,
+    )
     from anima_prompt import correct_prompt, load_knowledge_base
     from anima_prompt.parser import parse_prompt
     from settings import (
@@ -184,9 +282,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
-DEFAULT_HOST = "127.0.0.1"
-DEFAULT_PORT = 7243
-NAIA_LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
 DEFAULT_QUALITY_TAGS = (
     "newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic"
 )
@@ -206,14 +301,6 @@ ADVANCED_FIELD_LABELS = {
 ADVANCED_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_advanced_fields"
 WILDCARD_RESERVED_NEXT_SEED_INPUT = "easyuse_anima_reserved_wildcard_next_seed"
 WILDCARD_QUEUE_MAX_SAFE_SEED = PUBLIC_MAX_SEED
-WILDCARD_SEED_RANGE_NOTE = (
-    f"Browser/public editing and next-seed range: 0..{PUBLIC_MAX_SEED}. The Python "
-    "backend continues accepting uint64 values for legacy workflow validation, but "
-    "values above the public maximum are best-effort in the browser because JavaScript "
-    "may already have lost integer precision. Fixed does not intentionally advance a "
-    "legacy value; increment, decrement, and randomize return the next seed to the "
-    "public range."
-)
 REGIONAL_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_regional_fields"
 REGIONAL_CONFIG_WORKFLOW_PROPERTY = "easyuse_anima_regional_config"
 REGIONAL_FIELD_TYPES = {"quality", "artist", "trigger", "general"}
@@ -830,12 +917,6 @@ EXTEND_PROMPT_SLOT_SPECS = [
     ("negative_prompt_3", "negative", "general", "Negative Prompt 3", "", 120),
     ("negative_prompt_4", "negative", "general", "Negative Prompt 4", "", 120),
 ]
-NAIA_REQUEST_TIMEOUT = 30.0
-HTTP_TIMEOUT = NAIA_REQUEST_TIMEOUT + 5.0
-
-NAI_1MP = 1024 * 1024
-LATENT_ALIGN = 8
-NAIA_MAX_RESOLUTION = 8192
 AIO_FINAL_UPSCALE_BACKENDS = ("usdu", "resshift")
 AIO_USDU_MODE_TYPES = ("Linear", "Chess", "None")
 AIO_USDU_SEAM_FIX_MODES = ("None", "Band Pass", "Half Tile", "Half Tile + Intersections")
@@ -845,84 +926,7 @@ AIO_USDU_PROMPT_MODES = (AIO_USDU_PROMPT_FULL, AIO_USDU_PROMPT_NO_GENERAL)
 AIO_FINAL_FIT_MODES = ("max_long_edge", "megapixels")
 AIO_RESHIFT_SCALES = ("x2", "x4")
 AIO_RESHIFT_DTYPES = ("bf16", "fp32")
-ADVANCED_RESOLUTION_BUCKETS = {
-    "512": (
-        (256, 1024), (1024, 256),
-        (288, 896), (896, 288),
-        (384, 672), (672, 384),
-        (512, 512),
-        (448, 576), (576, 448),
-    ),
-    "768": (
-        (384, 1440), (1440, 384),
-        (480, 1152), (1152, 480),
-        (576, 960), (960, 576),
-        (640, 864), (864, 640),
-        (768, 768),
-    ),
-    "896": (
-        (448, 1728), (1728, 448),
-        (480, 1600), (1600, 480),
-        (576, 1344), (1344, 576),
-        (672, 1152), (1152, 672),
-        (800, 960), (960, 800),
-        (896, 896),
-    ),
-    "1024": (
-        (512, 2016), (2016, 512),
-        (576, 1792), (1792, 576),
-        (672, 1536), (1536, 672),
-        (672, 1600), (1600, 672),
-        (768, 1344), (1344, 768),
-        (800, 1344), (1344, 800),
-        (896, 1152), (1152, 896),
-        (960, 1120), (1120, 960),
-        (1024, 1024),
-    ),
-    "1280": (
-        (672, 2400), (2400, 672),
-        (800, 2016), (2016, 800),
-        (1024, 1536), (1536, 1024),
-        (1024, 1600), (1600, 1024),
-        (1120, 1440), (1440, 1120),
-        (1280, 1280),
-    ),
-    "1536": (
-        (1440, 1536), (1536, 1440),
-        (1280, 1728), (1728, 1280),
-        (1152, 1920), (1920, 1152),
-        (1024, 2176), (2176, 1024),
-        (960, 2304), (2304, 960),
-        (864, 2560), (2560, 864),
-        (768, 2880), (2880, 768),
-        (1536, 1536),
-    ),
-}
-CUSTOM_ADVANCED_RESOLUTION_BUCKET = "Custom"
-NAIA_ADVANCED_RESOLUTION_BUCKET = "NAIA"
-DEFAULT_ADVANCED_RESOLUTION_BUCKET = "1024"
-DEFAULT_ADVANCED_RESOLUTION_SIZE = "1024 * 1024 (1:1)"
-NAIA_RESOLUTION_MODE_SCALE = "scale"
-NAIA_RESOLUTION_MODE_BUCKET = "bucket"
 
-PREPROCESSING_KEYS = [
-    "remove_author",
-    "remove_work_title",
-    "remove_character_name",
-    "remove_character_features",
-    "remove_clothes",
-    "remove_color",
-    "remove_location_and_background_color",
-    "remove_expression",
-    "remove_pose_action",
-    "remove_meta_tags",
-    "remove_object_tags",
-    "remove_noise_tags",
-    "e621_auto_boost",
-    "danbooru_auto_weight",
-    "tag_implication_compression",
-]
-PP_STATE_CHOICES = ["skip", "on", "off"]
 
 _HASH_COMMENT_RE = re.compile(r"^[ \t]*#[^\n]*", re.MULTILINE)
 _MULTI_COMMA_RE = re.compile(r"(\s*,){2,}")
@@ -976,142 +980,6 @@ def _resolve_aio_runtime_seed(value) -> int:
     return max(0, min(MAX_SEED, seed))
 
 
-def _ratio_label(width: int, height: int) -> str:
-    divisor = gcd(max(1, int(width)), max(1, int(height)))
-    return f"{int(width) // divisor}:{int(height) // divisor}"
-
-
-def _resolution_label(width: int, height: int) -> str:
-    return f"{int(width)} * {int(height)} ({_ratio_label(width, height)})"
-
-
-def _sorted_resolution_options(bucket: str) -> list[tuple[int, int]]:
-    values = ADVANCED_RESOLUTION_BUCKETS.get(bucket) or ADVANCED_RESOLUTION_BUCKETS[DEFAULT_ADVANCED_RESOLUTION_BUCKET]
-    return sorted(values, key=lambda item: (item[0] / item[1], item[0], item[1]))
-
-
-def _normalize_resolution_bucket(value) -> str:
-    value = str(_single_value(value) or "").strip()
-    if value in {CUSTOM_ADVANCED_RESOLUTION_BUCKET, NAIA_ADVANCED_RESOLUTION_BUCKET}:
-        return value
-    return value if value in ADVANCED_RESOLUTION_BUCKETS else DEFAULT_ADVANCED_RESOLUTION_BUCKET
-
-
-def _snap_resolution_32(value, default: int = 1024) -> int:
-    raw = _as_int(value, default)
-    if raw <= 0:
-        raw = default
-    return max(32, int(round(raw / 32)) * 32)
-
-
-def _resolve_naia_resolution_scale(naia_settings: dict | None) -> float:
-    value = _as_float((naia_settings or {}).get("resolution_scale", 1.0), 1.0)
-    return max(0.25, min(4.0, value))
-
-
-def _resolve_naia_resolution_max_long_edge(naia_settings: dict | None) -> int:
-    value = _as_int((naia_settings or {}).get("resolution_max_long_edge", 0), 0)
-    if value <= 0:
-        return 0
-    return max(32, min(16384, value))
-
-
-def _resolve_naia_resolution_mode(naia_settings: dict | None) -> str:
-    value = str(
-        _single_value((naia_settings or {}).get("resolution_mode", NAIA_RESOLUTION_MODE_SCALE)) or ""
-    ).strip().lower()
-    if value == "bucket_fit":
-        return NAIA_RESOLUTION_MODE_BUCKET
-    return value if value in {NAIA_RESOLUTION_MODE_SCALE, NAIA_RESOLUTION_MODE_BUCKET} else NAIA_RESOLUTION_MODE_SCALE
-
-
-def _resolve_naia_resolution_bucket(naia_settings: dict | None) -> str:
-    bucket = _normalize_resolution_bucket((naia_settings or {}).get("resolution_bucket", DEFAULT_ADVANCED_RESOLUTION_BUCKET))
-    return bucket if bucket in ADVANCED_RESOLUTION_BUCKETS else DEFAULT_ADVANCED_RESOLUTION_BUCKET
-
-
-def _snap_scaled_resolution_32(value: float, max_value: int = 0, default: int = 1024) -> int:
-    raw = _as_float(value, float(default))
-    if raw <= 0:
-        raw = float(default)
-    snapped = max(32, int(round(raw / 32)) * 32)
-    if max_value > 0 and snapped > max_value:
-        snapped = max(32, int(max_value // 32) * 32)
-    return snapped
-
-
-def _scale_naia_resolution(
-    width: int,
-    height: int,
-    naia_settings: dict | None,
-) -> tuple[int, int]:
-    scale = _resolve_naia_resolution_scale(naia_settings)
-    max_long_edge = _resolve_naia_resolution_max_long_edge(naia_settings)
-    scaled_width = max(1.0, _as_float(width, 1024.0) * scale)
-    scaled_height = max(1.0, _as_float(height, 1024.0) * scale)
-
-    if max_long_edge > 0:
-        long_edge = max(scaled_width, scaled_height)
-        if long_edge > max_long_edge:
-            ratio = max_long_edge / long_edge
-            scaled_width *= ratio
-            scaled_height *= ratio
-
-    return (
-        _snap_scaled_resolution_32(scaled_width, max_long_edge, 1024),
-        _snap_scaled_resolution_32(scaled_height, max_long_edge, 1024),
-    )
-
-
-def _fit_naia_resolution_to_bucket(
-    width: int,
-    height: int,
-    naia_settings: dict | None,
-) -> tuple[int, int]:
-    bucket = _resolve_naia_resolution_bucket(naia_settings)
-    source_width = max(1.0, _as_float(width, 1024.0))
-    source_height = max(1.0, _as_float(height, 1024.0))
-    source_ratio = source_width / source_height
-    options = ADVANCED_RESOLUTION_BUCKETS.get(bucket) or ADVANCED_RESOLUTION_BUCKETS[DEFAULT_ADVANCED_RESOLUTION_BUCKET]
-
-    return min(
-        options,
-        key=lambda item: abs(log((item[0] / item[1]) / source_ratio)),
-    )
-
-
-def _resolve_naia_resolution(
-    width: int,
-    height: int,
-    naia_settings: dict | None,
-) -> tuple[int, int]:
-    if _resolve_naia_resolution_mode(naia_settings) == NAIA_RESOLUTION_MODE_BUCKET:
-        return _fit_naia_resolution_to_bucket(width, height, naia_settings)
-    return _scale_naia_resolution(width, height, naia_settings)
-
-
-def _advanced_resolution_from_selection(
-    bucket,
-    size,
-    custom_width: int | str = 1024,
-    custom_height: int | str = 1024,
-) -> tuple[int, int]:
-    bucket_name = _normalize_resolution_bucket(bucket)
-    if bucket_name in {CUSTOM_ADVANCED_RESOLUTION_BUCKET, NAIA_ADVANCED_RESOLUTION_BUCKET}:
-        return (
-            _snap_resolution_32(custom_width, 1024),
-            _snap_resolution_32(custom_height, 1024),
-        )
-    raw_size = str(_single_value(size) or "").strip()
-    match = _RESOLUTION_LABEL_RE.search(raw_size)
-    if match:
-        width, height = int(match.group(1)), int(match.group(2))
-        if (width, height) in ADVANCED_RESOLUTION_BUCKETS.get(bucket_name, ()):
-            return width, height
-    default_width, default_height = 1024, 1024
-    if (default_width, default_height) in ADVANCED_RESOLUTION_BUCKETS.get(bucket_name, ()):
-        return default_width, default_height
-    return _sorted_resolution_options(bucket_name)[0]
 
 
 def _clean_prompt(value: str) -> str:
@@ -7210,91 +7078,6 @@ def _regional_mask_bounds_area(mask, canvas_width: int | None = None, canvas_hei
     )
 
 
-def _fit_to_1mp(width: int, height: int) -> tuple[int, int]:
-    if width <= 0 or height <= 0:
-        return width, height
-    if width * height <= NAI_1MP:
-        return width, height
-
-    scale = sqrt(NAI_1MP / (width * height))
-    new_w = max(LATENT_ALIGN, round(width * scale / LATENT_ALIGN) * LATENT_ALIGN)
-    new_h = max(LATENT_ALIGN, round(height * scale / LATENT_ALIGN) * LATENT_ALIGN)
-    if new_w * new_h > NAI_1MP:
-        if new_w >= new_h:
-            new_w = (NAI_1MP // new_h // LATENT_ALIGN) * LATENT_ALIGN
-        else:
-            new_h = (NAI_1MP // new_w // LATENT_ALIGN) * LATENT_ALIGN
-    return new_w, new_h
-
-
-def _is_local_naia_host(host: str) -> bool:
-    return str(host or "").strip().strip("[]").lower() in NAIA_LOCAL_HOSTS
-
-
-def _build_naia_random_url(host: str, port: int, allow_remote_api: bool = False) -> str:
-    host_value = str(host or DEFAULT_HOST).strip() or DEFAULT_HOST
-    if any(token in host_value for token in ("://", "/", "\\", "?", "#", "@")) or re.search(r"\s", host_value):
-        raise RuntimeError("[EasyUse Anima] NAIA host must be a hostname or IP address, not a URL.")
-    if not allow_remote_api and not _is_local_naia_host(host_value):
-        raise RuntimeError(
-            "[EasyUse Anima] Remote NAIA API access is disabled. "
-            "Enable 'Allow remote API' in EasyUse Anima NAIA settings to use a non-local host."
-        )
-    url_host = host_value
-    if ":" in host_value and not host_value.startswith("["):
-        url_host = f"[{host_value}]"
-    return f"http://{url_host}:{int(port)}/api/comfyui/random"
-
-
-def _post_random(host: str, port: int, body: dict, allow_remote_api: bool = False) -> dict:
-    try:
-        import requests
-    except ImportError:
-        raise RuntimeError("[EasyUse Anima] requests is not installed. Install requirements.txt.")
-
-    url = _build_naia_random_url(host, port, allow_remote_api=allow_remote_api)
-    try:
-        # Explicit user-configured NAIA API call. Default use is localhost-only;
-        # remote hosts require allow_remote_api=True. The response is parsed as
-        # JSON and is never executed as code.
-        response = requests.post(url, json=body, timeout=HTTP_TIMEOUT)
-    except requests.RequestException as exc:
-        raise RuntimeError(f"[EasyUse Anima] NAIA API request failed: {exc}")
-
-    if not response.ok:
-        raise RuntimeError(
-            f"[EasyUse Anima] NAIA API error HTTP {response.status_code}: {response.text[:300]}"
-        )
-    try:
-        data = response.json()
-    except ValueError:
-        raise RuntimeError(f"[EasyUse Anima] NAIA API returned non-JSON: {response.text[:300]}")
-
-    if not data.get("ok", True):
-        raise RuntimeError(f"[EasyUse Anima] NAIA API returned error: {data}")
-    return data
-
-
-def _parse_random_response(resp: dict) -> tuple[str, str, int, int]:
-    prompt = _clean_prompt(resp.get("prompt", "") or "")
-    negative = _clean_prompt(resp.get("negative_prompt", "") or "")
-    w_raw, h_raw = resp.get("width"), resp.get("height")
-    if w_raw is None or h_raw is None:
-        raise RuntimeError("[EasyUse Anima] NAIA response is missing width/height.")
-    try:
-        raw_width, raw_height = int(w_raw), int(h_raw)
-    except (TypeError, ValueError):
-        raise RuntimeError(f"[EasyUse Anima] Invalid NAIA width/height: {w_raw!r}, {h_raw!r}")
-    if not (
-        1 <= raw_width <= NAIA_MAX_RESOLUTION
-        and 1 <= raw_height <= NAIA_MAX_RESOLUTION
-    ):
-        raise RuntimeError(
-            f"[EasyUse Anima] Invalid NAIA width/height: {w_raw!r}, {h_raw!r}; "
-            f"expected values from 1 to {NAIA_MAX_RESOLUTION}."
-        )
-    width, height = _fit_to_1mp(raw_width, raw_height)
-    return prompt, negative, width, height
 
 
 def _get_workflow_node(extra_pnginfo, node_id: str):
@@ -7419,6 +7202,24 @@ def _consume_reserved_wildcard_next_seed(
     else:
         return None
     return reservation_next_seed if reservation_next_seed == expected_next_seed else None
+
+
+_bind_wildcard_node_runtime(
+    get_workflow_node=lambda *args, **kwargs: _get_workflow_node(*args, **kwargs),
+    consume_reserved_next_seed=lambda *args, **kwargs: _consume_reserved_wildcard_next_seed(*args, **kwargs),
+    expand=lambda *args, **kwargs: expand_wildcards(*args, **kwargs),
+    has_syntax=lambda *args, **kwargs: has_wildcard_syntax(*args, **kwargs),
+    next_seed_value=lambda *args, **kwargs: next_seed(*args, **kwargs),
+    normalize_seed_value=lambda *args, **kwargs: normalize_seed(*args, **kwargs),
+    normalize_mode=lambda *args, **kwargs: normalize_wildcard_mode(*args, **kwargs),
+    sources_signature=lambda *args, **kwargs: wildcard_sources_signature(*args, **kwargs),
+)
+_bind_naia_node_runtime(
+    resolve_settings=lambda: resolve_naia_settings(),
+    get_workflow_node=lambda *args, **kwargs: _get_workflow_node(*args, **kwargs),
+    post_random=lambda *args, **kwargs: _post_random(*args, **kwargs),
+    parse_random_response=lambda *args, **kwargs: _parse_random_response(*args, **kwargs),
+)
 
 
 def _profile_key(profile_index: int) -> str:
@@ -7836,214 +7637,6 @@ class EasyUseAnimaPromptCorrectorSimple:
         return (corrected,)
 
 
-class EasyUseAnimaWildcard:
-    """Expand Impact Pack compatible wildcard and dynamic prompt syntax."""
-
-    DESCRIPTION = (
-        "Expands EasyUse Anima wildcard files and dynamic prompt syntax with fixed, sequential, "
-        "and reproducible modes."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Expanded prompt text.",
-        "Seed after applying the seed control option.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "text": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Prompt text with wildcard syntax such as __style__ or {2::a|5::b|c}.",
-                }),
-                "populated_text": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Cached expanded prompt used by fixed and reproduce modes.",
-                }),
-                "mode": (WILDCARD_MODE_LABELS, {
-                    "default": WILDCARD_MODE_LABELS[0],
-                    "tooltip": (
-                        "일반 채우기: seed-based random fill. 고정/재현: cached text. "
-                        "순차: seed modulo each wildcard option count."
-                    ),
-                }),
-                "seed": ("INT", {
-                    "default": 0,
-                    "min": 0,
-                    "max": MAX_SEED,
-                    "tooltip": (
-                        "Wildcard seed. Sequential mode uses seed % option_count for each wildcard. "
-                        f"{WILDCARD_SEED_RANGE_NOTE}"
-                    ),
-                }),
-                "seed_after_generate": (SEED_CONTROL_MODES, {
-                    "default": SEED_CONTROL_FIXED,
-                    "tooltip": "Seed control after generation: fixed, randomize, increment, or decrement.",
-                }),
-            },
-            "hidden": {
-                "workflow_prompt": "PROMPT",
-                "extra_pnginfo": "EXTRA_PNGINFO",
-                "unique_id": "UNIQUE_ID",
-            },
-            "optional": _FlexibleOptionalInputType("STRING"),
-        }
-
-    RETURN_TYPES = ("STRING", "INT")
-    RETURN_NAMES = ("text", "seed")
-    FUNCTION = "generate"
-    CATEGORY = "EasyUse Anima/Prompt"
-
-    @classmethod
-    def _widget_input_names(cls):
-        return tuple(cls.INPUT_TYPES().get("required", {}).keys())
-
-    @classmethod
-    def IS_CHANGED(cls, **kwargs):
-        mode = normalize_wildcard_mode(kwargs.get("mode", WILDCARD_MODE_LABELS[0]))
-        seed_control = str(kwargs.get("seed_after_generate", SEED_CONTROL_FIXED) or "")
-        text = str(kwargs.get("text", "") or "")
-        if (
-            mode in {WILDCARD_MODE_POPULATE, WILDCARD_MODE_FIXED, WILDCARD_MODE_SEQUENTIAL}
-            and seed_control == SEED_CONTROL_RANDOMIZE
-            and has_wildcard_syntax(text)
-        ):
-            return float("nan")
-        return _stable_change_key({
-            "mode": "wildcard",
-            "wildcard_sources": wildcard_sources_signature(),
-            **{key: str(value) for key, value in sorted(kwargs.items())},
-        })
-
-    @classmethod
-    def _update_metadata_cache(
-        cls,
-        workflow_prompt,
-        extra_pnginfo,
-        unique_id,
-        populated_text: str,
-        mode: str,
-        seed: int,
-    ) -> None:
-        node_id = _single_value(unique_id)
-        if node_id is None:
-            return
-        node_id = str(node_id)
-        updates = {
-            "populated_text": populated_text,
-            "mode": mode,
-            "seed": int(seed),
-        }
-
-        if isinstance(workflow_prompt, dict):
-            prompt_node = workflow_prompt.get(node_id)
-            if isinstance(prompt_node, dict):
-                inputs = prompt_node.setdefault("inputs", {})
-                for name, value in updates.items():
-                    inputs[name] = value
-
-        workflow_node = _get_workflow_node(extra_pnginfo, node_id)
-        if workflow_node is None:
-            return
-
-        input_names = cls._widget_input_names()
-        widgets_values = workflow_node.setdefault("widgets_values", [])
-        for name, value in updates.items():
-            if name not in input_names:
-                continue
-            index = input_names.index(name)
-            while len(widgets_values) <= index:
-                widgets_values.append(None)
-            widgets_values[index] = value
-
-    @staticmethod
-    def _ui(
-        populated_text: str,
-        mode: str,
-        seed: int,
-        status: str,
-        used_keys: tuple[str, ...],
-        missing_keys: tuple[str, ...],
-    ):
-        return {
-            "wildcard": [{
-                "populated_text": populated_text,
-                "mode": mode,
-                "seed": seed,
-                "status": status,
-                "used_keys": list(used_keys),
-                "missing_keys": list(missing_keys),
-            }]
-        }
-
-    def generate(
-        self,
-        text: str,
-        populated_text: str,
-        mode: str,
-        seed: int,
-        seed_after_generate: str,
-        workflow_prompt=None,
-        extra_pnginfo=None,
-        unique_id=None,
-        **reservation_inputs,
-    ):
-        mode_key = normalize_wildcard_mode(mode)
-        seed_value = normalize_seed(seed)
-        used_keys: tuple[str, ...] = ()
-        missing_keys: tuple[str, ...] = ()
-
-        if mode_key == WILDCARD_MODE_REPRODUCE:
-            output_text = str(populated_text if populated_text else text or "")
-            status = mode_key
-            metadata_mode = str(mode or WILDCARD_MODE_LABELS[3])
-        else:
-            expansion = expand_wildcards(str(text or ""), seed=seed_value, mode=mode_key)
-            output_text = expansion.text
-            used_keys = expansion.used_keys
-            missing_keys = expansion.missing_keys
-            status = WILDCARD_MODE_SEQUENTIAL if mode_key == WILDCARD_MODE_SEQUENTIAL else mode_key
-            metadata_mode = WILDCARD_MODE_LABELS[3]
-
-        effective_seed_control = (
-            SEED_CONTROL_INCREMENT
-            if mode_key == WILDCARD_MODE_SEQUENTIAL
-            else seed_after_generate
-        )
-        reserved_next_seed = _consume_reserved_wildcard_next_seed(
-            reservation_inputs,
-            workflow_prompt,
-            unique_id,
-            seed_value,
-            mode_key,
-            effective_seed_control,
-        )
-        next_seed_value = (
-            reserved_next_seed
-            if reserved_next_seed is not None
-            else next_seed(seed_value, effective_seed_control)
-        )
-        self._update_metadata_cache(
-            workflow_prompt,
-            extra_pnginfo,
-            unique_id,
-            output_text,
-            metadata_mode,
-            seed_value,
-        )
-        return {
-            "ui": self._ui(
-                output_text,
-                str(mode or WILDCARD_MODE_LABELS[0]),
-                next_seed_value,
-                status,
-                used_keys,
-                missing_keys,
-            ),
-            "result": (output_text, next_seed_value),
-        }
 
 
 class EasyUseAnimaPromptBuilder:
@@ -11578,554 +11171,3 @@ class EasyUseAnimaSAM3Detailer:
         )[0]
 
         return (detailed_image, segs, mask, image)
-
-
-class EasyUseAnimaNAIARandomPrompt:
-    """NAIA random prompt node with bypass and frozen-output cache."""
-
-    DESCRIPTION = (
-        "Requests a random prompt from NAIA Remote API, supports bypass and frozen output reuse, "
-        "and stores generated values so saved-image workflows can reproduce the same result."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Prompt text from NAIA or the original input when bypassed or not overridden.",
-        "Negative prompt text from NAIA or the original input when bypassed or not overridden.",
-        "Width from NAIA or the original input when bypassed or not overridden.",
-        "Height from NAIA or the original input when bypassed or not overridden.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        required = {
-            "use_naia_bridge": ("BOOLEAN", {
-                "default": True,
-                "tooltip": (
-                    "false: bypass NAIA and return prompt/negative_prompt/width/height as-is. "
-                    "This mode keeps ComfyUI cache stable when inputs are unchanged."
-                ),
-            }),
-            "freeze_naia_output": ("BOOLEAN", {
-                "default": False,
-                "tooltip": (
-                    "true: if cached output is valid, return it without calling NAIA. "
-                    "Saved-image workflows are written with this enabled."
-                ),
-            }),
-            "show_preview": ("BOOLEAN", {
-                "default": True,
-                "tooltip": "Show the large read-only preview widget in the node UI.",
-            }),
-            "cached_prompt": ("STRING", {
-                "multiline": True,
-                "default": "",
-                "tooltip": "Stored prompt used for frozen output and saved-image reproduction.",
-            }),
-            "cached_negative_prompt": ("STRING", {
-                "multiline": True,
-                "default": "",
-                "tooltip": "Stored negative prompt used for frozen output and saved-image reproduction.",
-            }),
-            "cached_width": ("INT", {
-                "default": 0, "min": 0, "max": NAIA_MAX_RESOLUTION, "step": 8,
-                "tooltip": "Stored width used for frozen output and saved-image reproduction.",
-            }),
-            "cached_height": ("INT", {
-                "default": 0, "min": 0, "max": NAIA_MAX_RESOLUTION, "step": 8,
-                "tooltip": "Stored height used for frozen output and saved-image reproduction.",
-            }),
-            "cached_signature": ("STRING", {
-                "multiline": True,
-                "default": "",
-                "tooltip": "Internal signature for validating cached output.",
-            }),
-            "prompt": ("STRING", {
-                "multiline": False,
-                "default": "",
-                "placeholder": "prompt",
-                "tooltip": "Returned as-is when bypassed or when override_prompt is false.",
-            }),
-            "override_prompt": ("BOOLEAN", {
-                "default": True,
-                "tooltip": "true: use NAIA prompt. false: preserve input prompt.",
-            }),
-            "negative_prompt": ("STRING", {
-                "multiline": False,
-                "default": "",
-                "placeholder": "negative_prompt",
-                "tooltip": "Returned as-is when bypassed or when override_negative is false.",
-            }),
-            "override_negative": ("BOOLEAN", {
-                "default": True,
-                "tooltip": "true: use NAIA negative prompt. false: preserve input negative_prompt.",
-            }),
-            "width": ("INT", {
-                "default": 1024, "min": 64, "max": NAIA_MAX_RESOLUTION, "step": 8,
-                "tooltip": "Returned as-is when bypassed or when override_width is false.",
-            }),
-            "override_width": ("BOOLEAN", {
-                "default": True,
-                "tooltip": "true: use NAIA width. false: preserve input width.",
-            }),
-            "height": ("INT", {
-                "default": 1024, "min": 64, "max": NAIA_MAX_RESOLUTION, "step": 8,
-                "tooltip": "Returned as-is when bypassed or when override_height is false.",
-            }),
-            "override_height": ("BOOLEAN", {
-                "default": True,
-                "tooltip": "true: use NAIA height. false: preserve input height.",
-            }),
-            "use_naia_settings": ("BOOLEAN", {
-                "default": True,
-                "tooltip": (
-                    "true: use NAIA desktop Prompt Engineering settings. "
-                    "false: send this node's pre/post/auto_hide and preprocessing options."
-                ),
-            }),
-            "pre_prompt": ("STRING", {
-                "multiline": True,
-                "default": "",
-                "placeholder": "pre_prompt",
-                "tooltip": "Used only when use_naia_settings is false.",
-            }),
-            "post_prompt": ("STRING", {
-                "multiline": True,
-                "default": "",
-                "placeholder": "post_prompt",
-                "tooltip": "Used only when use_naia_settings is false.",
-            }),
-            "auto_hide": ("STRING", {
-                "multiline": True,
-                "default": "",
-                "placeholder": "auto_hide",
-                "tooltip": "Used only when use_naia_settings is false.",
-            }),
-        }
-
-        pp_tooltip = (
-            "Used only when use_naia_settings is false.\n"
-            "skip: do not send this key\n"
-            "on: remove this category\n"
-            "off: explicitly keep this category"
-        )
-        for key in PREPROCESSING_KEYS:
-            required[key] = (PP_STATE_CHOICES, {
-                "default": "skip",
-                "tooltip": pp_tooltip,
-                "advanced": key.startswith("remove_"),
-                "socketless": key.startswith("remove_"),
-            })
-
-        required["host"] = ("STRING", {
-            "default": DEFAULT_HOST,
-            "tooltip": "NAIA Remote API host.",
-        })
-        required["port"] = ("INT", {
-            "default": DEFAULT_PORT, "min": 1, "max": 65535,
-            "tooltip": "NAIA Remote API port.",
-        })
-        return {
-            "required": required,
-            "hidden": {
-                "workflow_prompt": "PROMPT",
-                "extra_pnginfo": "EXTRA_PNGINFO",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    RETURN_TYPES = ("STRING", "STRING", "INT", "INT")
-    RETURN_NAMES = ("prompt", "negative_prompt", "width", "height")
-    FUNCTION = "request"
-    CATEGORY = "NAIA Bridge/API"
-
-    def __init__(self):
-        self._cache_signature: Optional[str] = None
-        self._cache_value: Optional[tuple[str, str, int, int]] = None
-
-    @classmethod
-    def IS_CHANGED(
-        cls,
-        use_naia_bridge: bool = True,
-        freeze_naia_output: bool = False,
-        show_preview: bool = True,
-        cached_prompt: str = "",
-        cached_negative_prompt: str = "",
-        cached_width: int = 0,
-        cached_height: int = 0,
-        cached_signature: str = "",
-        prompt: str = "",
-        override_prompt: bool = True,
-        negative_prompt: str = "",
-        override_negative: bool = True,
-        width: int = 1024,
-        override_width: bool = True,
-        height: int = 1024,
-        override_height: bool = True,
-        use_naia_settings: bool = True,
-        pre_prompt: str = "",
-        post_prompt: str = "",
-        auto_hide: str = "",
-        host: str = DEFAULT_HOST,
-        port: int = DEFAULT_PORT,
-        **kwargs,
-    ):
-        naia_settings = resolve_naia_settings()
-        use_naia_settings = naia_settings["use_naia_settings"]
-        pre_prompt = naia_settings["pre_prompt"]
-        post_prompt = naia_settings["post_prompt"]
-        auto_hide = naia_settings["auto_hide"]
-        host = naia_settings["host"]
-        port = naia_settings["port"]
-        pp_kwargs = naia_settings["preprocessing"]
-
-        if not _as_bool(use_naia_bridge, True):
-            return _stable_change_key({
-                "mode": "disabled",
-                "prompt": str(prompt),
-                "negative_prompt": str(negative_prompt),
-                "width": _as_int(width, 1024),
-                "height": _as_int(height, 1024),
-            })
-
-        signature = cls._make_signature(
-            prompt,
-            override_prompt,
-            negative_prompt,
-            override_negative,
-            width,
-            override_width,
-            height,
-            override_height,
-            use_naia_settings,
-            pre_prompt,
-            post_prompt,
-            auto_hide,
-            host,
-            port,
-            pp_kwargs,
-        )
-
-        if _as_bool(freeze_naia_output, False):
-            cached = cls._cached_tuple(
-                cached_prompt,
-                cached_negative_prompt,
-                cached_width,
-                cached_height,
-            )
-            if cached is not None and str(cached_signature) == signature:
-                return _stable_change_key({
-                    "mode": "frozen",
-                    "signature": signature,
-                    "prompt": cached[0],
-                    "negative_prompt": cached[1],
-                    "width": cached[2],
-                    "height": cached[3],
-                })
-            return float("nan")
-
-        return float("nan")
-
-    @staticmethod
-    def _cached_tuple(
-        cached_prompt: str,
-        cached_negative_prompt: str,
-        cached_width: int,
-        cached_height: int,
-    ) -> Optional[tuple[str, str, int, int]]:
-        width = _as_int(cached_width, 0)
-        height = _as_int(cached_height, 0)
-        if width <= 0 or height <= 0:
-            return None
-        if not cached_prompt and not cached_negative_prompt:
-            return None
-        return (str(cached_prompt), str(cached_negative_prompt), width, height)
-
-    @classmethod
-    def _widget_input_names(cls) -> list[str]:
-        return list(cls.INPUT_TYPES()["required"].keys())
-
-    @staticmethod
-    def _make_signature(
-        prompt: str,
-        override_prompt: bool,
-        negative_prompt: str,
-        override_negative: bool,
-        width: int,
-        override_width: bool,
-        height: int,
-        override_height: bool,
-        use_naia_settings: bool,
-        pre_prompt: str,
-        post_prompt: str,
-        auto_hide: str,
-        host: str,
-        port: int,
-        pp_kwargs: dict,
-    ) -> str:
-        use_settings = _as_bool(use_naia_settings, True)
-        preprocessing = {}
-        if not use_settings:
-            preprocessing = {
-                key: str(pp_kwargs.get(key, "skip"))
-                for key in PREPROCESSING_KEYS
-            }
-        payload = {
-            "prompt": str(prompt),
-            "override_prompt": _as_bool(override_prompt, True),
-            "negative_prompt": str(negative_prompt),
-            "override_negative": _as_bool(override_negative, True),
-            "width": _as_int(width, 1024),
-            "override_width": _as_bool(override_width, True),
-            "height": _as_int(height, 1024),
-            "override_height": _as_bool(override_height, True),
-            "use_naia_settings": use_settings,
-            "pre_prompt": "" if use_settings else str(pre_prompt),
-            "post_prompt": "" if use_settings else str(post_prompt),
-            "auto_hide": "" if use_settings else str(auto_hide),
-            "preprocessing": preprocessing,
-            "host": str(host),
-            "port": _as_int(port, DEFAULT_PORT),
-        }
-        return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-    @staticmethod
-    def _make_request_body(
-        use_naia_settings: bool,
-        pre_prompt: str,
-        post_prompt: str,
-        auto_hide: str,
-        pp_kwargs: dict,
-    ) -> dict:
-        body = {
-            "timeout": NAIA_REQUEST_TIMEOUT,
-            "respect_naia_autogen": True,
-            "force_naia_skip_generate": False,
-        }
-        if not use_naia_settings:
-            preprocessing_options = {}
-            for key in PREPROCESSING_KEYS:
-                state = pp_kwargs.get(key, "skip")
-                if state == "on":
-                    preprocessing_options[key] = True
-                elif state == "off":
-                    preprocessing_options[key] = False
-            body["peng_override"] = {
-                "pre_prompt": pre_prompt,
-                "post_prompt": post_prompt,
-                "auto_hide": auto_hide,
-                "preprocessing_options": preprocessing_options,
-            }
-        return body
-
-    @staticmethod
-    def _apply_overrides(
-        naia_value: tuple[str, str, int, int],
-        prompt: str,
-        override_prompt: bool,
-        negative_prompt: str,
-        override_negative: bool,
-        width: int,
-        override_width: bool,
-        height: int,
-        override_height: bool,
-    ) -> tuple[str, str, int, int]:
-        naia_prompt, naia_negative, naia_width, naia_height = naia_value
-        return (
-            naia_prompt if override_prompt else str(prompt),
-            naia_negative if override_negative else str(negative_prompt),
-            naia_width if override_width else _as_int(width, 1024),
-            naia_height if override_height else _as_int(height, 1024),
-        )
-
-    @classmethod
-    def _update_metadata_cache(
-        cls,
-        workflow_prompt,
-        extra_pnginfo,
-        unique_id,
-        output_value: tuple[str, str, int, int],
-        signature: str,
-    ) -> None:
-        node_id = _single_value(unique_id)
-        if node_id is None:
-            return
-        node_id = str(node_id)
-        out_prompt, out_negative, out_width, out_height = output_value
-        updates = {
-            "use_naia_bridge": True,
-            "freeze_naia_output": True,
-            "cached_prompt": out_prompt,
-            "cached_negative_prompt": out_negative,
-            "cached_width": int(out_width),
-            "cached_height": int(out_height),
-            "cached_signature": signature,
-        }
-
-        if isinstance(workflow_prompt, dict):
-            prompt_node = workflow_prompt.get(node_id)
-            if isinstance(prompt_node, dict):
-                inputs = prompt_node.setdefault("inputs", {})
-                for name, value in updates.items():
-                    inputs[name] = value
-
-        workflow_node = _get_workflow_node(extra_pnginfo, node_id)
-        if workflow_node is None:
-            return
-
-        input_names = cls._widget_input_names()
-        widgets_values = workflow_node.setdefault("widgets_values", [])
-        for name, value in updates.items():
-            if name not in input_names:
-                continue
-            index = input_names.index(name)
-            while len(widgets_values) <= index:
-                widgets_values.append(None)
-            widgets_values[index] = value
-
-    @staticmethod
-    def _ui(prompt: str, negative: str, width: int, height: int, status: str, signature: str):
-        return {
-            "prompt": [prompt],
-            "negative_prompt": [negative],
-            "width": [width],
-            "height": [height],
-            "status": [status],
-            "cached_signature": [signature],
-        }
-
-    def request(
-        self,
-        use_naia_bridge: bool,
-        freeze_naia_output: bool,
-        show_preview: bool,
-        cached_prompt: str,
-        cached_negative_prompt: str,
-        cached_width: int,
-        cached_height: int,
-        cached_signature: str,
-        prompt: str,
-        override_prompt: bool,
-        negative_prompt: str,
-        override_negative: bool,
-        width: int,
-        override_width: bool,
-        height: int,
-        override_height: bool,
-        use_naia_settings: bool,
-        pre_prompt: str,
-        post_prompt: str,
-        auto_hide: str,
-        host: str,
-        port: int,
-        workflow_prompt=None,
-        extra_pnginfo=None,
-        unique_id=None,
-        **pp_kwargs,
-    ):
-        naia_settings = resolve_naia_settings()
-        use_naia_settings = naia_settings["use_naia_settings"]
-        pre_prompt = naia_settings["pre_prompt"]
-        post_prompt = naia_settings["post_prompt"]
-        auto_hide = naia_settings["auto_hide"]
-        host = naia_settings["host"]
-        port = naia_settings["port"]
-        pp_kwargs = naia_settings["preprocessing"]
-
-        bridge_enabled = _as_bool(use_naia_bridge, True)
-        freeze_output = _as_bool(freeze_naia_output, False)
-        use_settings = _as_bool(use_naia_settings, True)
-        override_prompt = _as_bool(override_prompt, True)
-        override_negative = _as_bool(override_negative, True)
-        override_width = _as_bool(override_width, True)
-        override_height = _as_bool(override_height, True)
-
-        signature = self._make_signature(
-            prompt,
-            override_prompt,
-            negative_prompt,
-            override_negative,
-            width,
-            override_width,
-            height,
-            override_height,
-            use_settings,
-            pre_prompt,
-            post_prompt,
-            auto_hide,
-            host,
-            port,
-            pp_kwargs,
-        )
-
-        if not bridge_enabled:
-            out_prompt = str(prompt)
-            out_negative = str(negative_prompt)
-            out_width = _as_int(width, 1024)
-            out_height = _as_int(height, 1024)
-            return {
-                "ui": self._ui(out_prompt, out_negative, out_width, out_height, "disabled", signature),
-                "result": (out_prompt, out_negative, out_width, out_height),
-            }
-
-        saved_cache = self._cached_tuple(
-            cached_prompt,
-            cached_negative_prompt,
-            cached_width,
-            cached_height,
-        )
-        if freeze_output and saved_cache is not None and str(cached_signature) == signature:
-            out_prompt, out_negative, out_width, out_height = saved_cache
-            return {
-                "ui": self._ui(out_prompt, out_negative, out_width, out_height, "frozen", signature),
-                "result": (out_prompt, out_negative, out_width, out_height),
-            }
-
-        if self._cache_signature != signature:
-            self._cache_signature = signature
-            self._cache_value = (
-                saved_cache if saved_cache is not None and str(cached_signature) == signature else None
-            )
-
-        if self._cache_value is None or not freeze_output:
-            body = self._make_request_body(use_settings, pre_prompt, post_prompt, auto_hide, pp_kwargs)
-            resp = _post_random(
-                host,
-                port,
-                body,
-                allow_remote_api=bool(naia_settings.get("allow_remote_api", False)),
-            )
-            naia_value = _parse_random_response(resp)
-            self._cache_value = self._apply_overrides(
-                naia_value,
-                prompt,
-                override_prompt,
-                negative_prompt,
-                override_negative,
-                width,
-                override_width,
-                height,
-                override_height,
-            )
-            logger.debug(
-                "request_id=%s prompt_len=%d size=%dx%d use_naia_settings=%s",
-                resp.get("request_id"),
-                len(self._cache_value[0]),
-                self._cache_value[2],
-                self._cache_value[3],
-                use_settings,
-            )
-
-        if self._cache_value is None:
-            raise RuntimeError("[EasyUse Anima] Internal cache creation failed.")
-
-        out_prompt, out_negative, out_width, out_height = self._cache_value
-        self._update_metadata_cache(
-            workflow_prompt,
-            extra_pnginfo,
-            unique_id,
-            (out_prompt, out_negative, out_width, out_height),
-            signature,
-        )
-        return {
-            "ui": self._ui(out_prompt, out_negative, out_width, out_height, "fresh", signature),
-            "result": (out_prompt, out_negative, out_width, out_height),
-        }

--- a/nodes.py
+++ b/nodes.py
@@ -80,6 +80,7 @@ try:
         PP_STATE_CHOICES as PP_STATE_CHOICES,
         PREPROCESSING_KEYS as PREPROCESSING_KEYS,
         _build_naia_random_url as _build_naia_random_url,
+        _clean_prompt as _clean_prompt,
         _fit_to_1mp as _fit_to_1mp,
         _is_local_naia_host as _is_local_naia_host,
         _parse_random_response as _parse_random_response,
@@ -214,6 +215,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         PP_STATE_CHOICES as PP_STATE_CHOICES,
         PREPROCESSING_KEYS as PREPROCESSING_KEYS,
         _build_naia_random_url as _build_naia_random_url,
+        _clean_prompt as _clean_prompt,
         _fit_to_1mp as _fit_to_1mp,
         _is_local_naia_host as _is_local_naia_host,
         _parse_random_response as _parse_random_response,
@@ -929,7 +931,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 
 
 _HASH_COMMENT_RE = re.compile(r"^[ \t]*#[^\n]*", re.MULTILINE)
-_MULTI_COMMA_RE = re.compile(r"(\s*,){2,}")
 _INLINE_SPACE_RE = re.compile(r"[ \t]+")
 _WEIGHTED_TOKEN_RE = re.compile(r"^\(([^(),]+):[-+]?\d+(?:\.\d+)?\)$")
 _WEIGHTED_ARTIST_RE = re.compile(
@@ -940,7 +941,6 @@ _ARTIST_GROUP_RE = re.compile(
     re.DOTALL,
 )
 _SECTION_SEPARATOR_RE = re.compile(r"^\s*-{6,}\s*$", re.MULTILINE)
-_RESOLUTION_LABEL_RE = re.compile(r"(\d+)\s*(?:\*|x|×)\s*(\d+)")
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
 _ADVANCED_FIELD_SOCKET_PREFIX = "field_"
 _ADVANCED_FIELD_SOCKET_RE = re.compile(r"[^A-Za-z0-9_]")
@@ -980,14 +980,6 @@ def _resolve_aio_runtime_seed(value) -> int:
     return max(0, min(MAX_SEED, seed))
 
 
-
-
-def _clean_prompt(value: str) -> str:
-    if not value:
-        return value
-    value = _HASH_COMMENT_RE.sub("", value)
-    value = _MULTI_COMMA_RE.sub(",", value)
-    return value.strip(" ,\n\t")
 
 
 def _merge_versioned_settings(defaults: dict[str, Any], value) -> dict[str, Any]:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8266,6 +8266,37 @@
         "target": "easyuse_anima/naia/client.py"
       },
       {
+        "alias": "_clean_prompt",
+        "bound_name": "_clean_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_clean_prompt",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:_clean_prompt",
+        "kind": "static_from",
+        "line": 71,
+        "name": "_clean_prompt",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
         "alias": "_fit_to_1mp",
         "bound_name": "_fit_to_1mp",
         "branch_context": [
@@ -8411,7 +8442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8442,7 +8473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8473,7 +8504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8504,7 +8535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8535,7 +8566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8566,7 +8597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8597,7 +8628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8628,7 +8659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8659,7 +8690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8690,7 +8721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8721,7 +8752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8752,7 +8783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8783,7 +8814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8814,7 +8845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8845,7 +8876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8876,7 +8907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8907,7 +8938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8938,7 +8969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -8969,7 +9000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9000,7 +9031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9031,7 +9062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 88,
+        "line": 89,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9062,7 +9093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -9093,7 +9124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -9124,7 +9155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -9155,7 +9186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -9186,7 +9217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 115,
+        "line": 116,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -9217,7 +9248,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -9248,7 +9279,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -9279,7 +9310,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -9310,7 +9341,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -9341,7 +9372,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -9372,7 +9403,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -9403,7 +9434,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -9434,7 +9465,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 127,
+        "line": 128,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -9465,7 +9496,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9496,7 +9527,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9527,7 +9558,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9558,7 +9589,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9589,7 +9620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9620,7 +9651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9651,7 +9682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9682,7 +9713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9713,7 +9744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9744,7 +9775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9775,7 +9806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9806,7 +9837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9837,7 +9868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9868,7 +9899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9899,7 +9930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9930,7 +9961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9961,7 +9992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -9992,7 +10023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 128,
+        "line": 129,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -10011,7 +10042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10026,7 +10057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -10045,7 +10076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10060,7 +10091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -10079,7 +10110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10094,7 +10125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -10113,7 +10144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10128,7 +10159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -10147,7 +10178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10162,7 +10193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -10181,7 +10212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10196,7 +10227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -10215,7 +10246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10230,7 +10261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -10249,7 +10280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10264,7 +10295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -10283,7 +10314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10298,7 +10329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -10317,7 +10348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10332,7 +10363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -10351,7 +10382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10366,7 +10397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -10385,7 +10416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10400,7 +10431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -10419,7 +10450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10434,7 +10465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -10453,7 +10484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10468,7 +10499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -10487,7 +10518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10502,7 +10533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -10521,7 +10552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10536,7 +10567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -10555,7 +10586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10570,7 +10601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -10589,7 +10620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10604,7 +10635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -10623,7 +10654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10638,7 +10669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -10657,7 +10688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10672,7 +10703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -10691,7 +10722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10706,7 +10737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -10725,7 +10756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10740,7 +10771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -10759,7 +10790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10774,7 +10805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -10793,7 +10824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10808,7 +10839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -10827,7 +10858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10842,7 +10873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -10861,7 +10892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10876,7 +10907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -10895,7 +10926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10910,7 +10941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -10929,7 +10960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10944,7 +10975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -10963,7 +10994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -10978,7 +11009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -10997,7 +11028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11012,7 +11043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -11031,7 +11062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11046,7 +11077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -11065,7 +11096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11080,7 +11111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -11099,7 +11130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11114,7 +11145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -11133,7 +11164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11148,7 +11179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -11167,7 +11198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11182,7 +11213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -11201,7 +11232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11216,7 +11247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -11235,7 +11266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11250,7 +11281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -11269,7 +11300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11284,7 +11315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -11303,7 +11334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11318,7 +11349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11337,7 +11368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11352,7 +11383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11371,7 +11402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11386,7 +11417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11405,7 +11436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11420,7 +11451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11439,7 +11470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11454,7 +11485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11473,7 +11504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11488,7 +11519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11507,7 +11538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11522,7 +11553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11541,7 +11572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11556,7 +11587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11575,7 +11606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11590,7 +11621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11609,7 +11640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11624,7 +11655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11643,7 +11674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11658,8 +11689,42 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "_build_naia_random_url",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_clean_prompt",
+        "bound_name": "_clean_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 149,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_clean_prompt",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_clean_prompt",
+        "kind": "static_from",
+        "line": 206,
+        "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
         "role": "compatibility_fallback",
@@ -11677,7 +11742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11692,7 +11757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11711,7 +11776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11726,7 +11791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11745,7 +11810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11760,7 +11825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11779,7 +11844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11794,7 +11859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -11813,7 +11878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11828,7 +11893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -11847,7 +11912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11862,7 +11927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -11881,7 +11946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11896,7 +11961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -11915,7 +11980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11930,7 +11995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -11949,7 +12014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11964,7 +12029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -11983,7 +12048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -11998,7 +12063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12017,7 +12082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12032,7 +12097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12051,7 +12116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12066,7 +12131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12085,7 +12150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12100,7 +12165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12119,7 +12184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12134,7 +12199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12153,7 +12218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12168,7 +12233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12187,7 +12252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12202,7 +12267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12221,7 +12286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12236,7 +12301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12255,7 +12320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12270,7 +12335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12289,7 +12354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12304,7 +12369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12323,7 +12388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12338,7 +12403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12357,7 +12422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12372,7 +12437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12391,7 +12456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12406,7 +12471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12425,7 +12490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12440,7 +12505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12459,7 +12524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12474,7 +12539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12493,7 +12558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12508,7 +12573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -12527,7 +12592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12542,7 +12607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 245,
+        "line": 247,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -12561,7 +12626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12576,7 +12641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 245,
+        "line": 247,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -12595,7 +12660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12610,7 +12675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 249,
+        "line": 251,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -12629,7 +12694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12644,7 +12709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 249,
+        "line": 251,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -12663,7 +12728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12678,7 +12743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 249,
+        "line": 251,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -12697,7 +12762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12712,7 +12777,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 254,
+        "line": 256,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -12731,7 +12796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12746,7 +12811,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 254,
+        "line": 256,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -12765,7 +12830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12780,7 +12845,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 255,
+        "line": 257,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -12799,7 +12864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12814,7 +12879,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -12833,7 +12898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12848,7 +12913,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -12867,7 +12932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12882,7 +12947,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -12901,7 +12966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12916,7 +12981,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 261,
+        "line": 263,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -12935,7 +13000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12950,7 +13015,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 261,
+        "line": 263,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -12969,7 +13034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -12984,7 +13049,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13003,7 +13068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13018,7 +13083,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13037,7 +13102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13052,7 +13117,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13071,7 +13136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13086,7 +13151,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13105,7 +13170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13120,7 +13185,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13139,7 +13204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13154,7 +13219,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13173,7 +13238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13188,7 +13253,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13207,7 +13272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13222,7 +13287,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13241,7 +13306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13256,7 +13321,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13275,7 +13340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13290,7 +13355,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13309,7 +13374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13324,7 +13389,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13343,7 +13408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13358,7 +13423,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13377,7 +13442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13392,7 +13457,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13411,7 +13476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13426,7 +13491,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13445,7 +13510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13460,7 +13525,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13479,7 +13544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13494,7 +13559,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13513,7 +13578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13528,7 +13593,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13547,7 +13612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -13562,7 +13627,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -13580,7 +13645,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1953
+            "line": 1945
           }
         ],
         "classification": "external",
@@ -13588,7 +13653,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1954,
+        "line": 1946,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -13605,7 +13670,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2018
+            "line": 2010
           }
         ],
         "classification": "external",
@@ -13613,7 +13678,7 @@
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2019,
+        "line": 2011,
         "name": null,
         "optional": true,
         "requested": "impact.core",
@@ -13630,7 +13695,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2024
+            "line": 2016
           }
         ],
         "classification": "external",
@@ -13638,7 +13703,7 @@
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2025,
+        "line": 2017,
         "name": "core",
         "optional": true,
         "requested": "modules.impact",
@@ -13655,7 +13720,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2040
+            "line": 2032
           }
         ],
         "classification": "external",
@@ -13663,7 +13728,7 @@
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2041,
+        "line": 2033,
         "name": null,
         "optional": true,
         "requested": "comfy.samplers",
@@ -13680,7 +13745,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2049
+            "line": 2041
           }
         ],
         "classification": "external",
@@ -13688,7 +13753,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2050,
+        "line": 2042,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -13705,7 +13770,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2065
+            "line": 2057
           }
         ],
         "classification": "external",
@@ -13713,7 +13778,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2066,
+        "line": 2058,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -13730,7 +13795,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2071
+            "line": 2063
           }
         ],
         "classification": "external",
@@ -13738,7 +13803,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2072,
+        "line": 2064,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -13755,7 +13820,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2085
+            "line": 2077
           }
         ],
         "classification": "external",
@@ -13763,7 +13828,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2086,
+        "line": 2078,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -13780,7 +13845,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2184
+            "line": 2176
           }
         ],
         "classification": "external",
@@ -13788,7 +13853,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2185,
+        "line": 2177,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
@@ -13805,7 +13870,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2208
+            "line": 2200
           }
         ],
         "classification": "external",
@@ -13813,7 +13878,7 @@
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2209,
+        "line": 2201,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.segs_nodes",
@@ -13830,7 +13895,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2214
+            "line": 2206
           }
         ],
         "classification": "external",
@@ -13838,7 +13903,7 @@
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2215,
+        "line": 2207,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.segs_nodes",
@@ -13855,7 +13920,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2220
+            "line": 2212
           }
         ],
         "classification": "external",
@@ -13863,7 +13928,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2221,
+        "line": 2213,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -13880,7 +13945,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2226
+            "line": 2218
           }
         ],
         "classification": "external",
@@ -13888,7 +13953,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2227,
+        "line": 2219,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -13905,7 +13970,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2661
+            "line": 2653
           }
         ],
         "classification": "external",
@@ -13913,7 +13978,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2662,
+        "line": 2654,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -13930,7 +13995,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2701
+            "line": 2693
           }
         ],
         "classification": "external",
@@ -13938,7 +14003,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2702,
+        "line": 2694,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -13953,7 +14018,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3134,
+            "line": 3126,
             "type_checking": false
           },
           {
@@ -13961,7 +14026,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3135
+            "line": 3127
           }
         ],
         "classification": "external",
@@ -13969,7 +14034,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3136,
+        "line": 3128,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -13986,7 +14051,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3935
+            "line": 3927
           }
         ],
         "classification": "external",
@@ -13994,7 +14059,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3936,
+        "line": 3928,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -14011,7 +14076,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3997
+            "line": 3989
           }
         ],
         "classification": "external",
@@ -14019,7 +14084,7 @@
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 3998,
+        "line": 3990,
         "name": "PromptServer",
         "optional": true,
         "requested": "server",
@@ -14036,7 +14101,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
@@ -14044,7 +14109,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4025,
+        "line": 4017,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -14061,7 +14126,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
@@ -14069,7 +14134,7 @@
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4026,
+        "line": 4018,
         "name": null,
         "optional": true,
         "requested": "numpy",
@@ -14086,7 +14151,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
@@ -14094,7 +14159,7 @@
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4027,
+        "line": 4019,
         "name": "Image",
         "optional": true,
         "requested": "PIL",
@@ -14111,7 +14176,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4218
+            "line": 4210
           }
         ],
         "classification": "external",
@@ -14119,7 +14184,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4219,
+        "line": 4211,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14136,7 +14201,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5069
+            "line": 5061
           }
         ],
         "classification": "external",
@@ -14144,7 +14209,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5070,
+        "line": 5062,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14161,7 +14226,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5086
+            "line": 5078
           }
         ],
         "classification": "external",
@@ -14169,7 +14234,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5087,
+        "line": 5079,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14186,7 +14251,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5107
+            "line": 5099
           }
         ],
         "classification": "external",
@@ -14194,7 +14259,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5108,
+        "line": 5100,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14211,7 +14276,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5184
+            "line": 5176
           }
         ],
         "classification": "external",
@@ -14219,7 +14284,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5185,
+        "line": 5177,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14236,7 +14301,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5983
+            "line": 5975
           }
         ],
         "classification": "external",
@@ -14244,7 +14309,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5984,
+        "line": 5976,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14261,7 +14326,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7008
+            "line": 7000
           }
         ],
         "classification": "external",
@@ -14269,7 +14334,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7009,
+        "line": 7001,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14286,7 +14351,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7042
+            "line": 7034
           }
         ],
         "classification": "external",
@@ -14294,7 +14359,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7043,
+        "line": 7035,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14311,7 +14376,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7267
+            "line": 7259
           }
         ],
         "classification": "external",
@@ -14319,7 +14384,7 @@
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 7268,
+        "line": 7260,
         "name": "apply_lora_syntax_format",
         "optional": true,
         "requested": "py.nodes.utils",
@@ -14336,7 +14401,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7277
+            "line": 7269
           }
         ],
         "classification": "external",
@@ -14344,7 +14409,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7278,
+        "line": 7270,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -14361,7 +14426,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7299
+            "line": 7291
           }
         ],
         "classification": "external",
@@ -14369,7 +14434,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7300,
+        "line": 7292,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -14386,7 +14451,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7404
+            "line": 7396
           }
         ],
         "classification": "external",
@@ -14394,7 +14459,7 @@
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 7405,
+        "line": 7397,
         "name": "get_lora_info",
         "optional": true,
         "requested": "py.utils.utils",
@@ -14411,7 +14476,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7448
+            "line": 7440
           }
         ],
         "classification": "external",
@@ -14419,7 +14484,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7449,
+        "line": 7441,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -14436,7 +14501,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7473
+            "line": 7465
           }
         ],
         "classification": "external",
@@ -14444,7 +14509,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7474,
+        "line": 7466,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -16892,14 +16957,14 @@
       },
       {
         "is_package": false,
-        "loc": 11173,
+        "loc": 11165,
         "module": "nodes",
-        "normalized_git_blob_sha1": "b71aa17bd93a561b3597a7b9bd11296cb32dfaab",
+        "normalized_git_blob_sha1": "3b6b14485ab52a4f0839bf2b5dbece6b4bcf08aa",
         "path": "nodes.py",
         "top_level": {
           "class_count": 20,
-          "function_count": 241,
-          "global_count": 106
+          "function_count": 240,
+          "global_count": 104
         }
       },
       {
@@ -18064,7 +18129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18073,7 +18138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18087,7 +18152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18096,7 +18161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18110,7 +18175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18119,7 +18184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18133,7 +18198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18142,7 +18207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18156,7 +18221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18165,7 +18230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18179,7 +18244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18188,7 +18253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18202,7 +18267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18211,7 +18276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18225,7 +18290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18234,7 +18299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18248,7 +18313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18257,7 +18322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18271,7 +18336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18280,7 +18345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18294,7 +18359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18303,7 +18368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18317,7 +18382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18326,7 +18391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18340,7 +18405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18349,7 +18414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 161,
+        "line": 162,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18363,7 +18428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18372,7 +18437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 168,
+        "line": 169,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18386,7 +18451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18395,7 +18460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18409,7 +18474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18418,7 +18483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18432,7 +18497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18441,7 +18506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18455,7 +18520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18464,7 +18529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18478,7 +18543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18487,7 +18552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18501,7 +18566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18510,7 +18575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18524,7 +18589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18533,7 +18598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18547,7 +18612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18556,7 +18621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18570,7 +18635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18579,7 +18644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18593,7 +18658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18602,7 +18667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18616,7 +18681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18625,7 +18690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18639,7 +18704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18648,7 +18713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18662,7 +18727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18671,7 +18736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 179,
+        "line": 180,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18685,7 +18750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18694,7 +18759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18708,7 +18773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18717,7 +18782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18731,7 +18796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18740,7 +18805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18754,7 +18819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18763,7 +18828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18777,7 +18842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18786,7 +18851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18800,7 +18865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18809,7 +18874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18823,7 +18888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18832,7 +18897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18846,7 +18911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18855,7 +18920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18869,7 +18934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18878,7 +18943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 193,
+        "line": 194,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18892,7 +18957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18901,7 +18966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18915,7 +18980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18924,7 +18989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 201,
+        "line": 202,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18938,7 +19003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18947,7 +19012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18961,7 +19026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18970,7 +19035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -18984,7 +19049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -18993,7 +19058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19007,7 +19072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19016,7 +19081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19030,7 +19095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19039,7 +19104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19053,7 +19118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19062,7 +19127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19076,7 +19141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19085,7 +19150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19099,7 +19164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19108,7 +19173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19122,7 +19187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19131,7 +19196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19145,7 +19210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19154,7 +19219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19168,7 +19233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19177,7 +19242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19191,7 +19256,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_clean_prompt",
+        "kind": "static_from",
+        "line": 206,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19200,7 +19288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19214,7 +19302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19223,7 +19311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19237,7 +19325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19246,7 +19334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19260,7 +19348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19269,7 +19357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 205,
+        "line": 206,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19283,7 +19371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19292,7 +19380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19306,7 +19394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19315,7 +19403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19329,7 +19417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19338,7 +19426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19352,7 +19440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19361,7 +19449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19375,7 +19463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19384,7 +19472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19398,7 +19486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19407,7 +19495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19421,7 +19509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19430,7 +19518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19444,7 +19532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19453,7 +19541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19467,7 +19555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19476,7 +19564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19490,7 +19578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19499,7 +19587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19513,7 +19601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19522,7 +19610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19536,7 +19624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19545,7 +19633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19559,7 +19647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19568,7 +19656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19582,7 +19670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19591,7 +19679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19605,7 +19693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19614,7 +19702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19628,7 +19716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19637,7 +19725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19651,7 +19739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19660,7 +19748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19674,7 +19762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19683,7 +19771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19697,7 +19785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19706,7 +19794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19720,7 +19808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19729,7 +19817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19743,7 +19831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19752,7 +19840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 222,
+        "line": 224,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19766,7 +19854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19775,7 +19863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 245,
+        "line": 247,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19789,7 +19877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19798,7 +19886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 245,
+        "line": 247,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19812,7 +19900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19821,7 +19909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 249,
+        "line": 251,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19835,7 +19923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19844,7 +19932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 249,
+        "line": 251,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19858,7 +19946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19867,7 +19955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 249,
+        "line": 251,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19881,7 +19969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19890,7 +19978,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 254,
+        "line": 256,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19904,7 +19992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19913,7 +20001,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 254,
+        "line": 256,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19927,7 +20015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19936,7 +20024,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 255,
+        "line": 257,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19950,7 +20038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19959,7 +20047,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19973,7 +20061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -19982,7 +20070,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -19996,7 +20084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20005,7 +20093,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 256,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20019,7 +20107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20028,7 +20116,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 261,
+        "line": 263,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20042,7 +20130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20051,7 +20139,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 261,
+        "line": 263,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20065,7 +20153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20074,7 +20162,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20088,7 +20176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20097,7 +20185,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20111,7 +20199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20120,7 +20208,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20134,7 +20222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20143,7 +20231,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20157,7 +20245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20166,7 +20254,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20180,7 +20268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20189,7 +20277,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20203,7 +20291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20212,7 +20300,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20226,7 +20314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20235,7 +20323,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20249,7 +20337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20258,7 +20346,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20272,7 +20360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20281,7 +20369,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20295,7 +20383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20304,7 +20392,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20318,7 +20406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20327,7 +20415,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20341,7 +20429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20350,7 +20438,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20364,7 +20452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20373,7 +20461,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20387,7 +20475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20396,7 +20484,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20410,7 +20498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20419,7 +20507,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20433,7 +20521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20442,7 +20530,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20456,7 +20544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 148,
+            "handler_line": 149,
             "kind": "try",
             "line": 14
           }
@@ -20465,7 +20553,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 262,
+        "line": 264,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22160,14 +22248,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1953
+            "line": 1945
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1954,
+        "line": 1946,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22179,14 +22267,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2018
+            "line": 2010
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2019,
+        "line": 2011,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22198,14 +22286,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2024
+            "line": 2016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2025,
+        "line": 2017,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22217,14 +22305,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2040
+            "line": 2032
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2041,
+        "line": 2033,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22236,14 +22324,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2049
+            "line": 2041
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2050,
+        "line": 2042,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22255,14 +22343,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2065
+            "line": 2057
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2066,
+        "line": 2058,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22274,14 +22362,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2071
+            "line": 2063
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2072,
+        "line": 2064,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22293,14 +22381,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2085
+            "line": 2077
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2086,
+        "line": 2078,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22312,14 +22400,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2184
+            "line": 2176
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2185,
+        "line": 2177,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22331,14 +22419,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2208
+            "line": 2200
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2209,
+        "line": 2201,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22350,14 +22438,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2214
+            "line": 2206
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2215,
+        "line": 2207,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22369,14 +22457,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2220
+            "line": 2212
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2221,
+        "line": 2213,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22388,14 +22476,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2226
+            "line": 2218
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2227,
+        "line": 2219,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22407,14 +22495,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2661
+            "line": 2653
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2662,
+        "line": 2654,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22426,14 +22514,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2701
+            "line": 2693
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2702,
+        "line": 2694,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22443,7 +22531,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3134,
+            "line": 3126,
             "type_checking": false
           },
           {
@@ -22451,14 +22539,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3135
+            "line": 3127
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3136,
+        "line": 3128,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22470,14 +22558,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3935
+            "line": 3927
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3936,
+        "line": 3928,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22489,14 +22577,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3997
+            "line": 3989
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 3998,
+        "line": 3990,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22508,14 +22596,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4025,
+        "line": 4017,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22527,14 +22615,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4026,
+        "line": 4018,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22546,14 +22634,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4027,
+        "line": 4019,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22565,14 +22653,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4218
+            "line": 4210
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4219,
+        "line": 4211,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22584,14 +22672,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5069
+            "line": 5061
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5070,
+        "line": 5062,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22603,14 +22691,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5086
+            "line": 5078
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5087,
+        "line": 5079,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22622,14 +22710,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5107
+            "line": 5099
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5108,
+        "line": 5100,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22641,14 +22729,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5184
+            "line": 5176
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5185,
+        "line": 5177,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22660,14 +22748,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5983
+            "line": 5975
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5984,
+        "line": 5976,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22679,14 +22767,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7008
+            "line": 7000
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7009,
+        "line": 7001,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22698,14 +22786,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7042
+            "line": 7034
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7043,
+        "line": 7035,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22717,14 +22805,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7267
+            "line": 7259
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 7268,
+        "line": 7260,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22736,14 +22824,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7277
+            "line": 7269
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7278,
+        "line": 7270,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22755,14 +22843,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7299
+            "line": 7291
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7300,
+        "line": 7292,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22774,14 +22862,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7404
+            "line": 7396
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 7405,
+        "line": 7397,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22793,14 +22881,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7448
+            "line": 7440
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7449,
+        "line": 7441,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -22812,14 +22900,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7473
+            "line": 7465
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7474,
+        "line": 7466,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23588,14 +23676,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1953
+            "line": 1945
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1954,
+        "line": 1946,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23607,14 +23695,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2018
+            "line": 2010
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2019,
+        "line": 2011,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23626,14 +23714,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2024
+            "line": 2016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2025,
+        "line": 2017,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23645,14 +23733,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2040
+            "line": 2032
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2041,
+        "line": 2033,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23664,14 +23752,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2049
+            "line": 2041
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2050,
+        "line": 2042,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23683,14 +23771,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2065
+            "line": 2057
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2066,
+        "line": 2058,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23702,14 +23790,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2071
+            "line": 2063
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2072,
+        "line": 2064,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23721,14 +23809,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2085
+            "line": 2077
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2086,
+        "line": 2078,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23740,14 +23828,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2184
+            "line": 2176
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2185,
+        "line": 2177,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23759,14 +23847,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2208
+            "line": 2200
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2209,
+        "line": 2201,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23778,14 +23866,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2214
+            "line": 2206
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2215,
+        "line": 2207,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23797,14 +23885,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2220
+            "line": 2212
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2221,
+        "line": 2213,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23816,14 +23904,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2226
+            "line": 2218
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2227,
+        "line": 2219,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23835,14 +23923,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2661
+            "line": 2653
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2662,
+        "line": 2654,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23854,14 +23942,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2701
+            "line": 2693
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2702,
+        "line": 2694,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23871,7 +23959,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3134,
+            "line": 3126,
             "type_checking": false
           },
           {
@@ -23879,14 +23967,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3135
+            "line": 3127
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3136,
+        "line": 3128,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23898,14 +23986,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3935
+            "line": 3927
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3936,
+        "line": 3928,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23917,14 +24005,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3997
+            "line": 3989
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 3998,
+        "line": 3990,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23936,14 +24024,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4025,
+        "line": 4017,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23955,14 +24043,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4026,
+        "line": 4018,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23974,14 +24062,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4024
+            "line": 4016
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4027,
+        "line": 4019,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -23993,14 +24081,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4218
+            "line": 4210
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4219,
+        "line": 4211,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24012,14 +24100,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5069
+            "line": 5061
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5070,
+        "line": 5062,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24031,14 +24119,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5086
+            "line": 5078
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5087,
+        "line": 5079,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24050,14 +24138,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5107
+            "line": 5099
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5108,
+        "line": 5100,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24069,14 +24157,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5184
+            "line": 5176
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5185,
+        "line": 5177,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24088,14 +24176,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5983
+            "line": 5975
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5984,
+        "line": 5976,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24107,14 +24195,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7008
+            "line": 7000
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7009,
+        "line": 7001,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24126,14 +24214,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7042
+            "line": 7034
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7043,
+        "line": 7035,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24145,14 +24233,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7267
+            "line": 7259
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 7268,
+        "line": 7260,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24164,14 +24252,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7277
+            "line": 7269
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7278,
+        "line": 7270,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24183,14 +24271,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7299
+            "line": 7291
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7300,
+        "line": 7292,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24202,14 +24290,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7404
+            "line": 7396
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 7405,
+        "line": 7397,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24221,14 +24309,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7448
+            "line": 7440
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7449,
+        "line": 7441,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -24240,14 +24328,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7473
+            "line": 7465
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7474,
+        "line": 7466,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -25176,7 +25264,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 283,
+        "line": 285,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25185,7 +25273,7 @@
         "column": 62,
         "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "import_time_call",
-        "line": 426,
+        "line": 428,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25194,16 +25282,7 @@
         "column": 19,
         "context": "assign:_HASH_COMMENT_RE",
         "kind": "import_time_call",
-        "line": 931,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 18,
-        "context": "assign:_MULTI_COMMA_RE",
-        "kind": "import_time_call",
-        "line": 932,
+        "line": 933,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25212,7 +25291,7 @@
         "column": 19,
         "context": "assign:_INLINE_SPACE_RE",
         "kind": "import_time_call",
-        "line": 933,
+        "line": 934,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25221,7 +25300,7 @@
         "column": 21,
         "context": "assign:_WEIGHTED_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 934,
+        "line": 935,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25230,7 +25309,7 @@
         "column": 22,
         "context": "assign:_WEIGHTED_ARTIST_RE",
         "kind": "import_time_call",
-        "line": 935,
+        "line": 936,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25239,7 +25318,7 @@
         "column": 19,
         "context": "assign:_ARTIST_GROUP_RE",
         "kind": "import_time_call",
-        "line": 938,
+        "line": 939,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25247,15 +25326,6 @@
         "callee": "re.compile",
         "column": 24,
         "context": "assign:_SECTION_SEPARATOR_RE",
-        "kind": "import_time_call",
-        "line": 942,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 23,
-        "context": "assign:_RESOLUTION_LABEL_RE",
         "kind": "import_time_call",
         "line": 943,
         "module": "nodes.py",
@@ -25284,7 +25354,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1153,
+        "line": 1145,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25293,7 +25363,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7207,
+        "line": 7199,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25302,7 +25372,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7217,
+        "line": 7209,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -25690,85 +25760,85 @@
       },
       {
         "kind": "dict",
-        "line": 294,
+        "line": 296,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 293,
+        "line": 295,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 292,
+        "line": 294,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "dict",
-        "line": 446,
+        "line": 448,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 435,
+        "line": 437,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 3907,
+        "line": 3899,
         "module": "nodes.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
         "kind": "set",
-        "line": 430,
+        "line": 432,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "dict",
-        "line": 872,
+        "line": 874,
         "module": "nodes.py",
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
       },
       {
         "kind": "list",
-        "line": 903,
+        "line": 905,
         "module": "nodes.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 306,
+        "line": 308,
         "module": "nodes.py",
         "name": "REGIONAL_FIELD_TYPES"
       },
       {
         "kind": "set",
-        "line": 1152,
+        "line": 1144,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
       {
         "kind": "dict",
-        "line": 3920,
+        "line": 3912,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 3921,
+        "line": 3913,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
       {
         "kind": "set",
-        "line": 426,
+        "line": 428,
         "module": "nodes.py",
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
       },
@@ -25961,7 +26031,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 3920,
+        "line": 3912,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -25971,7 +26041,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 3921,
+        "line": 3913,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4689,6 +4689,204 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "sqrt",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:sqrt",
+        "kind": "static_from",
+        "line": 6,
+        "name": "sqrt",
+        "optional": false,
+        "requested": "math",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "requests",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "requests",
+        "kind": "static_import",
+        "line": 86,
+        "name": null,
+        "optional": true,
+        "requested": "requests",
+        "role": "optional_dependency",
+        "scope": "_post_random",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "gcd",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:gcd",
+        "kind": "static_from",
+        "line": 6,
+        "name": "gcd",
+        "optional": false,
+        "requested": "math",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "log",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "math:log",
+        "kind": "static_from",
+        "line": 6,
+        "name": "log",
+        "optional": false,
+        "requested": "math",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_float",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_float",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/resolution.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/resolution.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/naia/resolution.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/nodes/image_nodes.py"
       },
       {
@@ -4816,6 +5014,1448 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/image_nodes.py",
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Optional",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Optional",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Optional",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_stable_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.serialization:_stable_change_key",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_stable_change_key",
+        "optional": false,
+        "requested": "..common.serialization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_HOST",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:DEFAULT_HOST",
+        "kind": "static_from",
+        "line": 11,
+        "name": "DEFAULT_HOST",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_PORT",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:DEFAULT_PORT",
+        "kind": "static_from",
+        "line": 11,
+        "name": "DEFAULT_PORT",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "NAIA_MAX_RESOLUTION",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:NAIA_MAX_RESOLUTION",
+        "kind": "static_from",
+        "line": 11,
+        "name": "NAIA_MAX_RESOLUTION",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "NAIA_REQUEST_TIMEOUT",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:NAIA_REQUEST_TIMEOUT",
+        "kind": "static_from",
+        "line": 11,
+        "name": "NAIA_REQUEST_TIMEOUT",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PP_STATE_CHOICES",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:PP_STATE_CHOICES",
+        "kind": "static_from",
+        "line": 11,
+        "name": "PP_STATE_CHOICES",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PREPROCESSING_KEYS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:PREPROCESSING_KEYS",
+        "kind": "static_from",
+        "line": 11,
+        "name": "PREPROCESSING_KEYS",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_parse_random_response",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:_parse_random_response",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_parse_random_response",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_post_random",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.client:_post_random",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_post_random",
+        "optional": false,
+        "requested": "..naia.client",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/naia_nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_stable_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.serialization:_stable_change_key",
+        "kind": "static_from",
+        "line": 5,
+        "name": "_stable_change_key",
+        "optional": false,
+        "requested": "..common.serialization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 6,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 9,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 9,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 9,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 9,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 9,
+        "name": "SEED_CONTROL_MODES",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 9,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_FIXED",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 9,
+        "name": "WILDCARD_MODE_FIXED",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_LABELS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_LABELS",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 9,
+        "name": "WILDCARD_MODE_LABELS",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_POPULATE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_POPULATE",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 9,
+        "name": "WILDCARD_MODE_POPULATE",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_REPRODUCE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_REPRODUCE",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 9,
+        "name": "WILDCARD_MODE_REPRODUCE",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 9,
+        "name": "WILDCARD_MODE_SEQUENTIAL",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 9,
+        "name": "expand_wildcards",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_wildcard_syntax",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_wildcard_syntax",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 9,
+        "name": "has_wildcard_syntax",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 9,
+        "name": "next_seed",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 9,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_wildcard_mode",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_wildcard_mode",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 9,
+        "name": "normalize_wildcard_mode",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "wildcard_sources_signature",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "wildcard_sources_signature",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 9,
+        "name": "wildcard_sources_signature",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 29,
+        "name": "MAX_SEED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "PUBLIC_MAX_SEED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PUBLIC_MAX_SEED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 29,
+        "name": "PUBLIC_MAX_SEED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_FIXED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 29,
+        "name": "SEED_CONTROL_FIXED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_INCREMENT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_INCREMENT",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 29,
+        "name": "SEED_CONTROL_INCREMENT",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_MODES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_MODES",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 29,
+        "name": "SEED_CONTROL_MODES",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "SEED_CONTROL_RANDOMIZE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "SEED_CONTROL_RANDOMIZE",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 29,
+        "name": "SEED_CONTROL_RANDOMIZE",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_FIXED",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_FIXED",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 29,
+        "name": "WILDCARD_MODE_FIXED",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_LABELS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_LABELS",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 29,
+        "name": "WILDCARD_MODE_LABELS",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_POPULATE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_POPULATE",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 29,
+        "name": "WILDCARD_MODE_POPULATE",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_REPRODUCE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_REPRODUCE",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 29,
+        "name": "WILDCARD_MODE_REPRODUCE",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_MODE_SEQUENTIAL",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 29,
+        "name": "WILDCARD_MODE_SEQUENTIAL",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcards",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcards",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 29,
+        "name": "expand_wildcards",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_wildcard_syntax",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_wildcard_syntax",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 29,
+        "name": "has_wildcard_syntax",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "next_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "next_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 29,
+        "name": "next_seed",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 29,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_wildcard_mode",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_wildcard_mode",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 29,
+        "name": "normalize_wildcard_mode",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "wildcard_sources_signature",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "wildcard_sources_signature",
+          "target": "wildcard_engine.py",
+          "try_line": 8
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 29,
+        "name": "wildcard_sources_signature",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
@@ -5040,23 +6680,6 @@
       },
       {
         "alias": null,
-        "bound_name": "gcd",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "math:gcd",
-        "kind": "static_from",
-        "line": 11,
-        "name": "gcd",
-        "optional": false,
-        "requested": "math",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
         "bound_name": "isfinite",
         "branch_context": [],
         "classification": "external",
@@ -5066,23 +6689,6 @@
         "kind": "static_from",
         "line": 11,
         "name": "isfinite",
-        "optional": false,
-        "requested": "math",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "log",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "math:log",
-        "kind": "static_from",
-        "line": 11,
-        "name": "log",
         "optional": false,
         "requested": "math",
         "role": "ordinary",
@@ -6319,6 +7925,1277 @@
         "target": "easyuse_anima/nodes/image_nodes.py"
       },
       {
+        "alias": "DEFAULT_HOST",
+        "bound_name": "DEFAULT_HOST",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_HOST",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
+        "kind": "static_from",
+        "line": 71,
+        "name": "DEFAULT_HOST",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "DEFAULT_PORT",
+        "bound_name": "DEFAULT_PORT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PORT",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
+        "kind": "static_from",
+        "line": 71,
+        "name": "DEFAULT_PORT",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "HTTP_TIMEOUT",
+        "bound_name": "HTTP_TIMEOUT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "HTTP_TIMEOUT",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
+        "kind": "static_from",
+        "line": 71,
+        "name": "HTTP_TIMEOUT",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "LATENT_ALIGN",
+        "bound_name": "LATENT_ALIGN",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "LATENT_ALIGN",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
+        "kind": "static_from",
+        "line": 71,
+        "name": "LATENT_ALIGN",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAIA_LOCAL_HOSTS",
+        "bound_name": "NAIA_LOCAL_HOSTS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_LOCAL_HOSTS",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
+        "kind": "static_from",
+        "line": 71,
+        "name": "NAIA_LOCAL_HOSTS",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAIA_MAX_RESOLUTION",
+        "bound_name": "NAIA_MAX_RESOLUTION",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_MAX_RESOLUTION",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
+        "kind": "static_from",
+        "line": 71,
+        "name": "NAIA_MAX_RESOLUTION",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAIA_REQUEST_TIMEOUT",
+        "bound_name": "NAIA_REQUEST_TIMEOUT",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_REQUEST_TIMEOUT",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
+        "kind": "static_from",
+        "line": 71,
+        "name": "NAIA_REQUEST_TIMEOUT",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAI_1MP",
+        "bound_name": "NAI_1MP",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAI_1MP",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:NAI_1MP",
+        "kind": "static_from",
+        "line": 71,
+        "name": "NAI_1MP",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "PP_STATE_CHOICES",
+        "bound_name": "PP_STATE_CHOICES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PP_STATE_CHOICES",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
+        "kind": "static_from",
+        "line": 71,
+        "name": "PP_STATE_CHOICES",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "PREPROCESSING_KEYS",
+        "bound_name": "PREPROCESSING_KEYS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PREPROCESSING_KEYS",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
+        "kind": "static_from",
+        "line": 71,
+        "name": "PREPROCESSING_KEYS",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_build_naia_random_url",
+        "bound_name": "_build_naia_random_url",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_build_naia_random_url",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
+        "kind": "static_from",
+        "line": 71,
+        "name": "_build_naia_random_url",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_fit_to_1mp",
+        "bound_name": "_fit_to_1mp",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_fit_to_1mp",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
+        "kind": "static_from",
+        "line": 71,
+        "name": "_fit_to_1mp",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_is_local_naia_host",
+        "bound_name": "_is_local_naia_host",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_is_local_naia_host",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
+        "kind": "static_from",
+        "line": 71,
+        "name": "_is_local_naia_host",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_parse_random_response",
+        "bound_name": "_parse_random_response",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_random_response",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:_parse_random_response",
+        "kind": "static_from",
+        "line": 71,
+        "name": "_parse_random_response",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_post_random",
+        "bound_name": "_post_random",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_post_random",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.client:_post_random",
+        "kind": "static_from",
+        "line": 71,
+        "name": "_post_random",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.client",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "ADVANCED_RESOLUTION_BUCKETS",
+        "bound_name": "ADVANCED_RESOLUTION_BUCKETS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ADVANCED_RESOLUTION_BUCKETS",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
+        "kind": "static_from",
+        "line": 88,
+        "name": "ADVANCED_RESOLUTION_BUCKETS",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "bound_name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 88,
+        "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "bound_name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 88,
+        "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "bound_name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "kind": "static_from",
+        "line": 88,
+        "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "bound_name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 88,
+        "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "NAIA_RESOLUTION_MODE_BUCKET",
+        "bound_name": "NAIA_RESOLUTION_MODE_BUCKET",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_RESOLUTION_MODE_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
+        "kind": "static_from",
+        "line": 88,
+        "name": "NAIA_RESOLUTION_MODE_BUCKET",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "NAIA_RESOLUTION_MODE_SCALE",
+        "bound_name": "NAIA_RESOLUTION_MODE_SCALE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_RESOLUTION_MODE_SCALE",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
+        "kind": "static_from",
+        "line": 88,
+        "name": "NAIA_RESOLUTION_MODE_SCALE",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_advanced_resolution_from_selection",
+        "bound_name": "_advanced_resolution_from_selection",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_advanced_resolution_from_selection",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_advanced_resolution_from_selection",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_fit_naia_resolution_to_bucket",
+        "bound_name": "_fit_naia_resolution_to_bucket",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_fit_naia_resolution_to_bucket",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_fit_naia_resolution_to_bucket",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_normalize_resolution_bucket",
+        "bound_name": "_normalize_resolution_bucket",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_resolution_bucket",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_normalize_resolution_bucket",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_ratio_label",
+        "bound_name": "_ratio_label",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_ratio_label",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_ratio_label",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_ratio_label",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolution_label",
+        "bound_name": "_resolution_label",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolution_label",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_resolution_label",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_resolution_label",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution",
+        "bound_name": "_resolve_naia_resolution",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_resolve_naia_resolution",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_bucket",
+        "bound_name": "_resolve_naia_resolution_bucket",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_bucket",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_resolve_naia_resolution_bucket",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_max_long_edge",
+        "bound_name": "_resolve_naia_resolution_max_long_edge",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_max_long_edge",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_resolve_naia_resolution_max_long_edge",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_mode",
+        "bound_name": "_resolve_naia_resolution_mode",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_mode",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_resolve_naia_resolution_mode",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_scale",
+        "bound_name": "_resolve_naia_resolution_scale",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_scale",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_resolve_naia_resolution_scale",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_scale_naia_resolution",
+        "bound_name": "_scale_naia_resolution",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_scale_naia_resolution",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_scale_naia_resolution",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_snap_resolution_32",
+        "bound_name": "_snap_resolution_32",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_snap_resolution_32",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_snap_resolution_32",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_snap_scaled_resolution_32",
+        "bound_name": "_snap_scaled_resolution_32",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_snap_scaled_resolution_32",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_snap_scaled_resolution_32",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_sorted_resolution_options",
+        "bound_name": "_sorted_resolution_options",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_sorted_resolution_options",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
+        "kind": "static_from",
+        "line": 88,
+        "name": "_sorted_resolution_options",
+        "optional": false,
+        "requested": ".easyuse_anima.naia.resolution",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "EasyUseAnimaNAIARandomPrompt",
+        "bound_name": "EasyUseAnimaNAIARandomPrompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaNAIARandomPrompt",
+          "target": "easyuse_anima/nodes/naia_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
+        "kind": "static_from",
+        "line": 111,
+        "name": "EasyUseAnimaNAIARandomPrompt",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.naia_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": "_bind_naia_node_runtime",
+        "bound_name": "_bind_naia_node_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_naia_node_runtime",
+          "target": "easyuse_anima/nodes/naia_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
+        "kind": "static_from",
+        "line": 111,
+        "name": "_bind_naia_node_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.naia_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaWildcard",
+        "bound_name": "EasyUseAnimaWildcard",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaWildcard",
+          "target": "easyuse_anima/nodes/wildcard_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
+        "kind": "static_from",
+        "line": 115,
+        "name": "EasyUseAnimaWildcard",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.wildcard_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "alias": "WILDCARD_SEED_RANGE_NOTE",
+        "bound_name": "WILDCARD_SEED_RANGE_NOTE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_SEED_RANGE_NOTE",
+          "target": "easyuse_anima/nodes/wildcard_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
+        "kind": "static_from",
+        "line": 115,
+        "name": "WILDCARD_SEED_RANGE_NOTE",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.wildcard_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "alias": "_bind_wildcard_node_runtime",
+        "bound_name": "_bind_wildcard_node_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_wildcard_node_runtime",
+          "target": "easyuse_anima/nodes/wildcard_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
+        "kind": "static_from",
+        "line": 115,
+        "name": "_bind_wildcard_node_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.wildcard_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
         "alias": null,
         "bound_name": "correct_prompt",
         "branch_context": [
@@ -6340,7 +9217,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 71,
+        "line": 120,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -6371,7 +9248,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 71,
+        "line": 120,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -6402,7 +9279,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 72,
+        "line": 121,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -6433,7 +9310,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 73,
+        "line": 122,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -6464,7 +9341,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 122,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -6495,7 +9372,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 73,
+        "line": 122,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -6526,7 +9403,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 78,
+        "line": 127,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -6557,7 +9434,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 78,
+        "line": 127,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -6588,7 +9465,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6619,7 +9496,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6650,7 +9527,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6681,7 +9558,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6712,7 +9589,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6743,7 +9620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6774,7 +9651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6805,7 +9682,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6836,7 +9713,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6867,7 +9744,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6898,7 +9775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6929,7 +9806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6960,7 +9837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -6991,7 +9868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -7022,7 +9899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -7053,7 +9930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -7084,7 +9961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -7115,7 +9992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 79,
+        "line": 128,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -7134,7 +10011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7149,7 +10026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 100,
+        "line": 149,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -7168,7 +10045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7183,7 +10060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 100,
+        "line": 149,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -7202,7 +10079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7217,7 +10094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 100,
+        "line": 149,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -7236,7 +10113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7251,7 +10128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -7270,7 +10147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7285,7 +10162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -7304,7 +10181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7319,7 +10196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -7338,7 +10215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7353,7 +10230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -7372,7 +10249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7387,7 +10264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -7406,7 +10283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7421,7 +10298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -7440,7 +10317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7455,7 +10332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -7474,7 +10351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7489,7 +10366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -7508,7 +10385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7523,7 +10400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -7542,7 +10419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7557,7 +10434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -7576,7 +10453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7591,7 +10468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 119,
+        "line": 168,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -7610,7 +10487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7625,7 +10502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -7644,7 +10521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7659,7 +10536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -7678,7 +10555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7693,7 +10570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -7712,7 +10589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7727,7 +10604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -7746,7 +10623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7761,7 +10638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -7780,7 +10657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7795,7 +10672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -7814,7 +10691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7829,7 +10706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -7848,7 +10725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7863,7 +10740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -7882,7 +10759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7897,7 +10774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -7916,7 +10793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7931,7 +10808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -7950,7 +10827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7965,7 +10842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -7984,7 +10861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -7999,7 +10876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -8018,7 +10895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8033,7 +10910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -8052,7 +10929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8067,7 +10944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 139,
+        "line": 188,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -8086,7 +10963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8101,7 +10978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 139,
+        "line": 188,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -8120,7 +10997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8135,7 +11012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 139,
+        "line": 188,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -8154,7 +11031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8169,7 +11046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -8188,7 +11065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8203,7 +11080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -8222,7 +11099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8237,7 +11114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -8256,7 +11133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8271,7 +11148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -8290,7 +11167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8305,7 +11182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -8324,7 +11201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8339,7 +11216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -8358,7 +11235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8373,7 +11250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 152,
+        "line": 201,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -8392,7 +11269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8407,7 +11284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 152,
+        "line": 201,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -8415,6 +11292,1400 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "alias": "DEFAULT_HOST",
+        "bound_name": "DEFAULT_HOST",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_HOST",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
+        "kind": "static_from",
+        "line": 205,
+        "name": "DEFAULT_HOST",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "DEFAULT_PORT",
+        "bound_name": "DEFAULT_PORT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_PORT",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
+        "kind": "static_from",
+        "line": 205,
+        "name": "DEFAULT_PORT",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "HTTP_TIMEOUT",
+        "bound_name": "HTTP_TIMEOUT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "HTTP_TIMEOUT",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
+        "kind": "static_from",
+        "line": 205,
+        "name": "HTTP_TIMEOUT",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "LATENT_ALIGN",
+        "bound_name": "LATENT_ALIGN",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "LATENT_ALIGN",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
+        "kind": "static_from",
+        "line": 205,
+        "name": "LATENT_ALIGN",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAIA_LOCAL_HOSTS",
+        "bound_name": "NAIA_LOCAL_HOSTS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_LOCAL_HOSTS",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
+        "kind": "static_from",
+        "line": 205,
+        "name": "NAIA_LOCAL_HOSTS",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAIA_MAX_RESOLUTION",
+        "bound_name": "NAIA_MAX_RESOLUTION",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_MAX_RESOLUTION",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
+        "kind": "static_from",
+        "line": 205,
+        "name": "NAIA_MAX_RESOLUTION",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAIA_REQUEST_TIMEOUT",
+        "bound_name": "NAIA_REQUEST_TIMEOUT",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_REQUEST_TIMEOUT",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
+        "kind": "static_from",
+        "line": 205,
+        "name": "NAIA_REQUEST_TIMEOUT",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "NAI_1MP",
+        "bound_name": "NAI_1MP",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAI_1MP",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAI_1MP",
+        "kind": "static_from",
+        "line": 205,
+        "name": "NAI_1MP",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "PP_STATE_CHOICES",
+        "bound_name": "PP_STATE_CHOICES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PP_STATE_CHOICES",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
+        "kind": "static_from",
+        "line": 205,
+        "name": "PP_STATE_CHOICES",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "PREPROCESSING_KEYS",
+        "bound_name": "PREPROCESSING_KEYS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PREPROCESSING_KEYS",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
+        "kind": "static_from",
+        "line": 205,
+        "name": "PREPROCESSING_KEYS",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_build_naia_random_url",
+        "bound_name": "_build_naia_random_url",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_build_naia_random_url",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_build_naia_random_url",
+        "kind": "static_from",
+        "line": 205,
+        "name": "_build_naia_random_url",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_fit_to_1mp",
+        "bound_name": "_fit_to_1mp",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_fit_to_1mp",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_fit_to_1mp",
+        "kind": "static_from",
+        "line": 205,
+        "name": "_fit_to_1mp",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_is_local_naia_host",
+        "bound_name": "_is_local_naia_host",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_is_local_naia_host",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_is_local_naia_host",
+        "kind": "static_from",
+        "line": 205,
+        "name": "_is_local_naia_host",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_parse_random_response",
+        "bound_name": "_parse_random_response",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_random_response",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_parse_random_response",
+        "kind": "static_from",
+        "line": 205,
+        "name": "_parse_random_response",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "_post_random",
+        "bound_name": "_post_random",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_post_random",
+          "target": "easyuse_anima/naia/client.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_post_random",
+        "kind": "static_from",
+        "line": 205,
+        "name": "_post_random",
+        "optional": false,
+        "requested": "easyuse_anima.naia.client",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "alias": "ADVANCED_RESOLUTION_BUCKETS",
+        "bound_name": "ADVANCED_RESOLUTION_BUCKETS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ADVANCED_RESOLUTION_BUCKETS",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
+        "kind": "static_from",
+        "line": 222,
+        "name": "ADVANCED_RESOLUTION_BUCKETS",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "bound_name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "bound_name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "bound_name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "kind": "static_from",
+        "line": 222,
+        "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "bound_name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "NAIA_RESOLUTION_MODE_BUCKET",
+        "bound_name": "NAIA_RESOLUTION_MODE_BUCKET",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_RESOLUTION_MODE_BUCKET",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "name": "NAIA_RESOLUTION_MODE_BUCKET",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "NAIA_RESOLUTION_MODE_SCALE",
+        "bound_name": "NAIA_RESOLUTION_MODE_SCALE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "NAIA_RESOLUTION_MODE_SCALE",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
+        "kind": "static_from",
+        "line": 222,
+        "name": "NAIA_RESOLUTION_MODE_SCALE",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_advanced_resolution_from_selection",
+        "bound_name": "_advanced_resolution_from_selection",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_advanced_resolution_from_selection",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_advanced_resolution_from_selection",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_fit_naia_resolution_to_bucket",
+        "bound_name": "_fit_naia_resolution_to_bucket",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_fit_naia_resolution_to_bucket",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_fit_naia_resolution_to_bucket",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_normalize_resolution_bucket",
+        "bound_name": "_normalize_resolution_bucket",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_resolution_bucket",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_normalize_resolution_bucket",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_ratio_label",
+        "bound_name": "_ratio_label",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_ratio_label",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_ratio_label",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_ratio_label",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolution_label",
+        "bound_name": "_resolution_label",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolution_label",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolution_label",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_resolution_label",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution",
+        "bound_name": "_resolve_naia_resolution",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_resolve_naia_resolution",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_bucket",
+        "bound_name": "_resolve_naia_resolution_bucket",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_bucket",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_resolve_naia_resolution_bucket",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_max_long_edge",
+        "bound_name": "_resolve_naia_resolution_max_long_edge",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_max_long_edge",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_resolve_naia_resolution_max_long_edge",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_mode",
+        "bound_name": "_resolve_naia_resolution_mode",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_mode",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_resolve_naia_resolution_mode",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_resolve_naia_resolution_scale",
+        "bound_name": "_resolve_naia_resolution_scale",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_naia_resolution_scale",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_resolve_naia_resolution_scale",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_scale_naia_resolution",
+        "bound_name": "_scale_naia_resolution",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_scale_naia_resolution",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_scale_naia_resolution",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_snap_resolution_32",
+        "bound_name": "_snap_resolution_32",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_snap_resolution_32",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_snap_resolution_32",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_snap_scaled_resolution_32",
+        "bound_name": "_snap_scaled_resolution_32",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_snap_scaled_resolution_32",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_snap_scaled_resolution_32",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "_sorted_resolution_options",
+        "bound_name": "_sorted_resolution_options",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_sorted_resolution_options",
+          "target": "easyuse_anima/naia/resolution.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
+        "kind": "static_from",
+        "line": 222,
+        "name": "_sorted_resolution_options",
+        "optional": false,
+        "requested": "easyuse_anima.naia.resolution",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": "EasyUseAnimaNAIARandomPrompt",
+        "bound_name": "EasyUseAnimaNAIARandomPrompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaNAIARandomPrompt",
+          "target": "easyuse_anima/nodes/naia_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
+        "kind": "static_from",
+        "line": 245,
+        "name": "EasyUseAnimaNAIARandomPrompt",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.naia_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": "_bind_naia_node_runtime",
+        "bound_name": "_bind_naia_node_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_naia_node_runtime",
+          "target": "easyuse_anima/nodes/naia_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
+        "kind": "static_from",
+        "line": 245,
+        "name": "_bind_naia_node_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.naia_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaWildcard",
+        "bound_name": "EasyUseAnimaWildcard",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaWildcard",
+          "target": "easyuse_anima/nodes/wildcard_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
+        "kind": "static_from",
+        "line": 249,
+        "name": "EasyUseAnimaWildcard",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.wildcard_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "alias": "WILDCARD_SEED_RANGE_NOTE",
+        "bound_name": "WILDCARD_SEED_RANGE_NOTE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "WILDCARD_SEED_RANGE_NOTE",
+          "target": "easyuse_anima/nodes/wildcard_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
+        "kind": "static_from",
+        "line": 249,
+        "name": "WILDCARD_SEED_RANGE_NOTE",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.wildcard_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "alias": "_bind_wildcard_node_runtime",
+        "bound_name": "_bind_wildcard_node_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_wildcard_node_runtime",
+          "target": "easyuse_anima/nodes/wildcard_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
+        "kind": "static_from",
+        "line": 249,
+        "name": "_bind_wildcard_node_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.wildcard_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
         "alias": null,
@@ -8426,7 +12697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8441,7 +12712,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 156,
+        "line": 254,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -8460,7 +12731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8475,7 +12746,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 156,
+        "line": 254,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -8494,7 +12765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8509,7 +12780,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 157,
+        "line": 255,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -8528,7 +12799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8543,7 +12814,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 158,
+        "line": 256,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -8562,7 +12833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8577,7 +12848,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 158,
+        "line": 256,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -8596,7 +12867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8611,7 +12882,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 158,
+        "line": 256,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -8630,7 +12901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8645,7 +12916,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 163,
+        "line": 261,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -8664,7 +12935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8679,7 +12950,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 163,
+        "line": 261,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -8698,7 +12969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8713,7 +12984,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8732,7 +13003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8747,7 +13018,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8766,7 +13037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8781,7 +13052,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8800,7 +13071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8815,7 +13086,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8834,7 +13105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8849,7 +13120,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8868,7 +13139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8883,7 +13154,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8902,7 +13173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8917,7 +13188,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8936,7 +13207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8951,7 +13222,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -8970,7 +13241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -8985,7 +13256,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9004,7 +13275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9019,7 +13290,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9038,7 +13309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9053,7 +13324,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9072,7 +13343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9087,7 +13358,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9106,7 +13377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9121,7 +13392,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9140,7 +13411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9155,7 +13426,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9174,7 +13445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9189,7 +13460,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9208,7 +13479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9223,7 +13494,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9242,7 +13513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9257,7 +13528,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9276,7 +13547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -9291,7 +13562,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -9299,6 +13570,181 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1953
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1954,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
+        "scope": "_comfy_max_resolution",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "core",
+        "bound_name": "core",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2018
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "impact.core",
+        "kind": "static_import",
+        "line": 2019,
+        "name": null,
+        "optional": true,
+        "requested": "impact.core",
+        "role": "optional_dependency",
+        "scope": "_impact_core_module",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "core",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2024
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2025,
+        "name": "core",
+        "optional": true,
+        "requested": "modules.impact",
+        "role": "optional_dependency",
+        "scope": "_impact_core_module",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "comfy",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2040
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2041,
+        "name": null,
+        "optional": true,
+        "requested": "comfy.samplers",
+        "role": "optional_dependency",
+        "scope": "_impact_scheduler_names",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2049
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2050,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
+        "scope": "_find_impact_detailer_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DetailerForEach",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2065
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2066,
+        "name": "DetailerForEach",
+        "optional": true,
+        "requested": "impact.impact_pack",
+        "role": "optional_dependency",
+        "scope": "_find_impact_detailer_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DetailerForEach",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2071
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2072,
+        "name": "DetailerForEach",
+        "optional": true,
+        "requested": "modules.impact.impact_pack",
+        "role": "optional_dependency",
+        "scope": "_find_impact_detailer_class",
+        "source": "nodes.py"
       },
       {
         "alias": "comfy_nodes",
@@ -9322,181 +13768,6 @@
         "optional": true,
         "requested": "nodes",
         "role": "optional_dependency",
-        "scope": "_comfy_max_resolution",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "core",
-        "bound_name": "core",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2150
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "impact.core",
-        "kind": "static_import",
-        "line": 2151,
-        "name": null,
-        "optional": true,
-        "requested": "impact.core",
-        "role": "optional_dependency",
-        "scope": "_impact_core_module",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "core",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2156
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "modules.impact:core",
-        "kind": "static_from",
-        "line": 2157,
-        "name": "core",
-        "optional": true,
-        "requested": "modules.impact",
-        "role": "optional_dependency",
-        "scope": "_impact_core_module",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "comfy",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2172
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "comfy.samplers",
-        "kind": "static_import",
-        "line": 2173,
-        "name": null,
-        "optional": true,
-        "requested": "comfy.samplers",
-        "role": "optional_dependency",
-        "scope": "_impact_scheduler_names",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2181
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2182,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_find_impact_detailer_class",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "DetailerForEach",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2197
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2198,
-        "name": "DetailerForEach",
-        "optional": true,
-        "requested": "impact.impact_pack",
-        "role": "optional_dependency",
-        "scope": "_find_impact_detailer_class",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "DetailerForEach",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2203
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "modules.impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2204,
-        "name": "DetailerForEach",
-        "optional": true,
-        "requested": "modules.impact.impact_pack",
-        "role": "optional_dependency",
-        "scope": "_find_impact_detailer_class",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2217
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2218,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
         "scope": "_find_comfy_node_class",
         "source": "nodes.py"
       },
@@ -9509,7 +13780,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2316
+            "line": 2184
           }
         ],
         "classification": "external",
@@ -9517,7 +13788,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2317,
+        "line": 2185,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
@@ -9534,7 +13805,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2340
+            "line": 2208
           }
         ],
         "classification": "external",
@@ -9542,7 +13813,7 @@
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2341,
+        "line": 2209,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.segs_nodes",
@@ -9559,7 +13830,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2346
+            "line": 2214
           }
         ],
         "classification": "external",
@@ -9567,7 +13838,7 @@
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2347,
+        "line": 2215,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.segs_nodes",
@@ -9584,7 +13855,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2352
+            "line": 2220
           }
         ],
         "classification": "external",
@@ -9592,7 +13863,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2353,
+        "line": 2221,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -9609,7 +13880,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2358
+            "line": 2226
           }
         ],
         "classification": "external",
@@ -9617,7 +13888,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2359,
+        "line": 2227,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -9634,7 +13905,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2793
+            "line": 2661
           }
         ],
         "classification": "external",
@@ -9642,7 +13913,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2794,
+        "line": 2662,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -9659,7 +13930,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2833
+            "line": 2701
           }
         ],
         "classification": "external",
@@ -9667,7 +13938,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2834,
+        "line": 2702,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -9682,7 +13953,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3266,
+            "line": 3134,
             "type_checking": false
           },
           {
@@ -9690,7 +13961,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3267
+            "line": 3135
           }
         ],
         "classification": "external",
@@ -9698,7 +13969,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3268,
+        "line": 3136,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -9715,7 +13986,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4067
+            "line": 3935
           }
         ],
         "classification": "external",
@@ -9723,7 +13994,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4068,
+        "line": 3936,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -9740,7 +14011,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4129
+            "line": 3997
           }
         ],
         "classification": "external",
@@ -9748,7 +14019,7 @@
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4130,
+        "line": 3998,
         "name": "PromptServer",
         "optional": true,
         "requested": "server",
@@ -9765,7 +14036,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
@@ -9773,7 +14044,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4157,
+        "line": 4025,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -9790,7 +14061,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
@@ -9798,7 +14069,7 @@
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4158,
+        "line": 4026,
         "name": null,
         "optional": true,
         "requested": "numpy",
@@ -9815,7 +14086,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
@@ -9823,7 +14094,7 @@
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4159,
+        "line": 4027,
         "name": "Image",
         "optional": true,
         "requested": "PIL",
@@ -9840,7 +14111,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4350
+            "line": 4218
           }
         ],
         "classification": "external",
@@ -9848,7 +14119,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4351,
+        "line": 4219,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -9865,7 +14136,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5201
+            "line": 5069
           }
         ],
         "classification": "external",
@@ -9873,7 +14144,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5202,
+        "line": 5070,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -9890,7 +14161,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5218
+            "line": 5086
           }
         ],
         "classification": "external",
@@ -9898,7 +14169,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5219,
+        "line": 5087,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -9915,7 +14186,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5239
+            "line": 5107
           }
         ],
         "classification": "external",
@@ -9923,7 +14194,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5240,
+        "line": 5108,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -9940,7 +14211,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5316
+            "line": 5184
           }
         ],
         "classification": "external",
@@ -9948,7 +14219,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5317,
+        "line": 5185,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -9965,7 +14236,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6115
+            "line": 5983
           }
         ],
         "classification": "external",
@@ -9973,7 +14244,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6116,
+        "line": 5984,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -9990,7 +14261,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7140
+            "line": 7008
           }
         ],
         "classification": "external",
@@ -9998,7 +14269,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7141,
+        "line": 7009,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -10015,7 +14286,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7174
+            "line": 7042
           }
         ],
         "classification": "external",
@@ -10023,37 +14294,12 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7175,
+        "line": 7043,
         "name": null,
         "optional": true,
         "requested": "torch",
         "role": "optional_dependency",
         "scope": "_regional_mask_bounds_area",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "requests",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 7250
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "requests",
-        "kind": "static_import",
-        "line": 7251,
-        "name": null,
-        "optional": true,
-        "requested": "requests",
-        "role": "optional_dependency",
-        "scope": "_post_random",
         "source": "nodes.py"
       },
       {
@@ -10065,7 +14311,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7466
+            "line": 7267
           }
         ],
         "classification": "external",
@@ -10073,7 +14319,7 @@
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 7467,
+        "line": 7268,
         "name": "apply_lora_syntax_format",
         "optional": true,
         "requested": "py.nodes.utils",
@@ -10090,7 +14336,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7476
+            "line": 7277
           }
         ],
         "classification": "external",
@@ -10098,7 +14344,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7477,
+        "line": 7278,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -10115,7 +14361,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7498
+            "line": 7299
           }
         ],
         "classification": "external",
@@ -10123,7 +14369,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7499,
+        "line": 7300,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -10140,7 +14386,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7603
+            "line": 7404
           }
         ],
         "classification": "external",
@@ -10148,7 +14394,7 @@
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 7604,
+        "line": 7405,
         "name": "get_lora_info",
         "optional": true,
         "requested": "py.utils.utils",
@@ -10165,7 +14411,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7647
+            "line": 7448
           }
         ],
         "classification": "external",
@@ -10173,7 +14419,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7648,
+        "line": 7449,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -10190,7 +14436,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7672
+            "line": 7473
           }
         ],
         "classification": "external",
@@ -10198,7 +14444,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7673,
+        "line": 7474,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -11824,6 +16070,10 @@
         "to": "easyuse_anima/image/geometry.py"
       },
       {
+        "from": "easyuse_anima/naia/resolution.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
         "from": "easyuse_anima/nodes/image_nodes.py",
         "to": "easyuse_anima/image/detailer.py"
       },
@@ -11838,6 +16088,30 @@
       {
         "from": "easyuse_anima/nodes/image_nodes.py",
         "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/naia_nodes.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/naia_nodes.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/naia_nodes.py",
+        "to": "easyuse_anima/naia/client.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/wildcard_nodes.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/wildcard_nodes.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/wildcard_nodes.py",
+        "to": "wildcard_engine.py"
       },
       {
         "from": "nodes.py",
@@ -11881,7 +16155,23 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/naia/client.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
         "from": "nodes.py",
@@ -12082,6 +16372,24 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/naia/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/naia/client.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/naia/resolution.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/nodes/__init__.py"
         ]
       },
@@ -12089,6 +16397,18 @@
         "cyclic": false,
         "modules": [
           "easyuse_anima/nodes/image_nodes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/nodes/naia_nodes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/nodes/wildcard_nodes.py"
         ]
       },
       {
@@ -12136,7 +16456,7 @@
     ]
   },
   "inventory": {
-    "module_count": 36,
+    "module_count": 41,
     "modules": [
       {
         "is_package": true,
@@ -12453,6 +16773,42 @@
       {
         "is_package": true,
         "loc": 3,
+        "module": "easyuse_anima.naia",
+        "normalized_git_blob_sha1": "03e6739f5adacdf6c154f26f06d9876fb92124f8",
+        "path": "easyuse_anima/naia/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 134,
+        "module": "easyuse_anima.naia.client",
+        "normalized_git_blob_sha1": "38aa1aa65bb2d20a1adc5db7a2f21c43d055ef39",
+        "path": "easyuse_anima/naia/client.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 6,
+          "global_count": 13
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 211,
+        "module": "easyuse_anima.naia.resolution",
+        "normalized_git_blob_sha1": "e975513efcce8ad94c94f5147043eadec68fea5a",
+        "path": "easyuse_anima/naia/resolution.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 14,
+          "global_count": 9
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 3,
         "module": "easyuse_anima.nodes",
         "normalized_git_blob_sha1": "f980638ca8dbf3ba310d407154513156bcbf4502",
         "path": "easyuse_anima/nodes/__init__.py",
@@ -12472,6 +16828,30 @@
           "class_count": 2,
           "function_count": 0,
           "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 594,
+        "module": "easyuse_anima.nodes.naia_nodes",
+        "normalized_git_blob_sha1": "1a29810f320f3d35e3d2119c5a2c857fe50ced70",
+        "path": "easyuse_anima/nodes/naia_nodes.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 2,
+          "global_count": 4
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 303,
+        "module": "easyuse_anima.nodes.wildcard_nodes",
+        "normalized_git_blob_sha1": "e7bb2f568b150f944ce7619c6af14009e8d37d54",
+        "path": "easyuse_anima/nodes/wildcard_nodes.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 2,
+          "global_count": 4
         }
       },
       {
@@ -12512,14 +16892,14 @@
       },
       {
         "is_package": false,
-        "loc": 12131,
+        "loc": 11173,
         "module": "nodes",
-        "normalized_git_blob_sha1": "8e19ca24696f778904942382d143415d033a2b82",
+        "normalized_git_blob_sha1": "b71aa17bd93a561b3597a7b9bd11296cb32dfaab",
         "path": "nodes.py",
         "top_level": {
-          "class_count": 22,
-          "function_count": 260,
-          "global_count": 124
+          "class_count": 20,
+          "function_count": 241,
+          "global_count": 106
         }
       },
       {
@@ -13293,7 +17673,398 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:MAX_SEED",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:PUBLIC_MAX_SEED",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_FIXED",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_MODES",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:expand_wildcards",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:next_seed",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_wildcard_mode",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 28,
+            "kind": "try",
+            "line": 8
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:wildcard_sources_signature",
+        "kind": "static_from",
+        "line": 29,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13302,7 +18073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 100,
+        "line": 149,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13316,7 +18087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13325,7 +18096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 100,
+        "line": 149,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13339,7 +18110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13348,7 +18119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 100,
+        "line": 149,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13362,7 +18133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13371,7 +18142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13385,7 +18156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13394,7 +18165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13408,7 +18179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13417,7 +18188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13431,7 +18202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13440,7 +18211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13454,7 +18225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13463,7 +18234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 105,
+        "line": 154,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13477,7 +18248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13486,7 +18257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13500,7 +18271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13509,7 +18280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13523,7 +18294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13532,7 +18303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13546,7 +18317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13555,7 +18326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13569,7 +18340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13578,7 +18349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 112,
+        "line": 161,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13592,7 +18363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13601,7 +18372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 119,
+        "line": 168,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13615,7 +18386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13624,7 +18395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13638,7 +18409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13647,7 +18418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13661,7 +18432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13670,7 +18441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13684,7 +18455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13693,7 +18464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13707,7 +18478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13716,7 +18487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13730,7 +18501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13739,7 +18510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 122,
+        "line": 171,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13753,7 +18524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13762,7 +18533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13776,7 +18547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13785,7 +18556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13799,7 +18570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13808,7 +18579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13822,7 +18593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13831,7 +18602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13845,7 +18616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13854,7 +18625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13868,7 +18639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13877,7 +18648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13891,7 +18662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13900,7 +18671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 130,
+        "line": 179,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13914,7 +18685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13923,7 +18694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 139,
+        "line": 188,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13937,7 +18708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13946,7 +18717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 139,
+        "line": 188,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13960,7 +18731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13969,7 +18740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 139,
+        "line": 188,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -13983,7 +18754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -13992,7 +18763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14006,7 +18777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14015,7 +18786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14029,7 +18800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14038,7 +18809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14052,7 +18823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14061,7 +18832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14075,7 +18846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14084,7 +18855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14098,7 +18869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14107,7 +18878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 144,
+        "line": 193,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14121,7 +18892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14130,7 +18901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 152,
+        "line": 201,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14144,7 +18915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14153,7 +18924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 152,
+        "line": 201,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14167,7 +18938,950 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:NAI_1MP",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_build_naia_random_url",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_fit_to_1mp",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_is_local_naia_host",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_parse_random_response",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.client:_post_random",
+        "kind": "static_from",
+        "line": 205,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_ratio_label",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolution_label",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
+        "kind": "static_from",
+        "line": 222,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
+        "kind": "static_from",
+        "line": 245,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
+        "kind": "static_from",
+        "line": 245,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
+        "kind": "static_from",
+        "line": 249,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
+        "kind": "static_from",
+        "line": 249,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
+        "kind": "static_from",
+        "line": 249,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14176,7 +19890,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 156,
+        "line": 254,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14190,7 +19904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14199,7 +19913,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 156,
+        "line": 254,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14213,7 +19927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14222,7 +19936,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 157,
+        "line": 255,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14236,7 +19950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14245,7 +19959,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 158,
+        "line": 256,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14259,7 +19973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14268,7 +19982,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 158,
+        "line": 256,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14282,7 +19996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14291,7 +20005,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 158,
+        "line": 256,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14305,7 +20019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14314,7 +20028,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 163,
+        "line": 261,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14328,7 +20042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14337,7 +20051,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 163,
+        "line": 261,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14351,7 +20065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14360,7 +20074,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14374,7 +20088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14383,7 +20097,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14397,7 +20111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14406,7 +20120,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14420,7 +20134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14429,7 +20143,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14443,7 +20157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14452,7 +20166,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14466,7 +20180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14475,7 +20189,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14489,7 +20203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14498,7 +20212,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14512,7 +20226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14521,7 +20235,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14535,7 +20249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14544,7 +20258,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14558,7 +20272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14567,7 +20281,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14581,7 +20295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14590,7 +20304,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14604,7 +20318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14613,7 +20327,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14627,7 +20341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14636,7 +20350,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14650,7 +20364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14659,7 +20373,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14673,7 +20387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14682,7 +20396,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14696,7 +20410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14705,7 +20419,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14719,7 +20433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14728,7 +20442,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -14742,7 +20456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 99,
+            "handler_line": 148,
             "kind": "try",
             "line": 14
           }
@@ -14751,7 +20465,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 164,
+        "line": 262,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -16099,7 +21813,158 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "math:sqrt",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "requests",
+        "kind": "static_import",
+        "line": 86,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "math:gcd",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "math:log",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Optional",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/naia_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
         "branch_context": [],
@@ -16248,29 +22113,7 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "math:gcd",
-        "kind": "static_from",
-        "line": 11,
-        "optional": false,
-        "role": "ordinary",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "math:isfinite",
-        "kind": "static_from",
-        "line": 11,
-        "optional": false,
-        "role": "ordinary",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "math:log",
         "kind": "static_from",
         "line": 11,
         "optional": false,
@@ -16317,6 +22160,139 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
+            "line": 1953
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1954,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2018
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.core",
+        "kind": "static_import",
+        "line": 2019,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2024
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2025,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2040
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2041,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2049
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2050,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2065
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2066,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2071
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2072,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
             "line": 2085
           }
         ],
@@ -16336,147 +22312,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2150
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.core",
-        "kind": "static_import",
-        "line": 2151,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2156
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact:core",
-        "kind": "static_from",
-        "line": 2157,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2172
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "comfy.samplers",
-        "kind": "static_import",
-        "line": 2173,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2181
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2182,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2197
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2198,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2203
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2204,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2217
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2218,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2316
+            "line": 2184
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2317,
+        "line": 2185,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16488,14 +22331,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2340
+            "line": 2208
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2341,
+        "line": 2209,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16507,14 +22350,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2346
+            "line": 2214
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2347,
+        "line": 2215,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16526,14 +22369,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2352
+            "line": 2220
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2353,
+        "line": 2221,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16545,14 +22388,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2358
+            "line": 2226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2359,
+        "line": 2227,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16564,14 +22407,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2793
+            "line": 2661
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2794,
+        "line": 2662,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16583,14 +22426,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2833
+            "line": 2701
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2834,
+        "line": 2702,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16600,7 +22443,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3266,
+            "line": 3134,
             "type_checking": false
           },
           {
@@ -16608,14 +22451,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3267
+            "line": 3135
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3268,
+        "line": 3136,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16627,14 +22470,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4067
+            "line": 3935
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4068,
+        "line": 3936,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16646,14 +22489,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4129
+            "line": 3997
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4130,
+        "line": 3998,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16665,14 +22508,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4157,
+        "line": 4025,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16684,14 +22527,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4158,
+        "line": 4026,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16703,14 +22546,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4159,
+        "line": 4027,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16722,14 +22565,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4350
+            "line": 4218
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4351,
+        "line": 4219,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16741,14 +22584,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5201
+            "line": 5069
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5202,
+        "line": 5070,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16760,14 +22603,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5218
+            "line": 5086
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5219,
+        "line": 5087,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16779,14 +22622,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5239
+            "line": 5107
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5240,
+        "line": 5108,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16798,14 +22641,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5316
+            "line": 5184
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5317,
+        "line": 5185,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16817,14 +22660,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6115
+            "line": 5983
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6116,
+        "line": 5984,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16836,14 +22679,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7140
+            "line": 7008
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7141,
+        "line": 7009,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16855,33 +22698,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7174
+            "line": 7042
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7175,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 7250
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "requests",
-        "kind": "static_import",
-        "line": 7251,
+        "line": 7043,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16893,14 +22717,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7466
+            "line": 7267
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 7467,
+        "line": 7268,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16912,14 +22736,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7476
+            "line": 7277
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7477,
+        "line": 7278,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16931,14 +22755,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7498
+            "line": 7299
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7499,
+        "line": 7300,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16950,14 +22774,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7603
+            "line": 7404
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 7604,
+        "line": 7405,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16969,14 +22793,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7647
+            "line": 7448
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7648,
+        "line": 7449,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -16988,14 +22812,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7672
+            "line": 7473
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7673,
+        "line": 7474,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -17743,6 +23567,158 @@
           {
             "branch": "body",
             "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 85
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "requests",
+        "kind": "static_import",
+        "line": 86,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/naia/client.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1953
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1954,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2018
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.core",
+        "kind": "static_import",
+        "line": 2019,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2024
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2025,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2040
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2041,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2049
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 2050,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2065
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2066,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2071
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2072,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
             "line": 2085
@@ -17764,147 +23740,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2150
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.core",
-        "kind": "static_import",
-        "line": 2151,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2156
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact:core",
-        "kind": "static_from",
-        "line": 2157,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2172
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "comfy.samplers",
-        "kind": "static_import",
-        "line": 2173,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2181
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2182,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2197
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2198,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2203
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2204,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2217
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2218,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2316
+            "line": 2184
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2317,
+        "line": 2185,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -17916,14 +23759,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2340
+            "line": 2208
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2341,
+        "line": 2209,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -17935,14 +23778,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2346
+            "line": 2214
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2347,
+        "line": 2215,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -17954,14 +23797,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2352
+            "line": 2220
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2353,
+        "line": 2221,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -17973,14 +23816,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2358
+            "line": 2226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2359,
+        "line": 2227,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -17992,14 +23835,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2793
+            "line": 2661
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2794,
+        "line": 2662,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18011,14 +23854,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2833
+            "line": 2701
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2834,
+        "line": 2702,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18028,7 +23871,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3266,
+            "line": 3134,
             "type_checking": false
           },
           {
@@ -18036,14 +23879,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3267
+            "line": 3135
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3268,
+        "line": 3136,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18055,14 +23898,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4067
+            "line": 3935
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4068,
+        "line": 3936,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18074,14 +23917,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4129
+            "line": 3997
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4130,
+        "line": 3998,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18093,14 +23936,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4157,
+        "line": 4025,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18112,14 +23955,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4158,
+        "line": 4026,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18131,14 +23974,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4156
+            "line": 4024
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4159,
+        "line": 4027,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18150,14 +23993,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4350
+            "line": 4218
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4351,
+        "line": 4219,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18169,14 +24012,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5201
+            "line": 5069
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5202,
+        "line": 5070,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18188,14 +24031,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5218
+            "line": 5086
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5219,
+        "line": 5087,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18207,14 +24050,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5239
+            "line": 5107
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5240,
+        "line": 5108,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18226,14 +24069,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5316
+            "line": 5184
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5317,
+        "line": 5185,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18245,14 +24088,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6115
+            "line": 5983
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6116,
+        "line": 5984,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18264,14 +24107,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7140
+            "line": 7008
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7141,
+        "line": 7009,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18283,33 +24126,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7174
+            "line": 7042
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7175,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 7250
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "requests",
-        "kind": "static_import",
-        "line": 7251,
+        "line": 7043,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18321,14 +24145,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7466
+            "line": 7267
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 7467,
+        "line": 7268,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18340,14 +24164,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7476
+            "line": 7277
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7477,
+        "line": 7278,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18359,14 +24183,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7498
+            "line": 7299
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7499,
+        "line": 7300,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18378,14 +24202,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7603
+            "line": 7404
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 7604,
+        "line": 7405,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18397,14 +24221,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7647
+            "line": 7448
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7648,
+        "line": 7449,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18416,14 +24240,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7672
+            "line": 7473
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 7673,
+        "line": 7474,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -18570,8 +24394,13 @@
       "easyuse_anima/infrastructure/comfy/capabilities.py",
       "easyuse_anima/infrastructure/comfy/invocation.py",
       "easyuse_anima/infrastructure/comfy/resources.py",
+      "easyuse_anima/naia/__init__.py",
+      "easyuse_anima/naia/client.py",
+      "easyuse_anima/naia/resolution.py",
       "easyuse_anima/nodes/__init__.py",
       "easyuse_anima/nodes/image_nodes.py",
+      "easyuse_anima/nodes/naia_nodes.py",
+      "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
       "nodes.py",
@@ -18607,8 +24436,13 @@
       "easyuse_anima/infrastructure/comfy/capabilities.py",
       "easyuse_anima/infrastructure/comfy/invocation.py",
       "easyuse_anima/infrastructure/comfy/resources.py",
+      "easyuse_anima/naia/__init__.py",
+      "easyuse_anima/naia/client.py",
+      "easyuse_anima/naia/resolution.py",
       "easyuse_anima/nodes/__init__.py",
       "easyuse_anima/nodes/image_nodes.py",
+      "easyuse_anima/nodes/naia_nodes.py",
+      "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
       "easyuse_anima/prompt/__init__.py",
@@ -19275,6 +25109,42 @@
         "scope": "<module>"
       },
       {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:_HASH_COMMENT_RE",
+        "kind": "import_time_call",
+        "line": 36,
+        "module": "easyuse_anima/naia/client.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 18,
+        "context": "assign:_MULTI_COMMA_RE",
+        "kind": "import_time_call",
+        "line": 37,
+        "module": "easyuse_anima/naia/client.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 23,
+        "context": "assign:_RESOLUTION_LABEL_RE",
+        "kind": "import_time_call",
+        "line": 71,
+        "module": "easyuse_anima/naia/resolution.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "logging.getLogger",
+        "column": 9,
+        "context": "assign:logger",
+        "kind": "import_time_call",
+        "line": 23,
+        "module": "easyuse_anima/nodes/naia_nodes.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "uuid.UUID",
         "column": 23,
         "context": "assign:PROFILE_ID_NAMESPACE",
@@ -19306,7 +25176,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 185,
+        "line": 283,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19315,7 +25185,7 @@
         "column": 62,
         "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "import_time_call",
-        "line": 339,
+        "line": 426,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19324,7 +25194,7 @@
         "column": 19,
         "context": "assign:_HASH_COMMENT_RE",
         "kind": "import_time_call",
-        "line": 927,
+        "line": 931,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19333,7 +25203,7 @@
         "column": 18,
         "context": "assign:_MULTI_COMMA_RE",
         "kind": "import_time_call",
-        "line": 928,
+        "line": 932,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19342,7 +25212,7 @@
         "column": 19,
         "context": "assign:_INLINE_SPACE_RE",
         "kind": "import_time_call",
-        "line": 929,
+        "line": 933,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19351,7 +25221,7 @@
         "column": 21,
         "context": "assign:_WEIGHTED_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 930,
+        "line": 934,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19360,7 +25230,7 @@
         "column": 22,
         "context": "assign:_WEIGHTED_ARTIST_RE",
         "kind": "import_time_call",
-        "line": 931,
+        "line": 935,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19369,7 +25239,7 @@
         "column": 19,
         "context": "assign:_ARTIST_GROUP_RE",
         "kind": "import_time_call",
-        "line": 934,
+        "line": 938,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19378,7 +25248,7 @@
         "column": 24,
         "context": "assign:_SECTION_SEPARATOR_RE",
         "kind": "import_time_call",
-        "line": 938,
+        "line": 942,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19387,7 +25257,7 @@
         "column": 23,
         "context": "assign:_RESOLUTION_LABEL_RE",
         "kind": "import_time_call",
-        "line": 939,
+        "line": 943,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19396,7 +25266,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 942,
+        "line": 946,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19405,7 +25275,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 961,
+        "line": 965,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19414,7 +25284,25 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1285,
+        "line": 1153,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_wildcard_node_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 7207,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_naia_node_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 7217,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -19777,110 +25665,110 @@
         "name": "IMAGE_UPSCALE_METHODS"
       },
       {
+        "kind": "set",
+        "line": 11,
+        "module": "easyuse_anima/naia/client.py",
+        "name": "NAIA_LOCAL_HOSTS"
+      },
+      {
+        "kind": "list",
+        "line": 34,
+        "module": "easyuse_anima/naia/client.py",
+        "name": "PP_STATE_CHOICES"
+      },
+      {
+        "kind": "list",
+        "line": 17,
+        "module": "easyuse_anima/naia/client.py",
+        "name": "PREPROCESSING_KEYS"
+      },
+      {
         "kind": "dict",
-        "line": 199,
+        "line": 11,
+        "module": "easyuse_anima/naia/resolution.py",
+        "name": "ADVANCED_RESOLUTION_BUCKETS"
+      },
+      {
+        "kind": "dict",
+        "line": 294,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 198,
+        "line": 293,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 197,
+        "line": 292,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "dict",
-        "line": 848,
-        "module": "nodes.py",
-        "name": "ADVANCED_RESOLUTION_BUCKETS"
-      },
-      {
-        "kind": "dict",
-        "line": 359,
+        "line": 446,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 348,
+        "line": 435,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 4039,
+        "line": 3907,
         "module": "nodes.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
         "kind": "set",
-        "line": 343,
+        "line": 430,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "dict",
-        "line": 785,
+        "line": 872,
         "module": "nodes.py",
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
       },
       {
         "kind": "list",
-        "line": 816,
+        "line": 903,
         "module": "nodes.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 189,
-        "module": "nodes.py",
-        "name": "NAIA_LOCAL_HOSTS"
-      },
-      {
-        "kind": "list",
-        "line": 925,
-        "module": "nodes.py",
-        "name": "PP_STATE_CHOICES"
-      },
-      {
-        "kind": "list",
-        "line": 908,
-        "module": "nodes.py",
-        "name": "PREPROCESSING_KEYS"
-      },
-      {
-        "kind": "set",
-        "line": 219,
+        "line": 306,
         "module": "nodes.py",
         "name": "REGIONAL_FIELD_TYPES"
       },
       {
         "kind": "set",
-        "line": 1284,
+        "line": 1152,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
       {
         "kind": "dict",
-        "line": 4052,
+        "line": 3920,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 4053,
+        "line": 3921,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
       {
         "kind": "set",
-        "line": 339,
+        "line": 426,
         "module": "nodes.py",
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
       },
@@ -20073,7 +25961,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 4052,
+        "line": 3920,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -20083,7 +25971,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 4053,
+        "line": 3921,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_naia_settings.py
+++ b/tests/test_naia_settings.py
@@ -6,6 +6,7 @@ from nodes import (
     NAI_1MP,
     NAIA_MAX_RESOLUTION,
     EasyUseAnimaNAIARandomPrompt,
+    _advanced_resolution_from_selection,
     _build_naia_random_url,
     _fit_to_1mp,
     _parse_random_response,
@@ -80,6 +81,30 @@ class NaiaSettingsTests(unittest.TestCase):
             _parse_random_response({"width": NAIA_MAX_RESOLUTION, "height": NAIA_MAX_RESOLUTION}),
             ("", "", 1024, 1024),
         )
+
+    def test_parse_random_response_preserves_prompt_cleanup_boundaries(self):
+        self.assertEqual(
+            _parse_random_response({
+                "prompt": "\t# hidden comment\nkeep # inline, , subject",
+                "negative_prompt": "bad,  , hands",
+                "width": 1024,
+                "height": 1024,
+            }),
+            ("keep # inline, subject", "bad, hands", 1024, 1024),
+        )
+
+    def test_resolution_labels_accept_star_x_and_multiplication_sign(self):
+        cases = (
+            ("1024 * 1024 (1:1)", (1024, 1024)),
+            ("896 x 1152 (7:9)", (896, 1152)),
+            ("1152 × 896 (9:7)", (1152, 896)),
+        )
+        for label, expected in cases:
+            with self.subTest(label=label):
+                self.assertEqual(
+                    _advanced_resolution_from_selection("1024", label),
+                    expected,
+                )
 
     def test_request_uses_global_naia_settings_instead_of_node_values(self):
         calls = []

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -25,7 +25,9 @@ from easyuse_anima.image import scaling as image_scaling
 from easyuse_anima.infrastructure.comfy import capabilities as comfy_capabilities
 from easyuse_anima.infrastructure.comfy import invocation as comfy_invocation
 from easyuse_anima.infrastructure.comfy import resources as comfy_resources
-from easyuse_anima.nodes import image_nodes
+from easyuse_anima.naia import client as naia_client
+from easyuse_anima.naia import resolution as naia_resolution
+from easyuse_anima.nodes import image_nodes, naia_nodes, wildcard_nodes
 
 
 PACKAGE_INIT = ROOT / "__init__.py"
@@ -629,6 +631,98 @@ class ImageNodeMoveContractTests(unittest.TestCase):
             self.assertIs(
                 package_node_adapters._common_upscale_image,
                 package_invocation._common_upscale_image,
+            )
+
+
+class WildcardNaiaMoveContractTests(unittest.TestCase):
+    CLIENT_ALIASES = (
+        "DEFAULT_HOST",
+        "DEFAULT_PORT",
+        "HTTP_TIMEOUT",
+        "LATENT_ALIGN",
+        "NAI_1MP",
+        "NAIA_LOCAL_HOSTS",
+        "NAIA_MAX_RESOLUTION",
+        "NAIA_REQUEST_TIMEOUT",
+        "PP_STATE_CHOICES",
+        "PREPROCESSING_KEYS",
+        "_build_naia_random_url",
+        "_fit_to_1mp",
+        "_is_local_naia_host",
+        "_parse_random_response",
+        "_post_random",
+    )
+    RESOLUTION_ALIASES = (
+        "ADVANCED_RESOLUTION_BUCKETS",
+        "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
+        "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "NAIA_ADVANCED_RESOLUTION_BUCKET",
+        "NAIA_RESOLUTION_MODE_BUCKET",
+        "NAIA_RESOLUTION_MODE_SCALE",
+        "_advanced_resolution_from_selection",
+        "_fit_naia_resolution_to_bucket",
+        "_normalize_resolution_bucket",
+        "_ratio_label",
+        "_resolution_label",
+        "_resolve_naia_resolution",
+        "_resolve_naia_resolution_bucket",
+        "_resolve_naia_resolution_max_long_edge",
+        "_resolve_naia_resolution_mode",
+        "_resolve_naia_resolution_scale",
+        "_scale_naia_resolution",
+        "_snap_resolution_32",
+        "_snap_scaled_resolution_32",
+        "_sorted_resolution_options",
+    )
+
+    def test_root_nodes_wildcard_naia_objects_are_direct_canonical_aliases(self):
+        for name in self.CLIENT_ALIASES:
+            with self.subTest(module="client", name=name):
+                self.assertIs(getattr(nodes, name), getattr(naia_client, name))
+        for name in self.RESOLUTION_ALIASES:
+            with self.subTest(module="resolution", name=name):
+                self.assertIs(getattr(nodes, name), getattr(naia_resolution, name))
+
+        self.assertIs(
+            nodes.EasyUseAnimaWildcard,
+            wildcard_nodes.EasyUseAnimaWildcard,
+        )
+        self.assertIs(
+            nodes.EasyUseAnimaNAIARandomPrompt,
+            naia_nodes.EasyUseAnimaNAIARandomPrompt,
+        )
+        self.assertIs(
+            nodes.WILDCARD_SEED_RANGE_NOTE,
+            wildcard_nodes.WILDCARD_SEED_RANGE_NOTE,
+        )
+
+    def test_package_loaded_root_wildcard_naia_objects_are_direct_canonical_aliases(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_client = sys.modules[f"{package_name}.easyuse_anima.naia.client"]
+            package_resolution = sys.modules[f"{package_name}.easyuse_anima.naia.resolution"]
+            package_naia_nodes = sys.modules[f"{package_name}.easyuse_anima.nodes.naia_nodes"]
+            package_wildcard_nodes = sys.modules[
+                f"{package_name}.easyuse_anima.nodes.wildcard_nodes"
+            ]
+
+            for name in self.CLIENT_ALIASES:
+                with self.subTest(module="client", name=name):
+                    self.assertIs(getattr(package_nodes, name), getattr(package_client, name))
+            for name in self.RESOLUTION_ALIASES:
+                with self.subTest(module="resolution", name=name):
+                    self.assertIs(
+                        getattr(package_nodes, name),
+                        getattr(package_resolution, name),
+                    )
+            self.assertIs(
+                package_nodes.EasyUseAnimaWildcard,
+                package_wildcard_nodes.EasyUseAnimaWildcard,
+            )
+            self.assertIs(
+                package_nodes.EasyUseAnimaNAIARandomPrompt,
+                package_naia_nodes.EasyUseAnimaNAIARandomPrompt,
             )
 
 

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -647,6 +647,7 @@ class WildcardNaiaMoveContractTests(unittest.TestCase):
         "PP_STATE_CHOICES",
         "PREPROCESSING_KEYS",
         "_build_naia_random_url",
+        "_clean_prompt",
         "_fit_to_1mp",
         "_is_local_naia_host",
         "_parse_random_response",

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,15 +73,16 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "8e19ca24696f778904942382d143415d033a2b82")
-        # Issue #184 B-04 moved the image/Detailer vertical slice as direct aliases.
-        self.assertEqual(report["top_level"]["function_count"], 260)
-        self.assertEqual(report["top_level"]["class_count"], 22)
-        self.assertEqual(report["line_count"], 12_131)
+        self.assertEqual(report["git_blob_sha1"], "b71aa17bd93a561b3597a7b9bd11296cb32dfaab")
+        # Issue #184 B-05 moved the Wildcard/NAIA vertical slice as direct aliases.
+        self.assertEqual(report["top_level"]["function_count"], 241)
+        self.assertEqual(report["top_level"]["class_count"], 20)
+        self.assertEqual(report["line_count"], 11_173)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)
-        self.assertIn("EasyUseAnimaNAIARandomPrompt", class_names)
+        self.assertNotIn("EasyUseAnimaNAIARandomPrompt", class_names)
+        self.assertNotIn("EasyUseAnimaWildcard", class_names)
         self.assertNotIn("EasyUseAnimaImageScaleByMultiple", class_names)
         self.assertNotIn("EasyUseAnimaDetailerAlignHook", class_names)
 

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,11 +73,11 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "b71aa17bd93a561b3597a7b9bd11296cb32dfaab")
+        self.assertEqual(report["git_blob_sha1"], "3b6b14485ab52a4f0839bf2b5dbece6b4bcf08aa")
         # Issue #184 B-05 moved the Wildcard/NAIA vertical slice as direct aliases.
-        self.assertEqual(report["top_level"]["function_count"], 241)
+        self.assertEqual(report["top_level"]["function_count"], 240)
         self.assertEqual(report["top_level"]["class_count"], 20)
-        self.assertEqual(report["line_count"], 11_173)
+        self.assertEqual(report["line_count"], 11_165)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 36)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 36)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 34)
+        self.assertEqual(report["inventory"]["module_count"], 41)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 41)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 39)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
@@ -710,8 +710,13 @@ ignored/
                 "easyuse_anima/infrastructure/comfy/capabilities.py",
                 "easyuse_anima/infrastructure/comfy/invocation.py",
                 "easyuse_anima/infrastructure/comfy/resources.py",
+                "easyuse_anima/naia/__init__.py",
+                "easyuse_anima/naia/client.py",
+                "easyuse_anima/naia/resolution.py",
                 "easyuse_anima/nodes/__init__.py",
                 "easyuse_anima/nodes/image_nodes.py",
+                "easyuse_anima/nodes/naia_nodes.py",
+                "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/prompt/__init__.py",
@@ -729,7 +734,12 @@ ignored/
                 "easyuse_anima/infrastructure/comfy/capabilities.py",
                 "easyuse_anima/infrastructure/comfy/invocation.py",
                 "easyuse_anima/infrastructure/comfy/resources.py",
+                "easyuse_anima/naia/__init__.py",
+                "easyuse_anima/naia/client.py",
+                "easyuse_anima/naia/resolution.py",
                 "easyuse_anima/nodes/image_nodes.py",
+                "easyuse_anima/nodes/naia_nodes.py",
+                "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
             }.issubset(report["registry"]["runtime_import_closure"])

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -21,6 +21,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.infrastructure.comfy.capabilities",
     "easyuse_anima.infrastructure.comfy.invocation",
     "easyuse_anima.infrastructure.comfy.resources",
+    "easyuse_anima.naia",
     "easyuse_anima.nodes",
     "easyuse_anima.profiles",
     "easyuse_anima.profiles.contract",

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -30,8 +30,13 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/infrastructure/comfy/capabilities.py",
     "easyuse_anima/infrastructure/comfy/invocation.py",
     "easyuse_anima/infrastructure/comfy/resources.py",
+    "easyuse_anima/naia/__init__.py",
+    "easyuse_anima/naia/client.py",
+    "easyuse_anima/naia/resolution.py",
     "easyuse_anima/nodes/__init__.py",
     "easyuse_anima/nodes/image_nodes.py",
+    "easyuse_anima/nodes/naia_nodes.py",
+    "easyuse_anima/nodes/wildcard_nodes.py",
     "easyuse_anima/profiles/__init__.py",
     "easyuse_anima/profiles/contract.py",
     "easyuse_anima/prompt/__init__.py",
@@ -134,7 +139,11 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "easyuse_anima/infrastructure/comfy/resources.py",
             "easyuse_anima/image/detailer.py",
             "easyuse_anima/image/scaling.py",
+            "easyuse_anima/naia/client.py",
+            "easyuse_anima/naia/resolution.py",
             "easyuse_anima/nodes/image_nodes.py",
+            "easyuse_anima/nodes/naia_nodes.py",
+            "easyuse_anima/nodes/wildcard_nodes.py",
             "nodes.py",
             "prompt_translation.py",
             "settings.py",
@@ -148,6 +157,8 @@ class RegistryScannerSafetyTests(unittest.TestCase):
         runtime_files = (
             "api.py",
             "api_contract.py",
+            "easyuse_anima/naia/client.py",
+            "easyuse_anima/nodes/naia_nodes.py",
             "nodes.py",
             "prompt_translation.py",
             "settings.py",
@@ -158,8 +169,8 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             if "requests.post" in source:
                 matches.append(filename)
 
-        self.assertEqual(matches, ["nodes.py"])
-        source = (ROOT / "nodes.py").read_text(encoding="utf-8")
+        self.assertEqual(matches, ["easyuse_anima/naia/client.py"])
+        source = (ROOT / "easyuse_anima" / "naia" / "client.py").read_text(encoding="utf-8")
         self.assertIn("allow_remote_api=True", source)
         self.assertIn("localhost-only", source)
         self.assertIn("timeout=HTTP_TIMEOUT", source)


### PR DESCRIPTION
## 변경 요약

Issue #184 Phase B의 다음 Move PR로 Wildcard adapter와 NAIA node/client/resolution vertical slice를 canonical `easyuse_anima` package로 이동했습니다.

- `EasyUseAnimaWildcard`를 `easyuse_anima/nodes/wildcard_nodes.py`로 이동
- `EasyUseAnimaNAIARandomPrompt`를 `easyuse_anima/nodes/naia_nodes.py`로 이동
- NAIA HTTP client/response 정규화를 `easyuse_anima/naia/client.py`로 이동
- Prompt Studio/NAIA resolution 정책을 `easyuse_anima/naia/resolution.py`로 이동
- root `nodes.py`는 기존 private helper와 public node class를 canonical object로 직접 alias하고, 기존 root patch surface는 얇은 runtime binding으로 유지
- analyzer fixture, direct identity, import/package/Registry closure 검증을 새 모듈 경계에 맞게 갱신

## Move-only 경계

다음 동작은 변경하지 않았습니다.

- standalone `wildcard_engine.py` 구현과 snapshot/cache/budget
- wildcard seed 의미와 reservation 검증
- NAIA host 제한, timeout, request body, error 및 response 처리
- 1MP pixel cap, NAIA scale/max-long-edge/bucket-fit 정책
- AiO service/class, profile/API frontend, DOM/canvas/resize, settings/schema

`dev@18b0f1caac9c4c8e10a8e68f090be9d5b200d57c` 원본과 이동된 43개 class/function/constant의 AST dump를 비교해 mismatch 0을 확인했습니다.

## 주요 파일

- `easyuse_anima/naia/{__init__,client,resolution}.py`
- `easyuse_anima/nodes/{wildcard_nodes,naia_nodes}.py`
- `nodes.py`
- `tests/fixtures/python_backend_baseline.json`
- focused identity/behavior/import/package/Registry analyzer tests

## 메인 리뷰

- public node class와 private helper가 canonical 객체의 직접 alias인지 실제 diff와 주변 코드를 확인했습니다.
- runtime binding이 기존 `nodes._post_random`, wildcard helper, settings/workflow patch surface를 유지함을 확인했습니다.
- 중복 root `_clean_prompt`, `_MULTI_COMMA_RE`, `_RESOLUTION_LABEL_RE`를 제거하고 canonical `_clean_prompt` identity 계약을 추가했습니다.
- canonical package 내부에서 거대한 root `nodes.py`를 역참조하지 않으며, standalone `wildcard_engine.py`는 이번 Move-only 범위대로 유지했습니다.
- 최종 리뷰 기준 새 P0-P2 차단점은 없습니다.

## 검증

Focused / worker:

- AST move parity: 43 definitions, mismatch 0
- NAIA / Wildcard behavior, prompt corrector, identity, package/import/Registry/analyzer: 175 tests passed
- backend analyzer: shipped 41 / runtime closure 39 / missing internal import 0
- 공식 `tools/check_project.ps1 -Profile quick`: 통과
  - Python compile
  - frontend 111 JavaScript files
  - TypeScript 6.0.3
  - staged/unstaged diff check

Main final gate, exact HEAD `c1a67c926a0403944940c3af662c79b6f70228ee`:

- 공식 `tools/check_custom_node.ps1 -Profile full`: 통과
- Python unittest: 661 tests, OK
- frontend: 111 JavaScript files
- TypeScript 6.0.3
- Python compile 및 Git diff 검사 통과

테스트 표면: ComfyUI Codex test instance의 Python/module/static full.

## 남은 위험 / 미확인

- 실제 NAIA 네트워크 호출은 실행하지 않았고 mock 기반 behavior parity만 확인했습니다.
- 백엔드 Move-only 변경으로 DOM/canvas/widget/serialization 경계가 없어 Legacy canvas/Node 2.0 browser smoke는 실행하지 않았습니다.
- 새 Python 모듈을 로드하려면 ComfyUI 재시작이 필요합니다.

Refs #184 — B-05 vertical slice 일부이며 parent issue는 계속 유지합니다.