### PR TITLE
chore: checkJs 루트 엔트리 커버리지 ratchet 추가

### DIFF
--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -100,6 +100,50 @@ Prompt Studio entry 2개와 `prompt_studio/**/*.js` 52개는 총 54개·13,242�
 목표로 삼지는 않지만, 책임 경계와 검증 비용이 이 파일들에 집중돼 있다는
 신호로 사용한다. Regional entry의 축소는 줄 수보다 소유권 이동의 결과다.
 
+### Phase 3 checkJs coverage ratchet (2026-07-19)
+
+TypeScript 6.0.3으로 `web/js`의 기존 미포함 root entry를 각각 다시 측정했다.
+오류가 0개인 `easyuse_anima_api.js`, `easyuse_anima_i18n.js`,
+`easyuse_anima_prompt_rules.js`, `easyuse_anima_prompt_studio_common.js`는
+`jsconfig.json`의 명시적 include로 승격했다. root entry는 typecheck 대상 또는
+아래 debt 중 하나여야 하며, 계약 테스트가 새 미분류 entry, include 후 남은
+debt, root wildcard 추가를 실패시킨다.
+
+현재 debt ledger:
+
+| TODO 파일 | 총 오류 | TypeScript 오류 코드별 개수 |
+| --- | ---: | --- |
+| `easyuse_anima_aio.js` | 16 | TS1117 4, TS2307 4, TS2339 2, TS2345 2, TS6133 4 |
+| `easyuse_anima_autocomplete.js` | 5 | TS2307 1, TS2339 2, TS6133 2 |
+| `easyuse_anima_lora_preset.js` | 10 | TS2304 4, TS2307 2, TS2345 1, TS6133 3 |
+| `easyuse_anima_naia.js` | 5 | TS2307 2, TS2345 2, TS6133 1 |
+| `easyuse_anima_settings.js` | 4 | TS2307 1, TS2339 3 |
+
+코드는 TS1117 duplicate property, TS2304 undeclared host global, TS2307 외부
+Comfy import resolution, TS2339 DOM/window property shape, TS2345 argument/shape
+mismatch, TS6133 unused declaration/parameter를 뜻한다. TODO는 각 파일의 오류를
+동작 변경이나 광범위한 suppression 없이 해소한 뒤, 같은 PR에서 해당 entry를
+`jsconfig.json` include로 옮기고 테스트와 이 ledger의 debt에서 제거하는 것이다.
+
+재현 명령은 `jsconfig.json`과 같은 compiler option을 파일별로 적용한다.
+
+```powershell
+$files = @(
+  "web/js/easyuse_anima_aio.js",
+  "web/js/easyuse_anima_autocomplete.js",
+  "web/js/easyuse_anima_lora_preset.js",
+  "web/js/easyuse_anima_naia.js",
+  "web/js/easyuse_anima_settings.js"
+)
+foreach ($file in $files) {
+  npx --yes --package "typescript@6.0.3" -- tsc `
+    --allowJs --checkJs --noEmit --target ES2022 --module ES2022 `
+    --moduleResolution Bundler --lib "ES2022,DOM,DOM.Iterable" `
+    --skipLibCheck --noUnusedLocals --noUnusedParameters --strict false `
+    --pretty false $file
+}
+```
+
 ### Prompt Studio adapter 경계
 
 - `prompt_studio/regional/editor_adapter.js`와 `prompt_studio/highlight.js`에는

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -18,6 +18,10 @@
     "web/js/lora_preset/**/*.js",
     "web/js/lifecycle/**/*.js",
     "web/js/settings/**/*.js",
+    "web/js/easyuse_anima_api.js",
+    "web/js/easyuse_anima_i18n.js",
+    "web/js/easyuse_anima_prompt_rules.js",
+    "web/js/easyuse_anima_prompt_studio_common.js",
     "web/js/easyuse_anima_prompt_studio.js",
     "web/js/easyuse_anima_prompt_studio_regional.js",
     "web/js/prompt_studio/**/*.js"

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3363,6 +3363,41 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertIn(path, config["include"])
 
