### PR TITLE
fix: 프로필 mutation에 strict optimistic CAS 적용

### DIFF
--- a/api.py
+++ b/api.py
@@ -69,6 +69,13 @@ try:
         rename_profile_document,
         update_profile_document,
     )
+    from .easyuse_anima.profiles.mutation import (
+        PROFILE_MUTATION_COORDINATOR,
+        ProfileMutationError,
+        ProfileRevisionConflictError,
+        require_profile_precondition,
+        verify_profile_precondition,
+    )
 except ImportError:
     from easyuse_anima.profiles.contract import (
         PROFILE_KIND_AIO,
@@ -81,6 +88,13 @@ except ImportError:
         normalize_profile_filename_identity,
         rename_profile_document,
         update_profile_document,
+    )
+    from easyuse_anima.profiles.mutation import (
+        PROFILE_MUTATION_COORDINATOR,
+        ProfileMutationError,
+        ProfileRevisionConflictError,
+        require_profile_precondition,
+        verify_profile_precondition,
     )
 try:
     from .storage import AtomicJsonStore, USER_DATA_DIR
@@ -629,16 +643,17 @@ def _save_lora_profile(
     profile_id: str | None = None,
     revision: int | None = None,
 ) -> dict:
-    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
-    _ = profile_id, revision
     safe_name = _sanitize_lora_profile_name(name)
     payload = _normalize_lora_profile_payload(data)
-    LORA_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
     requested_path = _lora_profile_path(safe_name)
-    with AtomicJsonStore(requested_path).locked():
+    if overwrite:
+        require_profile_precondition(profile_id, revision)
+    with PROFILE_MUTATION_COORDINATOR.locked(LORA_PROFILE_DIR):
         existing = _find_lora_profile_path(safe_name)
         if existing is not None and not overwrite:
             raise FileExistsError("Profile already exists")
+        if existing is None and overwrite:
+            raise FileNotFoundError("Profile not found")
         path = existing or requested_path
         try:
             if existing is None:
@@ -651,6 +666,13 @@ def _save_lora_profile(
                 current = _read_profile_json(path)
                 if not isinstance(current, dict):
                     raise ProfileContractError("Profile data is invalid")
+                verify_profile_precondition(
+                    PROFILE_KIND_LORA,
+                    path.stem,
+                    current,
+                    profile_id=profile_id,
+                    revision=revision,
+                )
                 document = update_profile_document(
                     PROFILE_KIND_LORA,
                     path.stem,
@@ -765,15 +787,16 @@ def _save_aio_profile(
     profile_id: str | None = None,
     revision: int | None = None,
 ) -> dict:
-    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
-    _ = profile_id, revision
     payload = _normalize_aio_profile_payload(name, data)
-    AIO_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
     requested_path = _aio_profile_path(payload["name"])
-    with AtomicJsonStore(requested_path).locked():
+    if overwrite:
+        require_profile_precondition(profile_id, revision)
+    with PROFILE_MUTATION_COORDINATOR.locked(AIO_PROFILE_DIR):
         existing = _find_aio_profile_path(payload["name"])
         if existing is not None and not overwrite:
             raise FileExistsError("Profile already exists")
+        if existing is None and overwrite:
+            raise FileNotFoundError("Profile not found")
         if existing is None and len(_list_aio_profiles()) >= MAX_AIO_PROFILES:
             raise ValueError(f"A maximum of {MAX_AIO_PROFILES} profiles can be saved")
         path = existing or requested_path
@@ -788,6 +811,13 @@ def _save_aio_profile(
                 current = _read_profile_json(path)
                 if not isinstance(current, dict):
                     raise ProfileContractError("Profile data is invalid")
+                verify_profile_precondition(
+                    PROFILE_KIND_AIO,
+                    path.stem,
+                    current,
+                    profile_id=profile_id,
+                    revision=revision,
+                )
                 document = update_profile_document(
                     PROFILE_KIND_AIO,
                     path.stem,
@@ -835,25 +865,25 @@ def _delete_aio_profile(
     profile_id: str | None = None,
     revision: int | None = None,
 ) -> dict:
-    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
-    _ = profile_id, revision
-    path = _find_aio_profile_path(name)
-    if path is None or not path.is_file():
-        raise FileNotFoundError("Profile not found")
-    store = AtomicJsonStore(path)
-    with store.locked():
+    require_profile_precondition(profile_id, revision)
+    with PROFILE_MUTATION_COORDINATOR.locked(AIO_PROFILE_DIR):
+        path = _find_aio_profile_path(name)
+        if path is None or not path.is_file():
+            raise FileNotFoundError("Profile not found")
+        store = AtomicJsonStore(path)
         try:
             data = _read_profile_json(path)
             if not isinstance(data, dict):
                 raise ProfileContractError("Profile data is invalid")
-            interpreted = interpret_profile_document(PROFILE_KIND_AIO, path.stem, data)
-            deleted_profile_id = interpreted["profile_id"]
-            deleted_revision = interpreted["revision"]
+            deleted_profile_id, deleted_revision = verify_profile_precondition(
+                PROFILE_KIND_AIO,
+                path.stem,
+                data,
+                profile_id=profile_id,
+                revision=revision,
+            )
         except ProfileContractError as exc:
             raise InvalidProfileDataError(str(exc)) from exc
-        except (OSError, UnicodeError, json.JSONDecodeError):
-            deleted_profile_id = legacy_profile_id(PROFILE_KIND_AIO, path.stem)
-            deleted_revision = 0
         try:
             store.delete()
         except FileNotFoundError as exc:
@@ -875,41 +905,84 @@ def _rename_aio_profile(
     target_profile_id: str | None = None,
     target_revision: int | None = None,
 ) -> dict:
-    # Parsed optimistic-concurrency tokens are reserved for Issue #163 Part 3C.
-    _ = profile_id, revision, target_profile_id, target_revision
-    source = _find_aio_profile_path(old_name)
-    if source is None or not source.is_file():
-        raise FileNotFoundError("Profile not found")
-    safe_new_name = _sanitize_aio_profile_name(new_name)
-    if source.stem.casefold() == safe_new_name.casefold():
-        store = AtomicJsonStore(source, backup=False)
-        with store.locked():
+    require_profile_precondition(profile_id, revision, profile="source")
+    with PROFILE_MUTATION_COORDINATOR.locked(AIO_PROFILE_DIR):
+        source = _find_aio_profile_path(old_name)
+        if source is None or not source.is_file():
+            raise FileNotFoundError("Profile not found")
+        safe_new_name = _sanitize_aio_profile_name(new_name)
+        try:
             data = _read_profile_json(source)
+            if not isinstance(data, dict):
+                raise ProfileContractError("Profile data is invalid")
+            verify_profile_precondition(
+                PROFILE_KIND_AIO,
+                source.stem,
+                data,
+                profile_id=profile_id,
+                revision=revision,
+                profile="source",
+            )
+        except ProfileContractError as exc:
+            raise InvalidProfileDataError(str(exc)) from exc
+
+        if (
+            _windows_profile_filename_identity(source.stem)
+            == _windows_profile_filename_identity(safe_new_name)
+        ):
             renamed = _rename_aio_profile_payload(
                 source.stem,
                 source.stem,
                 data,
             )
             if data != renamed:
-                store.write(renamed)
+                AtomicJsonStore(source, backup=False).write(renamed)
             return renamed
 
-    target = _find_aio_profile_path(safe_new_name)
-    if target is not None and not overwrite:
-        raise FileExistsError("Profile already exists")
+        target = _find_aio_profile_path(safe_new_name)
+        if target is not None and not overwrite:
+            raise FileExistsError("Profile already exists")
+        if target is None and (
+            target_profile_id is not None or target_revision is not None
+        ):
+            raise ProfileRevisionConflictError(profile="target")
+        if target is not None:
+            require_profile_precondition(
+                target_profile_id,
+                target_revision,
+                id_field="target_profile_id",
+                revision_field="target_revision",
+                profile="target",
+            )
+            try:
+                target_data = _read_profile_json(target)
+                if not isinstance(target_data, dict):
+                    raise ProfileContractError("Profile data is invalid")
+                verify_profile_precondition(
+                    PROFILE_KIND_AIO,
+                    target.stem,
+                    target_data,
+                    profile_id=target_profile_id,
+                    revision=target_revision,
+                    id_field="target_profile_id",
+                    revision_field="target_revision",
+                    profile="target",
+                )
+            except ProfileContractError as exc:
+                raise InvalidProfileDataError(str(exc)) from exc
 
-    target_path = target or _aio_profile_path(safe_new_name)
-    renamed = AtomicJsonStore(target_path).replace_from(
-        AtomicJsonStore(source),
-        overwrite=overwrite,
-        backup_target=True,
-        transform=lambda data: _rename_aio_profile_payload(
-            source.stem,
-            target_path.stem,
-            data,
-        ),
-    )
-    return renamed
+        target_path = target or _aio_profile_path(safe_new_name)
+        renamed = AtomicJsonStore(target_path).replace_from(
+            AtomicJsonStore(source),
+            overwrite=overwrite,
+            backup_target=True,
+            transform=lambda current: _rename_aio_profile_payload(
+                source.stem,
+                target_path.stem,
+                current,
+            ),
+        )
+        return renamed
 
 
 def _rename_aio_profile_payload(source_name: str, target_name: str, data) -> dict:
@@ -970,6 +1043,13 @@ _SAFE_PROFILE_VALIDATION_MESSAGES = frozenset(
 
 
 def _profile_error_response(exc: Exception):
+    if isinstance(exc, ProfileMutationError):
+        return _error_response(
+            exc.status,
+            exc.code,
+            exc.message,
+            details=exc.details,
+        )
     if isinstance(exc, FileExistsError):
         return _error_response(409, "profile_exists", "Profile already exists")
     if isinstance(exc, FileNotFoundError):
@@ -1273,7 +1353,7 @@ if web is not None and routes is not None:
                 profile_id=profile_id,
                 revision=revision,
             )
-        except (FileExistsError, ValueError) as exc:
+        except (FileExistsError, FileNotFoundError, ValueError) as exc:
             return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 
@@ -1333,7 +1413,7 @@ if web is not None and routes is not None:
                 profile_id=profile_id,
                 revision=revision,
             )
-        except (FileExistsError, ValueError) as exc:
+        except (FileExistsError, FileNotFoundError, ValueError) as exc:
             return _profile_error_response(exc)
         return web.json_response({"status": "ok", "profile": payload})
 

--- a/easyuse_anima/profiles/mutation.py
+++ b/easyuse_anima/profiles/mutation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+import threading
+import weakref
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from .contract import read_profile_metadata
+
+
+class ProfileMutationError(ValueError):
+    """A public optimistic-concurrency failure with a stable API mapping."""
+
+    status: int
+    code: str
+    message: str
+
+    def __init__(
+        self,
+        *,
+        status: int,
+        code: str,
+        message: str,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = dict(details) if details is not None else None
+
+
+class ProfilePreconditionRequiredError(ProfileMutationError):
+    def __init__(self, fields: tuple[str, ...], *, profile: str = "profile") -> None:
+        super().__init__(
+            status=428,
+            code="profile_precondition_required",
+            message="Profile precondition is required",
+            details={"profile": profile, "fields": list(fields)},
+        )
+
+
+class ProfileIdentityMismatchError(ProfileMutationError):
+    def __init__(self, *, profile: str = "profile") -> None:
+        super().__init__(
+            status=409,
+            code="profile_identity_mismatch",
+            message="Profile identity does not match",
+            details={"profile": profile},
+        )
+
+
+class ProfileRevisionConflictError(ProfileMutationError):
+    def __init__(self, *, profile: str = "profile") -> None:
+        super().__init__(
+            status=409,
+            code="profile_revision_conflict",
+            message="Profile revision does not match",
+            details={"profile": profile},
+        )
+
+
+class DirectoryMutationCoordinator:
+    """Serialize profile discovery, CAS verification, and mutation per directory."""
+
+    def __init__(self) -> None:
+        self._guard = threading.Lock()
+        self._locks: weakref.WeakValueDictionary[str, threading.RLock] = (
+            weakref.WeakValueDictionary()
+        )
+
+    @staticmethod
+    def _key(directory: str | os.PathLike[str]) -> str:
+        return os.path.normcase(str(Path(directory).resolve(strict=False)))
+
+    def _lock(self, directory: str | os.PathLike[str]) -> threading.RLock:
+        key = self._key(directory)
+        with self._guard:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = threading.RLock()
+                self._locks[key] = lock
+            return lock
+
+    @contextmanager
+    def locked(self, directory: str | os.PathLike[str]) -> Iterator[None]:
+        lock = self._lock(directory)
+        with lock:
+            yield
+
+
+def require_profile_precondition(
+    profile_id: str | None,
+    revision: int | None,
+    *,
+    id_field: str = "profile_id",
+    revision_field: str = "revision",
+    profile: str = "profile",
+) -> None:
+    missing = tuple(
+        field
+        for field, value in (
+            (id_field, profile_id),
+            (revision_field, revision),
+        )
+        if value is None
+    )
+    if missing:
+        raise ProfilePreconditionRequiredError(missing, profile=profile)
+
+
+def verify_profile_precondition(
+    profile_kind: str,
+    filename: str,
+    current_document: Mapping[str, Any],
+    *,
+    profile_id: str | None,
+    revision: int | None,
+    id_field: str = "profile_id",
+    revision_field: str = "revision",
+    profile: str = "profile",
+) -> tuple[str, int]:
+    """Verify identity before revision against the document read under the lock."""
+
+    require_profile_precondition(
+        profile_id,
+        revision,
+        id_field=id_field,
+        revision_field=revision_field,
+        profile=profile,
+    )
+    current_profile_id, current_revision = read_profile_metadata(
+        profile_kind,
+        filename,
+        current_document,
+    )
+    if profile_id != current_profile_id:
+        raise ProfileIdentityMismatchError(profile=profile)
+    if revision != current_revision:
+        raise ProfileRevisionConflictError(profile=profile)
+    return current_profile_id, current_revision
+
+
+PROFILE_MUTATION_COORDINATOR = DirectoryMutationCoordinator()
+
+
+__all__ = ()

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -2269,6 +2269,161 @@
       },
       {
         "alias": null,
+        "bound_name": "PROFILE_MUTATION_COORDINATOR",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROFILE_MUTATION_COORDINATOR",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.mutation:PROFILE_MUTATION_COORDINATOR",
+        "kind": "static_from",
+        "line": 72,
+        "name": "PROFILE_MUTATION_COORDINATOR",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.mutation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ProfileMutationError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ProfileMutationError",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.mutation:ProfileMutationError",
+        "kind": "static_from",
+        "line": 72,
+        "name": "ProfileMutationError",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.mutation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ProfileRevisionConflictError",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ProfileRevisionConflictError",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.mutation:ProfileRevisionConflictError",
+        "kind": "static_from",
+        "line": 72,
+        "name": "ProfileRevisionConflictError",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.mutation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "require_profile_precondition",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "require_profile_precondition",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.mutation:require_profile_precondition",
+        "kind": "static_from",
+        "line": 72,
+        "name": "require_profile_precondition",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.mutation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "verify_profile_precondition",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "verify_profile_precondition",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.profiles.mutation:verify_profile_precondition",
+        "kind": "static_from",
+        "line": 72,
+        "name": "verify_profile_precondition",
+        "optional": false,
+        "requested": ".easyuse_anima.profiles.mutation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PROFILE_KIND_AIO",
         "branch_context": [
           {
@@ -2277,7 +2432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2292,7 +2447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "PROFILE_KIND_AIO",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2311,7 +2466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2326,7 +2481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "PROFILE_KIND_LORA",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2345,7 +2500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2360,7 +2515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:ProfileContractError",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "ProfileContractError",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2379,7 +2534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2394,7 +2549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:build_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "build_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2413,7 +2568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2428,7 +2583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:create_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "create_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2447,7 +2602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2462,7 +2617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:interpret_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "interpret_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2481,7 +2636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2496,7 +2651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:legacy_profile_id",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "legacy_profile_id",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2515,7 +2670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2530,7 +2685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:normalize_profile_filename_identity",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "normalize_profile_filename_identity",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2549,7 +2704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2564,7 +2719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:rename_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "rename_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2583,7 +2738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -2598,7 +2753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:update_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "name": "update_profile_document",
         "optional": false,
         "requested": "easyuse_anima.profiles.contract",
@@ -2609,6 +2764,176 @@
       },
       {
         "alias": null,
+        "bound_name": "PROFILE_MUTATION_COORDINATOR",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "PROFILE_MUTATION_COORDINATOR",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:PROFILE_MUTATION_COORDINATOR",
+        "kind": "static_from",
+        "line": 92,
+        "name": "PROFILE_MUTATION_COORDINATOR",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.mutation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ProfileMutationError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ProfileMutationError",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:ProfileMutationError",
+        "kind": "static_from",
+        "line": 92,
+        "name": "ProfileMutationError",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.mutation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ProfileRevisionConflictError",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "ProfileRevisionConflictError",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:ProfileRevisionConflictError",
+        "kind": "static_from",
+        "line": 92,
+        "name": "ProfileRevisionConflictError",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.mutation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "require_profile_precondition",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "require_profile_precondition",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:require_profile_precondition",
+        "kind": "static_from",
+        "line": 92,
+        "name": "require_profile_precondition",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.mutation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "verify_profile_precondition",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "verify_profile_precondition",
+          "target": "easyuse_anima/profiles/mutation.py",
+          "try_line": 59
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:verify_profile_precondition",
+        "kind": "static_from",
+        "line": 92,
+        "name": "verify_profile_precondition",
+        "optional": false,
+        "requested": "easyuse_anima.profiles.mutation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
         "bound_name": "AtomicJsonStore",
         "branch_context": [
           {
@@ -2616,7 +2941,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 85
+            "line": 99
           }
         ],
         "classification": "internal",
@@ -2624,12 +2949,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 85
+          "try_line": 99
         },
         "conditional": true,
         "imported": ".storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 86,
+        "line": 100,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": ".storage",
@@ -2647,7 +2972,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 85
+            "line": 99
           }
         ],
         "classification": "internal",
@@ -2655,12 +2980,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 85
+          "try_line": 99
         },
         "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 86,
+        "line": 100,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -2679,9 +3004,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 87,
+            "handler_line": 101,
             "kind": "try",
-            "line": 85
+            "line": 99
           }
         ],
         "classification": "compatibility_fallback",
