### PR TITLE
chore: Prompt Corrector vertical slice를 canonical package로 이동

### DIFF
--- a/easyuse_anima/nodes/prompt_nodes.py
+++ b/easyuse_anima/nodes/prompt_nodes.py
@@ -1,0 +1,167 @@
+"""ComfyUI adapters for ANIMA prompt correction."""
+
+from __future__ import annotations
+
+import json
+
+from ..common.serialization import _stable_change_key
+from ..prompt.correction import (
+    _prompt_translation_change_key,
+    _split_tag_text,
+    _translate_prompt_text,
+)
+
+try:
+    from ...anima_prompt import correct_prompt, load_knowledge_base
+except ImportError:
+    from anima_prompt import correct_prompt, load_knowledge_base
+
+
+def _bind_prompt_node_runtime(*, resolve_helper) -> None:
+    global _stable_change_key, _prompt_translation_change_key
+    global _split_tag_text, _translate_prompt_text, correct_prompt, load_knowledge_base
+
+    def runtime_helper(name):
+        def call(*args, **kwargs):
+            return resolve_helper(name)(*args, **kwargs)
+
+        return call
+
+    _stable_change_key = runtime_helper("_stable_change_key")
+    _prompt_translation_change_key = runtime_helper("_prompt_translation_change_key")
+    _split_tag_text = runtime_helper("_split_tag_text")
+    _translate_prompt_text = runtime_helper("_translate_prompt_text")
+    correct_prompt = runtime_helper("correct_prompt")
+    load_knowledge_base = runtime_helper("load_knowledge_base")
+
+
+def _correct_prompt_with_report(
+    prompt: str,
+    artist_overrides: str,
+    artist_exclusions: str,
+) -> tuple[str, str]:
+    prompt = _translate_prompt_text(prompt)
+    try:
+        kb = load_knowledge_base(allow_missing=True)
+        result = correct_prompt(
+            str(prompt or ""),
+            profile="prompt",
+            knowledge_base=kb,
+            validate_artist_tags=False,
+            artist_overrides=_split_tag_text(artist_overrides),
+            artist_exclusions=_split_tag_text(artist_exclusions),
+        )
+    except Exception as exc:
+        raise RuntimeError(f"[EasyUse Anima] prompt correction failed: {exc}") from exc
+
+    report = {
+        "changed": result.changed,
+        "unknown_tags": list(result.unknown_tags),
+        "duplicate_tags": list(result.duplicate_tags),
+        "warnings": list(result.warnings),
+        "sections": result.report.get("sections", []),
+    }
+    return (
+        result.text,
+        json.dumps(report, ensure_ascii=False, indent=2),
+    )
+
+
+class EasyUseAnimaPromptCorrector:
+    """ANIMA prompt order correction node."""
+
+    DESCRIPTION = (
+        "Normalizes ANIMA prompt text, keeps natural-language casing, reorders known "
+        "ANIMA sections, and reports unknown or duplicate tags."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Prompt text after ANIMA ordering and syntax cleanup.",
+        "JSON report containing changed state, unknown tags, duplicate tags, warnings, and sections.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "prompt": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Comma-separated prompt text to normalize and reorder for ANIMA.",
+                }),
+                "artist_overrides": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Comma- or newline-separated manual triggers to treat like artist tags.",
+                }),
+                "artist_exclusions": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Comma- or newline-separated triggers that must not be treated as artists.",
+                }),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("corrected_prompt", "report")
+    FUNCTION = "correct"
+    CATEGORY = "EasyUse Anima/Prompt"
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return _stable_change_key({
+            "mode": "prompt_corrector",
+            "prompt_translation": _prompt_translation_change_key(),
+            **{key: str(value) for key, value in sorted(kwargs.items())},
+        })
+
+    def correct(
+        self,
+        prompt: str,
+        artist_overrides: str,
+        artist_exclusions: str,
+    ):
+        return _correct_prompt_with_report(prompt, artist_overrides, artist_exclusions)
+
+
+class EasyUseAnimaPromptCorrectorSimple:
+    """Single-input ANIMA prompt correction node."""
+
+    DESCRIPTION = (
+        "Simplified ANIMA prompt correction node. It accepts one multiline prompt "
+        "and returns only the corrected prompt string."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Prompt text after ANIMA ordering and syntax cleanup.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "prompt": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Comma-separated prompt text to normalize and reorder for ANIMA.",
+                }),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("prompt",)
+    FUNCTION = "correct"
+    CATEGORY = "EasyUse Anima/Prompt"
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return _stable_change_key({
+            "mode": "prompt_corrector_simple",
+            "prompt_translation": _prompt_translation_change_key(),
+            **{key: str(value) for key, value in sorted(kwargs.items())},
+        })
+
+    def correct(self, prompt: str):
+        corrected, _report = _correct_prompt_with_report(prompt, "", "")
+        return (corrected,)
+
+
+__all__ = ("EasyUseAnimaPromptCorrector", "EasyUseAnimaPromptCorrectorSimple")

--- a/easyuse_anima/prompt/correction.py
+++ b/easyuse_anima/prompt/correction.py
@@ -1,0 +1,44 @@
+"""Prompt correction and translation helpers."""
+
+from __future__ import annotations
+
+try:
+    from ...prompt_translation import has_prompt_translation_markers, translate_prompt_markers
+    from ...settings import resolve_prompt_translation_settings
+except ImportError:
+    from prompt_translation import has_prompt_translation_markers, translate_prompt_markers
+    from settings import resolve_prompt_translation_settings
+
+
+def _bind_prompt_correction_runtime(*, resolve_settings) -> None:
+    global resolve_prompt_translation_settings
+
+    resolve_prompt_translation_settings = resolve_settings
+
+
+def _split_tag_text(value: str) -> list[str]:
+    if not value:
+        return []
+    parts: list[str] = []
+    for line in str(value).splitlines():
+        parts.extend(part.strip() for part in line.split(","))
+    return [part for part in parts if part]
+
+
+def _translate_prompt_text(value: str) -> str:
+    text = str(value or "")
+    if not text or not has_prompt_translation_markers(text):
+        return text
+    return translate_prompt_markers(text, resolve_prompt_translation_settings())
+
+
+def _prompt_translation_change_key() -> dict[str, str]:
+    settings = resolve_prompt_translation_settings()
+    return {
+        "provider": settings.provider,
+        "source": settings.source,
+        "target": settings.target,
+    }
+
+
+__all__ = ()

--- a/easyuse_anima/prompt/correction.py
+++ b/easyuse_anima/prompt/correction.py
@@ -10,10 +10,21 @@ except ImportError:
     from settings import resolve_prompt_translation_settings
 
 
-def _bind_prompt_correction_runtime(*, resolve_settings) -> None:
+def _bind_prompt_correction_runtime(*, resolve_helper) -> None:
+    global has_prompt_translation_markers, translate_prompt_markers
     global resolve_prompt_translation_settings
 
-    resolve_prompt_translation_settings = resolve_settings
+    def runtime_helper(name):
+        def call(*args, **kwargs):
+            return resolve_helper(name)(*args, **kwargs)
+
+        return call
+
+    has_prompt_translation_markers = runtime_helper("has_prompt_translation_markers")
+    translate_prompt_markers = runtime_helper("translate_prompt_markers")
+    resolve_prompt_translation_settings = runtime_helper(
+        "resolve_prompt_translation_settings"
+    )
 
 
 def _split_tag_text(value: str) -> list[str]:

