### PR TITLE
refactor: AiO·LoRA 전역 host hook registry 통합

### DIFF
--- a/tests/frontend_aio_extension_runtime_smoke.mjs
+++ b/tests/frontend_aio_extension_runtime_smoke.mjs
@@ -1,12 +1,19 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-function dataModule(relativePath) {
-  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [from, to] of Object.entries(replacements)) {
+    source = source.replaceAll(from, to);
+  }
   return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
 }
 
-const extensionModule = await import(dataModule("../web/js/aio/extension_runtime.js"));
+const registryModuleUrl = dataModule("../web/js/lifecycle/host_hook_registry.js");
+const extensionModule = await import(dataModule(
+  "../web/js/aio/extension_runtime.js",
+  { "../lifecycle/host_hook_registry.js": registryModuleUrl },
+));
 assert.deepEqual(
   Object.keys(extensionModule),
   ["aioCreateExtensionRuntime", "aioListAttachedGeneratorNodes"],
@@ -22,6 +29,7 @@ function createFixture(options = {}) {
   const eventRegistrations = [];
   let samplerSetupFailures = Number(options.samplerSetupFailures || 0);
   let userSetupFailures = Number(options.userSetupFailures || 0);
+  let queueHookActive = false;
   const callbacks = {
     refreshPanels() {
       trace.push("refreshPanels");
@@ -73,6 +81,15 @@ function createFixture(options = {}) {
       },
       installQueuePromptHook() {
         trace.push("installQueuePromptHook");
+        queueHookActive = true;
+        return () => {
+          if (!queueHookActive) {
+            return false;
+          }
+          queueHookActive = false;
+          trace.push("disposeQueuePromptHook");
+          return true;
+        };
       },
       watchLocale(callback) {
         trace.push("watchLocale");
@@ -432,13 +449,24 @@ function createNodeType(trace, options = {}) {
   const ownerFixture = createFixture();
   await ownerFixture.runtime.setup();
   await Promise.resolve();
+  const ownerTraceBeforeReentry = [...ownerFixture.trace];
   const reentryFixture = createFixture({ api: ownerFixture.api });
   assert.equal(await reentryFixture.runtime.setup(), undefined);
   await Promise.resolve();
   assert.deepEqual(
     reentryFixture.trace,
-    [],
-    "a new runtime sharing the installed API owner must not repeat setup",
+    ["installQueuePromptHook"],
+    "a new runtime sharing the installed API host must claim only the global queue lease",
+  );
+  assert.deepEqual(
+    ownerFixture.trace,
+    [...ownerTraceBeforeReentry, "disposeQueuePromptHook"],
+    "runtime takeover must release the previous global queue lease without repeating setup",
+  );
+  assert.equal(reentryFixture.runtime.dispose(), true);
+  assert.deepEqual(
+    reentryFixture.trace,
+    ["installQueuePromptHook", "disposeQueuePromptHook"],
   );
 }
 
@@ -482,7 +510,6 @@ function createNodeType(trace, options = {}) {
   for (const completedStep of [
     "ensureStyle",
     "installWheelForwarder",
-    "installQueuePromptHook",
     "watchLocale",
   ]) {
     assert.equal(
@@ -491,6 +518,16 @@ function createNodeType(trace, options = {}) {
       `${completedStep} must remain owned by factory A after the later failure`,
     );
   }
+  assert.equal(
+    combinedTrace.filter((item) => item === "installQueuePromptHook").length,
+    2,
+    "the retrying runtime must take over the global queue lease without repeating setup steps",
+  );
+  assert.equal(
+    factoryA.trace.filter((item) => item === "disposeQueuePromptHook").length,
+    1,
+    "global queue takeover must release the failed runtime's lease",
+  );
   assert.equal(
     factoryA.eventRegistrations.length,
     8,
@@ -512,9 +549,11 @@ function createNodeType(trace, options = {}) {
   await Promise.resolve();
   assert.deepEqual(
     factoryC.trace,
-    [],
-    "the successful retry must publish durable setup ownership",
+    ["installQueuePromptHook"],
+    "a later runtime must claim only the durable global queue lease",
   );
+  assert.equal(factoryB.trace.at(-1), "disposeQueuePromptHook");
+  assert.equal(factoryC.runtime.dispose(), true);
 }
 
 {

--- a/tests/frontend_aio_generator_queue_runtime_smoke.mjs
+++ b/tests/frontend_aio_generator_queue_runtime_smoke.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-function dataModule(relativePath) {
-  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [from, to] of Object.entries(replacements)) {
+    source = source.replaceAll(from, to);
+  }
   return "data:text/javascript;base64," + Buffer.from(source).toString("base64");
 }
 
@@ -20,7 +23,11 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
-const queueModule = await import(dataModule("../web/js/aio/generator_queue_runtime.js"));
+const registryModuleUrl = dataModule("../web/js/lifecycle/host_hook_registry.js");
+const queueModule = await import(dataModule(
+  "../web/js/aio/generator_queue_runtime.js",
+  { "../lifecycle/host_hook_registry.js": registryModuleUrl },
+));
 assert.deepEqual(
   Object.keys(queueModule),
   ["aioCreateGeneratorQueueRuntime", "aioInstallGeneratorQueuePromptHook"],
@@ -216,6 +223,7 @@ function createFixture(options = {}) {
         if (options.loadError) {
           throw options.loadError;
         }
+        await options.loadOptionalDependencies?.(loadOptions);
       },
     },
     randomSeed() {
@@ -400,6 +408,65 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
 }
 
 {
+  const dependencyGate = deferred();
+  let originalCalls = 0;
+  const fixture = createFixture({
+    seed: 12,
+    seedControl: "increment",
+    loadOptionalDependencies: () => dependencyGate.promise,
+  });
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => {
+    originalCalls += 1;
+    return { prompt_id: "after-dependencies", node_errors: {} };
+  });
+  const pending = wrapped(0, createPrompt());
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(originalCalls, 0, "the original queue must wait for optional dependency loading");
+  assert.deepEqual(fixture.trace, ["load:true"]);
+  dependencyGate.resolve();
+  assert.equal((await pending).prompt_id, "after-dependencies");
+  assert.equal(originalCalls, 1);
+  assert.deepEqual(fixture.trace, ["load:true", "sanitize", "commit:13:12:false"]);
+}
+
+{
+  const loadError = new Error("dependency load failed");
+  let originalCalls = 0;
+  const fixture = createFixture({ loadError });
+  const wrapped = fixture.runtime.wrapQueuePrompt(() => {
+    originalCalls += 1;
+    return { prompt_id: "unreachable", node_errors: {} };
+  });
+  await assert.rejects(wrapped(0, createPrompt()), (error) => error === loadError);
+  assert.equal(originalCalls, 0);
+  assert.deepEqual(fixture.trace, ["load:true"]);
+}
+
+{
+  const queueError = new Error("original queue threw");
+  const queuedSeeds = [];
+  const fixture = createFixture({ seed: 15, seedControl: "increment" });
+  const failing = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queuedSeeds.push(JSON.parse(
+      prompt.output["42"].inputs.generation_settings,
+    ).sampler.seed);
+    throw queueError;
+  });
+  await assert.rejects(failing(0, createPrompt()), (error) => error === queueError);
+  assert.equal(fixture.node.settings.sampler.seed, 15);
+  assert.equal(fixture.node.lastSeed, undefined);
+  const retry = fixture.runtime.wrapQueuePrompt((_number, prompt) => {
+    queuedSeeds.push(JSON.parse(
+      prompt.output["42"].inputs.generation_settings,
+    ).sampler.seed);
+    return { prompt_id: "retry-after-throw", node_errors: {} };
+  });
+  await retry(0, createPrompt());
+  assert.deepEqual(queuedSeeds, [15, 15], "a synchronous throw must reject its reservation");
+}
+
+{
   const fixture = createFixture({ seed: 7, seedControl: "increment" });
   assert.ok(fixture.runtime.preparePrompt(createPrompt()));
   let queuedSeed = null;
@@ -434,8 +501,7 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
     wrapped.call(owner, 0, prompt, options, tail),
     wrapped.call(owner, 0, prompt, options, tail),
   ];
-  await Promise.resolve();
-  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
 
   assert.equal(calls.length, 3, "direct API submissions must remain concurrent");
   assert.deepEqual(
@@ -513,8 +579,7 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
     wrapped(0, createPrompt()),
     wrapped(0, createPrompt()),
   ];
-  await Promise.resolve();
-  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
 
   gates[1].resolve({ prompt_id: "", node_errors: {} });
   await pending[1];
@@ -529,8 +594,7 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
   assert.equal(caught, rejection);
 
   const retry = wrapped(0, createPrompt());
-  await Promise.resolve();
-  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(
     queuedSeeds,
     [7, 8, 9, 8],
@@ -547,36 +611,34 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
 
 {
   const fixture = createFixture({ seed: 10, seedControl: "increment" });
+  const original = function () {
+    this.calls += 1;
+    return { prompt_id: "installed", node_errors: {} };
+  };
   const host = {
     calls: 0,
-    queuePrompt() {
-      this.calls += 1;
-      return { prompt_id: "installed", node_errors: {} };
-    },
+    queuePrompt: original,
   };
-  assert.equal(
-    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime),
-    true,
-  );
+  const dispose = queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime);
   const installed = host.queuePrompt;
   assert.equal(
-    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime),
+    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime)(),
     false,
   );
-  assert.equal(host.queuePrompt, installed, "repeated setup must not stack AiO wrappers");
+  assert.equal(host.queuePrompt, installed, "duplicate registration must not stack AiO callbacks");
 
   host.queuePrompt = async function (...args) {
     return installed.apply(this, args);
   };
   const foreignWrapper = host.queuePrompt;
   assert.equal(
-    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime),
+    queueModule.aioInstallGeneratorQueuePromptHook(host, fixture.runtime)(),
     false,
   );
   assert.equal(
     host.queuePrompt,
     foreignWrapper,
-    "the queue-owner marker must survive foreign outer wrapper composition",
+    "registry ownership must stay idempotent below a foreign outer wrapper",
   );
   const result = await host.queuePrompt(0, createPrompt(), "tail");
   assert.equal(result.prompt_id, "installed");
@@ -584,6 +646,27 @@ for (const seed of [SPECIAL_RANDOM, SPECIAL_INCREMENT, SPECIAL_DECREMENT]) {
   assert.deepEqual(fixture.trace, ["load:true", "sanitize", "commit:11:10:false"]);
   assert.equal(fixture.node.lastSeed, 10);
   assert.equal(fixture.node.settings.sampler.seed, 11);
+
+  fixture.trace.length = 0;
+  assert.equal(dispose(), true);
+  assert.equal(host.queuePrompt, foreignWrapper, "dispose must preserve a foreign outer wrapper");
+  assert.equal((await host.queuePrompt(0, createPrompt())).prompt_id, "installed");
+  assert.deepEqual(fixture.trace, [], "disposed AiO callbacks must not remain stale");
+
+  host.queuePrompt = installed;
+  const disposeReinstalled = queueModule.aioInstallGeneratorQueuePromptHook(
+    host,
+    fixture.runtime,
+  );
+  assert.equal(host.queuePrompt, installed, "reinstall must reuse the current stale registry wrapper");
+  await host.queuePrompt(0, createPrompt());
+  assert.equal(
+    fixture.trace.filter((item) => item === "load:true").length,
+    1,
+    "reinstall must execute the AiO callback exactly once",
+  );
+  assert.equal(disposeReinstalled(), true);
+  assert.equal(host.queuePrompt, original);
 }
 
 {

--- a/tests/frontend_host_hook_registry_smoke.mjs
+++ b/tests/frontend_host_hook_registry_smoke.mjs
@@ -1,19 +1,28 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-function dataModule(relativePath) {
-  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+function dataModule(relativePath, replacements = {}) {
+  let source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  for (const [from, to] of Object.entries(replacements)) {
+    source = source.replaceAll(from, to);
+  }
   return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
 }
 
-const registry = await import(dataModule(
+const registryModuleUrl = dataModule(
   "../web/js/lifecycle/host_hook_registry.js",
-));
+);
+const registry = await import(registryModuleUrl);
+const registryImportReplacement = {
+  "../lifecycle/host_hook_registry.js": registryModuleUrl,
+};
 const loraSaveSync = await import(dataModule(
   "../web/js/lora_preset/save_sync.js",
+  registryImportReplacement,
 ));
 const aioQueueRuntime = await import(dataModule(
   "../web/js/aio/generator_queue_runtime.js",
+  registryImportReplacement,
 ));
 
 assert.deepEqual(Object.keys(registry).sort(), [
@@ -274,6 +283,94 @@ assert.deepEqual(Object.keys(registry).sort(), [
   await assert.rejects(host.queuePrompt(), (error) => error === afterError);
   assert.equal(originalCalls, 1, "afterQueue failure must occur after the original resolves");
   disposeAfterFailure();
+}
+
+{
+  const events = [];
+  let releaseDependencies;
+  const dependencies = new Promise((resolve) => { releaseDependencies = resolve; });
+  const host = {
+    queuePrompt(...args) {
+      events.push(["original", this, args]);
+      return "queued";
+    },
+  };
+  const receiver = { async: true };
+  const originalArgs = [0, { prompt: "original" }, { tail: true }];
+  const replacementPrompt = { prompt: "replacement" };
+  const dispose = registry.registerHostHookCallbacks({
+    owner: Symbol("async-before-success"),
+    queueHost: host,
+    async beforeQueue(context) {
+      events.push(["before:start", context.thisArg, context.args]);
+      await dependencies;
+      context.args = [...context.args];
+      context.args[1] = replacementPrompt;
+      events.push(["before:end", context.args]);
+      return "async-state";
+    },
+    afterQueue(context) {
+      events.push(["after", context.ok, context.callbackState, context.result]);
+    },
+  });
+
+  const pending = host.queuePrompt.call(receiver, ...originalArgs);
+  assert.equal(typeof pending.then, "function");
+  assert.deepEqual(events.map(([name]) => name), ["before:start"]);
+  releaseDependencies();
+  assert.equal(await pending, "queued");
+  assert.deepEqual(events.map(([name]) => name), [
+    "before:start", "before:end", "original", "after",
+  ]);
+  assert.equal(events[2][1], receiver);
+  assert.deepEqual(events[2][2], [0, replacementPrompt, originalArgs[2]]);
+  assert.deepEqual(events[3], ["after", true, "async-state", "queued"]);
+  dispose();
+}
+
+{
+  const events = [];
+  const beforeError = new Error("async before failed");
+  let originalCalls = 0;
+  const host = {
+    queuePrompt() {
+      originalCalls += 1;
+      return "unreachable";
+    },
+  };
+  const disposeFailing = registry.registerHostHookCallbacks({
+    owner: Symbol("async-before-failing-inner"),
+    queueHost: host,
+    async beforeQueue() {
+      events.push("failing:before");
+      throw beforeError;
+    },
+    afterQueue() {
+      events.push("failing:after");
+    },
+  });
+  const disposeOuter = registry.registerHostHookCallbacks({
+    owner: Symbol("async-before-outer"),
+    queueHost: host,
+    beforeQueue() {
+      events.push("outer:before");
+      return "outer-state";
+    },
+    afterQueue(context) {
+      events.push(`outer:after:${context.ok}:${context.callbackState}`);
+      assert.equal(context.error, beforeError);
+    },
+  });
+
+  await assert.rejects(host.queuePrompt(), (error) => error === beforeError);
+  assert.equal(originalCalls, 0);
+  assert.deepEqual(events, [
+    "outer:before",
+    "failing:before",
+    "outer:after:false:outer-state",
+  ]);
+  disposeOuter();
+  disposeFailing();
 }
 
 {
@@ -547,7 +644,7 @@ assert.deepEqual(Object.keys(registry).sort(), [
   assert.equal(host.queuePrompt, original);
 }
 
-function exerciseLoraLegacyLoadOrder(registryFirst) {
+async function exerciseAioLoraLoadOrder(aioFirst) {
   const events = [];
   class Graph {
     constructor() {
@@ -566,99 +663,81 @@ function exerciseLoraLegacyLoadOrder(registryFirst) {
       return value;
     },
   };
-  const legacy = loraSaveSync.createLoraPresetSaveSync({
+  const originalSerialize = Graph.prototype.serialize;
+  const originalQueue = app.queuePrompt;
+  const lora = loraSaveSync.createLoraPresetSaveSync({
     app,
     nodeTypeName: "EasyUseAnimaLoraPreset",
-    saveCurrentProfile: () => events.push("legacy"),
+    saveCurrentProfile: () => events.push("lora"),
     getGraphPrototype: () => Graph.prototype,
   });
-  const installRegistry = () => registry.registerHostHookCallbacks({
-    owner: Symbol(`lora-registry-${registryFirst}`),
+  const promptOwner = Symbol(`prompt-${aioFirst}`);
+  const installPromptStudio = () => registry.registerHostHookCallbacks({
+    owner: promptOwner,
     serializeHost: Graph.prototype,
     queueHost: app,
-    beforeSerialize: () => events.push("registry"),
-    beforeQueue: () => events.push("registry"),
+    beforeSerialize: () => events.push("prompt:serialize"),
+    beforeQueue: () => {
+      events.push("prompt:before");
+      return "prompt-state";
+    },
+    afterQueue: (context) => events.push(
+      `prompt:after:${context.ok}:${context.callbackState}`,
+    ),
   });
-
-  let disposeRegistry;
-  let legacySerialize;
-  let legacyQueue;
-  if (registryFirst) {
-    disposeRegistry = installRegistry();
-    legacy.install();
-    legacySerialize = Graph.prototype.serialize;
-    legacyQueue = app.queuePrompt;
-  } else {
-    legacy.install();
-    legacySerialize = Graph.prototype.serialize;
-    legacyQueue = app.queuePrompt;
-    disposeRegistry = installRegistry();
-  }
-  Graph.prototype.serialize.call(app.graph, "serialize");
-  app.queuePrompt.call(app, "queue");
-  const expectedCall = registryFirst
-    ? ["legacy", "registry", "original:serialize", "legacy", "registry", "original:queue"]
-    : ["registry", "legacy", "original:serialize", "registry", "legacy", "original:queue"];
-  assert.deepEqual(events, expectedCall);
-
-  events.length = 0;
-  disposeRegistry();
-  assert.equal(Graph.prototype.serialize, legacySerialize);
-  assert.equal(app.queuePrompt, legacyQueue);
-  Graph.prototype.serialize.call(app.graph, "serialize");
-  app.queuePrompt.call(app, "queue");
-  assert.deepEqual(events, ["legacy", "original:serialize", "legacy", "original:queue"]);
-}
-
-exerciseLoraLegacyLoadOrder(false);
-exerciseLoraLegacyLoadOrder(true);
-
-function exerciseAioLegacyLoadOrder(registryFirst) {
-  const events = [];
-  const host = {
-    queuePrompt(value) {
-      events.push("original");
-      return value;
+  const aioRuntime = {
+    async beforeQueue() {
+      events.push("aio:before");
+      return "aio-state";
+    },
+    afterQueue(context) {
+      events.push(`aio:after:${context.ok}:${context.callbackState}`);
     },
   };
-  const runtime = {
-    wrapQueuePrompt(queuePrompt) {
-      return function (...args) {
-        events.push("legacy");
-        return queuePrompt.apply(this, args);
-      };
-    },
-  };
-  const installRegistry = () => registry.registerHostHookCallbacks({
-    owner: Symbol(`aio-registry-${registryFirst}`),
-    queueHost: host,
-    beforeQueue: () => events.push("registry"),
-  });
-  let disposeRegistry;
-  let legacyWrapper;
-  if (registryFirst) {
-    disposeRegistry = installRegistry();
-    aioQueueRuntime.aioInstallGeneratorQueuePromptHook(host, runtime);
-    legacyWrapper = host.queuePrompt;
+
+  const disposePrompt = installPromptStudio();
+  assert.equal(installPromptStudio()(), false, "Prompt Studio setup twice must be a no-op");
+  let disposeAio;
+  if (aioFirst) {
+    disposeAio = aioQueueRuntime.aioInstallGeneratorQueuePromptHook(app, aioRuntime);
+    assert.equal(lora.install(), true);
   } else {
-    aioQueueRuntime.aioInstallGeneratorQueuePromptHook(host, runtime);
-    legacyWrapper = host.queuePrompt;
-    disposeRegistry = installRegistry();
+    assert.equal(lora.install(), true);
+    disposeAio = aioQueueRuntime.aioInstallGeneratorQueuePromptHook(app, aioRuntime);
   }
-  assert.equal(host.queuePrompt("queued"), "queued");
-  assert.deepEqual(
-    events,
-    registryFirst ? ["legacy", "registry", "original"] : ["registry", "legacy", "original"],
+  assert.equal(lora.install(), false, "LoRA setup twice must reuse its lease");
+  assert.equal(
+    aioQueueRuntime.aioInstallGeneratorQueuePromptHook(app, aioRuntime)(),
+    false,
+    "AiO setup twice must not own the existing callback",
   );
 
+  Graph.prototype.serialize.call(app.graph, "serialize");
+  assert.deepEqual(events, ["lora", "prompt:serialize", "original:serialize"]);
+
   events.length = 0;
-  disposeRegistry();
-  assert.equal(host.queuePrompt, legacyWrapper);
-  assert.equal(host.queuePrompt("queued"), "queued");
-  assert.deepEqual(events, ["legacy", "original"]);
+  assert.equal(await app.queuePrompt.call(app, "queue"), "queue");
+  assert.deepEqual(
+    events,
+    aioFirst
+      ? [
+        "lora", "aio:before", "prompt:before", "original:queue",
+        "prompt:after:true:prompt-state", "aio:after:true:aio-state",
+      ]
+      : [
+        "aio:before", "lora", "prompt:before", "original:queue",
+        "prompt:after:true:prompt-state", "aio:after:true:aio-state",
+      ],
+  );
+
+  disposePrompt();
+  lora.dispose();
+  disposeAio();
+  assert.equal(Graph.prototype.serialize, originalSerialize);
+  assert.equal(app.queuePrompt, originalQueue, "the last owner must restore the original queue");
 }
 
-exerciseAioLegacyLoadOrder(false);
-exerciseAioLegacyLoadOrder(true);
+await exerciseAioLoraLoadOrder(false);
+await exerciseAioLoraLoadOrder(true);
 
 console.log("Host hook registry smoke passed.");

--- a/tests/frontend_lora_preset_entry_lifecycle_smoke.mjs
+++ b/tests/frontend_lora_preset_entry_lifecycle_smoke.mjs
@@ -53,9 +53,11 @@ function createRuntime(hostWindow, hostDocument, app) {
     menuInstalled: 0,
     refresh: 0,
     saveSync: 0,
+    saveSyncDisposed: 0,
   };
   let localeCallback = null;
   let now = 100;
+  let saveSyncInstalled = false;
   const lifecycle = createLoraPresetEntryLifecycle({
     app,
     hostDocument,
@@ -67,7 +69,24 @@ function createRuntime(hostWindow, hostDocument, app) {
     },
     clientPointToCanvas: (event) => [event.clientX, event.clientY],
     profileCount: (node) => node.profileCount,
-    saveSync: { install() { calls.saveSync += 1; } },
+    saveSync: {
+      install() {
+        calls.saveSync += 1;
+        if (saveSyncInstalled) {
+          return false;
+        }
+        saveSyncInstalled = true;
+        return true;
+      },
+      dispose() {
+        if (!saveSyncInstalled) {
+          return false;
+        }
+        saveSyncInstalled = false;
+        calls.saveSyncDisposed += 1;
+        return true;
+      },
+    },
     async loadSettings() { calls.loadSettings += 1; },
     refreshNodes() { calls.refresh += 1; },
     watchLocale(callback) {
@@ -241,6 +260,7 @@ assert.equal(replacement.lifecycle.extension.init(), true, "a newer entry owner 
 assert.equal(runtime.lifecycle.isActive(), false);
 assert.equal(runtime.calls.disposedLocale, 1);
 assert.equal(runtime.calls.menuDisposed, 1);
+assert.equal(runtime.calls.saveSyncDisposed, 1);
 assert.equal(hostDocument.listenerCount("wheel"), 1);
 assert.equal(hostDocument.listenerCount("pointerdown"), 1);
 assert.equal(hostWindow.listenerCount("easyuse-anima-settings-updated"), 1);
@@ -252,5 +272,6 @@ assert.equal(hostDocument.listenerCount("pointerdown"), 0);
 assert.equal(hostWindow.listenerCount("easyuse-anima-settings-updated"), 0);
 assert.equal(replacement.calls.disposedLocale, 1, "entry disposal must be idempotent");
 assert.equal(replacement.calls.menuDisposed, 1);
+assert.equal(replacement.calls.saveSyncDisposed, 1);
 
 console.log("LoRA preset entry lifecycle smoke passed.");

--- a/tests/frontend_lora_preset_profile_mutations_smoke.mjs
+++ b/tests/frontend_lora_preset_profile_mutations_smoke.mjs
@@ -532,4 +532,57 @@ const returnedRejection = app.queuePrompt.call(app, "reject");
 assert.strictEqual(returnedRejection, rejectedResult);
 await assert.rejects(returnedRejection, /queue failure/);
 
+const lateSyncCalls = [];
+const lateGraphPrototype = {
+  serialize(value) {
+    return { receiver: this, value };
+  },
+};
+const lateOriginalSerialize = lateGraphPrototype.serialize;
+const lateGraph = {
+  _nodes: [{ comfyClass: "EasyUseAnimaLoraPreset", id: 10 }],
+};
+const lateApp = {
+  graph: lateGraph,
+  queuePrompt(value) {
+    return { receiver: this, value };
+  },
+};
+const lateOriginalQueuePrompt = lateApp.queuePrompt;
+let availableGraphPrototype;
+const lateSaveSync = createLoraPresetSaveSync({
+  app: lateApp,
+  nodeTypeName: "EasyUseAnimaLoraPreset",
+  saveCurrentProfile: (profileNode) => lateSyncCalls.push(profileNode.id),
+  getGraphPrototype: () => availableGraphPrototype,
+});
+assert.equal(lateSaveSync.install(), true);
+assert.strictEqual(
+  lateGraphPrototype.serialize,
+  lateOriginalSerialize,
+  "an unavailable graph prototype must not create a placeholder serialize wrapper",
+);
+assert.equal(lateApp.queuePrompt.call(lateApp, "queue-before-graph").value, "queue-before-graph");
+assert.deepEqual(lateSyncCalls, [10]);
+
+lateSyncCalls.length = 0;
+availableGraphPrototype = lateGraphPrototype;
+assert.equal(
+  lateSaveSync.install(),
+  true,
+  "a later graph prototype must replace the queue-only lease and add serialize synchronization",
+);
+const lateSerialized = lateGraphPrototype.serialize.call(lateGraph, "serialize-after-graph");
+assert.strictEqual(lateSerialized.receiver, lateGraph);
+assert.equal(lateSerialized.value, "serialize-after-graph");
+assert.deepEqual(lateSyncCalls, [10]);
+lateSyncCalls.length = 0;
+assert.equal(lateApp.queuePrompt.call(lateApp, "queue-after-graph").value, "queue-after-graph");
+assert.deepEqual(lateSyncCalls, [10], "lease replacement must not stack queue synchronization");
+
+assert.equal(lateSaveSync.dispose(), true);
+assert.strictEqual(lateGraphPrototype.serialize, lateOriginalSerialize);
+assert.strictEqual(lateApp.queuePrompt, lateOriginalQueuePrompt);
+assert.equal(lateSaveSync.dispose(), false);
+
 console.log("LoRA profile mutation and save-sync smoke passed");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -630,7 +630,7 @@ class AIOFrontendSourceTests(unittest.TestCase):
         )
         setup_body = extension_source[setup_start:setup_end]
         self.assertIn("installWheelForwarder();", setup_body)
-        self.assertIn("installQueuePromptHook();", setup_body)
+        self.assertIn("installGlobalHooks();", setup_body)
         self.assertIn(
             "installWheelForwarder: installGeneratorWheelForwarder,", source
         )

--- a/tests/test_frontend_lora_preset.py
+++ b/tests/test_frontend_lora_preset.py
@@ -57,6 +57,7 @@ LORA_PRESET_PROFILE_MUTATIONS = (
     ROOT / "web" / "js" / "lora_preset" / "profile_mutations.js"
 )
 LORA_PRESET_SAVE_SYNC = ROOT / "web" / "js" / "lora_preset" / "save_sync.js"
+HOST_HOOK_REGISTRY = ROOT / "web" / "js" / "lifecycle" / "host_hook_registry.js"
 LORA_PRESET_PROFILE_MUTATIONS_SMOKE = (
     ROOT / "tests" / "frontend_lora_preset_profile_mutations_smoke.mjs"
 )
@@ -920,7 +921,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
         self.assertEqual(mutations_source.splitlines()[0], "import {")
-        self.assertEqual(save_sync_source.splitlines()[0], "/** Installs the graph-save and queue-preparation synchronization hooks. */")
+        self.assertEqual(save_sync_source.splitlines()[0], "// @ts-check")
+        self.assertIn('../lifecycle/host_hook_registry.js"', save_sync_source)
         self.assertEqual(
             re.findall(
                 r"^export\s+(?:const|function|class)\s+([A-Za-z0-9_]+)",
@@ -993,7 +995,8 @@ class LoraPresetFrontendTests(unittest.TestCase):
             const nodeRuntimePath = process.argv[8];
             const profileMutationsPath = process.argv[9];
             const saveSyncPath = process.argv[10];
-            const entryLifecyclePath = process.argv[11];
+            const hostHookRegistryPath = process.argv[11];
+            const entryLifecyclePath = process.argv[12];
             let profileDataSource = fs.readFileSync(profileDataPath, "utf8");
             profileDataSource = profileDataSource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
@@ -1036,7 +1039,13 @@ class LoraPresetFrontendTests(unittest.TestCase):
               "",
             );
             let saveSyncSource = fs.readFileSync(saveSyncPath, "utf8");
+            saveSyncSource = saveSyncSource.replace(/^import[\s\S]*?;\r?\n/gm, "");
             saveSyncSource = saveSyncSource.replace(
+              /^export\s+(?=(?:const|function|class)\b)/gm,
+              "",
+            );
+            let hostHookRegistrySource = fs.readFileSync(hostHookRegistryPath, "utf8");
+            hostHookRegistrySource = hostHookRegistrySource.replace(
               /^export\s+(?=(?:const|function|class)\b)/gm,
               "",
             );
@@ -1047,7 +1056,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
             );
             let source = fs.readFileSync(sourcePath, "utf8");
             source = source.replace(/^import[\s\S]*?;\r?\n/gm, "");
-            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${profileMutationsSource}\n${saveSyncSource}\n${entryLifecycleSource}\n${source}`;
+            source = `${profileDataSource}\n${loraStateSource}\n${apiClientSource}\n${previewLifecycleSource}\n${menuLifecycleSource}\n${canvasWidgetsSource}\n${nodeRuntimeSource}\n${profileMutationsSource}\n${hostHookRegistrySource}\n${saveSyncSource}\n${entryLifecycleSource}\n${source}`;
             source += "\nglobalThis.__loraPresetTest = { loraCanvasWidgets, LORA_PRESET_SETTINGS, applyLoraPresetSettings, loraPresetApi, loraPreviewLifecycle, loraMenuLifecycle, saveProfileSet };\n";
 
             const mutationObservers = [];
@@ -1383,6 +1392,7 @@ class LoraPresetFrontendTests(unittest.TestCase):
                 str(LORA_PRESET_NODE_RUNTIME),
                 str(LORA_PRESET_PROFILE_MUTATIONS),
                 str(LORA_PRESET_SAVE_SYNC),
+                str(HOST_HOOK_REGISTRY),
                 str(LORA_PRESET_ENTRY_LIFECYCLE),
             ],
             cwd=ROOT,

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -115,7 +115,7 @@ STATIC_IMPORT_RE = re.compile(
 
 
 class FrontendModuleStructureTests(unittest.TestCase):
-    def test_host_hook_registry_phase_1_is_owned_and_focused(self):
+    def test_host_hook_registry_phase_2_is_owned_and_focused(self):
         registry_source = HOST_HOOK_REGISTRY_JS.read_text(encoding="utf-8")
         node_hooks_source = (
             PROMPT_STUDIO_MODULES / "node_hooks.js"
@@ -171,14 +171,18 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertNotIn("serialize.__easyuseAnimaRegionalWrapped", regional_extension_source)
         self.assertNotIn("AdvancedQueueSeedInstalled", queue_seed_source)
 
-        self.assertNotIn(
-            "host_hook_registry",
-            AIO_GENERATOR_QUEUE_RUNTIME_JS.read_text(encoding="utf-8"),
-        )
-        self.assertNotIn(
-            "host_hook_registry",
-            (WEB_JS / "lora_preset" / "save_sync.js").read_text(encoding="utf-8"),
-        )
+        aio_queue_source = AIO_GENERATOR_QUEUE_RUNTIME_JS.read_text(encoding="utf-8")
+        aio_extension_source = AIO_EXTENSION_RUNTIME_JS.read_text(encoding="utf-8")
+        lora_save_sync_source = (
+            WEB_JS / "lora_preset" / "save_sync.js"
+        ).read_text(encoding="utf-8")
+        self.assertIn('../lifecycle/host_hook_registry.js"', aio_queue_source)
+        self.assertIn('../lifecycle/host_hook_registry.js"', aio_extension_source)
+        self.assertIn('../lifecycle/host_hook_registry.js"', lora_save_sync_source)
+        self.assertIn("registerHostHookCallbacks({", aio_queue_source)
+        self.assertIn("createHostHookRuntimeLifecycle(", aio_extension_source)
+        self.assertIn("createHostHookRuntimeLifecycle(", lora_save_sync_source)
+        self.assertIn("registerHostHookCallbacks({", lora_save_sync_source)
 
     def test_shared_api_module_exports_runtime_helpers(self):
         source = API_JS.read_text(encoding="utf-8")
@@ -426,7 +430,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
         self.assertEqual(source.splitlines()[0], "// @ts-check")
-        self.assertEqual(STATIC_IMPORT_RE.findall(source), [])
+        self.assertEqual(
+            STATIC_IMPORT_RE.findall(source),
+            ["../lifecycle/host_hook_registry.js"],
+        )
         self.assertNotIn("app.registerExtension", source)
         self.assertEqual(
             re.findall(
@@ -768,7 +775,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 "aioInstallGeneratorQueuePromptHook",
             ],
         )
-        self.assertNotRegex(source, re.compile(r"^\s*import\s", re.MULTILINE))
+        self.assertEqual(
+            STATIC_IMPORT_RE.findall(source),
+            ["../lifecycle/host_hook_registry.js"],
+        )
         self.assertNotRegex(source, r"\b(?:document|window|app)\b")
         self.assertNotIn("fetch(", source)
         self.assertNotIn("app.registerExtension", source)
@@ -850,12 +860,10 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "return aioInstallGeneratorQueuePromptHook(api, generatorQueueRuntime);",
             install_body,
         )
-        self.assertIn(
-            'const QUEUE_HOST_MARKER = "__easyuseAnimaAioQueuePromptInstalled";',
-            source,
-        )
-        self.assertIn("queueHost[QUEUE_HOST_MARKER]", source)
-        self.assertIn("wrappedQueuePrompt[QUEUE_HOOK_MARKER] = true;", source)
+        self.assertIn("const AIO_GENERATOR_QUEUE_OWNER = Symbol.for(", source)
+        self.assertIn('"easyuse-anima.aio.generator-queue"', source)
+        self.assertIn("return registerHostHookCallbacks({", source)
+        self.assertIn("owner: AIO_GENERATOR_QUEUE_OWNER,", source)
         self.assertIn("updateSeed: updateGeneratorSeed,", panel_source)
         self.assertLess(
             entry_source.index("const generatorPanelRuntime"),

--- a/web/js/aio/extension_runtime.js
+++ b/web/js/aio/extension_runtime.js
@@ -1,8 +1,15 @@
 // @ts-check
 
+import {
+  createHostHookRuntimeLifecycle,
+} from "../lifecycle/host_hook_registry.js";
+
 const INPUT_PROTOTYPE_HOOK_MARKER = "__easyuseAnimaAioInputHooksInstalled";
 const GENERATOR_PROTOTYPE_HOOK_MARKER = "__easyuseAnimaAioGeneratorHooksInstalled";
 const EXTENSION_SETUP_HOST_MARKER = "__easyuseAnimaAioExtensionSetupInstalled";
+const AIO_GLOBAL_HOOK_RUNTIME_OWNER = Symbol.for(
+  "easyuse-anima.aio.global-hook-runtime-owner",
+);
 
 function graphNodes(graph) {
   if (Array.isArray(graph?.nodes)) {
@@ -112,6 +119,21 @@ export function aioCreateExtensionRuntime(dependencies) {
       disposeNativePreviewLifecycle,
     },
   } = dependencies;
+  const globalHookLifecycle = createHostHookRuntimeLifecycle(
+    api,
+    AIO_GLOBAL_HOOK_RUNTIME_OWNER,
+  );
+
+  function installGlobalHooks() {
+    return globalHookLifecycle.install(
+      "generator-queue",
+      installQueuePromptHook,
+    );
+  }
+
+  function disposeGlobalHooks() {
+    return globalHookLifecycle.dispose();
+  }
 
   function hookNode(node, nodeData) {
     if (nodeData.name === INPUT_NODE_TYPE) {
@@ -122,9 +144,14 @@ export function aioCreateExtensionRuntime(dependencies) {
   }
 
   return {
+    dispose: disposeGlobalHooks,
     async setup() {
       const setupState = extensionSetupState(api);
-      if (!setupState || setupState.complete || setupState.inProgress) {
+      if (!setupState || setupState.inProgress) {
+        return;
+      }
+      if (setupState.complete) {
+        installGlobalHooks();
         return;
       }
       setupState.inProgress = true;
@@ -133,9 +160,7 @@ export function aioCreateExtensionRuntime(dependencies) {
         runExtensionSetupStep(setupState, "wheel-forwarder", () => {
           installWheelForwarder();
         });
-        runExtensionSetupStep(setupState, "queue-prompt-hook", () => {
-          installQueuePromptHook();
-        });
+        installGlobalHooks();
         runExtensionSetupStep(setupState, "locale-watch", () => {
           watchLocale(refreshPanels);
         });

--- a/web/js/aio/generator_queue_runtime.js
+++ b/web/js/aio/generator_queue_runtime.js
@@ -1,7 +1,12 @@
 // @ts-check
 
-const QUEUE_HOOK_MARKER = "__easyuseAnimaAioWrapped";
-const QUEUE_HOST_MARKER = "__easyuseAnimaAioQueuePromptInstalled";
+import {
+  registerHostHookCallbacks,
+} from "../lifecycle/host_hook_registry.js";
+
+const AIO_GENERATOR_QUEUE_OWNER = Symbol.for(
+  "easyuse-anima.aio.generator-queue",
+);
 
 /**
  * @typedef {object} AioGeneratorQueueSettingsCore
@@ -449,65 +454,85 @@ export function aioCreateGeneratorQueueRuntime(dependencies) {
     }
   }
 
+  async function beforeQueue(context) {
+    await loadOptionalDependencies({ retryErrors: true });
+    const transaction = preparePrompt(context.args[1], context.args[2], true);
+    if (transaction) {
+      context.args = [...context.args];
+      context.args[1] = transaction.prompt;
+    }
+    return transaction;
+  }
+
+  function afterQueue(context) {
+    const transaction = context.callbackState;
+    if (!transaction) {
+      return;
+    }
+    if (context.ok) {
+      settlePreparedSeeds(transaction, context.result);
+    } else {
+      rejectPreparedSeeds(transaction);
+    }
+  }
+
   /**
-   * Wrap api.queuePrompt without owning the global hook. The original receiver,
-   * argument tail, resolved value, and thrown/rejected error are preserved.
+   * Compatibility adapter for focused consumers that still compose a local
+   * function. Global queue ownership belongs to the host-hook registry below.
    *
    * @param {(...args: any[]) => any} queuePrompt
    */
   function wrapQueuePrompt(queuePrompt) {
-    return async function (...args) {
-      await loadOptionalDependencies({ retryErrors: true });
-      const transaction = preparePrompt(args[1], args[2], true);
-      const queueArgs = transaction ? [...args] : args;
-      if (transaction) {
-        queueArgs[1] = transaction.prompt;
-      }
-      let result;
-      try {
-        result = await queuePrompt.apply(this, queueArgs);
-      } catch (error) {
-        if (transaction) {
-          rejectPreparedSeeds(transaction);
+    return function (...args) {
+      const thisArg = this;
+      const context = {
+        host: null,
+        thisArg,
+        args,
+        originalArgs: args,
+      };
+      return Promise.resolve(beforeQueue(context)).then((transaction) => {
+        let result;
+        try {
+          result = queuePrompt.apply(thisArg, context.args);
+        } catch (error) {
+          afterQueue({ ...context, callbackState: transaction, ok: false, error });
+          throw error;
         }
-        throw error;
-      }
-      if (transaction) {
-        settlePreparedSeeds(transaction, result);
-      }
-      return result;
+        return Promise.resolve(result).then(
+          (value) => {
+            afterQueue({ ...context, callbackState: transaction, ok: true, result: value });
+            return value;
+          },
+          (error) => {
+            afterQueue({ ...context, callbackState: transaction, ok: false, error });
+            throw error;
+          },
+        );
+      });
     };
   }
 
   return {
+    afterQueue,
+    beforeQueue,
     preparePrompt,
     wrapQueuePrompt,
   };
 }
 
 /**
- * Install the AiO queue wrapper once per queue owner. The owner marker remains
- * visible when another extension later wraps queuePrompt, so repeated setup
- * cannot hide and then stack another AiO wrapper.
+ * Register the AiO queue transaction callbacks without directly owning the
+ * global function identity.
  *
  * @param {any} queueHost
- * @param {{wrapQueuePrompt: (queuePrompt: (...args: any[]) => any) => (...args: any[]) => any}} runtime
+ * @param {{beforeQueue: (context: any) => any, afterQueue: (context: any) => any}} runtime
  */
 export function aioInstallGeneratorQueuePromptHook(queueHost, runtime) {
-  if (
-    !queueHost
-    || typeof queueHost.queuePrompt !== "function"
-    || queueHost[QUEUE_HOST_MARKER]
-  ) {
-    return false;
-  }
-  if (queueHost.queuePrompt[QUEUE_HOOK_MARKER]) {
-    queueHost[QUEUE_HOST_MARKER] = true;
-    return false;
-  }
-  const wrappedQueuePrompt = runtime.wrapQueuePrompt(queueHost.queuePrompt);
-  wrappedQueuePrompt[QUEUE_HOOK_MARKER] = true;
-  queueHost.queuePrompt = wrappedQueuePrompt;
-  queueHost[QUEUE_HOST_MARKER] = true;
-  return true;
+  return registerHostHookCallbacks({
+    owner: AIO_GENERATOR_QUEUE_OWNER,
+    queueHost,
+    beforeQueue: runtime.beforeQueue,
+    afterQueue: runtime.afterQueue,
+  });
 }

--- a/web/js/lifecycle/host_hook_registry.js
+++ b/web/js/lifecycle/host_hook_registry.js
@@ -68,29 +68,81 @@ function invokeSerialize(state, thisArg, args) {
   return state.original.apply(thisArg, callArgs);
 }
 
+/** @param {any} value */
+function isThenable(value) {
+  return value != null && typeof value.then === "function";
+}
+
 /**
+ * Complete one queue wrapper after its before callback has settled. A failing
+ * before callback never enters this function, so its own after callback is not
+ * invoked; already-entered outer owners still observe the propagated failure.
+ *
  * @param {any} state
+ * @param {any[]} entries
+ * @param {number} index
  * @param {any} thisArg
  * @param {any[]} args
+ * @param {any[]} originalArgs
+ * @param {any} callbackState
  */
-function invokeQueueSync(state, thisArg, args) {
-  const originalArgs = args;
-  let callArgs = args;
-  for (const entry of callbacksOuterToInner(state)) {
-    const callback = entry.callbacks.beforeQueue;
-    if (typeof callback !== "function") {
-      continue;
-    }
-    const context = {
+function invokeQueueAfterBefore(
+  state,
+  entries,
+  index,
+  thisArg,
+  args,
+  originalArgs,
+  callbackState,
+) {
+  const entry = entries[index];
+  const afterQueue = entry.callbacks.afterQueue;
+
+  function runAfter(ok, value) {
+    const afterResult = afterQueue({
       host: state.target,
       thisArg,
-      args: callArgs,
+      args,
       originalArgs,
+      callbackState,
+      ok,
+      ...(ok ? { result: value } : { error: value }),
+    });
+    const continueResult = () => {
+      if (ok) {
+        return value;
+      }
+      throw value;
     };
-    callback(context);
-    callArgs = Array.isArray(context.args) ? context.args : callArgs;
+    return isThenable(afterResult)
+      ? Promise.resolve(afterResult).then(continueResult)
+      : continueResult();
   }
-  return state.original.apply(thisArg, callArgs);
+
+  let result;
+  try {
+    result = invokeQueueLayer(
+      state,
+      entries,
+      index + 1,
+      thisArg,
+      args,
+      originalArgs,
+    );
+  } catch (error) {
+    if (typeof afterQueue !== "function") {
+      throw error;
+    }
+    return runAfter(false, error);
+  }
+
+  if (typeof afterQueue !== "function") {
+    return result;
+  }
+  return Promise.resolve(result).then(
+    (value) => runAfter(true, value),
+    (error) => runAfter(false, error),
+  );
 }
 
 /**
@@ -112,7 +164,6 @@ function invokeQueueLayer(state, entries, index, thisArg, args, originalArgs) {
 
   const entry = entries[index];
   const beforeQueue = entry.callbacks.beforeQueue;
-  const afterQueue = entry.callbacks.afterQueue;
   const context = {
     host: state.target,
     thisArg,
@@ -122,78 +173,18 @@ function invokeQueueLayer(state, entries, index, thisArg, args, originalArgs) {
   const callbackState = typeof beforeQueue === "function"
     ? beforeQueue(context)
     : undefined;
-  const callArgs = Array.isArray(context.args) ? context.args : args;
-
-  let result;
-  try {
-    result = invokeQueueLayer(
-      state,
-      entries,
-      index + 1,
-      thisArg,
-      callArgs,
-      originalArgs,
-    );
-  } catch (error) {
-    if (typeof afterQueue === "function") {
-      afterQueue({
-        host: state.target,
-        thisArg,
-        args: callArgs,
-        originalArgs,
-        callbackState,
-        ok: false,
-        error,
-      });
-    }
-    throw error;
-  }
-
-  if (typeof afterQueue !== "function") {
-    return result;
-  }
-  return Promise.resolve(result).then(
-    (value) => {
-      afterQueue({
-        host: state.target,
-        thisArg,
-        args: callArgs,
-        originalArgs,
-        callbackState,
-        ok: true,
-        result: value,
-      });
-      return value;
-    },
-    (error) => {
-      afterQueue({
-        host: state.target,
-        thisArg,
-        args: callArgs,
-        originalArgs,
-        callbackState,
-        ok: false,
-        error,
-      });
-      throw error;
-    },
-  );
-}
-
-/**
- * @param {any} state
- * @param {any} thisArg
- * @param {any[]} args
- */
-async function invokeQueueAsync(state, thisArg, args) {
-  return invokeQueueLayer(
+  const continueQueue = (resolvedCallbackState) => invokeQueueAfterBefore(
     state,
-    callbacksOuterToInner(state),
-    0,
+    entries,
+    index,
     thisArg,
-    args,
-    args,
+    Array.isArray(context.args) ? context.args : args,
+    originalArgs,
+    resolvedCallbackState,
   );
+  return isThenable(callbackState)
+    ? Promise.resolve(callbackState).then(continueQueue)
+    : continueQueue(callbackState);
 }
 
 /**
@@ -202,12 +193,19 @@ async function invokeQueueAsync(state, thisArg, args) {
  * @param {any[]} args
  */
 function invokeQueue(state, thisArg, args) {
-  const hasAfterQueue = callbackEntries(state).some(
+  const entries = callbacksOuterToInner(state);
+  const hasAfterQueue = entries.some(
     (entry) => typeof entry.callbacks.afterQueue === "function",
   );
-  return hasAfterQueue
-    ? invokeQueueAsync(state, thisArg, args)
-    : invokeQueueSync(state, thisArg, args);
+  try {
+    const result = invokeQueueLayer(state, entries, 0, thisArg, args, args);
+    return hasAfterQueue ? Promise.resolve(result) : result;
+  } catch (error) {
+    if (hasAfterQueue) {
+      return Promise.reject(error);
+    }
+    throw error;
+  }
 }
 
 /**

--- a/web/js/lora_preset/entry_lifecycle.js
+++ b/web/js/lora_preset/entry_lifecycle.js
@@ -17,7 +17,7 @@ const LORA_PRESET_ENTRY_OWNER = Symbol.for(
  *   canvasWidgets: any,
  *   clientPointToCanvas: (event: any) => number[],
  *   profileCount: (node: any) => number,
- *   saveSync: {install: () => void},
+ *   saveSync: {install: () => boolean, dispose: () => boolean},
  *   loadSettings: () => Promise<any>,
  *   refreshNodes: () => void,
  *   watchLocale: (callback: () => void) => (() => void),
@@ -230,7 +230,7 @@ export function createLoraPresetEntryLifecycle(dependencies) {
       if (hostWindow[LORA_PRESET_ENTRY_OWNER] === lifecycle) {
         delete hostWindow[LORA_PRESET_ENTRY_OWNER];
       }
-      return false;
+      return saveSync.dispose();
     }
     installed = false;
     activeProfileWheelTarget = null;
@@ -248,6 +248,7 @@ export function createLoraPresetEntryLifecycle(dependencies) {
     };
     runCleanup(() => disposeLocaleWatch?.());
     disposeLocaleWatch = null;
+    runCleanup(() => saveSync.dispose());
     runCleanup(() => menuLifecycle.dispose?.());
     runCleanup(() => previewLifecycle.hidePreview());
     if (hostWindow[LORA_PRESET_ENTRY_OWNER] === lifecycle) {

--- a/web/js/lora_preset/save_sync.js
+++ b/web/js/lora_preset/save_sync.js
@@ -1,26 +1,31 @@
+// @ts-check
+
+import {
+  createHostHookRuntimeLifecycle,
+  registerHostHookCallbacks,
+} from "../lifecycle/host_hook_registry.js";
+
+const LORA_PRESET_SAVE_SYNC_OWNER = Symbol.for(
+  "easyuse-anima.lora-preset.save-sync",
+);
+const LORA_PRESET_SAVE_SYNC_RUNTIME_OWNER = Symbol.for(
+  "easyuse-anima.lora-preset.save-sync-runtime-owner",
+);
+
 /** Installs the graph-save and queue-preparation synchronization hooks. */
-const installStates = new WeakMap();
-
-function installStateFor(target, methodName) {
-  let states = installStates.get(target);
-  if (!states) {
-    states = new Map();
-    installStates.set(target, states);
-  }
-  let state = states.get(methodName);
-  if (!state) {
-    state = { wrapper: null, syncBeforeCall: null };
-    states.set(methodName, state);
-  }
-  return state;
-}
-
 export function createLoraPresetSaveSync({
   app,
   nodeTypeName,
   saveCurrentProfile,
   getGraphPrototype = () => globalThis.LGraph?.prototype || app.graph?.constructor?.prototype,
 }) {
+  const globalHookLifecycle = createHostHookRuntimeLifecycle(
+    app,
+    LORA_PRESET_SAVE_SYNC_RUNTIME_OWNER,
+  );
+  let leaseInstalled = false;
+  let serializeHost;
+
   function syncNode(node) {
     if (node?.comfyClass === nodeTypeName) {
       saveCurrentProfile(node);
@@ -33,36 +38,34 @@ export function createLoraPresetSaveSync({
     }
   }
 
-  function installWrapper(target, methodName, syncBeforeCall) {
-    const current = target?.[methodName];
-    if (typeof current !== "function") {
-      return;
-    }
-    const state = installStateFor(target, methodName);
-    state.syncBeforeCall = syncBeforeCall;
-    if (current === state.wrapper) {
-      return;
-    }
-    const wrapper = function () {
-      // A host extension can wrap our previous function between installs.  Only
-      // the outermost current wrapper owns synchronization.  The target-level
-      // state also survives a new lifecycle instance after another extension
-      // hides our marker by wrapping the previous function.
-      if (state.wrapper === wrapper) {
-        state.syncBeforeCall(this);
-      }
-      return current.apply(this, arguments);
-    };
-    wrapper.__easyuseAnimaLoraPresetWrapped = true;
-    state.wrapper = wrapper;
-    target[methodName] = wrapper;
-  }
-
   function install() {
     const graphPrototype = getGraphPrototype();
-    installWrapper(graphPrototype, "serialize", (graph) => syncAllNodes(graph));
-    installWrapper(app, "queuePrompt", () => syncAllNodes());
+    const replace = leaseInstalled
+      && graphPrototype != null
+      && graphPrototype !== serializeHost;
+    const installed = globalHookLifecycle.install(
+      "save-sync",
+      () => registerHostHookCallbacks({
+        owner: LORA_PRESET_SAVE_SYNC_OWNER,
+        serializeHost: graphPrototype,
+        queueHost: app,
+        beforeSerialize: ({ thisArg }) => syncAllNodes(thisArg),
+        beforeQueue: () => syncAllNodes(),
+      }),
+      { replace },
+    );
+    if (installed) {
+      leaseInstalled = true;
+      serializeHost = graphPrototype;
+    }
+    return installed;
   }
 
-  return { install, syncNode, syncAllNodes };
+  function dispose() {
+    leaseInstalled = false;
+    serializeHost = undefined;
+    return globalHookLifecycle.dispose();
+  }
+
+  return { dispose, install, syncNode, syncAllNodes };
 }


### PR DESCRIPTION
## 변경 요약

- 공통 `host_hook_registry`가 serialize, queue before/after, graph clear hook의 다중 owner 등록·해제와 foreign wrapper 공존을 소유하도록 확장했습니다.
- AiO queue hook을 직접 function wrapper/marker 방식에서 registry callback lease로 이동했습니다.
- AiO extension runtime은 process host의 collision-safe Symbol owner로 queue lease를 인계하고 이전 runtime disposer를 identity-safe하게 실행합니다.
- LoRA Preset save-sync의 serialize/queue hook도 같은 registry와 runtime lifecycle을 사용하며 entry lifecycle dispose에 연결했습니다.
- graph prototype이 초기에는 없고 나중에 생기는 경우 queue-only lease를 교체해 serialize hook을 설치하도록 보강했습니다.

## 원인과 영향

기능별 marker와 직접 monkey-patch가 전역 host method의 소유권·해제 순서를 분산시켰습니다. 다른 extension wrapper가 바깥에 설치되거나 factory/runtime이 교체되면 stale callback, 중복 실행, 원본 identity 복구 실패를 개별 모듈마다 다시 다뤄야 했습니다.

이번 Phase 2는 AiO queue와 LoRA serialize/queue hook을 중앙 registry로 옮깁니다. DOM, canvas widget, workflow 공개 값, node input/output 계약은 변경하지 않습니다.

## 주요 계약

- 동일 target/method/owner 재등록은 no-op
- before callback은 outer→inner, queue after callback은 inner→outer unwind
- async before/after, sync throw, rejected Promise의 원래 오류/결과/receiver/argument tail 보존
- 마지막 callback 해제 시 원본 host method 복원
- foreign outer wrapper를 disposer가 덮어쓰지 않음
- stale current registry wrapper는 stack 없이 재사용
- newer runtime takeover는 이전 owner를 terminal retire하고 자기 global lease만 설치
- LoRA graph prototype `undefined → available` 전환 시 queue-only lease를 serialize+queue lease로 교체

## 주요 파일

- `web/js/lifecycle/host_hook_registry.js`
- `web/js/aio/generator_queue_runtime.js`
- `web/js/aio/extension_runtime.js`
- `web/js/lora_preset/save_sync.js`
- `web/js/lora_preset/entry_lifecycle.js`
- 대응 frontend semantic smoke 5개와 Python source/VM contract tests

## 리뷰 반영

- factory takeover 기대를 새 terminal owner 계약에 맞추고 이전 disposer/새 install을 함께 검증
- 초기 graph prototype 부재 시 serialize hook 영구 누락 P1 수정 및 `undefined → available` 회귀 추가
- async pre-hook의 microtask 수에 고정된 concurrency assertion을 event-loop turn 기준으로 안정화
- Phase 2 registry import, global lifecycle setup, LoRA VM assembler를 새 모듈 경계에 맞춰 갱신

## 검증

Focused:

- `node tests/frontend_host_hook_registry_smoke.mjs`: passed
- `node tests/frontend_aio_generator_queue_runtime_smoke.mjs`: passed
- `node tests/frontend_aio_extension_runtime_smoke.mjs`: passed
- `node tests/frontend_lora_preset_profile_mutations_smoke.mjs`: passed
- `node tests/frontend_lora_preset_entry_lifecycle_smoke.mjs`: passed
- 관련 Python source/VM contract 101개: 최초 100 passed, stale queue marker 기대 1건 수정 후 영향 모듈 47개 passed

공식 quick, latest `dev@f328edf` rebase:

- Python compile: passed
- frontend semantic/syntax smoke: 111 JavaScript files
- TypeScript: 6.0.3
- git diff check: passed

공식 full, exact HEAD `5433ffe4128b0cdbb2d20029faac696ac4d1de47`:

- Python unittest: 671 passed
- frontend semantic/syntax smoke: 111 JavaScript files passed
- TypeScript: 6.0.3 passed
- git diff check: passed

첫 full은 구현과 달라진 Phase 1 테스트 계약 6건을 발견해 실패했습니다. production 코드를 되돌리지 않고 Phase 2 source/VM contract를 갱신한 뒤 위 exact HEAD에서 full 전체를 재실행해 통과했습니다.

Live ComfyUI browser smoke:

- ComfyUI 0.27.0 / frontend 1.45.20
- Legacy: Nodes 2.0 비활성 상태에서 AiO와 LoRA Preset workflow를 각각 열어 panel/DOM widget 로드를 확인
- Node 2.0: 설정 활성화 후 reload하고 AiO의 SAMPLER, HIGHRES, DETAILER, PREVIEW 표면을 확인
- Node 2.0 reload 이후 console error 0건, EasyUse 필터 로그 0건
- 테스트 종료 후 Nodes 2.0 설정을 기존 Legacy 상태로 복원하고 서버 종료

## 남은 위험

- 실제 모델/GPU queue 실행은 하지 않았습니다. queue/serialize callback 순서, 오류 보존, stale/foreign wrapper, dispose/takeover 동작은 deterministic semantic smoke와 671개 full suite로 검증했습니다.
- 사용자 인스턴스에는 반영하지 않았습니다.

Related to #166.