@@ -2689,12 +3014,12 @@
         "compatibility_pair": {
           "bound_name": "AtomicJsonStore",
           "target": "storage.py",
-          "try_line": 85
+          "try_line": 99
         },
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 88,
+        "line": 102,
         "name": "AtomicJsonStore",
         "optional": false,
         "requested": "storage",
@@ -2713,9 +3038,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 87,
+            "handler_line": 101,
             "kind": "try",
-            "line": 85
+            "line": 99
           }
         ],
         "classification": "compatibility_fallback",
@@ -2723,12 +3048,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 85
+          "try_line": 99
         },
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 88,
+        "line": 102,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -2746,7 +3071,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 424
+            "line": 438
           }
         ],
         "classification": "external",
@@ -2754,7 +3079,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 425,
+        "line": 439,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -2771,7 +3096,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 450
+            "line": 464
           }
         ],
         "classification": "external",
@@ -2779,7 +3104,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 451,
+        "line": 465,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -2796,7 +3121,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 932
+            "line": 1005
           }
         ],
         "classification": "external",
@@ -2804,7 +3129,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 933,
+        "line": 1006,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -6524,6 +6849,177 @@
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "os",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 3,
+        "name": null,
+        "optional": false,
+        "requested": "os",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "threading",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 4,
+        "name": null,
+        "optional": false,
+        "requested": "threading",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "weakref",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "weakref",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "weakref",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Iterator",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Iterator",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Iterator",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "contextmanager",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 7,
+        "name": "contextmanager",
+        "optional": false,
+        "requested": "contextlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Path",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Path",
+        "optional": false,
+        "requested": "pathlib",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 9,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "read_profile_metadata",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".contract:read_profile_metadata",
+        "kind": "static_from",
+        "line": 11,
+        "name": "read_profile_metadata",
+        "optional": false,
+        "requested": ".contract",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/profiles/mutation.py",
+        "target": "easyuse_anima/profiles/contract.py"
       },
       {
         "alias": null,
@@ -16076,6 +16572,10 @@
       },
       {
         "from": "api.py",
+        "to": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "from": "api.py",
         "to": "prompt_translation.py"
       },
       {
@@ -16177,6 +16677,10 @@
       {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
         "to": "wildcard_engine.py"
+      },
+      {
+        "from": "easyuse_anima/profiles/mutation.py",
+        "to": "easyuse_anima/profiles/contract.py"
       },
       {
         "from": "nodes.py",
@@ -16491,6 +16995,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/profiles/mutation.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "nodes.py"
         ]
       },