--- a/nodes.py
+++ b/nodes.py
@@ -7256,7 +7256,7 @@ def _consume_reserved_wildcard_next_seed(
 
 
 _bind_prompt_correction_runtime(
-    resolve_settings=lambda: resolve_prompt_translation_settings(),
+    resolve_helper=lambda name: globals()[name],
 )
 _bind_prompt_node_runtime(
     resolve_helper=lambda name: globals()[name],

--- a/nodes.py
+++ b/nodes.py
@@ -24,6 +24,12 @@ try:
         _choice as _choice,
         _single_value as _single_value,
     )
+    from .easyuse_anima.prompt.correction import (
+        _bind_prompt_correction_runtime as _bind_prompt_correction_runtime,
+        _prompt_translation_change_key as _prompt_translation_change_key,
+        _split_tag_text as _split_tag_text,
+        _translate_prompt_text as _translate_prompt_text,
+    )
     from .easyuse_anima.image.geometry import (
         _align_down as _align_down,
         _align_nearest as _align_nearest,
@@ -67,6 +73,11 @@ try:
     from .easyuse_anima.nodes.image_nodes import (
         EasyUseAnimaDetailerAlignHook as EasyUseAnimaDetailerAlignHook,
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
+    )
+    from .easyuse_anima.nodes.prompt_nodes import (
+        EasyUseAnimaPromptCorrector as EasyUseAnimaPromptCorrector,
+        EasyUseAnimaPromptCorrectorSimple as EasyUseAnimaPromptCorrectorSimple,
+        _bind_prompt_node_runtime as _bind_prompt_node_runtime,
     )
     from .easyuse_anima.naia.client import (
         DEFAULT_HOST as DEFAULT_HOST,
@@ -190,6 +201,12 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _choice as _choice,
         _single_value as _single_value,
     )
+    from easyuse_anima.prompt.correction import (
+        _bind_prompt_correction_runtime as _bind_prompt_correction_runtime,
+        _prompt_translation_change_key as _prompt_translation_change_key,
+        _split_tag_text as _split_tag_text,
+        _translate_prompt_text as _translate_prompt_text,
+    )
     from easyuse_anima.image.geometry import (
         _align_down as _align_down,
         _align_nearest as _align_nearest,
@@ -233,6 +250,11 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.nodes.image_nodes import (
         EasyUseAnimaDetailerAlignHook as EasyUseAnimaDetailerAlignHook,
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
+    )
+    from easyuse_anima.nodes.prompt_nodes import (
+        EasyUseAnimaPromptCorrector as EasyUseAnimaPromptCorrector,
+        EasyUseAnimaPromptCorrectorSimple as EasyUseAnimaPromptCorrectorSimple,
+        _bind_prompt_node_runtime as _bind_prompt_node_runtime,
     )
     from easyuse_anima.naia.client import (
         DEFAULT_HOST as DEFAULT_HOST,
@@ -4303,15 +4325,6 @@ def _call_impact_detailer(detailer, **kwargs):
     return method(**call_kwargs)
 
 
-def _split_tag_text(value: str) -> list[str]:
-    if not value:
-        return []
-    parts: list[str] = []
-    for line in str(value).splitlines():
-        parts.extend(part.strip() for part in line.split(","))
-    return [part for part in parts if part]
-
-
 def _prompt_tokens(value: str) -> list[str]:
     if not value:
         return []
@@ -4333,13 +4346,6 @@ def _join_prompt_tokens(*parts: str) -> str:
     return ", ".join(tokens)
 
 
-def _translate_prompt_text(value: str) -> str:
-    text = str(value or "")
-    if not text or not has_prompt_translation_markers(text):
-        return text
-    return translate_prompt_markers(text, resolve_prompt_translation_settings())
-
-
 def _translate_prompt_fields(fields: list[dict]) -> list[dict]:
     translated: list[dict] = []
     for field in fields:
@@ -4349,15 +4355,6 @@ def _translate_prompt_fields(fields: list[dict]) -> list[dict]:
             item["text"] = _translate_prompt_text(text)
         translated.append(item)
     return translated
-
-
-def _prompt_translation_change_key() -> dict[str, str]:
-    settings = resolve_prompt_translation_settings()
-    return {
-        "provider": settings.provider,
-        "source": settings.source,
-        "target": settings.target,
-    }
 
 
 def _correct_builder_prompt(prompt: str, artist_overrides: str = "") -> str:
@@ -7258,6 +7255,12 @@ def _consume_reserved_wildcard_next_seed(
     return reservation_next_seed if reservation_next_seed == expected_next_seed else None
 
 
+_bind_prompt_correction_runtime(
+    resolve_settings=lambda: resolve_prompt_translation_settings(),
+)
+_bind_prompt_node_runtime(
+    resolve_helper=lambda name: globals()[name],
+)
 _bind_wildcard_node_runtime(
     get_workflow_node=lambda *args, **kwargs: _get_workflow_node(*args, **kwargs),
     consume_reserved_next_seed=lambda *args, **kwargs: _consume_reserved_wildcard_next_seed(*args, **kwargs),
@@ -7288,133 +7291,6 @@ _bind_lora_node_runtime(
     flexible_optional_input_type=_FlexibleOptionalInputType,
     any_type=_ANY_TYPE,
 )
-
-
-class EasyUseAnimaPromptCorrector:
-    """ANIMA prompt order correction node."""
-
-    DESCRIPTION = (
-        "Normalizes ANIMA prompt text, keeps natural-language casing, reorders known "
-        "ANIMA sections, and reports unknown or duplicate tags."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Prompt text after ANIMA ordering and syntax cleanup.",
-        "JSON report containing changed state, unknown tags, duplicate tags, warnings, and sections.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "prompt": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Comma-separated prompt text to normalize and reorder for ANIMA.",
-                }),
-                "artist_overrides": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Comma- or newline-separated manual triggers to treat like artist tags.",
-                }),
-                "artist_exclusions": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Comma- or newline-separated triggers that must not be treated as artists.",
-                }),
-            }
-        }
-
-    RETURN_TYPES = ("STRING", "STRING")
-    RETURN_NAMES = ("corrected_prompt", "report")
-    FUNCTION = "correct"
-    CATEGORY = "EasyUse Anima/Prompt"
-
-    @classmethod
-    def IS_CHANGED(cls, **kwargs):
-        return _stable_change_key({
-            "mode": "prompt_corrector",
-            "prompt_translation": _prompt_translation_change_key(),
-            **{key: str(value) for key, value in sorted(kwargs.items())},
-        })
-
-    def correct(
-        self,
-        prompt: str,
-        artist_overrides: str,
-        artist_exclusions: str,
-    ):
-        prompt = _translate_prompt_text(prompt)
-        try:
-            kb = load_knowledge_base(allow_missing=True)
-            result = correct_prompt(
-                str(prompt or ""),
-                profile="prompt",
-                knowledge_base=kb,
-                validate_artist_tags=False,
-                artist_overrides=_split_tag_text(artist_overrides),
-                artist_exclusions=_split_tag_text(artist_exclusions),
-            )
-        except Exception as exc:
-            raise RuntimeError(f"[EasyUse Anima] prompt correction failed: {exc}") from exc
-
-        report = {
-            "changed": result.changed,
-            "unknown_tags": list(result.unknown_tags),
-            "duplicate_tags": list(result.duplicate_tags),
-            "warnings": list(result.warnings),
-            "sections": result.report.get("sections", []),
-        }
-        return (
-            result.text,
-            json.dumps(report, ensure_ascii=False, indent=2),
-        )
-
-
-class EasyUseAnimaPromptCorrectorSimple:
-    """Single-input ANIMA prompt correction node."""
-
-    DESCRIPTION = (
-        "Simplified ANIMA prompt correction node. It accepts one multiline prompt "
-        "and returns only the corrected prompt string."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Prompt text after ANIMA ordering and syntax cleanup.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "prompt": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Comma-separated prompt text to normalize and reorder for ANIMA.",
-                }),
-            }
-        }
-
-    RETURN_TYPES = ("STRING",)
-    RETURN_NAMES = ("prompt",)
-    FUNCTION = "correct"
-    CATEGORY = "EasyUse Anima/Prompt"
-
-    @classmethod
-    def IS_CHANGED(cls, **kwargs):
-        return _stable_change_key({
-            "mode": "prompt_corrector_simple",
-            "prompt_translation": _prompt_translation_change_key(),
-            **{key: str(value) for key, value in sorted(kwargs.items())},
-        })
-
-    def correct(self, prompt: str):
-        corrected, _report = EasyUseAnimaPromptCorrector().correct(
-            prompt,
-            "",
-            "",
-        )
-        return (corrected,)
-
-
 
 
 class EasyUseAnimaPromptBuilder:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -20556,9 +20556,9 @@
       },
       {
         "is_package": false,
-        "loc": 44,
+        "loc": 55,
         "module": "easyuse_anima.prompt.correction",
-        "normalized_git_blob_sha1": "c624e7c3d9cc3790715957fcfd4b8a1cd944376f",
+        "normalized_git_blob_sha1": "aefbd67e85ae99ad41992aa2b94ee90493c58d68",
         "path": "easyuse_anima/prompt/correction.py",
         "top_level": {
           "class_count": 0,
@@ -20570,7 +20570,7 @@
         "is_package": false,
         "loc": 10664,
         "module": "nodes",
-        "normalized_git_blob_sha1": "fa3d9999ff4e5192c5da7e5c43e57e5f4aeb924a",
+        "normalized_git_blob_sha1": "d968590df0342a380a1103bdf95b0b942fab8fb2",
         "path": "nodes.py",
         "top_level": {
           "class_count": 17,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6176,6 +6176,242 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_stable_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.serialization:_stable_change_key",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_stable_change_key",
+        "optional": false,
+        "requested": "..common.serialization",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_prompt_translation_change_key",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.correction:_prompt_translation_change_key",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_prompt_translation_change_key",
+        "optional": false,
+        "requested": "..prompt.correction",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_split_tag_text",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.correction:_split_tag_text",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_split_tag_text",
+        "optional": false,
+        "requested": "..prompt.correction",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_translate_prompt_text",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.correction:_translate_prompt_text",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_translate_prompt_text",
+        "optional": false,
+        "requested": "..prompt.correction",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correct_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "correct_prompt",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "...anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 15,
+        "name": "correct_prompt",
+        "optional": false,
+        "requested": "...anima_prompt",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "load_knowledge_base",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "load_knowledge_base",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "...anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 15,
+        "name": "load_knowledge_base",
+        "optional": false,
+        "requested": "...anima_prompt",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correct_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "correct_prompt",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 17,
+        "name": "correct_prompt",
+        "optional": false,
+        "requested": "anima_prompt",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "load_knowledge_base",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "load_knowledge_base",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 17,
+        "name": "load_knowledge_base",
+        "optional": false,
+        "requested": "anima_prompt",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
@@ -7567,6 +7803,218 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "...prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 6,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": "...prompt_translation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "translate_prompt_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "translate_prompt_markers",
+          "target": "prompt_translation.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "...prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 6,
+        "name": "translate_prompt_markers",
+        "optional": false,
+        "requested": "...prompt_translation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_prompt_translation_settings",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_prompt_translation_settings",
+          "target": "settings.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 7,
+        "name": "resolve_prompt_translation_settings",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 8,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 9,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": "prompt_translation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "translate_prompt_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 8,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "translate_prompt_markers",
+          "target": "prompt_translation.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 9,
+        "name": "translate_prompt_markers",
+        "optional": false,
+        "requested": "prompt_translation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_prompt_translation_settings",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 8,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_prompt_translation_settings",
+          "target": "settings.py",
+          "try_line": 5
+        },
+        "conditional": true,
+        "imported": "settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 10,
+        "name": "resolve_prompt_translation_settings",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "name": "annotations",
         "optional": false,
@@ -8028,6 +8476,130 @@
         "target": "easyuse_anima/common/values.py"
       },
       {
+        "alias": "_bind_prompt_correction_runtime",
+        "bound_name": "_bind_prompt_correction_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_prompt_correction_runtime",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_bind_prompt_correction_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.correction",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": "_prompt_translation_change_key",
+        "bound_name": "_prompt_translation_change_key",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_prompt_translation_change_key",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_prompt_translation_change_key",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.correction",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": "_split_tag_text",
+        "bound_name": "_split_tag_text",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_split_tag_text",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_split_tag_text",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.correction",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": "_translate_prompt_text",
+        "bound_name": "_translate_prompt_text",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_translate_prompt_text",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_translate_prompt_text",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.correction",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
         "alias": "_align_down",
         "bound_name": "_align_down",
         "branch_context": [
@@ -8049,7 +8621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 27,
+        "line": 33,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8080,7 +8652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 27,
+        "line": 33,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8111,7 +8683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 27,
+        "line": 33,
         "name": "_align_up",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8142,7 +8714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 27,
+        "line": 33,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8173,7 +8745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 27,
+        "line": 33,
         "name": "_alignment_value",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8204,7 +8776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 34,
+        "line": 40,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": ".easyuse_anima.image.detailer",
@@ -8235,7 +8807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 37,
+        "line": 43,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8266,7 +8838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 37,
+        "line": 43,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8297,7 +8869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 37,
+        "line": 43,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8328,7 +8900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 37,
+        "line": 43,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8359,7 +8931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 37,
+        "line": 43,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8390,7 +8962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 37,
+        "line": 43,
         "name": "_scale_by_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8421,7 +8993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 45,
+        "line": 51,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -8452,7 +9024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 45,
+        "line": 51,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -8483,7 +9055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 45,
+        "line": 51,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -8514,7 +9086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 45,
+        "line": 51,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -8545,7 +9117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 45,
+        "line": 51,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -8576,7 +9148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 45,
+        "line": 51,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -8607,7 +9179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 45,
+        "line": 51,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -8638,7 +9210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 54,
+        "line": 60,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -8669,7 +9241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 54,
+        "line": 60,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -8700,7 +9272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 54,
+        "line": 60,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -8731,7 +9303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 59,
+        "line": 65,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -8762,7 +9334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 59,
+        "line": 65,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -8793,7 +9365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 59,
+        "line": 65,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -8824,7 +9396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 59,
+        "line": 65,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -8855,7 +9427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 59,
+        "line": 65,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -8886,7 +9458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 59,
+        "line": 65,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -8917,7 +9489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 67,
+        "line": 73,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -8948,7 +9520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 67,
+        "line": 73,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -8956,6 +9528,99 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptCorrector",
+        "bound_name": "EasyUseAnimaPromptCorrector",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptCorrector",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
+        "kind": "static_from",
+        "line": 77,
+        "name": "EasyUseAnimaPromptCorrector",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptCorrectorSimple",
+        "bound_name": "EasyUseAnimaPromptCorrectorSimple",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptCorrectorSimple",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
+        "kind": "static_from",
+        "line": 77,
+        "name": "EasyUseAnimaPromptCorrectorSimple",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "_bind_prompt_node_runtime",
+        "bound_name": "_bind_prompt_node_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_prompt_node_runtime",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
+        "kind": "static_from",
+        "line": 77,
+        "name": "_bind_prompt_node_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
       },
       {
         "alias": "DEFAULT_HOST",
@@ -8979,7 +9644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9010,7 +9675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9041,7 +9706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9072,7 +9737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9103,7 +9768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9134,7 +9799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9165,7 +9830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9196,7 +9861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "NAI_1MP",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9227,7 +9892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9258,7 +9923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9289,7 +9954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9320,7 +9985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "_clean_prompt",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9351,7 +10016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9382,7 +10047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9413,7 +10078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9444,7 +10109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 71,
+        "line": 82,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9475,7 +10140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9506,7 +10171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9537,7 +10202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9568,7 +10233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9599,7 +10264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9630,7 +10295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9661,7 +10326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9692,7 +10357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9723,7 +10388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9754,7 +10419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9785,7 +10450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9816,7 +10481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9847,7 +10512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9878,7 +10543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9909,7 +10574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9940,7 +10605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -9971,7 +10636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10002,7 +10667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10033,7 +10698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10064,7 +10729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10095,7 +10760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 89,
+        "line": 100,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10126,7 +10791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 112,
+        "line": 123,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -10157,7 +10822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 112,
+        "line": 123,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -10188,7 +10853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 116,
+        "line": 127,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -10219,7 +10884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 116,
+        "line": 127,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -10250,7 +10915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 116,
+        "line": 127,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -10281,7 +10946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10312,7 +10977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10343,7 +11008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10374,7 +11039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10405,7 +11070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10436,7 +11101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10467,7 +11132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10498,7 +11163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10529,7 +11194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10560,7 +11225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10591,7 +11256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10622,7 +11287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10653,7 +11318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10684,7 +11349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10715,7 +11380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 121,
+        "line": 132,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10746,7 +11411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10777,7 +11442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10808,7 +11473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10839,7 +11504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10870,7 +11535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10901,7 +11566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10932,7 +11597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10963,7 +11628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 138,
+        "line": 149,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -10994,7 +11659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 148,
+        "line": 159,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -11025,7 +11690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 148,
+        "line": 159,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -11056,7 +11721,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 152,
+        "line": 163,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -11087,7 +11752,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 152,
+        "line": 163,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -11118,7 +11783,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 153,
+        "line": 164,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -11149,7 +11814,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 154,
+        "line": 165,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -11180,7 +11845,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 154,
+        "line": 165,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -11211,7 +11876,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 154,
+        "line": 165,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -11242,7 +11907,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 159,
+        "line": 170,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -11273,7 +11938,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 159,
+        "line": 170,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -11304,7 +11969,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11335,7 +12000,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11366,7 +12031,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11397,7 +12062,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11428,7 +12093,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11459,7 +12124,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11490,7 +12155,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11521,7 +12186,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11552,7 +12217,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11583,7 +12248,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11614,7 +12279,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11645,7 +12310,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11676,7 +12341,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11707,7 +12372,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11738,7 +12403,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11769,7 +12434,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11800,7 +12465,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11831,7 +12496,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 160,
+        "line": 171,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -11850,7 +12515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -11865,7 +12530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 181,
+        "line": 192,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -11884,7 +12549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -11899,7 +12564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 181,
+        "line": 192,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -11918,7 +12583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -11933,7 +12598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 181,
+        "line": 192,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -11952,7 +12617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -11967,7 +12632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -11986,7 +12651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12001,7 +12666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12020,7 +12685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12035,7 +12700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12054,7 +12719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12069,7 +12734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12088,7 +12753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12103,7 +12768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12111,6 +12776,142 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": "_bind_prompt_correction_runtime",
+        "bound_name": "_bind_prompt_correction_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_prompt_correction_runtime",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
+        "kind": "static_from",
+        "line": 204,
+        "name": "_bind_prompt_correction_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.correction",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": "_prompt_translation_change_key",
+        "bound_name": "_prompt_translation_change_key",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_prompt_translation_change_key",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
+        "kind": "static_from",
+        "line": 204,
+        "name": "_prompt_translation_change_key",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.correction",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": "_split_tag_text",
+        "bound_name": "_split_tag_text",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_split_tag_text",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_split_tag_text",
+        "kind": "static_from",
+        "line": 204,
+        "name": "_split_tag_text",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.correction",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": "_translate_prompt_text",
+        "bound_name": "_translate_prompt_text",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_translate_prompt_text",
+          "target": "easyuse_anima/prompt/correction.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
+        "kind": "static_from",
+        "line": 204,
+        "name": "_translate_prompt_text",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.correction",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
       },
       {
         "alias": "_align_down",
@@ -12122,7 +12923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12137,7 +12938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -12156,7 +12957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12171,7 +12972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -12190,7 +12991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12205,7 +13006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -12224,7 +13025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12239,7 +13040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -12258,7 +13059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12273,7 +13074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -12292,7 +13093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12307,7 +13108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 200,
+        "line": 217,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -12326,7 +13127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12341,7 +13142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -12360,7 +13161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12375,7 +13176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -12394,7 +13195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12409,7 +13210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -12428,7 +13229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12443,7 +13244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -12462,7 +13263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12477,7 +13278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -12496,7 +13297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12511,7 +13312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -12530,7 +13331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12545,7 +13346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -12564,7 +13365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12579,7 +13380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -12598,7 +13399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12613,7 +13414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -12632,7 +13433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12647,7 +13448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -12666,7 +13467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12681,7 +13482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -12700,7 +13501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12715,7 +13516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -12734,7 +13535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12749,7 +13550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -12768,7 +13569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12783,7 +13584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 220,
+        "line": 237,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -12802,7 +13603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12817,7 +13618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 220,
+        "line": 237,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -12836,7 +13637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12851,7 +13652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 220,
+        "line": 237,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -12870,7 +13671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12885,7 +13686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -12904,7 +13705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12919,7 +13720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -12938,7 +13739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12953,7 +13754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -12972,7 +13773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -12987,7 +13788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13006,7 +13807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13021,7 +13822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13040,7 +13841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13055,7 +13856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13074,7 +13875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13089,7 +13890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 233,
+        "line": 250,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -13108,7 +13909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13123,7 +13924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 233,
+        "line": 250,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -13131,6 +13932,108 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptCorrector",
+        "bound_name": "EasyUseAnimaPromptCorrector",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptCorrector",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
+        "kind": "static_from",
+        "line": 254,
+        "name": "EasyUseAnimaPromptCorrector",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptCorrectorSimple",
+        "bound_name": "EasyUseAnimaPromptCorrectorSimple",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptCorrectorSimple",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
+        "kind": "static_from",
+        "line": 254,
+        "name": "EasyUseAnimaPromptCorrectorSimple",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "_bind_prompt_node_runtime",
+        "bound_name": "_bind_prompt_node_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_prompt_node_runtime",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
+        "kind": "static_from",
+        "line": 254,
+        "name": "_bind_prompt_node_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
       },
       {
         "alias": "DEFAULT_HOST",
@@ -13142,7 +14045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13157,7 +14060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13176,7 +14079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13191,7 +14094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13210,7 +14113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13225,7 +14128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13244,7 +14147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13259,7 +14162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13278,7 +14181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13293,7 +14196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13312,7 +14215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13327,7 +14230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13346,7 +14249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13361,7 +14264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13380,7 +14283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13395,7 +14298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13414,7 +14317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13429,7 +14332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13448,7 +14351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13463,7 +14366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13482,7 +14385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13497,7 +14400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13516,7 +14419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13531,7 +14434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13550,7 +14453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13565,7 +14468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13584,7 +14487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13599,7 +14502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13618,7 +14521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13633,7 +14536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13652,7 +14555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13667,7 +14570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -13686,7 +14589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13701,7 +14604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13720,7 +14623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13735,7 +14638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13754,7 +14657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13769,7 +14672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13788,7 +14691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13803,7 +14706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13822,7 +14725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13837,7 +14740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13856,7 +14759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13871,7 +14774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13890,7 +14793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13905,7 +14808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13924,7 +14827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13939,7 +14842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13958,7 +14861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -13973,7 +14876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -13992,7 +14895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14007,7 +14910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14026,7 +14929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14041,7 +14944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14060,7 +14963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14075,7 +14978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14094,7 +14997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14109,7 +15012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14128,7 +15031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14143,7 +15046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14162,7 +15065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14177,7 +15080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14196,7 +15099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14211,7 +15114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14230,7 +15133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14245,7 +15148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14264,7 +15167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14279,7 +15182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14298,7 +15201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14313,7 +15216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14332,7 +15235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14347,7 +15250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14366,7 +15269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14381,7 +15284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14400,7 +15303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14415,7 +15318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 278,
+        "line": 300,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -14434,7 +15337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14449,7 +15352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 278,
+        "line": 300,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -14468,7 +15371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14483,7 +15386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 282,
+        "line": 304,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -14502,7 +15405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14517,7 +15420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 282,
+        "line": 304,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -14536,7 +15439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14551,7 +15454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 282,
+        "line": 304,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -14570,7 +15473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14585,7 +15488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14604,7 +15507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14619,7 +15522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14638,7 +15541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14653,7 +15556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14672,7 +15575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14687,7 +15590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14706,7 +15609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14721,7 +15624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14740,7 +15643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14755,7 +15658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14774,7 +15677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14789,7 +15692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14808,7 +15711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14823,7 +15726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14842,7 +15745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14857,7 +15760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14876,7 +15779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14891,7 +15794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14910,7 +15813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14925,7 +15828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14944,7 +15847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14959,7 +15862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -14978,7 +15881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -14993,7 +15896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15012,7 +15915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15027,7 +15930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15046,7 +15949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15061,7 +15964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15080,7 +15983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15095,7 +15998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15114,7 +16017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15129,7 +16032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15148,7 +16051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15163,7 +16066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15182,7 +16085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15197,7 +16100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15216,7 +16119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15231,7 +16134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15250,7 +16153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15265,7 +16168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15284,7 +16187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15299,7 +16202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15318,7 +16221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15333,7 +16236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -15352,7 +16255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15367,7 +16270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 314,
+        "line": 336,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -15386,7 +16289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15401,7 +16304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 314,
+        "line": 336,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -15420,7 +16323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15435,7 +16338,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 318,
+        "line": 340,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -15454,7 +16357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15469,7 +16372,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 318,
+        "line": 340,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -15488,7 +16391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15503,7 +16406,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 319,
+        "line": 341,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -15522,7 +16425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15537,7 +16440,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 320,
+        "line": 342,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -15556,7 +16459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15571,7 +16474,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 320,
+        "line": 342,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -15590,7 +16493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15605,7 +16508,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 320,
+        "line": 342,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -15624,7 +16527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15639,7 +16542,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 325,
+        "line": 347,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -15658,7 +16561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15673,7 +16576,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 325,
+        "line": 347,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -15692,7 +16595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15707,7 +16610,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15726,7 +16629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15741,7 +16644,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15760,7 +16663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15775,7 +16678,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15794,7 +16697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15809,7 +16712,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15828,7 +16731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15843,7 +16746,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15862,7 +16765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15877,7 +16780,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15896,7 +16799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15911,7 +16814,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15930,7 +16833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15945,7 +16848,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15964,7 +16867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -15979,7 +16882,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -15998,7 +16901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16013,7 +16916,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16032,7 +16935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16047,7 +16950,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16066,7 +16969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16081,7 +16984,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16100,7 +17003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16115,7 +17018,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16134,7 +17037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16149,7 +17052,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16168,7 +17071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16183,7 +17086,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16202,7 +17105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16217,7 +17120,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16236,7 +17139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16251,7 +17154,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16270,7 +17173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -16285,7 +17188,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16303,7 +17206,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2007
+            "line": 2029
           }
         ],
         "classification": "external",
@@ -16311,7 +17214,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2008,
+        "line": 2030,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -16328,7 +17231,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2072
+            "line": 2094
           }
         ],
         "classification": "external",
