### PR TITLE
chore: Settings root entry checkJs debt 제거

### DIFF
--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -80,23 +80,23 @@ Issue #14 범위에서 `dev`에 병합됐다.
 
 ### 정량 스냅샷
 
-`web/js`에는 JavaScript 85개, 총 30,857줄이 있다. `jsconfig.json`의 명시적
-include 패턴은 중복 제거 기준 76개·17,586줄로 전체 라인의 57.0%다. 이 중
-Prompt Studio entry 2개와 `prompt_studio/**/*.js` 52개는 총 54개·13,242줄로
-전체 라인의 42.9%다. import를 따라 추가로 검사되는 dependency는 이 수치에
+`web/js`에는 JavaScript 111개, 총 38,914줄이 있다. `jsconfig.json`의 명시적
+include 패턴은 중복 제거 기준 107개·31,497줄로 전체 라인의 80.9%다. 이 중
+Prompt Studio entry 2개와 `prompt_studio/**/*.js` 55개는 총 57개·14,587줄로
+전체 라인의 37.5%다. import를 따라 추가로 검사되는 dependency는 이 수치에
 포함하지 않았다.
 
 | 파일 | 줄 수 | 전체 비율 | 현재 판단 |
 | --- | ---: | ---: | --- |
-| `easyuse_anima_aio.js` | 7,676 | 24.9% | 가장 큰 후속 hotspot |
-| `easyuse_anima_lora_preset.js` | 2,670 | 8.7% | canvas/UI/state lifecycle이 남음 |
-| `easyuse_anima_autocomplete.js` | 1,739 | 5.6% | popup, input runtime이 남음 |
-| `easyuse_anima_settings.js` | 613 | 2.0% | 등록과 fallback lifecycle 중심 entry |
-| `prompt_studio/regional/editor_adapter.js` | 1,410 | 4.6% | Regional text/style/tooltip/highlight/textarea adapter |
+| `easyuse_anima_aio.js` | 4,278 | 11.0% | 가장 큰 후속 hotspot |
+| `easyuse_anima_lora_preset.js` | 943 | 2.4% | canvas/UI/state lifecycle이 남음 |
+| `easyuse_anima_autocomplete.js` | 1,860 | 4.8% | popup, input runtime이 남음 |
+| `easyuse_anima_settings.js` | 625 | 1.6% | 등록과 fallback lifecycle 중심 entry |
+| `prompt_studio/regional/editor_adapter.js` | 1,406 | 3.6% | Regional text/style/tooltip/highlight/textarea adapter |
 | `easyuse_anima_prompt_studio_common.js` | 5 | 0.0% | 이전 import 경로를 위한 호환 re-export |
 | `easyuse_anima_prompt_studio_regional.js` | 64 | 0.2% | registration과 runtime 조립만 담당 |
 
-앞의 5개 파일이 전체 frontend JS의 약 45.7%를 차지한다. 줄 수 자체를
+앞의 5개 파일이 전체 frontend JS의 약 23.4%를 차지한다. 줄 수 자체를
 목표로 삼지는 않지만, 책임 경계와 검증 비용이 이 파일들에 집중돼 있다는
 신호로 사용한다. Regional entry의 축소는 줄 수보다 소유권 이동의 결과다.
 
@@ -109,6 +109,11 @@ TypeScript 6.0.3으로 `web/js`의 기존 미포함 root entry를 각각 다시 
 아래 debt 중 하나여야 하며, 계약 테스트가 새 미분류 entry, include 후 남은
 debt, root wildcard 추가를 실패시킨다.
 
+Phase 4a에서는 `easyuse_anima_settings.js`의 4개 오류(TS2307 1개,
+TS2339 3개)를 host import 한 줄 suppression과 좁은 window alias로 해소하고
+명시적 include로 승격했다. 현재 root entry 11개 중 7개가 typecheck 대상이고,
+debt는 4개 entry·36개 오류다.
+
 현재 debt ledger:
 
 | TODO 파일 | 총 오류 | TypeScript 오류 코드별 개수 |
@@ -117,7 +122,6 @@ debt, root wildcard 추가를 실패시킨다.
 | `easyuse_anima_autocomplete.js` | 5 | TS2307 1, TS2339 2, TS6133 2 |
 | `easyuse_anima_lora_preset.js` | 10 | TS2304 4, TS2307 2, TS2345 1, TS6133 3 |
 | `easyuse_anima_naia.js` | 5 | TS2307 2, TS2345 2, TS6133 1 |
-| `easyuse_anima_settings.js` | 4 | TS2307 1, TS2339 3 |
 
 코드는 TS1117 duplicate property, TS2304 undeclared host global, TS2307 외부
 Comfy import resolution, TS2339 DOM/window property shape, TS2345 argument/shape