@@ -16521,7 +17031,7 @@
     ]
   },
   "inventory": {
-    "module_count": 41,
+    "module_count": 42,
     "modules": [
       {
         "is_package": true,
@@ -16621,9 +17131,9 @@
       },
       {
         "is_package": false,
-        "loc": 1439,
+        "loc": 1519,
         "module": "api",
-        "normalized_git_blob_sha1": "5a6bc68e39ef4b724baf6e55769c8ddcef9babc4",
+        "normalized_git_blob_sha1": "ef44140e33e14c1de62afe5422c8fb0968c84033",
         "path": "api.py",
         "top_level": {
           "class_count": 2,
@@ -16944,6 +17454,18 @@
         }
       },
       {
+        "is_package": false,
+        "loc": 150,
+        "module": "easyuse_anima.profiles.mutation",
+        "normalized_git_blob_sha1": "02ae1d049371541dc8ae4fe7c1f3181ca3536aed",
+        "path": "easyuse_anima/profiles/mutation.py",
+        "top_level": {
+          "class_count": 5,
+          "function_count": 2,
+          "global_count": 2
+        }
+      },
+      {
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.prompt",
@@ -17209,7 +17731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17218,7 +17740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_AIO",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17232,7 +17754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17241,7 +17763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:PROFILE_KIND_LORA",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17255,7 +17777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17264,7 +17786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:ProfileContractError",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17278,7 +17800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17287,7 +17809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:build_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17301,7 +17823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17310,7 +17832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:create_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17324,7 +17846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17333,7 +17855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:interpret_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17347,7 +17869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17356,7 +17878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:legacy_profile_id",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17370,7 +17892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17379,7 +17901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:normalize_profile_filename_identity",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17393,7 +17915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17402,7 +17924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:rename_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17416,7 +17938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 72,
+            "handler_line": 79,
             "kind": "try",
             "line": 59
           }
@@ -17425,7 +17947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.profiles.contract:update_profile_document",
         "kind": "static_from",
-        "line": 73,
+        "line": 80,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17439,16 +17961,131 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 87,
+            "handler_line": 79,
             "kind": "try",
-            "line": 85
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:PROFILE_MUTATION_COORDINATOR",
+        "kind": "static_from",
+        "line": 92,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:ProfileMutationError",
+        "kind": "static_from",
+        "line": 92,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:ProfileRevisionConflictError",
+        "kind": "static_from",
+        "line": 92,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:require_profile_precondition",
+        "kind": "static_from",
+        "line": 92,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 79,
+            "kind": "try",
+            "line": 59
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.profiles.mutation:verify_profile_precondition",
+        "kind": "static_from",
+        "line": 92,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "api.py",
+        "target": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 101,
+            "kind": "try",
+            "line": 99
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:AtomicJsonStore",
         "kind": "static_from",
-        "line": 88,
+        "line": 102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -17462,16 +18099,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 87,
+            "handler_line": 101,
             "kind": "try",
-            "line": 85
+            "line": 99
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 88,
+        "line": 102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "api.py",
@@ -21175,14 +21812,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 424
+            "line": 438
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 425,
+        "line": 439,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -21194,14 +21831,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 450
+            "line": 464
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 451,
+        "line": 465,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -21213,14 +21850,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 932
+            "line": 1005
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 933,
+        "line": 1006,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -22097,6 +22734,105 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "os",
+        "kind": "static_import",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "threading",
+        "kind": "static_import",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "weakref",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Iterator",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "contextlib:contextmanager",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "pathlib:Path",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/profiles/mutation.py"
       },
       {
         "branch_context": [],
@@ -23505,14 +24241,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 424
+            "line": 438
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 425,
+        "line": 439,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -23524,14 +24260,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 450
+            "line": 464
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 451,
+        "line": 465,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -23543,14 +24279,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 932
+            "line": 1005
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 933,
+        "line": 1006,
         "optional": true,
         "role": "optional_dependency",
         "source": "api.py"
@@ -24491,6 +25227,7 @@
       "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
+      "easyuse_anima/profiles/mutation.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -24533,6 +25270,7 @@
       "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
+      "easyuse_anima/profiles/mutation.py",
       "easyuse_anima/prompt/__init__.py",
       "nodes.py",
       "prompt_translation.py",
@@ -24742,7 +25480,7 @@
         "column": 29,
         "context": "assign:INVALID_PROFILE_NAME_CHARS",
         "kind": "import_time_call",
-        "line": 94,
+        "line": 108,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24751,7 +25489,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 119,
+        "line": 133,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24760,7 +25498,7 @@
         "column": 33,
         "context": "assign:WINDOWS_RESERVED_FILE_BASENAMES",
         "kind": "import_time_call",
-        "line": 120,
+        "line": 134,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24769,7 +25507,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 126,
+        "line": 140,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24778,7 +25516,7 @@
         "column": 25,
         "context": "assign:_FILE_IO_LIMITERS_LOCK",
         "kind": "import_time_call",
-        "line": 133,
+        "line": 147,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24787,7 +25525,7 @@
         "column": 47,
         "context": "assign:_FILE_IO_LIMITERS",
         "kind": "import_time_call",
-        "line": 134,
+        "line": 148,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24796,7 +25534,7 @@
         "column": 29,
         "context": "assign:_PROMPT_TRANSLATION_WORKER",
         "kind": "import_time_call",
-        "line": 183,
+        "line": 197,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24805,7 +25543,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 184,
+        "line": 198,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24814,7 +25552,7 @@
         "column": 36,
         "context": "assign:_SAFE_PROFILE_VALIDATION_MESSAGES",
         "kind": "import_time_call",
-        "line": 959,
+        "line": 1032,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24823,7 +25561,7 @@
         "column": 9,
         "context": "assign:routes",
         "kind": "route_registry_creation",
-        "line": 1109,
+        "line": 1189,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24832,7 +25570,7 @@
         "column": 5,
         "context": "decorator:get_settings_handler",
         "kind": "route_registration",
-        "line": 1114,
+        "line": 1194,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24841,7 +25579,7 @@
         "column": 5,
         "context": "decorator:set_setting_handler",
         "kind": "route_registration",
-        "line": 1119,
+        "line": 1199,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24850,7 +25588,7 @@
         "column": 5,
         "context": "decorator:get_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 1137,
+        "line": 1217,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24859,7 +25597,7 @@
         "column": 5,
         "context": "decorator:get_wildcards_handler",
         "kind": "route_registration",
-        "line": 1144,
+        "line": 1224,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24868,7 +25606,7 @@
         "column": 5,
         "context": "decorator:save_long_text_settings_handler",
         "kind": "route_registration",
-        "line": 1149,
+        "line": 1229,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24877,7 +25615,7 @@
         "column": 5,
         "context": "decorator:autocomplete_status_handler",
         "kind": "route_registration",
-        "line": 1161,
+        "line": 1241,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24886,7 +25624,7 @@
         "column": 5,
         "context": "decorator:autocomplete_handler",
         "kind": "route_registration",
-        "line": 1166,
+        "line": 1246,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24895,7 +25633,7 @@
         "column": 5,
         "context": "decorator:classify_prompt_handler",
         "kind": "route_registration",
-        "line": 1184,
+        "line": 1264,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24904,7 +25642,7 @@
         "column": 5,
         "context": "decorator:translate_prompt_handler",
         "kind": "route_registration",
-        "line": 1203,
+        "line": 1283,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24913,7 +25651,7 @@
         "column": 5,
         "context": "decorator:lora_preview_handler",
         "kind": "route_registration",
-        "line": 1217,
+        "line": 1297,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24922,7 +25660,7 @@
         "column": 5,
         "context": "decorator:loras_handler",
         "kind": "route_registration",
-        "line": 1231,
+        "line": 1311,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24931,7 +25669,7 @@
         "column": 5,
         "context": "decorator:lora_profiles_handler",
         "kind": "route_registration",
-        "line": 1236,
+        "line": 1316,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24940,7 +25678,7 @@
         "column": 5,
         "context": "decorator:save_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1245,
+        "line": 1325,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24949,7 +25687,7 @@
         "column": 5,
         "context": "decorator:load_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1280,
+        "line": 1360,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24958,7 +25696,7 @@
         "column": 5,
         "context": "decorator:aio_profiles_handler",
         "kind": "route_registration",
-        "line": 1297,
+        "line": 1377,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24967,7 +25705,7 @@
         "column": 5,
         "context": "decorator:save_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1306,
+        "line": 1386,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24976,7 +25714,7 @@
         "column": 5,
         "context": "decorator:load_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1340,
+        "line": 1420,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24985,7 +25723,7 @@
         "column": 5,
         "context": "decorator:delete_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1352,
+        "line": 1432,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -24994,7 +25732,7 @@
         "column": 5,
         "context": "decorator:rename_aio_profile_handler",
         "kind": "route_registration",
-        "line": 1382,
+        "line": 1462,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -25003,7 +25741,7 @@
         "column": 5,
         "context": "decorator:fix_lora_profile_handler",
         "kind": "route_registration",
-        "line": 1429,
+        "line": 1509,
         "module": "api.py",
         "scope": "<module>"
       },
@@ -25257,6 +25995,15 @@
         "kind": "import_time_call",
         "line": 14,
         "module": "easyuse_anima/profiles/contract.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "DirectoryMutationCoordinator",
+        "column": 31,
+        "context": "assign:PROFILE_MUTATION_COORDINATOR",
+        "kind": "import_time_call",
+        "line": 147,
+        "module": "easyuse_anima/profiles/mutation.py",
         "scope": "<module>"
       },
       {
@@ -25670,13 +26417,13 @@
       },
       {
         "kind": "set",
-        "line": 98,
+        "line": 112,
         "module": "api.py",
         "name": "AIO_RESERVED_PROFILE_NAMES"
       },
       {
         "kind": "set",
-        "line": 114,
+        "line": 128,
         "module": "api.py",
         "name": "WINDOWS_RESERVED_FILE_BASENAMES"
       },
@@ -25963,7 +26710,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 133,
+        "line": 147,
         "module": "api.py",
         "name": "_FILE_IO_LIMITERS_LOCK"
       },
@@ -25972,7 +26719,7 @@
           "executor"
         ],
         "initializer": "_PromptTranslationWorker",