@@ -16336,7 +17239,7 @@
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2073,
+        "line": 2095,
         "name": null,
         "optional": true,
         "requested": "impact.core",
@@ -16353,7 +17256,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2078
+            "line": 2100
           }
         ],
         "classification": "external",
@@ -16361,7 +17264,7 @@
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2079,
+        "line": 2101,
         "name": "core",
         "optional": true,
         "requested": "modules.impact",
@@ -16378,7 +17281,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2094
+            "line": 2116
           }
         ],
         "classification": "external",
@@ -16386,7 +17289,7 @@
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2095,
+        "line": 2117,
         "name": null,
         "optional": true,
         "requested": "comfy.samplers",
@@ -16403,7 +17306,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2103
+            "line": 2125
           }
         ],
         "classification": "external",
@@ -16411,7 +17314,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2104,
+        "line": 2126,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -16428,7 +17331,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2119
+            "line": 2141
           }
         ],
         "classification": "external",
@@ -16436,7 +17339,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2120,
+        "line": 2142,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -16453,7 +17356,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2125
+            "line": 2147
           }
         ],
         "classification": "external",
@@ -16461,7 +17364,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2126,
+        "line": 2148,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -16478,7 +17381,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2139
+            "line": 2161
           }
         ],
         "classification": "external",
