### PR TITLE
chore(frontend): NAIA root entry checkJs debt 제거

### DIFF
--- a/docs/development/frontend-maintenance-roadmap.md
+++ b/docs/development/frontend-maintenance-roadmap.md
@@ -80,8 +80,8 @@ Issue #14 범위에서 `dev`에 병합됐다.
 
 ### 정량 스냅샷
 
-`web/js`에는 JavaScript 111개, 총 38,914줄이 있다. `jsconfig.json`의 명시적
-include 패턴은 중복 제거 기준 107개·31,497줄로 전체 라인의 80.9%다. 이 중
+`web/js`에는 JavaScript 111개, 총 38,923줄이 있다. `jsconfig.json`의 명시적
+include 패턴은 중복 제거 기준 108개·31,842줄로 전체 라인의 81.8%다. 이 중
 Prompt Studio entry 2개와 `prompt_studio/**/*.js` 55개는 총 57개·14,587줄로
 전체 라인의 37.5%다. import를 따라 추가로 검사되는 dependency는 이 수치에
 포함하지 않았다.
@@ -111,8 +111,14 @@ debt, root wildcard 추가를 실패시킨다.
 
 Phase 4a에서는 `easyuse_anima_settings.js`의 4개 오류(TS2307 1개,
 TS2339 3개)를 host import 한 줄 suppression과 좁은 window alias로 해소하고
-명시적 include로 승격했다. 현재 root entry 11개 중 7개가 typecheck 대상이고,
-debt는 4개 entry·36개 오류다.
+명시적 include로 승격했다. 당시 root entry 11개 중 7개가 typecheck 대상이고,
+debt는 4개 entry·36개 오류였다.
+
+Phase 4b에서는 `easyuse_anima_naia.js`의 5개 오류(TS2307 2개, TS2345 2개,
+TS6133 1개)를 ComfyUI host import 두 줄의 line-specific suppression,
+혼합 server payload를 위한 `unknown` 경계, 기존 `arguments` forwarding을 유지한
+unused callback formal 제거로 해소하고 명시적 include로 승격했다. 현재 root
+entry 11개 중 8개가 typecheck 대상이고, debt는 3개 entry·31개 오류다.
 
 현재 debt ledger:
 
@@ -121,7 +127,6 @@ debt는 4개 entry·36개 오류다.
 | `easyuse_anima_aio.js` | 16 | TS1117 4, TS2307 4, TS2339 2, TS2345 2, TS6133 4 |
 | `easyuse_anima_autocomplete.js` | 5 | TS2307 1, TS2339 2, TS6133 2 |
 | `easyuse_anima_lora_preset.js` | 10 | TS2304 4, TS2307 2, TS2345 1, TS6133 3 |
-| `easyuse_anima_naia.js` | 5 | TS2307 2, TS2345 2, TS6133 1 |
 
 코드는 TS1117 duplicate property, TS2304 undeclared host global, TS2307 외부
 Comfy import resolution, TS2339 DOM/window property shape, TS2345 argument/shape