-        "line": 183,
+        "line": 197,
         "module": "api.py",
         "name": "_PROMPT_TRANSLATION_WORKER"
       },

--- a/tests/test_aio_profiles.py
+++ b/tests/test_aio_profiles.py
@@ -20,6 +20,21 @@ ROOT = Path(__file__).resolve().parents[1]
 PRESETS_JS = ROOT / "web" / "js" / "aio" / "presets.js"
 
 
+def profile_tokens(profile: dict, *, prefix: str = "") -> dict:
+    return {
+        f"{prefix}profile_id": profile["profile_id"],
+        f"{prefix}revision": profile["revision"],
+    }
+
+
+def directory_snapshot(root: Path) -> dict:
+    return {
+        path.name: (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in root.iterdir()
+        if path.is_file()
+    }
+
+
 def load_api_module():
     package_name = "easyuse_anima_aio_profile_test_package"
     package = types.ModuleType(package_name)
@@ -103,7 +118,11 @@ class AIOProfileStorageTests(unittest.TestCase):
                     api._load_aio_profile("my_ profile")["settings"]["future_section"]["kept"]
                 )
 
-                renamed = api._rename_aio_profile("My_ Profile", "Production")
+                renamed = api._rename_aio_profile(
+                    "My_ Profile",
+                    "Production",
+                    **profile_tokens(saved),
+                )
                 self.assertEqual(renamed["name"], "Production")
                 self.assertEqual(renamed["profile_id"], saved["profile_id"])
                 self.assertEqual(renamed["revision"], 1)
@@ -114,7 +133,10 @@ class AIOProfileStorageTests(unittest.TestCase):
                     renamed,
                 )
 
-                deleted = api._delete_aio_profile("production")
+                deleted = api._delete_aio_profile(
+                    "production",
+                    **profile_tokens(renamed),
+                )
                 self.assertEqual(deleted["name"], "Production")
                 self.assertEqual(deleted["profile_id"], saved["profile_id"])
                 self.assertEqual(deleted["revision"], 1)
@@ -125,18 +147,22 @@ class AIOProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Delete Me", {"settings": {"value": "old"}})
-                api._save_aio_profile(
+                first = api._save_aio_profile("Delete Me", {"settings": {"value": "old"}})
+                current = api._save_aio_profile(
                     "Delete Me",
                     {"settings": {"value": "current"}},
                     overwrite=True,
+                    **profile_tokens(first),
                 )
                 primary = root / "Delete Me.json"
                 backup = root / "Delete Me.json.bak"
                 self.assertTrue(primary.is_file())
                 self.assertTrue(backup.is_file())
 
-                deleted = api._delete_aio_profile("delete me")
+                deleted = api._delete_aio_profile(
+                    "delete me",
+                    **profile_tokens(current),
+                )
 
                 self.assertEqual(deleted["name"], "Delete Me")
                 self.assertFalse(primary.exists())
@@ -147,11 +173,12 @@ class AIOProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Preserved", {"settings": {"value": "old"}})
-                api._save_aio_profile(
+                first = api._save_aio_profile("Preserved", {"settings": {"value": "old"}})
+                current = api._save_aio_profile(
                     "Preserved",
                     {"settings": {"value": "current"}},
                     overwrite=True,
+                    **profile_tokens(first),
                 )
                 primary = (root / "Preserved.json").resolve()
                 backup = (root / "Preserved.json.bak").resolve()
@@ -164,7 +191,10 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 with patch.object(Path, "unlink", autospec=True, side_effect=fail_backup_unlink):
                     with self.assertRaisesRegex(OSError, "backup unlink failed"):
-                        api._delete_aio_profile("Preserved")
+                        api._delete_aio_profile(
+                            "Preserved",
+                            **profile_tokens(current),
+                        )
 
                 self.assertEqual(api._load_aio_profile("Preserved")["settings"]["value"], "current")
                 self.assertTrue(primary.is_file())
@@ -175,13 +205,14 @@ class AIOProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Recreated", {"settings": {"value": "old"}})
-                api._save_aio_profile(
+                first = api._save_aio_profile("Recreated", {"settings": {"value": "old"}})
+                current = api._save_aio_profile(
                     "Recreated",
                     {"settings": {"value": "current"}},
                     overwrite=True,
+                    **profile_tokens(first),
                 )
-                api._delete_aio_profile("Recreated")
+                api._delete_aio_profile("Recreated", **profile_tokens(current))
 
                 api._save_aio_profile("Recreated", {"settings": {"value": "recreated"}})
                 primary = root / "Recreated.json"
@@ -199,13 +230,18 @@ class AIOProfileStorageTests(unittest.TestCase):
             source = root / "Source.json"
             source_backup = root / "Source.json.bak"
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Source", {"settings": {"value": "old"}})
+                first = api._save_aio_profile("Source", {"settings": {"value": "old"}})
                 current = api._save_aio_profile(
                     "Source",
                     {"settings": {"value": "current"}},
                     overwrite=True,
+                    **profile_tokens(first),
                 )
-                renamed = api._rename_aio_profile("Source", "Renamed")
+                renamed = api._rename_aio_profile(
+                    "Source",
+                    "Renamed",
+                    **profile_tokens(current),
+                )
 
                 self.assertEqual(renamed["profile_id"], current["profile_id"])
                 self.assertFalse(source_backup.exists())
@@ -220,7 +256,7 @@ class AIOProfileStorageTests(unittest.TestCase):
                     api._load_aio_profile("Source")
                 self.assertNotEqual(recreated["profile_id"], renamed["profile_id"])
 
-    def test_delete_waits_for_in_progress_write_on_same_profile_path(self):
+    def test_overwrite_delete_race_allows_exactly_one_same_revision_success(self):
         api = load_api_module()
         profile_storage = sys.modules[api.AtomicJsonStore.__module__]
         with tempfile.TemporaryDirectory() as tmp:
@@ -235,7 +271,10 @@ class AIOProfileStorageTests(unittest.TestCase):
             real_replace = profile_storage.os.replace
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Concurrent Delete", {"settings": {"value": "old"}})
+                original = api._save_aio_profile(
+                    "Concurrent Delete",
+                    {"settings": {"value": "old"}},
+                )
 
                 def block_primary_publish(source, target):
                     if Path(target) == profile_path:
@@ -250,6 +289,7 @@ class AIOProfileStorageTests(unittest.TestCase):
                             "Concurrent Delete",
                             {"settings": {"value": "new"}},
                             overwrite=True,
+                            **profile_tokens(original),
                         )
                     except BaseException as exc:
                         errors.append(exc)
@@ -257,7 +297,12 @@ class AIOProfileStorageTests(unittest.TestCase):
                 def delete_profile():
                     delete_started.set()
                     try:
-                        deleted.append(api._delete_aio_profile("Concurrent Delete"))
+                        deleted.append(
+                            api._delete_aio_profile(
+                                "Concurrent Delete",
+                                **profile_tokens(original),
+                            )
+                        )
                     except BaseException as exc:
                         errors.append(exc)
                     finally:
@@ -277,26 +322,26 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 self.assertFalse(writer.is_alive())
                 self.assertFalse(deleter.is_alive())
-                self.assertEqual(errors, [])
-                self.assertEqual(deleted[0]["name"], "Concurrent Delete")
-                self.assertIn("profile_id", deleted[0])
-                self.assertEqual(deleted[0]["revision"], 2)
-                self.assertFalse(profile_path.exists())
-                self.assertFalse((root / "Concurrent Delete.json.bak").exists())
+                self.assertEqual(len(deleted), 0)
+                self.assertEqual(len(errors), 1)
+                self.assertEqual(errors[0].code, "profile_revision_conflict")
+                current = api._load_aio_profile("Concurrent Delete")
+                self.assertEqual(current["revision"], 2)
+                self.assertEqual(current["settings"]["value"], "new")
+                self.assertTrue(profile_path.exists())
 
-    def test_delete_metadata_snapshot_and_delete_share_one_path_lock(self):
+    def test_delete_metadata_snapshot_and_delete_share_one_directory_lock(self):
         api = load_api_module()
-        profile_storage = sys.modules[api.AtomicJsonStore.__module__]
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            profile_path = (root / "Snapshot.json").resolve()
             metadata_ready = threading.Event()
             release_metadata = threading.Event()
             overwrite_started = threading.Event()
+            overwrite_done = threading.Event()
             errors: list[BaseException] = []
             deleted: list[dict] = []
             overwritten: list[dict] = []
-            real_interpret = api.interpret_profile_document
+            real_verify = api.verify_profile_precondition
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
                 original = api._save_aio_profile(
@@ -304,8 +349,8 @@ class AIOProfileStorageTests(unittest.TestCase):
                     {"settings": {"value": "original"}},
                 )
 
-                def block_after_metadata_read(profile_kind, filename, document):
-                    result = real_interpret(profile_kind, filename, document)
+                def block_after_metadata_read(profile_kind, filename, document, **kwargs):
+                    result = real_verify(profile_kind, filename, document, **kwargs)
                     if filename == "Snapshot":
                         metadata_ready.set()
                         if not release_metadata.wait(2):
@@ -314,7 +359,12 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 def delete_profile():
                     try:
-                        deleted.append(api._delete_aio_profile("Snapshot"))
+                        deleted.append(
+                            api._delete_aio_profile(
+                                "Snapshot",
+                                **profile_tokens(original),
+                            )
+                        )
                     except BaseException as exc:
                         errors.append(exc)
 
@@ -326,42 +376,38 @@ class AIOProfileStorageTests(unittest.TestCase):
                                 "Snapshot",
                                 {"settings": {"value": "replacement"}},
                                 overwrite=True,
+                                **profile_tokens(original),
                             )
                         )
                     except BaseException as exc:
                         errors.append(exc)
+                    finally:
+                        overwrite_done.set()
 
                 with patch.object(
                     api,
-                    "interpret_profile_document",
+                    "verify_profile_precondition",
                     side_effect=block_after_metadata_read,
                 ):
                     deleter = threading.Thread(target=delete_profile)
                     overwriter = threading.Thread(target=overwrite_profile)
                     deleter.start()
                     self.assertTrue(metadata_ready.wait(2))
-                    path_lock = profile_storage._path_lock(profile_path)
-                    lock_was_available = path_lock.acquire(blocking=False)
-                    if lock_was_available:
-                        path_lock.release()
                     overwriter.start()
                     self.assertTrue(overwrite_started.wait(2))