@@ -16486,7 +17389,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2140,
+        "line": 2162,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -16503,7 +17406,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2238
+            "line": 2260
           }
         ],
         "classification": "external",
@@ -16511,7 +17414,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2239,
+        "line": 2261,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
@@ -16528,7 +17431,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2262
+            "line": 2284
           }
         ],
         "classification": "external",
@@ -16536,7 +17439,7 @@
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2263,
+        "line": 2285,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.segs_nodes",
@@ -16553,7 +17456,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2268
+            "line": 2290
           }
         ],
         "classification": "external",
@@ -16561,7 +17464,7 @@
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2269,
+        "line": 2291,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.segs_nodes",
@@ -16578,7 +17481,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2274
+            "line": 2296
           }
         ],
         "classification": "external",
@@ -16586,7 +17489,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2275,
+        "line": 2297,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -16603,7 +17506,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2280
+            "line": 2302
           }
         ],
         "classification": "external",
@@ -16611,7 +17514,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2281,
+        "line": 2303,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -16628,7 +17531,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2715
+            "line": 2737
           }
         ],
         "classification": "external",
@@ -16636,7 +17539,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2716,
+        "line": 2738,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -16653,7 +17556,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2755
+            "line": 2777
           }
         ],
         "classification": "external",
@@ -16661,7 +17564,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2756,
+        "line": 2778,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -16676,7 +17579,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3188,
+            "line": 3210,
             "type_checking": false
           },
           {
@@ -16684,7 +17587,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3189
+            "line": 3211
           }
         ],
         "classification": "external",
@@ -16692,7 +17595,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3190,
+        "line": 3212,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -16709,7 +17612,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3989
+            "line": 4011
           }
         ],
         "classification": "external",
@@ -16717,7 +17620,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3990,
+        "line": 4012,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -16734,7 +17637,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4051
+            "line": 4073
           }
         ],
         "classification": "external",
@@ -16742,7 +17645,7 @@
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4052,
+        "line": 4074,
         "name": "PromptServer",
         "optional": true,
         "requested": "server",
@@ -16759,7 +17662,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
@@ -16767,7 +17670,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4079,
+        "line": 4101,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -16784,7 +17687,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
@@ -16792,7 +17695,7 @@
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4080,
+        "line": 4102,
         "name": null,
         "optional": true,
         "requested": "numpy",
@@ -16809,7 +17712,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
@@ -16817,7 +17720,7 @@
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4081,
+        "line": 4103,
         "name": "Image",
         "optional": true,
         "requested": "PIL",
@@ -16834,7 +17737,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4272
+            "line": 4294
           }
         ],
         "classification": "external",
@@ -16842,7 +17745,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4273,
+        "line": 4295,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -16859,7 +17762,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5123
+            "line": 5120
           }
         ],
         "classification": "external",
@@ -16867,7 +17770,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5124,
+        "line": 5121,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -16884,7 +17787,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5140
+            "line": 5137
           }
         ],
         "classification": "external",
@@ -16892,7 +17795,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5141,
+        "line": 5138,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -16909,7 +17812,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5161
+            "line": 5158
           }
         ],
         "classification": "external",