@@ -132,8 +136,7 @@ $files = @(
   "web/js/easyuse_anima_aio.js",
   "web/js/easyuse_anima_autocomplete.js",
   "web/js/easyuse_anima_lora_preset.js",
-  "web/js/easyuse_anima_naia.js",
-  "web/js/easyuse_anima_settings.js"
+  "web/js/easyuse_anima_naia.js"
 )
 foreach ($file in $files) {
   npx --yes --package "typescript@6.0.3" -- tsc `

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -21,6 +21,7 @@
     "web/js/easyuse_anima_api.js",
     "web/js/easyuse_anima_i18n.js",
     "web/js/easyuse_anima_prompt_rules.js",
+    "web/js/easyuse_anima_settings.js",
     "web/js/easyuse_anima_prompt_studio_common.js",
     "web/js/easyuse_anima_prompt_studio.js",
     "web/js/easyuse_anima_prompt_studio_regional.js",

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3377,7 +3377,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "web/js/easyuse_anima_autocomplete.js",
             "web/js/easyuse_anima_lora_preset.js",
             "web/js/easyuse_anima_naia.js",
-            "web/js/easyuse_anima_settings.js",
         }
         actual_root_entries = {
             path.relative_to(ROOT).as_posix()

--- a/tests/test_frontend_settings.py
+++ b/tests/test_frontend_settings.py
@@ -52,6 +52,40 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class SettingsFrontendTests(unittest.TestCase):
+    def test_entry_checkjs_host_boundary_and_settings_window_contract(self):
+        entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+
+        self.assertEqual(entry_source.splitlines()[0], "// @ts-check")
+        expect_error_targets = re.findall(
+            r"^// @ts-expect-error[^\n]*\n([^\n]+)",
+            entry_source,
+            re.MULTILINE,
+        )
+        self.assertEqual(
+            expect_error_targets,
+            ['import { app } from "../../../scripts/app.js";'],
+        )
+        self.assertIn(
+            "// @ts-expect-error ComfyUI provides this host module at runtime.\n"
+            'import { app } from "../../../scripts/app.js";',
+            entry_source,
+        )
+        self.assertEqual(entry_source.count("// @ts-expect-error"), 1)
+        for broad_suppression in ("@ts-ignore", "@ts-nocheck"):
+            with self.subTest(broad_suppression=broad_suppression):
+                self.assertNotIn(broad_suppression, entry_source)
+
+        self.assertIn("EasyUseAnimaSettingsWindow", entry_source)
+        self.assertIn("Record<string, unknown>", entry_source)
+        self.assertIn("const settingsWindow = window;", entry_source)
+        self.assertEqual(
+            entry_source.count("settingsWindow.__easyuseAnimaSettings"),
+            3,
+        )
+        self.assertNotIn("window.__easyuseAnimaSettings", entry_source)
+        self.assertIn("web/js/easyuse_anima_settings.js", config["include"])
+
     def test_prompt_translation_setting_discloses_external_marker_text_transfer(self):
         entry_source = SETTINGS_ENTRY.read_text(encoding="utf-8")
         definitions_source = SETTINGS_DEFINITIONS.read_text(encoding="utf-8")
@@ -149,9 +183,9 @@ class SettingsFrontendTests(unittest.TestCase):
                 if line.strip()
             },
             {
-                "getSettingsState: () => window.__easyuseAnimaSettings",
+                "getSettingsState: () => settingsWindow.__easyuseAnimaSettings",
                 "setSettingsState: (value) => {",
-                "window.__easyuseAnimaSettings = value;",
+                "settingsWindow.__easyuseAnimaSettings = value;",
                 "}",
                 "notifySettingsUpdated: (detail) => {",
                 "window.dispatchEvent(",
@@ -207,7 +241,7 @@ class SettingsFrontendTests(unittest.TestCase):
         )
         self.assertRegex(
             setup_match.group("body"),
-            r"window\.__easyuseAnimaSettings\s*=\s*await\s+loadInitialSettings\(\);"
+            r"settingsWindow\.__easyuseAnimaSettings\s*=\s*await\s+loadInitialSettings\(\);"
             r"\s*addSettingsFallback\(\);",
         )
         self.assertTrue(SETTINGS_RUNTIME_SMOKE.is_file())
@@ -567,7 +601,7 @@ class SettingsFrontendTests(unittest.TestCase):
                     setting_match.group("body"),
                 )
 
-        self.assertIn("window.__easyuseAnimaSettings", entry_source)
+        self.assertIn("settingsWindow.__easyuseAnimaSettings", entry_source)
         self.assertTrue(SETTINGS_RESOLUTION_EDITORS_SMOKE.is_file())
         self.assertIn("web/js/settings/**/*.js", config["include"])
         self.assertIn(
@@ -663,7 +697,7 @@ class SettingsFrontendTests(unittest.TestCase):
         self.assertIn("easyuse-anima-long-text-overlay", module_source)
         self.assertIn("easyuse-anima-long-text-panel", module_source)
 
-        self.assertIn("window.__easyuseAnimaSettings", entry_source)
+        self.assertIn("settingsWindow.__easyuseAnimaSettings", entry_source)
         self.assertIn('new CustomEvent("easyuse-anima-settings-updated"', entry_source)
 
         self.assertTrue(SETTINGS_LONG_TEXT_EDITOR_SMOKE.is_file())

--- a/web/js/easyuse_anima_settings.js
+++ b/web/js/easyuse_anima_settings.js
@@ -1,3 +1,6 @@
+// @ts-check
+
+// @ts-expect-error ComfyUI provides this host module at runtime.
 import { app } from "../../../scripts/app.js";
 import { easyuseAnimaFetchJson, easyuseAnimaGetSettings, easyuseAnimaPostJson } from "./easyuse_anima_api.js";
 import {
@@ -15,6 +18,15 @@ import { createLongTextEditorButtonFactory } from "./settings/long_text_editor.j
 import { createResolutionEditors } from "./settings/resolution_editors.js";
 import { createSettingsRuntime } from "./settings/runtime.js";
 import { createWildcardExtraPathsEditorFactory } from "./settings/wildcard_path_editor.js";
+
+/**
+ * @typedef {Window & typeof globalThis & {
+ *   __easyuseAnimaSettings?: Record<string, unknown>
+ * }} EasyUseAnimaSettingsWindow
+ */
+
+/** @type {EasyUseAnimaSettingsWindow} */
+const settingsWindow = window;
 
 
 const TEXT = {
@@ -527,9 +539,9 @@ const {
   saveLongTextSettings,
   loadInitialSettings,
 } = createSettingsRuntime({
-  getSettingsState: () => window.__easyuseAnimaSettings,
+  getSettingsState: () => settingsWindow.__easyuseAnimaSettings,
   setSettingsState: (value) => {
-    window.__easyuseAnimaSettings = value;
+    settingsWindow.__easyuseAnimaSettings = value;
   },
   notifySettingsUpdated: (detail) => {
     window.dispatchEvent(
@@ -607,7 +619,7 @@ app.registerExtension({
   name: "easyuse-anima.settings",
   settings: EASYUSE_ANIMA_SETTINGS,
   async setup() {
-    window.__easyuseAnimaSettings = await loadInitialSettings();
+    settingsWindow.__easyuseAnimaSettings = await loadInitialSettings();
     addSettingsFallback();
   },
 });


### PR DESCRIPTION
## 변경 요약

- Issue #166 Phase 4a로 Settings root entry의 TypeScript 6.0.3 checkJs 오류 4개(TS2307 1개, TS2339 3개)를 제거했습니다.
- ComfyUI host import에만 한 줄 `@ts-expect-error`를 두고, `Record<string, unknown>` 기반의 좁은 `EasyUseAnimaSettingsWindow` alias로 owned settings global 접근을 정리했습니다.
- Settings entry를 `jsconfig.json`의 명시적 include로 승격하고 root-entry debt ledger에서 제거했습니다.
- Settings runtime/setup/fallback/extension registration 동작은 변경하지 않았습니다.

## 주요 파일

- `web/js/easyuse_anima_settings.js`
- `jsconfig.json`
- `tests/test_frontend_settings.py`
- `tests/test_frontend_modules.py`
- `docs/development/frontend-maintenance-roadmap.md`

## 검증

- `python -m unittest discover -s tests -p test_frontend_settings.py`: 17 tests, OK
- `python -m unittest discover -s tests -p test_frontend_modules.py`: 48 tests, OK
- `node --check web/js/easyuse_anima_settings.js`: 통과
- Settings entry 개별 TypeScript 6.0.3 checkJs: 통과
- `npx --yes --package "typescript@6.0.3" -- tsc -p jsconfig.json --pretty false`: 통과
- `tools/check_project.ps1 -Profile quick`: 통과 (frontend 111 JavaScript files, TypeScript 6.0.3)
- `git diff --check`: 통과

## 정량 변화

- Settings errors: `4 → 0`
- root-entry debt: `5 entries / 40 errors → 4 entries / 36 errors`
- root-entry coverage: `6/11 → 7/11`
- 명시적 include: `106 files / 30,872 lines / 79.4% → 107 files / 31,497 lines / 80.9%`
- 독립 리뷰에서 정량 지표를 재계산했으며 일치했습니다.

## 최종 검증 표면

- 최신 `dev@3a71de4` 위로 rebase한 정확한 HEAD `81e57b7`에서 공식 full validation 통과
  - Python 689 tests
  - frontend 111 JavaScript files
  - TypeScript 6.0.3
  - Python compile 및 Git diff check
- 메인 및 독립 actual-diff 리뷰: P0–P2 finding 없음
- Live browser smoke: 실행하지 않음
  - 유일한 실행 코드 변화는 동일한 `window` 객체를 가리키는 local alias이며, DOM/lifecycle/registration/fallback 흐름은 변경하지 않았습니다.