+                    self.assertFalse(overwrite_done.wait(0.05))
                     release_metadata.set()
                     deleter.join(2)
                     overwriter.join(2)
 
                 self.assertFalse(deleter.is_alive())
                 self.assertFalse(overwriter.is_alive())
-                self.assertFalse(lock_was_available)
-                self.assertEqual(errors, [])
+                self.assertEqual(len(errors), 1)
+                self.assertIsInstance(errors[0], FileNotFoundError)
                 self.assertEqual(deleted[0]["profile_id"], original["profile_id"])
                 self.assertEqual(deleted[0]["revision"], original["revision"])
-                self.assertNotEqual(overwritten[0]["profile_id"], original["profile_id"])
-                self.assertEqual(overwritten[0]["revision"], 1)
-                self.assertEqual(
-                    api._load_aio_profile("Snapshot")["settings"]["value"],
-                    "replacement",
-                )
+                self.assertEqual(overwritten, [])
+                self.assertFalse((root / "Snapshot.json").exists())
 
     def test_same_name_rename_serializes_transform_and_publish_with_overwrite(self):
         api = load_api_module()
@@ -393,7 +439,14 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 def rename_same_name():
                     try:
-                        renamed_profiles.append(api._rename_aio_profile("Same", "Same"))
+                        renamed_profiles.append(
+                            api._rename_aio_profile(
+                                "Same",
+                                "Same",
+                                profile_id=legacy_id,
+                                revision=0,
+                            )
+                        )
                     except BaseException as exc:
                         errors.append(exc)
 
@@ -405,6 +458,8 @@ class AIOProfileStorageTests(unittest.TestCase):
                                 "Same",
                                 {"settings": {"value": "replacement"}},
                                 overwrite=True,
+                                profile_id=legacy_id,
+                                revision=0,
                             )
                         )
                     except BaseException as exc:
@@ -419,10 +474,10 @@ class AIOProfileStorageTests(unittest.TestCase):
                     overwriter = threading.Thread(target=overwrite_profile)
                     renamer.start()
                     self.assertTrue(transform_ready.wait(2))
-                    path_lock = profile_storage._path_lock(profile_path)
-                    lock_was_available = path_lock.acquire(blocking=False)
+                    directory_lock = api.PROFILE_MUTATION_COORDINATOR._lock(root)
+                    lock_was_available = directory_lock.acquire(blocking=False)
                     if lock_was_available:
-                        path_lock.release()
+                        directory_lock.release()
                     overwriter.start()
                     self.assertTrue(overwrite_started.wait(2))
                     release_transform.set()
@@ -468,7 +523,10 @@ class AIOProfileStorageTests(unittest.TestCase):
                     encoding="utf-8",
                 )
                 source_profile_id = api.legacy_profile_id(api.PROFILE_KIND_AIO, "Source")
-                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+                target_profile = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "target"}},
+                )
                 target_bytes = target.read_bytes()
 
                 def block_after_source_move(current, destination):
@@ -489,7 +547,14 @@ class AIOProfileStorageTests(unittest.TestCase):
                 def rename_profile():
                     try:
                         renamed_profiles.append(
-                            api._rename_aio_profile("Source", "Target", overwrite=True)
+                            api._rename_aio_profile(
+                                "Source",
+                                "Target",
+                                overwrite=True,
+                                profile_id=source_profile_id,
+                                revision=0,
+                                **profile_tokens(target_profile, prefix="target_"),
+                            )
                         )
                     except BaseException as exc:
                         errors.append(exc)
@@ -576,7 +641,10 @@ class AIOProfileStorageTests(unittest.TestCase):
                     "Source",
                     {"settings": {"value": "source"}},
                 )
-                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+                target_profile = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "target"}},
+                )
 
                 def block_after_profile_move(current, destination):
                     result = real_replace(current, destination)
@@ -595,14 +663,25 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 def rename_profile():
                     try:
-                        api._rename_aio_profile("Source", "Target", overwrite=True)
+                        api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            overwrite=True,
+                            **profile_tokens(source_profile),
+                            **profile_tokens(target_profile, prefix="target_"),
+                        )
                     except BaseException as exc:
                         errors.append(exc)
 
                 def delete_target():
                     delete_started.set()
                     try:
-                        deleted.append(api._delete_aio_profile("Target"))
+                        deleted.append(
+                            api._delete_aio_profile(
+                                "Target",
+                                **profile_tokens(source_profile),
+                            )
+                        )
                     except BaseException as exc:
                         errors.append(exc)
                     finally:
@@ -630,8 +709,9 @@ class AIOProfileStorageTests(unittest.TestCase):
                     self.assertFalse(delete_done.wait(0.05))
                     release_move.set()
                     self.assertTrue(transaction_done.wait(2))
-                    self.assertTrue(delete_done.wait(2))
+                    self.assertFalse(delete_done.wait(0.05))
                     release_api_return.set()
+                    self.assertTrue(delete_done.wait(2))
                     renamer.join(2)
                     deleter.join(2)
 
@@ -657,7 +737,7 @@ class AIOProfileStorageTests(unittest.TestCase):
             with self.subTest(original_name=original_name, colliding_name=colliding_name):
                 with tempfile.TemporaryDirectory() as tmp:
                     with patch.object(api, "AIO_PROFILE_DIR", Path(tmp)):
-                        api._save_aio_profile(
+                        created = api._save_aio_profile(
                             original_name,
                             {"settings": {"sampler": {"steps": 30}}},
                         )
@@ -678,6 +758,7 @@ class AIOProfileStorageTests(unittest.TestCase):
                             colliding_name,
                             {"settings": {"sampler": {"steps": 10}}},
                             overwrite=True,
+                            **profile_tokens(created),
                         )
                         self.assertEqual(overwritten["name"], filename)
                         self.assertEqual(overwritten["settings"]["sampler"]["steps"], 10)
@@ -689,6 +770,206 @@ class AIOProfileStorageTests(unittest.TestCase):
                             [path.name for path in Path(tmp).glob("*.json")],
                             [f"{filename}.json"],
                         )
+
+    def test_save_delete_and_rename_require_strict_source_preconditions(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                created = api._save_aio_profile("Strict", {"settings": {}})
+                operations = (
+                    lambda: api._save_aio_profile(
+                        "Strict",
+                        {"settings": {}},
+                        overwrite=True,
+                    ),
+                    lambda: api._delete_aio_profile("Strict"),
+                    lambda: api._rename_aio_profile("Strict", "Renamed"),
+                )
+
+                for operation in operations:
+                    with self.assertRaises(api.ProfileMutationError) as required:
+                        operation()
+                    self.assertEqual(
+                        required.exception.code,
+                        "profile_precondition_required",
+                    )
+
+                (root / "Strict.json").unlink()
+                with self.assertRaises(FileNotFoundError):
+                    api._save_aio_profile(
+                        "Strict",
+                        {"settings": {}},
+                        overwrite=True,
+                        **profile_tokens(created),
+                    )
+
+    def test_delete_and_rename_mismatches_preserve_bytes_backups_mtime_and_temps(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                source_v1 = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "source-v1"}},
+                )
+                source = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "source-v2"}},
+                    overwrite=True,
+                    **profile_tokens(source_v1),
+                )
+                target_v1 = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "target-v1"}},
+                )
+                target = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "target-v2"}},
+                    overwrite=True,
+                    **profile_tokens(target_v1),
+                )
+                wrong_id = "00000000-0000-4000-8000-000000000000"
+                cases = (
+                    (
+                        "delete identity",
+                        lambda: api._delete_aio_profile(
+                            "Source",
+                            profile_id=wrong_id,
+                            revision=source["revision"] - 1,
+                        ),
+                        "profile_identity_mismatch",
+                    ),
+                    (
+                        "delete revision",
+                        lambda: api._delete_aio_profile(
+                            "Source",
+                            profile_id=source["profile_id"],
+                            revision=source["revision"] - 1,
+                        ),
+                        "profile_revision_conflict",
+                    ),
+                    (
+                        "rename source identity",
+                        lambda: api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            overwrite=True,
+                            profile_id=wrong_id,
+                            revision=source["revision"] - 1,
+                            **profile_tokens(target, prefix="target_"),
+                        ),
+                        "profile_identity_mismatch",
+                    ),
+                    (
+                        "rename source revision",
+                        lambda: api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            overwrite=True,
+                            profile_id=source["profile_id"],
+                            revision=source["revision"] - 1,
+                            **profile_tokens(target, prefix="target_"),
+                        ),
+                        "profile_revision_conflict",
+                    ),
+                    (
+                        "rename target identity",
+                        lambda: api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            overwrite=True,
+                            **profile_tokens(source),
+                            target_profile_id=wrong_id,
+                            target_revision=target["revision"] - 1,
+                        ),
+                        "profile_identity_mismatch",
+                    ),
+                    (
+                        "rename target revision",
+                        lambda: api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            overwrite=True,
+                            **profile_tokens(source),
+                            target_profile_id=target["profile_id"],
+                            target_revision=target["revision"] - 1,
+                        ),
+                        "profile_revision_conflict",
+                    ),
+                )
+
+                for label, operation, code in cases:
+                    with self.subTest(label=label):
+                        before = directory_snapshot(root)
+                        with self.assertRaises(api.ProfileMutationError) as mismatch:
+                            operation()
+                        self.assertEqual(mismatch.exception.code, code)
+                        self.assertEqual(directory_snapshot(root), before)
+
+    def test_rename_target_rules_preserve_profile_exists_and_detect_disappearance(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                source = api._save_aio_profile("Source", {"settings": {}})
+                target = api._save_aio_profile("Target", {"settings": {}})
+
+                with self.assertRaises(FileExistsError):
+                    api._rename_aio_profile(
+                        "Source",
+                        "Target",
+                        **profile_tokens(source),
+                    )
+
+                with self.assertRaises(api.ProfileMutationError) as required:
+                    api._rename_aio_profile(
+                        "Source",
+                        "Target",
+                        overwrite=True,
+                        **profile_tokens(source),
+                    )
+                self.assertEqual(
+                    required.exception.code,
+                    "profile_precondition_required",
+                )
+
+                (root / "Target.json").unlink()
+                before = directory_snapshot(root)
+                with self.assertRaises(api.ProfileMutationError) as disappeared:
+                    api._rename_aio_profile(
+                        "Source",
+                        "Target",
+                        overwrite=True,
+                        **profile_tokens(source),
+                        **profile_tokens(target, prefix="target_"),
+                    )
+                self.assertEqual(
+                    disappeared.exception.code,
+                    "profile_revision_conflict",
+                )
+                self.assertEqual(disappeared.exception.details, {"profile": "target"})
+                self.assertEqual(directory_snapshot(root), before)
+
+    def test_same_name_v2_rename_verifies_source_without_unnecessary_write(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                source = api._save_aio_profile(
+                    "Same",
+                    {"settings": {"value": "stable"}},
+                )
+                before = directory_snapshot(root)
+
+                renamed = api._rename_aio_profile(
+                    "same. ",
+                    "SAME",
+                    **profile_tokens(source),
+                )
+
+                self.assertEqual(renamed, source)
+                self.assertEqual(directory_snapshot(root), before)
 
     def test_windows_reserved_profile_names_are_rejected(self):
         api = load_api_module()
@@ -746,7 +1027,11 @@ class AIOProfileStorageTests(unittest.TestCase):
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
                 with self.assertRaises(api.InvalidProfileDataError):
-                    api._delete_aio_profile("Incomplete")
+                    api._delete_aio_profile(
+                        "Incomplete",
+                        profile_id="00000000-0000-4000-8000-000000000000",
+                        revision=0,
+                    )
 
             self.assertEqual(profile.read_bytes(), before)
 
@@ -832,15 +1117,14 @@ class AIOProfileStorageTests(unittest.TestCase):
                     "Legacy",
                     {"settings": {"future_section": {"kept": "updated"}}},
                     overwrite=True,
-                    profile_id="00000000-0000-4000-8000-000000000000",
-                    revision=999,
+                    **profile_tokens(listed),
                 )
 
             self.assertEqual(promoted["profile_id"], listed["profile_id"])
             self.assertEqual(promoted["revision"], 1)
             self.assertEqual(json.loads(primary.read_text(encoding="utf-8")), promoted)
 
-    def test_v2_overwrite_preserves_id_and_advances_revision_without_strict_token(self):
+    def test_v2_overwrite_preserves_id_and_advances_matching_revision(self):
         api = load_api_module()
         with tempfile.TemporaryDirectory() as tmp:
             with patch.object(api, "AIO_PROFILE_DIR", Path(tmp)):
@@ -849,8 +1133,7 @@ class AIOProfileStorageTests(unittest.TestCase):
                     "Updated",
                     {"settings": {"value": 2}},
                     overwrite=True,
-                    profile_id="00000000-0000-4000-8000-000000000000",
-                    revision=0,
+                    **profile_tokens(created),
                 )
 
         self.assertEqual(updated["profile_id"], created["profile_id"])