@@ -16917,7 +17820,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5162,
+        "line": 5159,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -16934,7 +17837,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5238
+            "line": 5235
           }
         ],
         "classification": "external",
@@ -16942,7 +17845,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5239,
+        "line": 5236,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -16959,7 +17862,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6037
+            "line": 6034
           }
         ],
         "classification": "external",
@@ -16967,7 +17870,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6038,
+        "line": 6035,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -16984,7 +17887,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7062
+            "line": 7059
           }
         ],
         "classification": "external",
@@ -16992,7 +17895,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7063,
+        "line": 7060,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17009,7 +17912,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7096
+            "line": 7093
           }
         ],
         "classification": "external",
@@ -17017,7 +17920,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7097,
+        "line": 7094,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -18699,6 +19602,18 @@
         "to": "easyuse_anima/naia/client.py"
       },
       {
+        "from": "easyuse_anima/nodes/prompt_nodes.py",
+        "to": "anima_prompt/__init__.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_nodes.py",
+        "to": "easyuse_anima/common/serialization.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_nodes.py",
+        "to": "easyuse_anima/prompt/correction.py"
+      },
+      {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
         "to": "easyuse_anima/common/serialization.py"
       },
@@ -18713,6 +19628,14 @@
       {
         "from": "easyuse_anima/profiles/mutation.py",
         "to": "easyuse_anima/profiles/contract.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/correction.py",
+        "to": "prompt_translation.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/correction.py",
+        "to": "settings.py"
       },
       {
         "from": "nodes.py",
@@ -18784,7 +19707,15 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/prompt/correction.py"
       },
       {
         "from": "nodes.py",
@@ -19045,6 +19976,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/nodes/prompt_nodes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/nodes/wildcard_nodes.py"
         ]
       },