@@ -135,8 +140,7 @@ mismatch, TS6133 unused declaration/parameter를 뜻한다. TODO는 각 파일�
 $files = @(
   "web/js/easyuse_anima_aio.js",
   "web/js/easyuse_anima_autocomplete.js",
-  "web/js/easyuse_anima_lora_preset.js",
-  "web/js/easyuse_anima_naia.js"
+  "web/js/easyuse_anima_lora_preset.js"
 )
 foreach ($file in $files) {
   npx --yes --package "typescript@6.0.3" -- tsc `

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -20,6 +20,7 @@
     "web/js/settings/**/*.js",
     "web/js/easyuse_anima_api.js",
     "web/js/easyuse_anima_i18n.js",
+    "web/js/easyuse_anima_naia.js",
     "web/js/easyuse_anima_prompt_rules.js",
     "web/js/easyuse_anima_settings.js",
     "web/js/easyuse_anima_prompt_studio_common.js",

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3376,7 +3376,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
             "web/js/easyuse_anima_aio.js",
             "web/js/easyuse_anima_autocomplete.js",
             "web/js/easyuse_anima_lora_preset.js",
-            "web/js/easyuse_anima_naia.js",
         }
         actual_root_entries = {
             path.relative_to(ROOT).as_posix()

--- a/tests/test_naia_frontend.py
+++ b/tests/test_naia_frontend.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NAIA_ENTRY = ROOT / "web" / "js" / "easyuse_anima_naia.js"
+JSCONFIG = ROOT / "jsconfig.json"
+
+
+class NaiaFrontendTests(unittest.TestCase):
+    def test_entry_checkjs_host_boundaries_are_line_specific(self):
+        entry_source = NAIA_ENTRY.read_text(encoding="utf-8")
+        config = json.loads(JSCONFIG.read_text(encoding="utf-8"))
+
+        self.assertEqual(entry_source.splitlines()[0], "// @ts-check")
+        expect_error_targets = re.findall(
+            r"^// @ts-expect-error[^\n]*\n([^\n]+)",
+            entry_source,
+            re.MULTILINE,
+        )
+        self.assertEqual(
+            expect_error_targets,
+            [
+                'import { app } from "../../../scripts/app.js";',
+                'import { ComfyWidgets } from "../../../scripts/widgets.js";',
+            ],
+        )
+        for import_line in expect_error_targets:
+            with self.subTest(import_line=import_line):
+                self.assertIn(
+                    "// @ts-expect-error ComfyUI provides this host module at runtime.\n"
+                    f"{import_line}",
+                    entry_source,
+                )
+        self.assertEqual(entry_source.count("// @ts-expect-error"), 2)
+        for broad_suppression in ("@ts-ignore", "@ts-nocheck"):
+            with self.subTest(broad_suppression=broad_suppression):
+                self.assertNotIn(broad_suppression, entry_source)
+        self.assertIn("web/js/easyuse_anima_naia.js", config["include"])
+
+    def test_mixed_server_values_stay_unknown_until_consumers_coerce(self):
+        entry_source = NAIA_ENTRY.read_text(encoding="utf-8")
+
+        for annotation in (
+            "@param {unknown} value",
+            "@param {unknown} fallback",
+            "@returns {unknown}",
+        ):
+            with self.subTest(annotation=annotation):
+                self.assertIn(annotation, entry_source)
+        self.assertIn(
+            "return value.length > 0 ? value[0] : fallback;",
+            entry_source,
+        )
+        self.assertIn("return value ?? fallback;", entry_source)
+        for consumer in (
+            "String(firstValue(message.prompt))",
+            "String(firstValue(message.negative_prompt))",
+            "Number(firstValue(message.width, 0))",
+            "Number(firstValue(message.height, 0))",
+            'String(firstValue(message.status, ""))',
+            'String(firstValue(message.cached_signature, ""))',
+        ):
+            with self.subTest(consumer=consumer):
+                self.assertIn(consumer, entry_source)
+
+    def test_show_preview_hook_forwards_original_arguments_without_unused_formal(self):
+        entry_source = NAIA_ENTRY.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "widget.callback = function () {\n"
+            "    const result = callback?.apply(this, arguments);",
+            entry_source,
+        )
+        self.assertNotIn("widget.callback = function (value)", entry_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_naia_frontend.py
+++ b/tests/test_naia_frontend.py
@@ -66,14 +66,15 @@ class NaiaFrontendTests(unittest.TestCase):
             with self.subTest(consumer=consumer):
                 self.assertIn(consumer, entry_source)
 
-    def test_show_preview_hook_forwards_original_arguments_without_unused_formal(self):
+    def test_show_preview_hook_preserves_callback_length_and_forwards_arguments(self):
         entry_source = NAIA_ENTRY.read_text(encoding="utf-8")
 
         self.assertIn(
-            "widget.callback = function () {\n"
+            "widget.callback = function (_value) {\n"
             "    const result = callback?.apply(this, arguments);",
             entry_source,
         )
+        self.assertNotIn("widget.callback = function ()", entry_source)
         self.assertNotIn("widget.callback = function (value)", entry_source)
 
 

--- a/web/js/easyuse_anima_naia.js
+++ b/web/js/easyuse_anima_naia.js
@@ -1,4 +1,8 @@
+// @ts-check
+
+// @ts-expect-error ComfyUI provides this host module at runtime.
 import { app } from "../../../scripts/app.js";
+// @ts-expect-error ComfyUI provides this host module at runtime.
 import { ComfyWidgets } from "../../../scripts/widgets.js";
 
 const NODE_TYPE = "EasyUseAnimaNAIARandomPrompt";
@@ -35,6 +39,11 @@ const NAIA_SETTING_WIDGETS = [
   "port",
 ];
 
+/**
+ * @param {unknown} value
+ * @param {unknown} fallback
+ * @returns {unknown}
+ */
 function firstValue(value, fallback = "") {
   if (Array.isArray(value)) {
     return value.length > 0 ? value[0] : fallback;
@@ -201,7 +210,7 @@ function hookShowPreviewWidget(node) {
     return;
   }
   const callback = widget.callback;
-  widget.callback = function (value) {
+  widget.callback = function () {
     const result = callback?.apply(this, arguments);
     updatePreviewVisibility(node);
     return result;

--- a/web/js/easyuse_anima_naia.js
+++ b/web/js/easyuse_anima_naia.js
@@ -210,7 +210,7 @@ function hookShowPreviewWidget(node) {
     return;
   }
   const callback = widget.callback;
-  widget.callback = function () {
+  widget.callback = function (_value) {
     const result = callback?.apply(this, arguments);
     updatePreviewVisibility(node);
     return result;


### PR DESCRIPTION
## 변경 요약

- `easyuse_anima_naia.js`를 root-entry checkJs 범위에 포함했습니다.
- ComfyUI host runtime import 2개에만 line-specific `@ts-expect-error`를 적용했습니다.
- 혼합 서버 payload를 보존하도록 `firstValue`의 입력, fallback, 반환 경계를 `unknown`으로 명시했습니다.
- 기존 `arguments` forwarding과 `callback.length === 1`을 모두 유지하도록 callback formal을 `_value`로 이름만 바꿨습니다.
- NAIA 전용 계약 테스트와 root debt ledger, 정량 로드맵을 갱신했습니다.

## 주요 파일

- `web/js/easyuse_anima_naia.js`
- `jsconfig.json`
- `tests/test_frontend_modules.py`
- `tests/test_naia_frontend.py`
- `docs/development/frontend-maintenance-roadmap.md`

## 정량 결과

- NAIA 오류: 5 → 0
- root debt: 4 entries / 36 errors → 3 entries / 31 errors
- root-entry coverage: 7/11 → 8/11
- 명시적 include: 107 files / 31,497 lines / 80.9% → 108 files / 31,842 lines / 81.8%
- 전체 frontend: 111 files / 38,923 lines

## 검증

- `python -m unittest discover -s tests -p test_naia_frontend.py` — 3 tests, OK
- `python -m unittest discover -s tests -p test_frontend_modules.py` — 48 tests, OK
- `node --check web/js/easyuse_anima_naia.js` — 통과
- TypeScript 6.0.3 isolated NAIA check — 통과
- TypeScript 6.0.3 `tsc -p jsconfig.json --pretty false` — 통과
- `tools/check_project.ps1 -Profile quick` — 111 JavaScript files, TypeScript 6.0.3, 통과
- `git diff --check` — 통과

## 리뷰 반영

- 초기 구현이 callback formal을 제거해 표준 `Function.length`를 1→0으로 바꾸는 호환성 문제를 메인·독립 리뷰에서 확인했습니다.
- formal을 `_value`로 이름만 바꿔 TypeScript unused-parameter 오류를 제거하면서 기존 arity 1, `this`, `arguments` forwarding을 모두 보존했습니다.
- 수정 후 메인·독립 actual-diff 리뷰 기준 추가 P0–P2 finding은 없습니다.

## 최종 검증 표면

- 최신 `dev@462f37d` 위 정확한 HEAD `dd6422a`에서 공식 full validation 통과
  - Python 692 tests
  - frontend 111 JavaScript files
  - TypeScript 6.0.3
  - Python compile 및 Git diff check
- ComfyUI runtime/browser smoke: 실행하지 않음
  - executable semantics와 callback arity를 기존과 동일하게 유지했고, DOM/lifecycle/serialization 흐름은 변경하지 않았습니다.

## 남은 위험

- ComfyUI가 runtime에 제공하는 host import 2개는 의도적으로 line-specific suppression에 의존합니다.