@@ -862,11 +1145,15 @@ class AIOProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Recoverable", {"settings": {"value": "first"}})
+                first = api._save_aio_profile(
+                    "Recoverable",
+                    {"settings": {"value": "first"}},
+                )
                 api._save_aio_profile(
                     "Recoverable",
                     {"settings": {"value": "second"}},
                     overwrite=True,
+                    **profile_tokens(first),
                 )
                 (root / "Recoverable.json").write_text("{", encoding="utf-8")
 
@@ -887,7 +1174,10 @@ class AIOProfileStorageTests(unittest.TestCase):
             real_replace = profile_storage.os.replace
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Concurrent", {"settings": {"value": "old"}})
+                original = api._save_aio_profile(
+                    "Concurrent",
+                    {"settings": {"value": "old"}},
+                )
 
                 def block_primary_publish(source, target):
                     if Path(target) == profile_path:
@@ -902,6 +1192,7 @@ class AIOProfileStorageTests(unittest.TestCase):
                             "Concurrent",
                             {"settings": {"value": "new", "items": list(range(1000))}},
                             overwrite=True,
+                            **profile_tokens(original),
                         )
                     except BaseException as exc:
                         errors.append(exc)
@@ -944,7 +1235,15 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 with patch.object(api, "AIO_PROFILE_DIR", root):
                     with self.assertRaisesRegex(api.InvalidProfileDataError, message):
-                        api._rename_aio_profile("Source", "Target")
+                        api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            profile_id=api.legacy_profile_id(
+                                api.PROFILE_KIND_AIO,
+                                "Source",
+                            ),
+                            revision=0,
+                        )
 
                 self.assertEqual(source.read_bytes(), source_bytes)
                 self.assertFalse(target.exists())
@@ -955,11 +1254,15 @@ class AIOProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Target", {"settings": {"value": "old target"}})
-                api._save_aio_profile(
+                first_target = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "old target"}},
+                )
+                target_profile = api._save_aio_profile(
                     "Target",
                     {"settings": {"value": "current target"}},
                     overwrite=True,
+                    **profile_tokens(first_target),
                 )
                 source = root / "Source.json"
                 target = root / "Target.json"
@@ -970,7 +1273,14 @@ class AIOProfileStorageTests(unittest.TestCase):
                 backup_bytes = backup.read_bytes()
 
                 with self.assertRaisesRegex(ValueError, "Profile settings must be an object"):
-                    api._rename_aio_profile("Source", "Target", overwrite=True)
+                    api._rename_aio_profile(
+                        "Source",
+                        "Target",
+                        overwrite=True,
+                        profile_id=api.legacy_profile_id(api.PROFILE_KIND_AIO, "Source"),
+                        revision=0,
+                        **profile_tokens(target_profile, prefix="target_"),
+                    )
 
                 self.assertEqual(source.read_bytes(), source_bytes)
                 self.assertEqual(target.read_bytes(), target_bytes)
@@ -985,10 +1295,22 @@ class AIOProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Source", {"settings": {"value": "source"}})
-                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+                source_profile = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "source"}},
+                )
+                target_profile = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "target"}},
+                )
 
-                renamed = api._rename_aio_profile("Source", "Target", overwrite=True)
+                renamed = api._rename_aio_profile(
+                    "Source",
+                    "Target",
+                    overwrite=True,
+                    **profile_tokens(source_profile),
+                    **profile_tokens(target_profile, prefix="target_"),
+                )
 
                 backup = json.loads((root / "Target.json.bak").read_text(encoding="utf-8"))
                 self.assertEqual(renamed["name"], "Target")
@@ -1019,8 +1341,8 @@ class AIOProfileStorageTests(unittest.TestCase):
                     "Source",
                     "Target",
                     overwrite=True,
-                    profile_id="00000000-0000-4000-8000-000000000000",
-                    revision=99,
+                    profile_id=source_id,
+                    revision=0,
                     target_profile_id=target["profile_id"],
                     target_revision=target["revision"],
                 )
@@ -1048,13 +1370,20 @@ class AIOProfileStorageTests(unittest.TestCase):
             real_replace = profile_storage.os.replace
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Source", {"settings": {"value": "old source"}})
-                api._save_aio_profile(
+                first_source = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "old source"}},
+                )
+                source_profile = api._save_aio_profile(
                     "Source",
                     {"settings": {"value": "source"}},
                     overwrite=True,
+                    **profile_tokens(first_source),
                 )
-                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+                target_profile = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "target"}},
+                )
                 source_backup_bytes = (root / "Source.json.bak").read_bytes()
 
                 def fail_move(current, destination):
@@ -1064,7 +1393,13 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 with patch.object(profile_storage.os, "replace", side_effect=fail_move):
                     with self.assertRaisesRegex(OSError, "rename move failed"):
-                        api._rename_aio_profile("Source", "Target", overwrite=True)
+                        api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            overwrite=True,
+                            **profile_tokens(source_profile),
+                            **profile_tokens(target_profile, prefix="target_"),
+                        )
 
                 self.assertEqual(api._load_aio_profile("Source")["settings"]["value"], "source")
                 self.assertEqual(api._load_aio_profile("Target")["settings"]["value"], "target")
@@ -1084,8 +1419,14 @@ class AIOProfileStorageTests(unittest.TestCase):
             real_replace = profile_storage.os.replace
 
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Source", {"settings": {"value": "source"}})
-                api._save_aio_profile("Target", {"settings": {"value": "target"}})
+                source_profile = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "source"}},
+                )
+                target_profile = api._save_aio_profile(
+                    "Target",
+                    {"settings": {"value": "target"}},
+                )
 
                 def fail_backup(current, destination):
                     if Path(destination) == backup_path:
@@ -1094,7 +1435,13 @@ class AIOProfileStorageTests(unittest.TestCase):
 
                 with patch.object(profile_storage.os, "replace", side_effect=fail_backup):
                     with self.assertRaisesRegex(OSError, "target backup failed"):
-                        api._rename_aio_profile("Source", "Target", overwrite=True)
+                        api._rename_aio_profile(
+                            "Source",
+                            "Target",
+                            overwrite=True,
+                            **profile_tokens(source_profile),
+                            **profile_tokens(target_profile, prefix="target_"),
+                        )
 
                 self.assertEqual(api._load_aio_profile("Source")["settings"]["value"], "source")
                 self.assertEqual(api._load_aio_profile("Target")["settings"]["value"], "target")
@@ -1105,10 +1452,17 @@ class AIOProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "AIO_PROFILE_DIR", root):
-                api._save_aio_profile("Source", {"settings": {"value": "source"}})
+                source_profile = api._save_aio_profile(
+                    "Source",
+                    {"settings": {"value": "source"}},
+                )
 
                 with patch.object(Path, "unlink", side_effect=OSError("unlink failed")):
-                    renamed = api._rename_aio_profile("Source", "Renamed")
+                    renamed = api._rename_aio_profile(
+                        "Source",
+                        "Renamed",
+                        **profile_tokens(source_profile),
+                    )
 
                 self.assertEqual(renamed["name"], "Renamed")
                 self.assertFalse((root / "Source.json").exists())
@@ -1322,6 +1676,130 @@ class AIOProfileApiRouteTests(unittest.TestCase):
                 "message": "Profile not found",
             },
         )