@@ -19064,6 +20001,18 @@
         "cyclic": false,
         "modules": [
           "easyuse_anima/profiles/mutation.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/prompt/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/prompt/correction.py"
         ]
       },
       {
@@ -19099,7 +20048,7 @@
     ]
   },
   "inventory": {
-    "module_count": 46,
+    "module_count": 48,
     "modules": [
       {
         "is_package": true,
@@ -19535,6 +20484,18 @@
       },
       {
         "is_package": false,
+        "loc": 167,
+        "module": "easyuse_anima.nodes.prompt_nodes",
+        "normalized_git_blob_sha1": "862e46cc2e24e18d00c71732258f9538a46fc9c1",
+        "path": "easyuse_anima/nodes/prompt_nodes.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 2,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
         "loc": 303,
         "module": "easyuse_anima.nodes.wildcard_nodes",
         "normalized_git_blob_sha1": "e7bb2f568b150f944ce7619c6af14009e8d37d54",
@@ -19595,13 +20556,25 @@
       },
       {
         "is_package": false,
-        "loc": 10788,
+        "loc": 44,
+        "module": "easyuse_anima.prompt.correction",
+        "normalized_git_blob_sha1": "c624e7c3d9cc3790715957fcfd4b8a1cd944376f",
+        "path": "easyuse_anima/prompt/correction.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 4,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 10664,
         "module": "nodes",
-        "normalized_git_blob_sha1": "f17e44281d25ef6322aca6a91fd15304769720d5",
+        "normalized_git_blob_sha1": "fa3d9999ff4e5192c5da7e5c43e57e5f4aeb924a",
         "path": "nodes.py",
         "top_level": {
-          "class_count": 19,
-          "function_count": 219,
+          "class_count": 17,
+          "function_count": 216,
           "global_count": 104
         }
       },
@@ -20491,6 +21464,52 @@
             "exceptions": [
               "ImportError"
             ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 17,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 16,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 17,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
             "handler_line": 28,
             "kind": "try",
             "line": 8
@@ -20882,7 +21901,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 8,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 8,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:translate_prompt_markers",
+        "kind": "static_from",
+        "line": 9,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 8,
+            "kind": "try",
+            "line": 5
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_prompt_translation_settings",
+        "kind": "static_from",
+        "line": 10,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/correction.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -20891,7 +21979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 181,
+        "line": 192,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20905,7 +21993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -20914,7 +22002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 181,
+        "line": 192,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20928,7 +22016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -20937,7 +22025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 181,
+        "line": 192,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20951,7 +22039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -20960,7 +22048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20974,7 +22062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -20983,7 +22071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -20997,7 +22085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21006,7 +22094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21020,7 +22108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21029,7 +22117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21043,7 +22131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21052,7 +22140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 186,
+        "line": 197,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21066,7 +22154,99 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
+        "kind": "static_from",
+        "line": 204,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
+        "kind": "static_from",
+        "line": 204,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_split_tag_text",
+        "kind": "static_from",
+        "line": 204,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
+        "kind": "static_from",
+        "line": 204,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21075,7 +22255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21089,7 +22269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21098,7 +22278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21112,7 +22292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21121,7 +22301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21135,7 +22315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21144,7 +22324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21158,7 +22338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21167,7 +22347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 193,
+        "line": 210,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21181,7 +22361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21190,7 +22370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 200,
+        "line": 217,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21204,7 +22384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21213,7 +22393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21227,7 +22407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21236,7 +22416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21250,7 +22430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21259,7 +22439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21273,7 +22453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21282,7 +22462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21296,7 +22476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21305,7 +22485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21319,7 +22499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21328,7 +22508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 203,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21342,7 +22522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21351,7 +22531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21365,7 +22545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21374,7 +22554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21388,7 +22568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21397,7 +22577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21411,7 +22591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21420,7 +22600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21434,7 +22614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21443,7 +22623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21457,7 +22637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21466,7 +22646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21480,7 +22660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21489,7 +22669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 211,
+        "line": 228,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21503,7 +22683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21512,7 +22692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 220,
+        "line": 237,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21526,7 +22706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21535,7 +22715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 220,
+        "line": 237,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21549,7 +22729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21558,7 +22738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 220,
+        "line": 237,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21572,7 +22752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21581,7 +22761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21595,7 +22775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21604,7 +22784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21618,7 +22798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21627,7 +22807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21641,7 +22821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21650,7 +22830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21664,7 +22844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21673,7 +22853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21687,7 +22867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21696,7 +22876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 225,
+        "line": 242,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21710,7 +22890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21719,7 +22899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 233,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21733,7 +22913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21742,7 +22922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 233,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21756,7 +22936,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
+        "kind": "static_from",
+        "line": 254,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
+        "kind": "static_from",
+        "line": 254,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
+        "kind": "static_from",
+        "line": 254,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21765,7 +23014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21779,7 +23028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21788,7 +23037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21802,7 +23051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21811,7 +23060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21825,7 +23074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21834,7 +23083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21848,7 +23097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21857,7 +23106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21871,7 +23120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21880,7 +23129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21894,7 +23143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21903,7 +23152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21917,7 +23166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21926,7 +23175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21940,7 +23189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21949,7 +23198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21963,7 +23212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21972,7 +23221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21986,7 +23235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -21995,7 +23244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22009,7 +23258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22018,7 +23267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22032,7 +23281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22041,7 +23290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22055,7 +23304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22064,7 +23313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22078,7 +23327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22087,7 +23336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22101,7 +23350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22110,7 +23359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 237,
+        "line": 259,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22124,7 +23373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22133,7 +23382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22147,7 +23396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22156,7 +23405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22170,7 +23419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22179,7 +23428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22193,7 +23442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22202,7 +23451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22216,7 +23465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22225,7 +23474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22239,7 +23488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22248,7 +23497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22262,7 +23511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22271,7 +23520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22285,7 +23534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22294,7 +23543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22308,7 +23557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22317,7 +23566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22331,7 +23580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22340,7 +23589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22354,7 +23603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22363,7 +23612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22377,7 +23626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22386,7 +23635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22400,7 +23649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22409,7 +23658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22423,7 +23672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22432,7 +23681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22446,7 +23695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22455,7 +23704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22469,7 +23718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22478,7 +23727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22492,7 +23741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22501,7 +23750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22515,7 +23764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22524,7 +23773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22538,7 +23787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22547,7 +23796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22561,7 +23810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22570,7 +23819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22584,7 +23833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22593,7 +23842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 255,
+        "line": 277,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22607,7 +23856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22616,7 +23865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 278,
+        "line": 300,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22630,7 +23879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22639,7 +23888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 278,
+        "line": 300,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22653,7 +23902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22662,7 +23911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 282,
+        "line": 304,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22676,7 +23925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22685,7 +23934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 282,
+        "line": 304,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22699,7 +23948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22708,7 +23957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 282,
+        "line": 304,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22722,7 +23971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22731,7 +23980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22745,7 +23994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22754,7 +24003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22768,7 +24017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22777,7 +24026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22791,7 +24040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22800,7 +24049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22814,7 +24063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22823,7 +24072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22837,7 +24086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22846,7 +24095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22860,7 +24109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22869,7 +24118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22883,7 +24132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22892,7 +24141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22906,7 +24155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22915,7 +24164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22929,7 +24178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22938,7 +24187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22952,7 +24201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22961,7 +24210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22975,7 +24224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -22984,7 +24233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22998,7 +24247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23007,7 +24256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23021,7 +24270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23030,7 +24279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23044,7 +24293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23053,7 +24302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 287,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23067,7 +24316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23076,7 +24325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23090,7 +24339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23099,7 +24348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23113,7 +24362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23122,7 +24371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23136,7 +24385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23145,7 +24394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23159,7 +24408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23168,7 +24417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23182,7 +24431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23191,7 +24440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23205,7 +24454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23214,7 +24463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23228,7 +24477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23237,7 +24486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 304,
+        "line": 326,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23251,7 +24500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23260,7 +24509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 314,
+        "line": 336,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23274,7 +24523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23283,7 +24532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 314,
+        "line": 336,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23297,7 +24546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23306,7 +24555,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 318,
+        "line": 340,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23320,7 +24569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23329,7 +24578,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 318,
+        "line": 340,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23343,7 +24592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23352,7 +24601,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 319,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23366,7 +24615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23375,7 +24624,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 320,
+        "line": 342,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23389,7 +24638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23398,7 +24647,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 320,
+        "line": 342,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23412,7 +24661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23421,7 +24670,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 320,
+        "line": 342,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23435,7 +24684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23444,7 +24693,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 325,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23458,7 +24707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23467,7 +24716,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 325,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23481,7 +24730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23490,7 +24739,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23504,7 +24753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23513,7 +24762,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23527,7 +24776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23536,7 +24785,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23550,7 +24799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23559,7 +24808,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23573,7 +24822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23582,7 +24831,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23596,7 +24845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23605,7 +24854,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23619,7 +24868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23628,7 +24877,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23642,7 +24891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23651,7 +24900,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23665,7 +24914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23674,7 +24923,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23688,7 +24937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23697,7 +24946,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23711,7 +24960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23720,7 +24969,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23734,7 +24983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23743,7 +24992,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23757,7 +25006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23766,7 +25015,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23780,7 +25029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23789,7 +25038,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23803,7 +25052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23812,7 +25061,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23826,7 +25075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23835,7 +25084,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23849,7 +25098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23858,7 +25107,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23872,7 +25121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 180,
+            "handler_line": 191,
             "kind": "try",
             "line": 14
           }
@@ -23881,7 +25130,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 326,
+        "line": 348,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -25593,6 +26842,28 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
@@ -25744,6 +27015,17 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "optional": false,
         "role": "ordinary",
@@ -25888,52 +27170,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2007
+            "line": 2029
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2008,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2072
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.core",
-        "kind": "static_import",
-        "line": 2073,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2078
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact:core",
-        "kind": "static_from",
-        "line": 2079,
+        "line": 2030,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -25950,7 +27194,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "comfy.samplers",
+        "imported": "impact.core",
         "kind": "static_import",
         "line": 2095,
         "optional": true,
@@ -25964,14 +27208,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2103
+            "line": 2100
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2104,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2101,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -25983,14 +27227,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2119
+            "line": 2116
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2120,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2117,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26007,8 +27251,8 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
+        "imported": "nodes",
+        "kind": "static_import",
         "line": 2126,
         "optional": true,
         "role": "optional_dependency",
@@ -26021,14 +27265,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2139
+            "line": 2141
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2142,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2147
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2148,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2161
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2140,
+        "line": 2162,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26040,14 +27322,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2238
+            "line": 2260
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2239,
+        "line": 2261,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26059,14 +27341,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2262
+            "line": 2284
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2263,
+        "line": 2285,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26078,14 +27360,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2268
+            "line": 2290
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2269,
+        "line": 2291,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26097,14 +27379,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2274
+            "line": 2296
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2275,
+        "line": 2297,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26116,14 +27398,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2280
+            "line": 2302
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2281,
+        "line": 2303,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26135,14 +27417,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2715
+            "line": 2737
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2716,
+        "line": 2738,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26154,14 +27436,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2755
+            "line": 2777
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2756,
+        "line": 2778,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26171,7 +27453,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3188,
+            "line": 3210,
             "type_checking": false
           },
           {
@@ -26179,14 +27461,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3189
+            "line": 3211
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3190,
+        "line": 3212,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26198,14 +27480,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3989
+            "line": 4011
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3990,
+        "line": 4012,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26217,14 +27499,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4051
+            "line": 4073
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4052,
+        "line": 4074,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26236,14 +27518,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4079,
+        "line": 4101,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26255,14 +27537,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4080,
+        "line": 4102,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26274,14 +27556,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4081,
+        "line": 4103,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26293,14 +27575,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4272
+            "line": 4294
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4273,
+        "line": 4295,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26312,14 +27594,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5123
+            "line": 5120
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5124,
+        "line": 5121,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26331,14 +27613,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5140
+            "line": 5137
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5141,
+        "line": 5138,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26350,14 +27632,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5161
+            "line": 5158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5162,
+        "line": 5159,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26369,14 +27651,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5238
+            "line": 5235
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5239,
+        "line": 5236,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26388,14 +27670,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6037
+            "line": 6034
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6038,
+        "line": 6035,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26407,14 +27689,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7062
+            "line": 7059
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7063,
+        "line": 7060,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -26426,14 +27708,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7096
+            "line": 7093
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7097,
+        "line": 7094,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27316,52 +28598,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2007
+            "line": 2029
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2008,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2072
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.core",
-        "kind": "static_import",
-        "line": 2073,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2078
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact:core",
-        "kind": "static_from",
-        "line": 2079,
+        "line": 2030,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27378,7 +28622,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "comfy.samplers",
+        "imported": "impact.core",
         "kind": "static_import",
         "line": 2095,
         "optional": true,
@@ -27392,14 +28636,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2103
+            "line": 2100
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2104,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2101,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27411,14 +28655,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2119
+            "line": 2116
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2120,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2117,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27435,8 +28679,8 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
+        "imported": "nodes",
+        "kind": "static_import",
         "line": 2126,
         "optional": true,
         "role": "optional_dependency",
@@ -27449,14 +28693,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2139
+            "line": 2141
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2142,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2147
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2148,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2161
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2140,
+        "line": 2162,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27468,14 +28750,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2238
+            "line": 2260
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2239,
+        "line": 2261,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27487,14 +28769,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2262
+            "line": 2284
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2263,
+        "line": 2285,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27506,14 +28788,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2268
+            "line": 2290
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2269,
+        "line": 2291,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27525,14 +28807,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2274
+            "line": 2296
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2275,
+        "line": 2297,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27544,14 +28826,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2280
+            "line": 2302
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2281,
+        "line": 2303,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27563,14 +28845,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2715
+            "line": 2737
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2716,
+        "line": 2738,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27582,14 +28864,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2755
+            "line": 2777
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2756,
+        "line": 2778,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27599,7 +28881,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3188,
+            "line": 3210,
             "type_checking": false
           },
           {
@@ -27607,14 +28889,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3189
+            "line": 3211
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3190,
+        "line": 3212,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27626,14 +28908,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3989
+            "line": 4011
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3990,
+        "line": 4012,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27645,14 +28927,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4051
+            "line": 4073
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4052,
+        "line": 4074,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27664,14 +28946,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4079,
+        "line": 4101,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27683,14 +28965,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4080,
+        "line": 4102,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27702,14 +28984,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4100
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4081,
+        "line": 4103,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27721,14 +29003,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4272
+            "line": 4294
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4273,
+        "line": 4295,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27740,14 +29022,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5123
+            "line": 5120
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5124,
+        "line": 5121,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27759,14 +29041,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5140
+            "line": 5137
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5141,
+        "line": 5138,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27778,14 +29060,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5161
+            "line": 5158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5162,
+        "line": 5159,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27797,14 +29079,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5238
+            "line": 5235
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5239,
+        "line": 5236,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27816,14 +29098,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6037
+            "line": 6034
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6038,
+        "line": 6035,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27835,14 +29117,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7062
+            "line": 7059
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7063,
+        "line": 7060,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27854,14 +29136,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7096
+            "line": 7093
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7097,
+        "line": 7094,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28018,10 +29300,13 @@
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/lora_nodes.py",
       "easyuse_anima/nodes/naia_nodes.py",
+      "easyuse_anima/nodes/prompt_nodes.py",
       "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
       "easyuse_anima/profiles/mutation.py",
+      "easyuse_anima/prompt/__init__.py",
+      "easyuse_anima/prompt/correction.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -28065,11 +29350,13 @@
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/lora_nodes.py",
       "easyuse_anima/nodes/naia_nodes.py",
+      "easyuse_anima/nodes/prompt_nodes.py",
       "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
       "easyuse_anima/profiles/mutation.py",
       "easyuse_anima/prompt/__init__.py",
+      "easyuse_anima/prompt/correction.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -28077,8 +29364,7 @@
       "wildcard_engine.py"
     ],
     "unreachable_shipped_python_modules": [
-      "easyuse_anima/aio/__init__.py",
-      "easyuse_anima/prompt/__init__.py"
+      "easyuse_anima/aio/__init__.py"
     ]
   },
   "schema_version": 2,
@@ -28827,7 +30113,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 347,
+        "line": 369,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28836,7 +30122,7 @@
         "column": 62,
         "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "import_time_call",
-        "line": 490,
+        "line": 512,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28845,7 +30131,7 @@
         "column": 19,
         "context": "assign:_HASH_COMMENT_RE",
         "kind": "import_time_call",
-        "line": 995,
+        "line": 1017,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28854,7 +30140,7 @@
         "column": 19,
         "context": "assign:_INLINE_SPACE_RE",
         "kind": "import_time_call",
-        "line": 996,
+        "line": 1018,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28863,7 +30149,7 @@
         "column": 21,
         "context": "assign:_WEIGHTED_TOKEN_RE",
         "kind": "import_time_call",
-        "line": 997,
+        "line": 1019,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28872,7 +30158,7 @@
         "column": 22,
         "context": "assign:_WEIGHTED_ARTIST_RE",
         "kind": "import_time_call",
-        "line": 998,
+        "line": 1020,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28881,7 +30167,7 @@
         "column": 19,
         "context": "assign:_ARTIST_GROUP_RE",
         "kind": "import_time_call",
-        "line": 1001,
+        "line": 1023,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28890,7 +30176,7 @@
         "column": 24,
         "context": "assign:_SECTION_SEPARATOR_RE",
         "kind": "import_time_call",