+    def test_root_entry_typecheck_coverage_has_explicit_debt(self):
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+        covered_root_entries = {
+            entry
+            for entry in config["include"]
+            if entry.startswith("web/js/")
+            and "/" not in entry.removeprefix("web/js/")
+            and "*" not in entry
+        }
+        debt_root_entries = {
+            "web/js/easyuse_anima_aio.js",
+            "web/js/easyuse_anima_autocomplete.js",
+            "web/js/easyuse_anima_lora_preset.js",
+            "web/js/easyuse_anima_naia.js",
+            "web/js/easyuse_anima_settings.js",
+        }
+        actual_root_entries = {
+            path.relative_to(ROOT).as_posix()
+            for path in WEB_JS.glob("*.js")
+        }
+
+        for entry in config["include"]:
+            if entry.startswith("web/js/"):
+                first_component = entry.removeprefix("web/js/").split("/", 1)[0]
+                self.assertFalse(
+                    any(marker in first_component for marker in "*?["),
+                    f"Root-level wildcard would bypass the explicit debt ledger: {entry}",
+                )
+
+        self.assertTrue(covered_root_entries.isdisjoint(debt_root_entries))
+        self.assertEqual(
+            actual_root_entries,
+            covered_root_entries | debt_root_entries,
+        )
+
     def test_frontend_check_script_runs_syntax_and_typecheck(self):
         source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 변경 요약

- Issue #166 Phase 3의 no-build `checkJs` 커버리지 ratchet을 추가했습니다.
- TypeScript 6.0.3에서 오류가 없던 root entry 4개(`easyuse_anima_api.js`, `easyuse_anima_i18n.js`, `easyuse_anima_prompt_rules.js`, `easyuse_anima_prompt_studio_common.js`)를 `jsconfig.json` include에 추가했습니다.
- 모든 `web/js` root entry가 typecheck 대상 또는 명시적 debt 중 하나인지 고정하고 root wildcard 우회를 차단하는 계약 테스트를 추가했습니다.
- 남은 5개 entry의 재현 가능한 TypeScript 오류 코드별 개수를 기존 frontend maintenance roadmap에 기록했습니다.
- production JavaScript, lifecycle hook, DOM/canvas, Comfy import, runner version, Python backend는 변경하지 않았습니다.

## 주요 파일

- `jsconfig.json`
- `tests/test_frontend_modules.py`
- `docs/development/frontend-maintenance-roadmap.md`

## 검증

- `python -m unittest test_frontend_modules.FrontendModuleStructureTests.test_root_entry_typecheck_coverage_has_explicit_debt test_frontend_modules.FrontendModuleStructureTests.test_prompt_studio_typecheck_config_tracks_current_slice`
  - 2 tests, OK
- `npx --yes --package "typescript@6.0.3" -- tsc -p jsconfig.json`
  - 통과
- `powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile quick`
  - 통과, frontend JavaScript 111개, TypeScript 6.0.3
- 공식 project full profile
  - Python unittest 681개 통과
  - frontend JavaScript 111개 및 TypeScript 6.0.3 통과
  - Python compile 및 diff check 통과
- `git diff --check`
  - 통과

## 테스트 표면

- ComfyUI Codex test instance: 공식 full project validation
- Live ComfyUI/browser smoke: production/runtime 변경이 없어 실행하지 않음

## 남은 위험 및 미확인 항목

- debt ledger는 현재 TypeScript 6.0.3 파일별 측정 스냅샷입니다. 해당 production entry가 바뀌면 오류 개수와 ledger를 함께 갱신해야 합니다.
- 이 PR은 오류가 남은 5개 entry 자체를 수정하지 않습니다. 각 entry의 debt 해소와 composition-root 축소는 후속 PR로 분리합니다.

Refs #166