+
+    def test_actual_routes_enforce_source_and_target_cas_taxonomy(self):
+        api, routes = load_api_routes()
+        save_handler = routes.handlers["/easyuse_anima/aio_profiles/save"]
+        delete_handler = routes.handlers["/easyuse_anima/aio_profiles/delete"]
+        rename_handler = routes.handlers["/easyuse_anima/aio_profiles/rename"]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "AIO_PROFILE_DIR", root):
+                source = asyncio.run(
+                    save_handler(JsonRequest({"name": "Source", "settings": {}}))
+                )["payload"]["profile"]
+                target = asyncio.run(
+                    save_handler(JsonRequest({"name": "Target", "settings": {}}))
+                )["payload"]["profile"]
+
+                for handler, payload in (
+                    (
+                        save_handler,
+                        {"name": "Source", "settings": {}, "overwrite": True},
+                    ),
+                    (delete_handler, {"name": "Source"}),
+                    (
+                        rename_handler,
+                        {"old_name": "Source", "new_name": "Renamed"},
+                    ),
+                ):
+                    with self.subTest(payload=payload):
+                        response = asyncio.run(handler(JsonRequest(payload)))
+                        self.assertEqual(response["status"], 428)
+                        self.assertEqual(
+                            response["payload"]["code"],
+                            "profile_precondition_required",
+                        )
+
+                exists = asyncio.run(
+                    rename_handler(
+                        JsonRequest(
+                            {
+                                "old_name": "Source",
+                                "new_name": "Target",
+                                **profile_tokens(source),
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(exists["status"], 409)
+                self.assertEqual(exists["payload"]["code"], "profile_exists")
+
+                target_required = asyncio.run(
+                    rename_handler(
+                        JsonRequest(
+                            {
+                                "old_name": "Source",
+                                "new_name": "Target",
+                                "overwrite": True,
+                                **profile_tokens(source),
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(target_required["status"], 428)
+                self.assertEqual(
+                    target_required["payload"]["code"],
+                    "profile_precondition_required",
+                )
+                self.assertEqual(
+                    target_required["payload"]["details"]["profile"],
+                    "target",
+                )
+
+                (root / "Target.json").unlink()
+                disappeared = asyncio.run(
+                    rename_handler(
+                        JsonRequest(
+                            {
+                                "old_name": "Source",
+                                "new_name": "Target",
+                                "overwrite": True,
+                                **profile_tokens(source),
+                                **profile_tokens(target, prefix="target_"),
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(disappeared["status"], 409)
+                self.assertEqual(
+                    disappeared["payload"]["code"],
+                    "profile_revision_conflict",
+                )
+
+                identity = asyncio.run(
+                    delete_handler(
+                        JsonRequest(
+                            {
+                                "name": "Source",
+                                "profile_id": "00000000-0000-4000-8000-000000000000",
+                                "revision": source["revision"] - 1,
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(identity["status"], 409)
+                self.assertEqual(
+                    identity["payload"]["code"],
+                    "profile_identity_mismatch",
+                )
+
+                revision = asyncio.run(
+                    delete_handler(
+                        JsonRequest(
+                            {
+                                "name": "Source",
+                                "profile_id": source["profile_id"],
+                                "revision": source["revision"] - 1,
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(revision["status"], 409)
+                self.assertEqual(
+                    revision["payload"]["code"],
+                    "profile_revision_conflict",
+                )
 
 
 class AIOBuiltinProfileTests(unittest.TestCase):

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -480,6 +480,43 @@ class ApiRequestContractTests(unittest.TestCase):
                 self.assertNotIn("private", serialized)
                 self.assertNotIn("/home/", serialized)
 
+    def test_profile_cas_errors_keep_request_correlation_and_safe_details(self):
+        api, routes = load_api_routes()
+        cases = (
+            (428, "profile_precondition_required", "Profile precondition is required"),
+            (409, "profile_identity_mismatch", "Profile identity does not match"),
+            (409, "profile_revision_conflict", "Profile revision does not match"),
+        )
+
+        for status, code, message in cases:
+            with self.subTest(code=code), patch.object(
+                api,
+                "_save_aio_profile",
+                side_effect=api.ProfileMutationError(
+                    status=status,
+                    code=code,
+                    message=message,
+                    details={"profile": "source"},
+                ),
+            ):
+                response = asyncio.run(
+                    routes.handlers["/easyuse_anima/aio_profiles/save"](
+                        JsonRequest({"name": "Saved", "settings": {}})
+                    )
+                )
+
+            self.assertEqual(response.status, status)
+            self.assertEqual(response["payload"]["code"], code)
+            self.assertEqual(response["payload"]["details"], {"profile": "source"})
+            self.assertEqual(
+                response["payload"]["request_id"],
+                response.headers["X-Request-ID"],
+            )
+            serialized = json.dumps(response["payload"])
+            self.assertNotIn("C:\\", serialized)
+            self.assertNotIn("/home/", serialized)
+            self.assertNotIn("secret", serialized)
+
     def test_invalid_profile_json_files_have_stable_422_code(self):
         api, routes = load_api_routes()
         cases = (
@@ -660,7 +697,15 @@ class ApiRequestContractTests(unittest.TestCase):
                     response = asyncio.run(
                         handler(
                             JsonRequest(
-                                {"old_name": "Source", "new_name": "Target"}
+                                {
+                                    "old_name": "Source",
+                                    "new_name": "Target",
+                                    "profile_id": api.legacy_profile_id(
+                                        api.PROFILE_KIND_AIO,
+                                        "Source",
+                                    ),
+                                    "revision": 0,
+                                }
                             )
                         )
                     )

--- a/tests/test_lora_profiles.py
+++ b/tests/test_lora_profiles.py
@@ -3,6 +3,7 @@ import importlib.util
 import json
 import sys
 import tempfile
+import threading
 import types
 import unittest
 import uuid
@@ -11,6 +12,13 @@ from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def profile_tokens(profile: dict) -> dict:
+    return {
+        "profile_id": profile["profile_id"],
+        "revision": profile["revision"],
+    }
 
 
 def load_api_module():
@@ -125,7 +133,7 @@ class LoraProfileStorageTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with patch.object(api, "LORA_PROFILE_DIR", root):
-                api._save_lora_profile(
+                first = api._save_lora_profile(
                     "Recoverable",
                     {"profile_data": {"1": {"style_prompt": "first"}}},
                 )
@@ -133,6 +141,7 @@ class LoraProfileStorageTests(unittest.TestCase):
                     "Recoverable",
                     {"profile_data": {"1": {"style_prompt": "second"}}},
                     overwrite=True,
+                    **profile_tokens(first),
                 )
                 (root / "Recoverable.json").write_text("{", encoding="utf-8")
 
@@ -218,8 +227,7 @@ class LoraProfileStorageTests(unittest.TestCase):
                     "Legacy",
                     {"profile_data": {"1": {"style_prompt": "updated"}}},
                     overwrite=True,
-                    profile_id="00000000-0000-4000-8000-000000000000",
-                    revision=999,
+                    **profile_tokens(listed),
                 )
 
             stored = json.loads(primary.read_text(encoding="utf-8"))
@@ -227,7 +235,7 @@ class LoraProfileStorageTests(unittest.TestCase):
             self.assertEqual(promoted["revision"], 1)
             self.assertEqual(stored, promoted)
 
-    def test_v2_overwrite_preserves_id_and_advances_revision_without_strict_token(self):
+    def test_v2_overwrite_preserves_id_and_advances_matching_revision(self):
         api = load_api_module()
         with tempfile.TemporaryDirectory() as tmp:
             with patch.object(api, "LORA_PROFILE_DIR", Path(tmp)):
@@ -239,8 +247,7 @@ class LoraProfileStorageTests(unittest.TestCase):
                     "Updated",
                     {"profile_data": {"1": {"style_prompt": "second"}}},
                     overwrite=True,
-                    profile_id="00000000-0000-4000-8000-000000000000",
-                    revision=0,
+                    **profile_tokens(created),
                 )
 
         self.assertEqual(updated["profile_id"], created["profile_id"])
@@ -260,7 +267,7 @@ class LoraProfileStorageTests(unittest.TestCase):
             with self.subTest(original_name=original_name, colliding_name=colliding_name):
                 with tempfile.TemporaryDirectory() as tmp:
                     with patch.object(api, "LORA_PROFILE_DIR", Path(tmp)):
-                        api._save_lora_profile(
+                        created = api._save_lora_profile(
                             original_name,
                             {"profile_data": {"1": {"style_prompt": "first"}}},
                         )
@@ -281,6 +288,7 @@ class LoraProfileStorageTests(unittest.TestCase):
                             colliding_name,
                             {"profile_data": {"1": {"style_prompt": "second"}}},
                             overwrite=True,
+                            **profile_tokens(created),
                         )
                         self.assertEqual(overwritten["name"], filename)
                         self.assertEqual(
@@ -291,6 +299,119 @@ class LoraProfileStorageTests(unittest.TestCase):
                             [path.name for path in Path(tmp).glob("*.json")],
                             [f"{filename}.json"],
                         )
+
+    def test_overwrite_requires_matching_tokens_and_does_not_recreate_missing_profile(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                created = api._save_lora_profile("Strict", {"profile_data": {}})
+
+                with self.assertRaises(api.ProfileMutationError) as missing_tokens:
+                    api._save_lora_profile(
+                        "Strict",
+                        {"profile_data": {}},
+                        overwrite=True,
+                    )
+                self.assertEqual(
+                    missing_tokens.exception.code,
+                    "profile_precondition_required",
+                )
+
+                (root / "Strict.json").unlink()
+                with self.assertRaises(FileNotFoundError):
+                    api._save_lora_profile(
+                        "Strict",
+                        {"profile_data": {}},
+                        overwrite=True,
+                        **profile_tokens(created),
+                    )
+                self.assertFalse((root / "Strict.json").exists())
+
+    def test_identity_and_revision_mismatch_leave_all_storage_artifacts_unchanged(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                first = api._save_lora_profile("Stable", {"profile_data": {}})
+                current = api._save_lora_profile(
+                    "Stable",
+                    {"profile_data": {"1": {"style_prompt": "current"}}},
+                    overwrite=True,
+                    **profile_tokens(first),
+                )
+                primary = root / "Stable.json"
+                backup = root / "Stable.json.bak"
+
+                for field, value, code in (
+                    ("profile_id", "00000000-0000-4000-8000-000000000000", "profile_identity_mismatch"),
+                    ("revision", current["revision"] - 1, "profile_revision_conflict"),
+                ):
+                    before = {
+                        path.name: (path.read_bytes(), path.stat().st_mtime_ns)
+                        for path in (primary, backup)
+                    }
+                    temps_before = {path.name for path in root.glob("*.tmp")}
+                    tokens = profile_tokens(current)
+                    tokens[field] = value
+
+                    with self.assertRaises(api.ProfileMutationError) as mismatch:
+                        api._save_lora_profile(
+                            "stable. ",
+                            {"profile_data": {"1": {"style_prompt": "rejected"}}},
+                            overwrite=True,
+                            **tokens,
+                        )
+
+                    self.assertEqual(mismatch.exception.code, code)
+                    self.assertEqual(
+                        {
+                            path.name: (path.read_bytes(), path.stat().st_mtime_ns)
+                            for path in (primary, backup)
+                        },
+                        before,
+                    )
+                    self.assertEqual({path.name for path in root.glob("*.tmp")}, temps_before)
+
+    def test_same_revision_concurrent_overwrite_allows_exactly_one_success(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                created = api._save_lora_profile("Concurrent", {"profile_data": {}})
+                barrier = threading.Barrier(3)
+                successes = []
+                failures = []
+
+                def overwrite(value):
+                    barrier.wait()
+                    try:
+                        successes.append(
+                            api._save_lora_profile(
+                                "Concurrent",
+                                {"profile_data": {"1": {"style_prompt": value}}},
+                                overwrite=True,
+                                **profile_tokens(created),
+                            )
+                        )
+                    except BaseException as exc:
+                        failures.append(exc)
+
+                workers = [
+                    threading.Thread(target=overwrite, args=(value,))
+                    for value in ("one", "two")
+                ]
+                for worker in workers:
+                    worker.start()
+                barrier.wait()
+                for worker in workers:
+                    worker.join(2)
+
+                self.assertTrue(all(not worker.is_alive() for worker in workers))
+                self.assertEqual(len(successes), 1)
+                self.assertEqual(successes[0]["revision"], 2)
+                self.assertEqual(len(failures), 1)
+                self.assertEqual(failures[0].code, "profile_revision_conflict")
 
     def test_windows_reserved_profile_names_are_rejected(self):
         api = load_api_module()
@@ -576,6 +697,79 @@ class LoraProfileApiRouteTests(unittest.TestCase):
                 "message": "Profile already exists",
             },
         )
+
+    def test_overwrite_route_exposes_strict_428_409_and_404_taxonomy(self):
+        api, routes = load_api_routes()
+        handler = routes.handlers[self.PATH]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(api, "LORA_PROFILE_DIR", root):
+                created_response = asyncio.run(handler(JsonRequest(self.BASE_PAYLOAD)))
+                created = created_response["payload"]["profile"]
+
+                missing = asyncio.run(
+                    handler(JsonRequest({**self.BASE_PAYLOAD, "overwrite": True}))
+                )
+                self.assertEqual(missing["status"], 428)
+                self.assertEqual(
+                    missing["payload"]["code"],
+                    "profile_precondition_required",
+                )
+
+                identity = asyncio.run(
+                    handler(
+                        JsonRequest(
+                            {
+                                **self.BASE_PAYLOAD,
+                                "overwrite": True,
+                                "profile_id": "00000000-0000-4000-8000-000000000000",
+                                "revision": created["revision"] - 1,
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(identity["status"], 409)
+                self.assertEqual(
+                    identity["payload"]["code"],
+                    "profile_identity_mismatch",
+                )
+
+                revision = asyncio.run(
+                    handler(
+                        JsonRequest(
+                            {
+                                **self.BASE_PAYLOAD,
+                                "overwrite": True,
+                                "profile_id": created["profile_id"],
+                                "revision": created["revision"] - 1,
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(revision["status"], 409)
+                self.assertEqual(
+                    revision["payload"]["code"],
+                    "profile_revision_conflict",
+                )
+
+                (root / "Saved.json").unlink()
+                missing_profile = asyncio.run(
+                    handler(
+                        JsonRequest(
+                            {
+                                **self.BASE_PAYLOAD,
+                                "overwrite": True,
+                                **profile_tokens(created),
+                            }
+                        )
+                    )
+                )
+                self.assertEqual(missing_profile["status"], 404)
+                self.assertEqual(
+                    missing_profile["payload"]["code"],
+                    "profile_not_found",
+                )
+                self.assertFalse((root / "Saved.json").exists())
 
 
 class AutocompleteApiRouteTests(unittest.TestCase):

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 41)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 41)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 39)
+        self.assertEqual(report["inventory"]["module_count"], 42)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 42)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 40)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
@@ -719,6 +719,7 @@ ignored/
                 "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
+                "easyuse_anima/profiles/mutation.py",
                 "easyuse_anima/prompt/__init__.py",
             }.issubset(report["registry"]["shipped_python_modules"])
         )
@@ -742,6 +743,7 @@ ignored/
                 "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
+                "easyuse_anima/profiles/mutation.py",
             }.issubset(report["registry"]["runtime_import_closure"])
         )
         self.assertIn(
@@ -768,6 +770,10 @@ ignored/
             {"from": "api.py", "to": "easyuse_anima/profiles/contract.py"},
             report["imports"]["module_graph"],
         )
+        self.assertIn(
+            {"from": "api.py", "to": "easyuse_anima/profiles/mutation.py"},
+            report["imports"]["module_graph"],
+        )
         self.assertNotIn(
             "tests/test_python_backend_analyzer.py",
             report["registry"]["shipped_python_modules"],
@@ -784,6 +790,7 @@ ignored/
             {
                 ("api.py", "storage.py"),
                 ("api.py", "easyuse_anima/profiles/contract.py"),
+                ("api.py", "easyuse_anima/profiles/mutation.py"),
                 ("nodes.py", "prompt_translation.py"),
                 ("nodes.py", "settings.py"),
                 ("nodes.py", "wildcard_engine.py"),

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -25,6 +25,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.nodes",
     "easyuse_anima.profiles",
     "easyuse_anima.profiles.contract",
+    "easyuse_anima.profiles.mutation",
     "easyuse_anima.prompt",
 )
 

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -39,6 +39,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/nodes/wildcard_nodes.py",
     "easyuse_anima/profiles/__init__.py",
     "easyuse_anima/profiles/contract.py",
+    "easyuse_anima/profiles/mutation.py",
     "easyuse_anima/prompt/__init__.py",
 }
 STATIC_IMPORT_FROM_RE = re.compile(


### PR DESCRIPTION
## 변경 요약

- LoRA/AiO overwrite 저장에 `profile_id`와 `revision` strict precondition을 적용했습니다.
- AiO delete와 rename source에 strict precondition을 적용하고, overwrite rename target의 identity/revision도 검증합니다.
- 누락 precondition은 428 `profile_precondition_required`, identity 불일치는 409 `profile_identity_mismatch`, revision 불일치는 409 `profile_revision_conflict`로 구분합니다.
- profile directory 단위 process-local mutation coordinator 아래에서 이름 해석, current read, source/target 검증, mutation을 직렬화합니다.
- legacy revision 0 token의 첫 overwrite 승격, same-name rename no-op, overwrite target identity 폐기 등 기존 profile envelope 계약을 유지합니다.
- 새 profile mutation 모듈을 repository Python backend analyzer baseline, Registry package surface, 직접 import 안전성 검사에 반영했습니다.

## 원인 및 영향

기존 Part 3A/3B에서는 concurrency token을 API가 파싱하고 frontend가 전달했지만 backend mutation이 이를 검증하지 않았습니다. 같은 revision의 동시 mutation이 순차적으로 모두 성공하거나, stale overwrite가 삭제된 profile을 재생성할 수 있었습니다. 이번 변경은 mutation 직전 current document를 다시 읽고 identity를 revision보다 먼저 검증하여 stale mutation을 차단합니다.

## 주요 파일

- `api.py`: LoRA/AiO save, AiO delete/rename strict CAS 및 public error mapping
- `easyuse_anima/profiles/mutation.py`: directory mutation coordinator와 CAS domain errors/precondition 검증
- `tests/test_lora_profiles.py`
- `tests/test_aio_profiles.py`
- `tests/test_api_contract.py`
- `tests/fixtures/python_backend_baseline.json`: 공식 generator로 현재 backend inventory 재생성
- `tests/test_python_backend_analyzer.py`: mutation module count/closure/import edge 기대값
- `tests/test_registry_scanner_safety.py`, `tests/test_python_package_skeleton.py`: Registry/package import 안전성

## 검증

Focused/quick:

- `python -m unittest discover -s tests -p test_lora_profiles.py`: 25 tests OK
- `python -m unittest discover -s tests -p test_aio_profiles.py`: 41 tests OK
- `python -m unittest discover -s tests -p test_api_contract.py`: 32 tests OK
- `python -m unittest discover -s tests -p test_profile_contract.py`: 8 tests OK
- `python -m unittest discover -s tests -p test_python_backend_analyzer.py`: 18 tests OK
- `python -m unittest discover -s tests -p test_registry_scanner_safety.py`: 8 tests OK
- `python -m unittest discover -s tests -p test_python_import_boundaries.py`: 9 tests OK
- `python -m unittest discover -s tests -p test_python_package_skeleton.py`: 1 test OK
- `tools/check_project.ps1 -Profile quick`: passed
- 별도 `git diff --check`: passed

메인 세션 공식 full, exact HEAD `c41c4cd50ec7655a884c0e4633e564ea45b59d28`:

- `powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project D:\ComfyUI\custom_nodes_workplace\worktrees\ComfyUI-EasyUseAnima\codex\issue-163-part3c-strict-cas -Profile full`
- Python `unittest discover`: 671 tests OK
- frontend semantic/syntax smoke: 111 JavaScript files
- TypeScript: 6.0.3
- Python compile 및 git diff check: passed

Live ComfyUI 0.27.0 Codex test instance:

- node pack 전체 mirror sync 후 신규 서버에서 대상 custom node 정상 import
- `/system_stats`: OK
- AiO save CAS: create 200/rev1, token 누락 428, identity mismatch 409, update 200/rev2, stale revision 409, delete 200, 삭제 후 stale overwrite 404/no recreate
- AiO overwrite rename CAS: target token 누락 428, source+target token 일치 시 200, current token delete 200
- 고유 테스트 프로필은 각 스모크 후 목록에서 0건임을 확인
- 브라우저: 실제 profile list/load/apply 경로에서 사용자 프로필이 표시되고 sampler step이 `1 → 17`로 적용됨
- 브라우저 EasyUseAnima error log: 0건

Analyzer actual inventory: module `41→42`, Registry shipped `41→42`, runtime import closure `39→40`; 추가는 모두 `easyuse_anima/profiles/mutation.py` 1개이며 제거는 없습니다.

## 남은 위험

- coordinator는 설계 범위대로 단일 process 안에서만 직렬화하며 cross-process CAS는 제공하지 않습니다.
- production frontend 파일은 변경하지 않았으므로 별도 Legacy canvas/Node 2.0 상호작용 매트릭스는 재실행하지 않았습니다.
- 사용자 인스턴스에는 반영하지 않았습니다.

Related to #163.