-        "line": 1005,
+        "line": 1027,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28899,7 +30185,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 1008,
+        "line": 1030,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28908,7 +30194,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1027,
+        "line": 1049,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28917,12 +30203,21 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1207,
+        "line": 1229,
         "module": "nodes.py",
         "scope": "<module>"
       },
       {
-        "callee": "_bind_wildcard_node_runtime",
+        "callee": "_bind_prompt_correction_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 7258,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_prompt_node_runtime",
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
@@ -28931,11 +30226,20 @@
         "scope": "<module>"
       },
       {
+        "callee": "_bind_wildcard_node_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 7264,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "_bind_naia_node_runtime",
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7271,
+        "line": 7274,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28944,7 +30248,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7277,
+        "line": 7280,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28953,7 +30257,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7282,
+        "line": 7285,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -28962,7 +30266,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7286,
+        "line": 7289,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -29350,85 +30654,85 @@
       },
       {
         "kind": "dict",
-        "line": 358,
+        "line": 380,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 357,
+        "line": 379,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 356,
+        "line": 378,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "dict",
-        "line": 510,
+        "line": 532,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 499,
+        "line": 521,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 3961,
+        "line": 3983,
         "module": "nodes.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
         "kind": "set",
-        "line": 494,
+        "line": 516,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "dict",
-        "line": 936,
+        "line": 958,
         "module": "nodes.py",
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
       },
       {
         "kind": "list",
-        "line": 967,
+        "line": 989,
         "module": "nodes.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 370,
+        "line": 392,
         "module": "nodes.py",
         "name": "REGIONAL_FIELD_TYPES"
       },
       {
         "kind": "set",
-        "line": 1206,
+        "line": 1228,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
       {
         "kind": "dict",
-        "line": 3974,
+        "line": 3996,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 3975,
+        "line": 3997,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
       {
         "kind": "set",
-        "line": 490,
+        "line": 512,
         "module": "nodes.py",
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
       },
@@ -29621,7 +30925,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 3974,
+        "line": 3996,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -29631,7 +30935,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 3975,
+        "line": 3997,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -927,6 +927,47 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
             ["changed", "unknown_tags", "duplicate_tags", "warnings", "sections"],
         )
 
+    def test_root_translation_monkeypatches_drive_the_canonical_helper(self):
+        settings = types.SimpleNamespace(provider="off", source="auto", target="en")
+
+        with (
+            patch.object(
+                nodes,
+                "has_prompt_translation_markers",
+                return_value=False,
+            ) as has_markers,
+            patch.object(nodes, "translate_prompt_markers") as translate_markers,
+        ):
+            untranslated = nodes._translate_prompt_text("%{abc}")
+
+        self.assertEqual(untranslated, "%{abc}")
+        has_markers.assert_called_once_with("%{abc}")
+        translate_markers.assert_not_called()
+
+        with (
+            patch.object(
+                nodes,
+                "has_prompt_translation_markers",
+                return_value=True,
+            ) as has_markers,
+            patch.object(
+                nodes,
+                "translate_prompt_markers",
+                return_value="bound",
+            ) as translate_markers,
+            patch.object(
+                nodes,
+                "resolve_prompt_translation_settings",
+                return_value=settings,
+            ) as resolve_settings,
+        ):
+            translated = nodes._translate_prompt_text("%{abc}")
+
+        self.assertEqual(translated, "bound")
+        has_markers.assert_called_once_with("%{abc}")
+        resolve_settings.assert_called_once_with()
+        translate_markers.assert_called_once_with("%{abc}", settings)
+
     def test_translation_stays_outside_the_correction_error_mapping(self):
         with patch.object(nodes, "_translate_prompt_text", side_effect=ValueError("translate")):
             with self.assertRaisesRegex(ValueError, "^translate$"):

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -11,7 +11,7 @@ import types
 import unittest
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -30,7 +30,8 @@ from easyuse_anima.lora import metadata as lora_metadata
 from easyuse_anima.lora import preset as lora_preset
 from easyuse_anima.naia import client as naia_client
 from easyuse_anima.naia import resolution as naia_resolution
-from easyuse_anima.nodes import image_nodes, lora_nodes, naia_nodes, wildcard_nodes
+from easyuse_anima.nodes import image_nodes, lora_nodes, naia_nodes, prompt_nodes, wildcard_nodes
+from easyuse_anima.prompt import correction as prompt_correction
 
 
 PACKAGE_INIT = ROOT / "__init__.py"
@@ -830,6 +831,167 @@ print(json.dumps({{
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["class_module"], "easyuse_anima.nodes.lora_nodes")
+        self.assertFalse(payload["root_nodes_loaded"])
+
+
+class PromptCorrectorMoveContractTests(unittest.TestCase):
+    CORRECTION_HELPERS = (
+        "_split_tag_text",
+        "_translate_prompt_text",
+        "_prompt_translation_change_key",
+    )
+    NODE_CLASSES = (
+        "EasyUseAnimaPromptCorrector",
+        "EasyUseAnimaPromptCorrectorSimple",
+    )
+
+    def test_root_prompt_corrector_objects_are_direct_canonical_aliases(self):
+        for name in self.CORRECTION_HELPERS:
+            with self.subTest(name=name):
+                self.assertIs(getattr(nodes, name), getattr(prompt_correction, name))
+        for name in self.NODE_CLASSES:
+            with self.subTest(name=name):
+                self.assertIs(getattr(nodes, name), getattr(prompt_nodes, name))
+
+    def test_package_loaded_root_prompt_corrector_objects_are_direct_canonical_aliases(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_correction = sys.modules[
+                f"{package_name}.easyuse_anima.prompt.correction"
+            ]
+            package_prompt_nodes = sys.modules[
+                f"{package_name}.easyuse_anima.nodes.prompt_nodes"
+            ]
+
+            for name in self.CORRECTION_HELPERS:
+                with self.subTest(name=name):
+                    self.assertIs(getattr(package_nodes, name), getattr(package_correction, name))
+            for name in self.NODE_CLASSES:
+                with self.subTest(name=name):
+                    self.assertIs(getattr(package_nodes, name), getattr(package_prompt_nodes, name))
+
+    def test_root_monkeypatches_drive_the_canonical_prompt_corrector_nodes(self):
+        settings = types.SimpleNamespace(provider="off", source="auto", target="en")
+        correction_result = types.SimpleNamespace(
+            text="canonical result",
+            changed=True,
+            unknown_tags=("unknown",),
+            duplicate_tags=("duplicate",),
+            warnings=("warning",),
+            report={"sections": ["count", "general"]},
+        )
+
+        with (
+            patch.object(
+                nodes,
+                "resolve_prompt_translation_settings",
+                return_value=settings,
+            ) as resolve_settings,
+            patch.object(
+                nodes,
+                "_prompt_translation_change_key",
+                return_value={"bound": "translation"},
+            ) as translation_key,
+            patch.object(nodes, "_stable_change_key", side_effect=lambda payload: payload) as stable_key,
+            patch.object(nodes, "load_knowledge_base", return_value="bound kb") as load_kb,
+            patch.object(nodes, "correct_prompt", return_value=correction_result) as correct,
+        ):
+            change_key = prompt_nodes.EasyUseAnimaPromptCorrector.IS_CHANGED(
+                prompt="%{bound prompt}",
+                artist_overrides="artist_a\nartist_b",
+                artist_exclusions="artist_c",
+            )
+            corrected, report_text = prompt_nodes.EasyUseAnimaPromptCorrector().correct(
+                "%{bound prompt}",
+                "artist_a\nartist_b",
+                "artist_c",
+            )
+
+        self.assertEqual(change_key["prompt_translation"], {"bound": "translation"})
+        translation_key.assert_called_once_with()
+        stable_key.assert_called_once_with(change_key)
+        resolve_settings.assert_called_once_with()
+        load_kb.assert_called_once_with(allow_missing=True)
+        correct.assert_called_once_with(
+            "bound prompt",
+            profile="prompt",
+            knowledge_base="bound kb",
+            validate_artist_tags=False,
+            artist_overrides=["artist_a", "artist_b"],
+            artist_exclusions=["artist_c"],
+        )
+        self.assertEqual(corrected, "canonical result")
+        report = json.loads(report_text, object_pairs_hook=dict)
+        self.assertEqual(
+            list(report),
+            ["changed", "unknown_tags", "duplicate_tags", "warnings", "sections"],
+        )
+
+    def test_translation_stays_outside_the_correction_error_mapping(self):
+        with patch.object(nodes, "_translate_prompt_text", side_effect=ValueError("translate")):
+            with self.assertRaisesRegex(ValueError, "^translate$"):
+                prompt_nodes.EasyUseAnimaPromptCorrector().correct("prompt", "", "")
+
+        with patch.object(nodes, "load_knowledge_base", side_effect=ValueError("correct")):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"^\[EasyUse Anima\] prompt correction failed: correct$",
+            ):
+                prompt_nodes.EasyUseAnimaPromptCorrector().correct("prompt", "", "")
+
+    def test_public_nodes_share_the_private_correction_adapter(self):
+        with patch.object(
+            prompt_nodes,
+            "_correct_prompt_with_report",
+            return_value=("shared", "{}"),
+        ) as adapter:
+            full = prompt_nodes.EasyUseAnimaPromptCorrector().correct("prompt", "a", "b")
+            simple = prompt_nodes.EasyUseAnimaPromptCorrectorSimple().correct("prompt")
+
+        self.assertEqual(full, ("shared", "{}"))
+        self.assertEqual(simple, ("shared",))
+        self.assertEqual(
+            adapter.call_args_list,
+            [
+                call("prompt", "a", "b"),
+                call("prompt", "", ""),
+            ],
+        )
+
+    def test_fresh_process_direct_imports_do_not_load_root_nodes(self):
+        script = f"""
+import importlib
+import json
+import sys
+sys.path.insert(0, {str(ROOT)!r})
+sys.dont_write_bytecode = True
+modules = [
+    importlib.import_module("easyuse_anima.prompt.correction"),
+    importlib.import_module("easyuse_anima.nodes.prompt_nodes"),
+]
+print(json.dumps({{
+    "class_modules": [
+        modules[-1].EasyUseAnimaPromptCorrector.__module__,
+        modules[-1].EasyUseAnimaPromptCorrectorSimple.__module__,
+    ],
+    "root_nodes_loaded": "nodes" in sys.modules,
+}}))
+"""
+        result = subprocess.run(
+            [sys.executable, "-I", "-B", "-c", script],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["class_modules"],
+            ["easyuse_anima.nodes.prompt_nodes", "easyuse_anima.nodes.prompt_nodes"],
+        )
         self.assertFalse(payload["root_nodes_loaded"])
 
 

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,7 +73,7 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "fa3d9999ff4e5192c5da7e5c43e57e5f4aeb924a")
+        self.assertEqual(report["git_blob_sha1"], "d968590df0342a380a1103bdf95b0b942fab8fb2")
         # Issue #184 B-07a moved the Prompt Corrector vertical slice as direct aliases.
         self.assertEqual(report["top_level"]["function_count"], 216)
         self.assertEqual(report["top_level"]["class_count"], 17)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,11 +73,11 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "f17e44281d25ef6322aca6a91fd15304769720d5")
-        # Issue #184 B-06 moved the LoRA Preset vertical slice as direct aliases.
-        self.assertEqual(report["top_level"]["function_count"], 219)
-        self.assertEqual(report["top_level"]["class_count"], 19)
-        self.assertEqual(report["line_count"], 10_788)
+        self.assertEqual(report["git_blob_sha1"], "fa3d9999ff4e5192c5da7e5c43e57e5f4aeb924a")
+        # Issue #184 B-07a moved the Prompt Corrector vertical slice as direct aliases.
+        self.assertEqual(report["top_level"]["function_count"], 216)
+        self.assertEqual(report["top_level"]["class_count"], 17)
+        self.assertEqual(report["line_count"], 10_664)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)
@@ -86,6 +86,8 @@ def load_dynamic():
         self.assertNotIn("EasyUseAnimaImageScaleByMultiple", class_names)
         self.assertNotIn("EasyUseAnimaDetailerAlignHook", class_names)
         self.assertNotIn("EasyUseAnimaLoraPreset", class_names)
+        self.assertNotIn("EasyUseAnimaPromptCorrector", class_names)
+        self.assertNotIn("EasyUseAnimaPromptCorrectorSimple", class_names)
 
     def test_external_source_label_does_not_expose_parent_directories(self):
         label = analyzer._source_label(Path("Z:/private/user/data/example.py"))

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,15 +683,14 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 46)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 46)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 44)
+        self.assertEqual(report["inventory"]["module_count"], 48)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 48)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 47)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
             [
                 "easyuse_anima/aio/__init__.py",
-                "easyuse_anima/prompt/__init__.py",
             ],
         )
         self.assertTrue(
@@ -720,11 +719,13 @@ ignored/
                 "easyuse_anima/nodes/image_nodes.py",
                 "easyuse_anima/nodes/lora_nodes.py",
                 "easyuse_anima/nodes/naia_nodes.py",
+                "easyuse_anima/nodes/prompt_nodes.py",
                 "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",
                 "easyuse_anima/prompt/__init__.py",
+                "easyuse_anima/prompt/correction.py",
             }.issubset(report["registry"]["shipped_python_modules"])
         )
         self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
@@ -748,7 +749,10 @@ ignored/
                 "easyuse_anima/nodes/image_nodes.py",
                 "easyuse_anima/nodes/lora_nodes.py",
                 "easyuse_anima/nodes/naia_nodes.py",
+                "easyuse_anima/nodes/prompt_nodes.py",
                 "easyuse_anima/nodes/wildcard_nodes.py",
+                "easyuse_anima/prompt/__init__.py",
+                "easyuse_anima/prompt/correction.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -40,11 +40,13 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/nodes/image_nodes.py",
     "easyuse_anima/nodes/lora_nodes.py",
     "easyuse_anima/nodes/naia_nodes.py",
+    "easyuse_anima/nodes/prompt_nodes.py",
     "easyuse_anima/nodes/wildcard_nodes.py",
     "easyuse_anima/profiles/__init__.py",
     "easyuse_anima/profiles/contract.py",
     "easyuse_anima/profiles/mutation.py",
     "easyuse_anima/prompt/__init__.py",
+    "easyuse_anima/prompt/correction.py",
 }
 STATIC_IMPORT_FROM_RE = re.compile(
     r"""
@@ -151,7 +153,9 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "easyuse_anima/nodes/image_nodes.py",
             "easyuse_anima/nodes/lora_nodes.py",
             "easyuse_anima/nodes/naia_nodes.py",
+            "easyuse_anima/nodes/prompt_nodes.py",
             "easyuse_anima/nodes/wildcard_nodes.py",
+            "easyuse_anima/prompt/correction.py",
             "nodes.py",
             "prompt_translation.py",
             "settings.py",


### PR DESCRIPTION
## 요약

- Issue #184 B-07a 범위로 `EasyUseAnimaPromptCorrector`와 `EasyUseAnimaPromptCorrectorSimple` 구현을 canonical package로 이동했습니다.
- correction/translation helper 경계를 `easyuse_anima/prompt/correction.py`로 분리하고, 두 public node adapter를 `easyuse_anima/nodes/prompt_nodes.py`로 이동했습니다.
- 루트 `nodes.py`는 두 public class와 세 helper를 direct alias로 유지하고, runtime resolver를 통해 기존 root monkeypatch 표면을 보존합니다.
- Prompt Builder/Studio/Artist/Regional/AiO 및 translation/settings 동작은 변경하지 않았습니다.

## 주요 변경 파일

- `easyuse_anima/prompt/correction.py`: tag 분리, marker translation, translation change key 및 lazy runtime binding
- `easyuse_anima/nodes/prompt_nodes.py`: 두 public node class와 공용 private correction adapter
- `nodes.py`: canonical direct alias/runtime wiring, 기존 구현 삭제
- analyzer/Registry fixture와 이동 회귀 테스트 갱신

## 호환성 설계

- 루트와 canonical public class는 동일 객체입니다.
- `has_prompt_translation_markers`, `translate_prompt_markers`, `resolve_prompt_translation_settings`는 호출 시점마다 root globals에서 lazy resolve되어 기존 root monkeypatch 동작을 보존합니다.
- `_prompt_translation_change_key`, `correct_prompt`, `load_knowledge_base`, `_stable_change_key`의 root monkeypatch도 canonical node 실행에 계속 반영됩니다.
- translation은 correction 예외 변환 바깥에 유지했고, correction 실패만 기존 `[EasyUse Anima] prompt correction failed: ...` 형식으로 매핑됩니다.
- report key 순서, Simple 단일 tuple, INPUT/OUTPUT 및 `IS_CHANGED` 계약은 0.5.2 fixture와 동일합니다.
- 내부 canonical module은 루트 `nodes.py`를 import하지 않습니다.

## 리뷰 반영

- 초기 이동 구현이 translation helper를 canonical module에 캡처해 root monkeypatch 호환성을 깨뜨리는 문제를 재현했습니다.
- 세 translation dependency를 호출 시점에 root global에서 resolve하도록 수정하고, `has_prompt_translation_markers` 및 `translate_prompt_markers` monkeypatch 회귀 테스트를 추가했습니다.
- 수정 후 루트 monkeypatch 재현과 공식 full validation을 정확한 최종 HEAD에서 다시 확인했습니다.

## 검증

- `python -m py_compile nodes.py easyuse_anima/prompt/correction.py easyuse_anima/nodes/prompt_nodes.py` — 통과
- focused `unittest` — 195 tests 통과
- `tools/check_project.ps1 -Profile quick` — 통과
- 공식 `tools/check_custom_node.ps1 -Project <PR worktree> -Profile full` — 통과
  - Python 688 tests 통과
  - frontend 111 JavaScript files 통과
  - TypeScript 6.0.3 통과
  - Python compile 및 Git diff check 통과
- `git diff --check` — 통과

## 분석기 결과

- `nodes.py`: functions 216, classes 17, lines 10,664, blob `d968590df0342a380a1103bdf95b0b942fab8fb2`
- Python backend: shipped modules 48, runtime import closure 47, missing internal imports 0
- `easyuse_anima/prompt/__init__.py`가 새 correction module의 parent package로 runtime closure에 포함되어, intentional unreachable module은 `easyuse_anima/aio/__init__.py` 1개입니다.

## ComfyUI 검증 표면

- ComfyUI 0.27.0 / frontend 1.45.20 Codex test instance
- `/object_info`에서 Full/Simple 노드의 category, 입력, 출력 이름과 타입 확인
- Legacy canvas에서 예제 workflow 로드, Prompt Corrector 입력 표면과 missing node 0 확인
- Node 2.0에서 같은 workflow 로드, Prompt Corrector 입력/출력 preview와 missing node 0 확인
- Node 2.0 설정을 원래 Legacy 상태로 복원
- GPU queue와 실제 translation network 호출은 실행하지 않음
- 초기 페이지 로드의 `ComfyApp graph accessed before initialization` 및 Vite preload 오류는 기존 baseline으로 관찰됐고, 이번 workflow 로드 후 새 EasyUse Anima 오류는 없었습니다.

Related: #184
