### PR TITLE
chore: Prompt Builder와 classic Prompt Studio를 canonical package로 이동

### DIFF
--- a/easyuse_anima/nodes/prompt_nodes.py
+++ b/easyuse_anima/nodes/prompt_nodes.py
@@ -5,21 +5,33 @@ from __future__ import annotations
 import json
 
 from ..common.serialization import _stable_change_key
+from ..common.values import _as_bool
 from ..prompt.correction import (
     _prompt_translation_change_key,
     _split_tag_text,
     _translate_prompt_text,
 )
+from ..prompt.fields import (
+    DEFAULT_QUALITY_TAGS,
+    DEFAULT_TRAILING_QUALITY_TAGS,
+    _correct_builder_prompt,
+    _filter_metadata_prompt,
+    _join_prompt_tokens,
+)
 
 try:
     from ...anima_prompt import correct_prompt, load_knowledge_base
+    from ...settings import resolve_metadata_filter_words
 except ImportError:
     from anima_prompt import correct_prompt, load_knowledge_base
+    from settings import resolve_metadata_filter_words
 
 
 def _bind_prompt_node_runtime(*, resolve_helper) -> None:
-    global _stable_change_key, _prompt_translation_change_key
+    global _as_bool, _stable_change_key, _prompt_translation_change_key
     global _split_tag_text, _translate_prompt_text, correct_prompt, load_knowledge_base
+    global _correct_builder_prompt, _filter_metadata_prompt, _join_prompt_tokens
+    global resolve_metadata_filter_words
 
     def runtime_helper(name):
         def call(*args, **kwargs):
@@ -27,12 +39,17 @@ def _bind_prompt_node_runtime(*, resolve_helper) -> None:
 
         return call
 
+    _as_bool = runtime_helper("_as_bool")
     _stable_change_key = runtime_helper("_stable_change_key")
     _prompt_translation_change_key = runtime_helper("_prompt_translation_change_key")
     _split_tag_text = runtime_helper("_split_tag_text")
     _translate_prompt_text = runtime_helper("_translate_prompt_text")
+    _correct_builder_prompt = runtime_helper("_correct_builder_prompt")
+    _filter_metadata_prompt = runtime_helper("_filter_metadata_prompt")
+    _join_prompt_tokens = runtime_helper("_join_prompt_tokens")
     correct_prompt = runtime_helper("correct_prompt")
     load_knowledge_base = runtime_helper("load_knowledge_base")
+    resolve_metadata_filter_words = runtime_helper("resolve_metadata_filter_words")
 
 
 def _correct_prompt_with_report(
@@ -164,4 +181,241 @@ class EasyUseAnimaPromptCorrectorSimple:
         return (corrected,)
 
 
-__all__ = ("EasyUseAnimaPromptCorrector", "EasyUseAnimaPromptCorrectorSimple")
+class EasyUseAnimaPromptBuilder:
+    """Build cleaned ANIMA prompts for NAIA and Anima Mod Guidance workflows."""
+
+    DESCRIPTION = (
+        "Combines quality, trigger, LoRA trigger, body, and trailing prompt fields into "
+        "ANIMA-friendly prompt outputs, including metadata and Mod Guidance outputs."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Final positive prompt. When Mod Guidance is enabled, leading quality tags are excluded.",
+        "Quality prompt text intended for Anima Mod Guidance.",
+        "Boolean flag passed through for Anima Mod Guidance workflow control.",
+        "Prompt text for metadata, independent from Mod Guidance routing and metadata filters.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "use_anima_mod_guidance": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": (
+                        "true: output prompt excludes quality fields and sends them "
+                        "through anima_mod_guidance_quality_tags."
+                    ),
+                }),
+                "pin_trigger_tags_to_front": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": (
+                        "true: keep trigger/artist and LoRA trigger fields at the very front "
+                        "instead of placing quality tags before them."
+                    ),
+                }),
+                "lora_trigger_tags": ("STRING", {
+                    "multiline": False,
+                    "default": "",
+                    "tooltip": "One-line trigger tags received from a LoRA manager or pasted manually.",
+                }),
+                "quality_tags": ("STRING", {
+                    "multiline": True,
+                    "default": DEFAULT_QUALITY_TAGS,
+                    "tooltip": "Leading quality tags. With AMG enabled, these are excluded from prompt output.",
+                }),
+                "trigger_and_artist_tags": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Manual model triggers and @artist tags.",
+                }),
+                "prompt": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Main prompt body. This is the expected place for NAIA output.",
+                }),
+                "trailing_quality_tags": ("STRING", {
+                    "multiline": True,
+                    "default": DEFAULT_TRAILING_QUALITY_TAGS,
+                    "tooltip": "Trailing quality or style tags.",
+                }),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "BOOLEAN", "STRING")
+    RETURN_NAMES = (
+        "prompt",
+        "anima_mod_guidance_quality_tags",
+        "use_anima_mod_guidance",
+        "metadata_prompt",
+    )
+    FUNCTION = "build"
+    CATEGORY = "EasyUse Anima/Prompt"
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return _stable_change_key({
+            "mode": "prompt_builder",
+            "metadata_filter_words": resolve_metadata_filter_words(),
+            "prompt_translation": _prompt_translation_change_key(),
+            **{key: str(value) for key, value in sorted(kwargs.items())},
+        })
+
+    def build(
+        self,
+        use_anima_mod_guidance: bool,
+        pin_trigger_tags_to_front: bool,
+        quality_tags: str,
+        trigger_and_artist_tags: str,
+        lora_trigger_tags: str,
+        prompt: str,
+        trailing_quality_tags: str,
+    ):
+        use_amg = _as_bool(use_anima_mod_guidance, False)
+        pin_triggers = _as_bool(pin_trigger_tags_to_front, False)
+        quality_tags = _translate_prompt_text(quality_tags)
+        trigger_and_artist_tags = _translate_prompt_text(trigger_and_artist_tags)
+        lora_trigger_tags = _translate_prompt_text(lora_trigger_tags)
+        prompt = _translate_prompt_text(prompt)
+        trailing_quality_tags = _translate_prompt_text(trailing_quality_tags)
+
+        trigger_prompt = _join_prompt_tokens(trigger_and_artist_tags, lora_trigger_tags)
+        quality_prompt = _join_prompt_tokens(quality_tags)
+        body_prompt = _join_prompt_tokens(prompt)
+        trailing_prompt = _join_prompt_tokens(trailing_quality_tags)
+
+        if pin_triggers:
+            metadata_body = _correct_builder_prompt(
+                _join_prompt_tokens(quality_tags, body_prompt)
+            )
+            regular_prompt = _join_prompt_tokens(trigger_prompt, metadata_body, trailing_prompt)
+            amg_prompt = _join_prompt_tokens(
+                trigger_prompt,
+                _correct_builder_prompt(body_prompt),
+                trailing_prompt,
+            )
+            metadata_prompt = regular_prompt
+        else:
+            metadata_core = _correct_builder_prompt(
+                _join_prompt_tokens(
+                    quality_tags,
+                    trigger_prompt,
+                    body_prompt,
+                ),
+                artist_overrides=trigger_prompt,
+            )
+            metadata_prompt = _join_prompt_tokens(metadata_core, trailing_prompt)
+            regular_prompt = metadata_prompt
+            amg_core = _correct_builder_prompt(
+                _join_prompt_tokens(trigger_prompt, body_prompt),
+                artist_overrides=trigger_prompt,
+            )
+            amg_prompt = _join_prompt_tokens(amg_core, trailing_prompt)
+
+        metadata_prompt = _filter_metadata_prompt(
+            metadata_prompt,
+            resolve_metadata_filter_words(),
+        )
+        output_prompt = amg_prompt if use_amg else regular_prompt
+
+        return (
+            output_prompt,
+            quality_prompt,
+            use_amg,
+            metadata_prompt,
+        )
+
+
+class EasyUseAnimaPromptStudio(EasyUseAnimaPromptBuilder):
+    """Prompt Builder variant with enhanced front-end editing helpers."""
+
+    DESCRIPTION = (
+        "An enhanced Prompt Builder with front-end editing, autocomplete, and tag highlighting helpers."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "use_anima_mod_guidance": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": (
+                        "true: output prompt excludes quality fields and sends them "
+                        "through anima_mod_guidance_quality_tags."
+                    ),
+                }),
+                "pin_trigger_tags_to_front": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": (
+                        "true: keep trigger/artist and LoRA trigger fields at the very front "
+                        "instead of placing quality tags before them."
+                    ),
+                }),
+                "lora_trigger_tags": ("STRING", {
+                    "multiline": False,
+                    "default": "",
+                    "tooltip": "One-line trigger tags received from a LoRA manager or pasted manually.",
+                }),
+                "quality_tags": ("STRING", {
+                    "multiline": True,
+                    "default": DEFAULT_QUALITY_TAGS,
+                    "tooltip": "Leading quality tags. With AMG enabled, these are excluded from prompt output.",
+                }),
+                "trigger_and_artist_tags": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Manual model triggers and @artist tags.",
+                }),
+                "prompt": ("STRING", {
+                    "multiline": True,
+                    "default": "",
+                    "tooltip": "Main prompt body. This is the expected place for NAIA output.",
+                }),
+                "trailing_quality_tags": ("STRING", {
+                    "multiline": True,
+                    "default": DEFAULT_TRAILING_QUALITY_TAGS,
+                    "tooltip": "Trailing quality or style tags.",
+                }),
+            }
+        }
+
+    CATEGORY = "EasyUse Anima/Prompt"
+
+    def build(
+        self,
+        use_anima_mod_guidance: bool,
+        pin_trigger_tags_to_front: bool,
+        quality_tags: str,
+        trigger_and_artist_tags: str,
+        lora_trigger_tags: str,
+        prompt: str,
+        trailing_quality_tags: str,
+    ):
+        result = super().build(
+            use_anima_mod_guidance,
+            pin_trigger_tags_to_front,
+            quality_tags,
+            trigger_and_artist_tags,
+            lora_trigger_tags,
+            prompt,
+            trailing_quality_tags,
+        )
+        return {
+            "ui": {
+                "prompt_studio_inputs": [{
+                    "lora_trigger_tags": str(lora_trigger_tags or ""),
+                    "quality_tags": str(quality_tags or ""),
+                    "trigger_and_artist_tags": str(trigger_and_artist_tags or ""),
+                    "prompt": str(prompt or ""),
+                    "trailing_quality_tags": str(trailing_quality_tags or ""),
+                }]
+            },
+            "result": result,
+        }
+
+
+__all__ = (
+    "EasyUseAnimaPromptBuilder",
+    "EasyUseAnimaPromptCorrector",
+    "EasyUseAnimaPromptCorrectorSimple",
+    "EasyUseAnimaPromptStudio",
+)

--- a/easyuse_anima/prompt/fields.py
+++ b/easyuse_anima/prompt/fields.py
@@ -1,0 +1,114 @@
+"""Classic Prompt Builder field assembly helpers."""
+
+from __future__ import annotations
+
+import re
+
+try:
+    from ...anima_prompt import correct_prompt, load_knowledge_base
+    from ...anima_prompt.parser import parse_prompt
+except ImportError:
+    from anima_prompt import correct_prompt, load_knowledge_base
+    from anima_prompt.parser import parse_prompt
+
+
+DEFAULT_QUALITY_TAGS = (
+    "newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic"
+)
+DEFAULT_TRAILING_QUALITY_TAGS = (
+    "location, (A highly aesthetic Pixiv style illustration, clean composition, "
+    "high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)"
+)
+
+_HASH_COMMENT_RE = re.compile(r"^[ \t]*#[^\n]*", re.MULTILINE)
+_INLINE_SPACE_RE = re.compile(r"[ \t]+")
+_WEIGHTED_TOKEN_RE = re.compile(r"^\(([^(),]+):[-+]?\d+(?:\.\d+)?\)$")
+_RUNTIME_HELPER_RESOLVER = None
+
+
+def _bind_prompt_fields_runtime(*, resolve_helper) -> None:
+    global _RUNTIME_HELPER_RESOLVER
+    _RUNTIME_HELPER_RESOLVER = resolve_helper
+
+
+def _runtime_helper(name, fallback):
+    if _RUNTIME_HELPER_RESOLVER is None:
+        return fallback
+    return _RUNTIME_HELPER_RESOLVER(name)
+
+
+def _prompt_tokens(value: str) -> list[str]:
+    if not value:
+        return []
+    hash_comment_re = _runtime_helper("_HASH_COMMENT_RE", _HASH_COMMENT_RE)
+    inline_space_re = _runtime_helper("_INLINE_SPACE_RE", _INLINE_SPACE_RE)
+    prompt_parser = _runtime_helper("parse_prompt", parse_prompt)
+    cleaned_val = hash_comment_re.sub("", value)
+    normalized = str(cleaned_val).replace("\r\n", "\n").replace("\r", "\n")
+    normalized = normalized.replace("，", ",").replace("\n", ",")
+    tokens: list[str] = []
+    for token in prompt_parser(normalized, profile="prompt").tokens:
+        cleaned = inline_space_re.sub(" ", str(token).strip(" ,\n\t"))
+        if cleaned:
+            tokens.append(cleaned)
+    return tokens
+
+
+def _join_prompt_tokens(*parts: str) -> str:
+    prompt_tokens = _runtime_helper("_prompt_tokens", _prompt_tokens)
+    tokens: list[str] = []
+    for part in parts:
+        tokens.extend(prompt_tokens(part))
+    return ", ".join(tokens)
+
+
+def _correct_builder_prompt(prompt: str, artist_overrides: str = "") -> str:
+    if not prompt:
+        return ""
+    correction = _runtime_helper("correct_prompt", correct_prompt)
+    knowledge_base_loader = _runtime_helper("load_knowledge_base", load_knowledge_base)
+    prompt_tokens = _runtime_helper("_prompt_tokens", _prompt_tokens)
+    result = correction(
+        prompt,
+        profile="prompt",
+        knowledge_base=knowledge_base_loader(allow_missing=True),
+        validate_artist_tags=False,
+        artist_overrides=prompt_tokens(artist_overrides),
+    )
+    return result.text
+
+
+def _metadata_filter_key(value: str) -> str:
+    inline_space_re = _runtime_helper("_INLINE_SPACE_RE", _INLINE_SPACE_RE)
+    value = inline_space_re.sub(" ", str(value or "").strip(" ,\n\t"))
+    return value.replace("_", " ").casefold()
+
+
+def _metadata_filter_keys(value: str) -> set[str]:
+    metadata_filter_key = _runtime_helper("_metadata_filter_key", _metadata_filter_key)
+    weighted_token_re = _runtime_helper("_WEIGHTED_TOKEN_RE", _WEIGHTED_TOKEN_RE)
+    keys = {metadata_filter_key(value)}
+    weighted = weighted_token_re.match(str(value or "").strip())
+    if weighted:
+        keys.add(metadata_filter_key(weighted.group(1)))
+    return {key for key in keys if key}
+
+
+def _filter_metadata_prompt(prompt: str, filter_words: str) -> str:
+    prompt_tokens = _runtime_helper("_prompt_tokens", _prompt_tokens)
+    metadata_filter_keys = _runtime_helper("_metadata_filter_keys", _metadata_filter_keys)
+    filter_keys: set[str] = set()
+    for word in prompt_tokens(filter_words):
+        filter_keys.update(metadata_filter_keys(word))
+    if not prompt or not filter_keys:
+        return prompt
+
+    kept = [
+        token
+        for token in prompt_tokens(prompt)
+        if metadata_filter_keys(token).isdisjoint(filter_keys)
+    ]
+    return ", ".join(kept)
+
+
+__all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -30,6 +30,20 @@ try:
         _split_tag_text as _split_tag_text,
         _translate_prompt_text as _translate_prompt_text,
     )
+    from .easyuse_anima.prompt.fields import (
+        DEFAULT_QUALITY_TAGS as DEFAULT_QUALITY_TAGS,
+        DEFAULT_TRAILING_QUALITY_TAGS as DEFAULT_TRAILING_QUALITY_TAGS,
+        _HASH_COMMENT_RE as _HASH_COMMENT_RE,
+        _INLINE_SPACE_RE as _INLINE_SPACE_RE,
+        _WEIGHTED_TOKEN_RE as _WEIGHTED_TOKEN_RE,
+        _bind_prompt_fields_runtime as _bind_prompt_fields_runtime,
+        _correct_builder_prompt as _correct_builder_prompt,
+        _filter_metadata_prompt as _filter_metadata_prompt,
+        _join_prompt_tokens as _join_prompt_tokens,
+        _metadata_filter_key as _metadata_filter_key,
+        _metadata_filter_keys as _metadata_filter_keys,
+        _prompt_tokens as _prompt_tokens,
+    )
     from .easyuse_anima.image.geometry import (
         _align_down as _align_down,
         _align_nearest as _align_nearest,
@@ -75,8 +89,10 @@ try:
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
     )
     from .easyuse_anima.nodes.prompt_nodes import (
+        EasyUseAnimaPromptBuilder as EasyUseAnimaPromptBuilder,
         EasyUseAnimaPromptCorrector as EasyUseAnimaPromptCorrector,
         EasyUseAnimaPromptCorrectorSimple as EasyUseAnimaPromptCorrectorSimple,
+        EasyUseAnimaPromptStudio as EasyUseAnimaPromptStudio,
         _bind_prompt_node_runtime as _bind_prompt_node_runtime,
     )
     from .easyuse_anima.naia.client import (
@@ -207,6 +223,20 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _split_tag_text as _split_tag_text,
         _translate_prompt_text as _translate_prompt_text,
     )
+    from easyuse_anima.prompt.fields import (
+        DEFAULT_QUALITY_TAGS as DEFAULT_QUALITY_TAGS,
+        DEFAULT_TRAILING_QUALITY_TAGS as DEFAULT_TRAILING_QUALITY_TAGS,
+        _HASH_COMMENT_RE as _HASH_COMMENT_RE,
+        _INLINE_SPACE_RE as _INLINE_SPACE_RE,
+        _WEIGHTED_TOKEN_RE as _WEIGHTED_TOKEN_RE,
+        _bind_prompt_fields_runtime as _bind_prompt_fields_runtime,
+        _correct_builder_prompt as _correct_builder_prompt,
+        _filter_metadata_prompt as _filter_metadata_prompt,
+        _join_prompt_tokens as _join_prompt_tokens,
+        _metadata_filter_key as _metadata_filter_key,
+        _metadata_filter_keys as _metadata_filter_keys,
+        _prompt_tokens as _prompt_tokens,
+    )
     from easyuse_anima.image.geometry import (
         _align_down as _align_down,
         _align_nearest as _align_nearest,
@@ -252,8 +282,10 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
     )
     from easyuse_anima.nodes.prompt_nodes import (
+        EasyUseAnimaPromptBuilder as EasyUseAnimaPromptBuilder,
         EasyUseAnimaPromptCorrector as EasyUseAnimaPromptCorrector,
         EasyUseAnimaPromptCorrectorSimple as EasyUseAnimaPromptCorrectorSimple,
+        EasyUseAnimaPromptStudio as EasyUseAnimaPromptStudio,
         _bind_prompt_node_runtime as _bind_prompt_node_runtime,
     )
     from easyuse_anima.naia.client import (
@@ -368,13 +400,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
-DEFAULT_QUALITY_TAGS = (
-    "newest, masterpiece, best quality, score_8, score_7:, highres, absurdres, very aesthetic"
-)
-DEFAULT_TRAILING_QUALITY_TAGS = (
-    "location, (A highly aesthetic Pixiv style illustration, clean composition, "
-    "high-quality digital art, detailed background, sharp focus on facial expressions.:0.6)"
-)
 ADVANCED_FIELD_TYPES = {"quality", "artist", "trigger", "general", "naia"}
 ADVANCED_FIELD_PANES = {"positive", "negative"}
 ADVANCED_FIELD_LABELS = {
@@ -1014,9 +1039,6 @@ AIO_RESHIFT_SCALES = ("x2", "x4")
 AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 
 
-_HASH_COMMENT_RE = re.compile(r"^[ \t]*#[^\n]*", re.MULTILINE)
-_INLINE_SPACE_RE = re.compile(r"[ \t]+")
-_WEIGHTED_TOKEN_RE = re.compile(r"^\(([^(),]+):[-+]?\d+(?:\.\d+)?\)$")
 _WEIGHTED_ARTIST_RE = re.compile(
     r"^\(\s*(?P<tag>.*?)\s*:\s*(?P<weight>[+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*\)$"
 )
@@ -4325,27 +4347,6 @@ def _call_impact_detailer(detailer, **kwargs):
     return method(**call_kwargs)
 
 
-def _prompt_tokens(value: str) -> list[str]:
-    if not value:
-        return []
-    cleaned_val = _HASH_COMMENT_RE.sub("", value)
-    normalized = str(cleaned_val).replace("\r\n", "\n").replace("\r", "\n")
-    normalized = normalized.replace("，", ",").replace("\n", ",")
-    tokens: list[str] = []
-    for token in parse_prompt(normalized, profile="prompt").tokens:
-        cleaned = _INLINE_SPACE_RE.sub(" ", str(token).strip(" ,\n\t"))
-        if cleaned:
-            tokens.append(cleaned)
-    return tokens
-
-
-def _join_prompt_tokens(*parts: str) -> str:
-    tokens: list[str] = []
-    for part in parts:
-        tokens.extend(_prompt_tokens(part))
-    return ", ".join(tokens)
-
-
 def _translate_prompt_fields(fields: list[dict]) -> list[dict]:
     translated: list[dict] = []
     for field in fields:
@@ -4355,47 +4356,6 @@ def _translate_prompt_fields(fields: list[dict]) -> list[dict]:
             item["text"] = _translate_prompt_text(text)
         translated.append(item)
     return translated
-
-
-def _correct_builder_prompt(prompt: str, artist_overrides: str = "") -> str:
-    if not prompt:
-        return ""
-    result = correct_prompt(
-        prompt,
-        profile="prompt",
-        knowledge_base=load_knowledge_base(allow_missing=True),
-        validate_artist_tags=False,
-        artist_overrides=_prompt_tokens(artist_overrides),
-    )
-    return result.text
-
-
-def _metadata_filter_key(value: str) -> str:
-    value = _INLINE_SPACE_RE.sub(" ", str(value or "").strip(" ,\n\t"))
-    return value.replace("_", " ").casefold()
-
-
-def _metadata_filter_keys(value: str) -> set[str]:
-    keys = {_metadata_filter_key(value)}
-    weighted = _WEIGHTED_TOKEN_RE.match(str(value or "").strip())
-    if weighted:
-        keys.add(_metadata_filter_key(weighted.group(1)))
-    return {key for key in keys if key}
-
-
-def _filter_metadata_prompt(prompt: str, filter_words: str) -> str:
-    filter_keys: set[str] = set()
-    for word in _prompt_tokens(filter_words):
-        filter_keys.update(_metadata_filter_keys(word))
-    if not prompt or not filter_keys:
-        return prompt
-
-    kept = [
-        token
-        for token in _prompt_tokens(prompt)
-        if _metadata_filter_keys(token).isdisjoint(filter_keys)
-    ]
-    return ", ".join(kept)
 
 
 def _advanced_default_fields() -> list[dict]:
@@ -7255,6 +7215,9 @@ def _consume_reserved_wildcard_next_seed(
     return reservation_next_seed if reservation_next_seed == expected_next_seed else None
 
 
+_bind_prompt_fields_runtime(
+    resolve_helper=lambda name: globals()[name],
+)
 _bind_prompt_correction_runtime(
     resolve_helper=lambda name: globals()[name],
 )
@@ -7291,238 +7254,6 @@ _bind_lora_node_runtime(
     flexible_optional_input_type=_FlexibleOptionalInputType,
     any_type=_ANY_TYPE,
 )
-
-
-class EasyUseAnimaPromptBuilder:
-    """Build cleaned ANIMA prompts for NAIA and Anima Mod Guidance workflows."""
-
-    DESCRIPTION = (
-        "Combines quality, trigger, LoRA trigger, body, and trailing prompt fields into "
-        "ANIMA-friendly prompt outputs, including metadata and Mod Guidance outputs."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Final positive prompt. When Mod Guidance is enabled, leading quality tags are excluded.",
-        "Quality prompt text intended for Anima Mod Guidance.",
-        "Boolean flag passed through for Anima Mod Guidance workflow control.",
-        "Prompt text for metadata, independent from Mod Guidance routing and metadata filters.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "use_anima_mod_guidance": ("BOOLEAN", {
-                    "default": False,
-                    "tooltip": (
-                        "true: output prompt excludes quality fields and sends them "
-                        "through anima_mod_guidance_quality_tags."
-                    ),
-                }),
-                "pin_trigger_tags_to_front": ("BOOLEAN", {
-                    "default": False,
-                    "tooltip": (
-                        "true: keep trigger/artist and LoRA trigger fields at the very front "
-                        "instead of placing quality tags before them."
-                    ),
-                }),
-                "lora_trigger_tags": ("STRING", {
-                    "multiline": False,
-                    "default": "",
-                    "tooltip": "One-line trigger tags received from a LoRA manager or pasted manually.",
-                }),
-                "quality_tags": ("STRING", {
-                    "multiline": True,
-                    "default": DEFAULT_QUALITY_TAGS,
-                    "tooltip": "Leading quality tags. With AMG enabled, these are excluded from prompt output.",
-                }),
-                "trigger_and_artist_tags": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Manual model triggers and @artist tags.",
-                }),
-                "prompt": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Main prompt body. This is the expected place for NAIA output.",
-                }),
-                "trailing_quality_tags": ("STRING", {
-                    "multiline": True,
-                    "default": DEFAULT_TRAILING_QUALITY_TAGS,
-                    "tooltip": "Trailing quality or style tags.",
-                }),
-            }
-        }
-
-    RETURN_TYPES = ("STRING", "STRING", "BOOLEAN", "STRING")
-    RETURN_NAMES = (
-        "prompt",
-        "anima_mod_guidance_quality_tags",
-        "use_anima_mod_guidance",
-        "metadata_prompt",
-    )
-    FUNCTION = "build"
-    CATEGORY = "EasyUse Anima/Prompt"
-
-    @classmethod
-    def IS_CHANGED(cls, **kwargs):
-        return _stable_change_key({
-            "mode": "prompt_builder",
-            "metadata_filter_words": resolve_metadata_filter_words(),
-            "prompt_translation": _prompt_translation_change_key(),
-            **{key: str(value) for key, value in sorted(kwargs.items())},
-        })
-
-    def build(
-        self,
-        use_anima_mod_guidance: bool,
-        pin_trigger_tags_to_front: bool,
-        quality_tags: str,
-        trigger_and_artist_tags: str,
-        lora_trigger_tags: str,
-        prompt: str,
-        trailing_quality_tags: str,
-    ):
-        use_amg = _as_bool(use_anima_mod_guidance, False)
-        pin_triggers = _as_bool(pin_trigger_tags_to_front, False)
-        quality_tags = _translate_prompt_text(quality_tags)
-        trigger_and_artist_tags = _translate_prompt_text(trigger_and_artist_tags)
-        lora_trigger_tags = _translate_prompt_text(lora_trigger_tags)
-        prompt = _translate_prompt_text(prompt)
-        trailing_quality_tags = _translate_prompt_text(trailing_quality_tags)
-
-        trigger_prompt = _join_prompt_tokens(trigger_and_artist_tags, lora_trigger_tags)
-        quality_prompt = _join_prompt_tokens(quality_tags)
-        body_prompt = _join_prompt_tokens(prompt)
-        trailing_prompt = _join_prompt_tokens(trailing_quality_tags)
-
-        if pin_triggers:
-            metadata_body = _correct_builder_prompt(
-                _join_prompt_tokens(quality_tags, body_prompt)
-            )
-            regular_prompt = _join_prompt_tokens(trigger_prompt, metadata_body, trailing_prompt)
-            amg_prompt = _join_prompt_tokens(
-                trigger_prompt,
-                _correct_builder_prompt(body_prompt),
-                trailing_prompt,
-            )
-            metadata_prompt = regular_prompt
-        else:
-            metadata_core = _correct_builder_prompt(
-                _join_prompt_tokens(
-                    quality_tags,
-                    trigger_prompt,
-                    body_prompt,
-                ),
-                artist_overrides=trigger_prompt,
-            )
-            metadata_prompt = _join_prompt_tokens(metadata_core, trailing_prompt)
-            regular_prompt = metadata_prompt
-            amg_core = _correct_builder_prompt(
-                _join_prompt_tokens(trigger_prompt, body_prompt),
-                artist_overrides=trigger_prompt,
-            )
-            amg_prompt = _join_prompt_tokens(amg_core, trailing_prompt)
-
-        metadata_prompt = _filter_metadata_prompt(
-            metadata_prompt,
-            resolve_metadata_filter_words(),
-        )
-        output_prompt = amg_prompt if use_amg else regular_prompt
-
-        return (
-            output_prompt,
-            quality_prompt,
-            use_amg,
-            metadata_prompt,
-        )
-
-
-class EasyUseAnimaPromptStudio(EasyUseAnimaPromptBuilder):
-    """Prompt Builder variant with enhanced front-end editing helpers."""
-
-    DESCRIPTION = (
-        "An enhanced Prompt Builder with front-end editing, autocomplete, and tag highlighting helpers."
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "use_anima_mod_guidance": ("BOOLEAN", {
-                    "default": False,
-                    "tooltip": (
-                        "true: output prompt excludes quality fields and sends them "
-                        "through anima_mod_guidance_quality_tags."
-                    ),
-                }),
-                "pin_trigger_tags_to_front": ("BOOLEAN", {
-                    "default": False,
-                    "tooltip": (
-                        "true: keep trigger/artist and LoRA trigger fields at the very front "
-                        "instead of placing quality tags before them."
-                    ),
-                }),
-                "lora_trigger_tags": ("STRING", {
-                    "multiline": False,
-                    "default": "",
-                    "tooltip": "One-line trigger tags received from a LoRA manager or pasted manually.",
-                }),
-                "quality_tags": ("STRING", {
-                    "multiline": True,
-                    "default": DEFAULT_QUALITY_TAGS,
-                    "tooltip": "Leading quality tags. With AMG enabled, these are excluded from prompt output.",
-                }),
-                "trigger_and_artist_tags": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Manual model triggers and @artist tags.",
-                }),
-                "prompt": ("STRING", {
-                    "multiline": True,
-                    "default": "",
-                    "tooltip": "Main prompt body. This is the expected place for NAIA output.",
-                }),
-                "trailing_quality_tags": ("STRING", {
-                    "multiline": True,
-                    "default": DEFAULT_TRAILING_QUALITY_TAGS,
-                    "tooltip": "Trailing quality or style tags.",
-                }),
-            }
-        }
-
-    CATEGORY = "EasyUse Anima/Prompt"
-
-    def build(
-        self,
-        use_anima_mod_guidance: bool,
-        pin_trigger_tags_to_front: bool,
-        quality_tags: str,
-        trigger_and_artist_tags: str,
-        lora_trigger_tags: str,
-        prompt: str,
-        trailing_quality_tags: str,
-    ):
-        result = super().build(
-            use_anima_mod_guidance,
-            pin_trigger_tags_to_front,
-            quality_tags,
-            trigger_and_artist_tags,
-            lora_trigger_tags,
-            prompt,
-            trailing_quality_tags,
-        )
-        return {
-            "ui": {
-                "prompt_studio_inputs": [{
-                    "lora_trigger_tags": str(lora_trigger_tags or ""),
-                    "quality_tags": str(quality_tags or ""),
-                    "trigger_and_artist_tags": str(trigger_and_artist_tags or ""),
-                    "prompt": str(prompt or ""),
-                    "trailing_quality_tags": str(trailing_quality_tags or ""),
-                }]
-            },
-            "result": result,
-        }
 
 
 class EasyUseAnimaPromptStudioAdvanced:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6215,6 +6215,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 8,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_prompt_translation_change_key",
         "branch_context": [],
         "classification": "internal",
@@ -6222,7 +6240,7 @@
         "conditional": false,
         "imported": "..prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "..prompt.correction",
@@ -6240,7 +6258,7 @@
         "conditional": false,
         "imported": "..prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "..prompt.correction",
@@ -6258,7 +6276,7 @@
         "conditional": false,
         "imported": "..prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 8,
+        "line": 9,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "..prompt.correction",
@@ -6269,6 +6287,96 @@
       },
       {
         "alias": null,
+        "bound_name": "DEFAULT_QUALITY_TAGS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.fields:DEFAULT_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 14,
+        "name": "DEFAULT_QUALITY_TAGS",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 14,
+        "name": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_correct_builder_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.fields:_correct_builder_prompt",
+        "kind": "static_from",
+        "line": 14,
+        "name": "_correct_builder_prompt",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_filter_metadata_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.fields:_filter_metadata_prompt",
+        "kind": "static_from",
+        "line": 14,
+        "name": "_filter_metadata_prompt",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_join_prompt_tokens",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 14,
+        "name": "_join_prompt_tokens",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
         "bound_name": "correct_prompt",
         "branch_context": [
           {
@@ -6276,7 +6384,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 14
+            "line": 22
           }
         ],
         "classification": "internal",
@@ -6284,12 +6392,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 14
+          "try_line": 22
         },
         "conditional": true,
         "imported": "...anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 15,
+        "line": 23,
         "name": "correct_prompt",
         "optional": false,
         "requested": "...anima_prompt",
@@ -6307,7 +6415,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 14
+            "line": 22
           }
         ],
         "classification": "internal",
@@ -6315,12 +6423,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 14
+          "try_line": 22
         },
         "conditional": true,
         "imported": "...anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 15,
+        "line": 23,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "...anima_prompt",
@@ -6328,6 +6436,37 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/prompt_nodes.py",
         "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 22
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 22
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 24,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "settings.py"
       },
       {
         "alias": null,
@@ -6339,9 +6478,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 16,
+            "handler_line": 25,
             "kind": "try",
-            "line": 14
+            "line": 22
           }
         ],
         "classification": "compatibility_fallback",
@@ -6349,12 +6488,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 14
+          "try_line": 22
         },
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 17,
+        "line": 26,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -6373,9 +6512,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 16,
+            "handler_line": 25,
             "kind": "try",
-            "line": 14
+            "line": 22
           }
         ],
         "classification": "compatibility_fallback",
@@ -6383,12 +6522,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 14
+          "try_line": 22
         },
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 17,
+        "line": 26,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -6396,6 +6535,40 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/prompt_nodes.py",
         "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 25,
+            "kind": "try",
+            "line": 22
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 22
+        },
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 27,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "settings.py"
       },
       {
         "alias": null,
@@ -8015,6 +8188,235 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correct_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "correct_prompt",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 7
+        },
+        "conditional": true,
+        "imported": "...anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 8,
+        "name": "correct_prompt",
+        "optional": false,
+        "requested": "...anima_prompt",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "load_knowledge_base",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "load_knowledge_base",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 7
+        },
+        "conditional": true,
+        "imported": "...anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 8,
+        "name": "load_knowledge_base",
+        "optional": false,
+        "requested": "...anima_prompt",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "parse_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "parse_prompt",
+          "target": "anima_prompt/parser.py",
+          "try_line": 7
+        },
+        "conditional": true,
+        "imported": "...anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 9,
+        "name": "parse_prompt",
+        "optional": false,
+        "requested": "...anima_prompt.parser",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "correct_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 10,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "correct_prompt",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 7
+        },
+        "conditional": true,
+        "imported": "anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 11,
+        "name": "correct_prompt",
+        "optional": false,
+        "requested": "anima_prompt",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "load_knowledge_base",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 10,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "load_knowledge_base",
+          "target": "anima_prompt/__init__.py",
+          "try_line": 7
+        },
+        "conditional": true,
+        "imported": "anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 11,
+        "name": "load_knowledge_base",
+        "optional": false,
+        "requested": "anima_prompt",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "parse_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 10,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "parse_prompt",
+          "target": "anima_prompt/parser.py",
+          "try_line": 7
+        },
+        "conditional": true,
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 12,
+        "name": "parse_prompt",
+        "optional": false,
+        "requested": "anima_prompt.parser",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "name": "annotations",
         "optional": false,
@@ -8600,6 +9002,378 @@
         "target": "easyuse_anima/prompt/correction.py"
       },
       {
+        "alias": "DEFAULT_QUALITY_TAGS",
+        "bound_name": "DEFAULT_QUALITY_TAGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_QUALITY_TAGS",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 33,
+        "name": "DEFAULT_QUALITY_TAGS",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 33,
+        "name": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_HASH_COMMENT_RE",
+        "bound_name": "_HASH_COMMENT_RE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_HASH_COMMENT_RE",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_HASH_COMMENT_RE",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_INLINE_SPACE_RE",
+        "bound_name": "_INLINE_SPACE_RE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_INLINE_SPACE_RE",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_INLINE_SPACE_RE",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_WEIGHTED_TOKEN_RE",
+        "bound_name": "_WEIGHTED_TOKEN_RE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WEIGHTED_TOKEN_RE",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_WEIGHTED_TOKEN_RE",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_bind_prompt_fields_runtime",
+        "bound_name": "_bind_prompt_fields_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_prompt_fields_runtime",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_bind_prompt_fields_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_correct_builder_prompt",
+        "bound_name": "_correct_builder_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_correct_builder_prompt",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_correct_builder_prompt",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_filter_metadata_prompt",
+        "bound_name": "_filter_metadata_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_filter_metadata_prompt",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_filter_metadata_prompt",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_join_prompt_tokens",
+        "bound_name": "_join_prompt_tokens",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_join_prompt_tokens",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_join_prompt_tokens",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_metadata_filter_key",
+        "bound_name": "_metadata_filter_key",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_metadata_filter_key",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_metadata_filter_key",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_metadata_filter_keys",
+        "bound_name": "_metadata_filter_keys",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_metadata_filter_keys",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_metadata_filter_keys",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_prompt_tokens",
+        "bound_name": "_prompt_tokens",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_prompt_tokens",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
+        "kind": "static_from",
+        "line": 33,
+        "name": "_prompt_tokens",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.fields",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
         "alias": "_align_down",
         "bound_name": "_align_down",
         "branch_context": [
@@ -8621,7 +9395,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 33,
+        "line": 47,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8652,7 +9426,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 33,
+        "line": 47,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8683,7 +9457,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 33,
+        "line": 47,
         "name": "_align_up",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8714,7 +9488,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 33,
+        "line": 47,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8745,7 +9519,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 33,
+        "line": 47,
         "name": "_alignment_value",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -8776,7 +9550,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 40,
+        "line": 54,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": ".easyuse_anima.image.detailer",
@@ -8807,7 +9581,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 43,
+        "line": 57,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8838,7 +9612,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 43,
+        "line": 57,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8869,7 +9643,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 43,
+        "line": 57,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8900,7 +9674,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 43,
+        "line": 57,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8931,7 +9705,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 43,
+        "line": 57,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8962,7 +9736,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 43,
+        "line": 57,
         "name": "_scale_by_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -8993,7 +9767,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 51,
+        "line": 65,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -9024,7 +9798,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 51,
+        "line": 65,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -9055,7 +9829,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 51,
+        "line": 65,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -9086,7 +9860,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 51,
+        "line": 65,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -9117,7 +9891,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 51,
+        "line": 65,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -9148,7 +9922,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 51,
+        "line": 65,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -9179,7 +9953,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 51,
+        "line": 65,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -9210,7 +9984,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 60,
+        "line": 74,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -9241,7 +10015,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 60,
+        "line": 74,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -9272,7 +10046,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 60,
+        "line": 74,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -9303,7 +10077,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 65,
+        "line": 79,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -9334,7 +10108,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 65,
+        "line": 79,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -9365,7 +10139,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 65,
+        "line": 79,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -9396,7 +10170,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 65,
+        "line": 79,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -9427,7 +10201,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 65,
+        "line": 79,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -9458,7 +10232,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 65,
+        "line": 79,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -9489,7 +10263,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 73,
+        "line": 87,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -9520,7 +10294,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 73,
+        "line": 87,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -9528,6 +10302,37 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptBuilder",
+        "bound_name": "EasyUseAnimaPromptBuilder",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptBuilder",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
+        "kind": "static_from",
+        "line": 91,
+        "name": "EasyUseAnimaPromptBuilder",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
       },
       {
         "alias": "EasyUseAnimaPromptCorrector",
@@ -9551,7 +10356,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 77,
+        "line": 91,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -9582,8 +10387,39 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 77,
+        "line": 91,
         "name": "EasyUseAnimaPromptCorrectorSimple",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptStudio",
+        "bound_name": "EasyUseAnimaPromptStudio",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptStudio",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
+        "kind": "static_from",
+        "line": 91,
+        "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
         "role": "compatibility_primary",
@@ -9613,7 +10449,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 77,
+        "line": 91,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -9644,7 +10480,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9675,7 +10511,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9706,7 +10542,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9737,7 +10573,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9768,7 +10604,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9799,7 +10635,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9830,7 +10666,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9861,7 +10697,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "NAI_1MP",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9892,7 +10728,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9923,7 +10759,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9954,7 +10790,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -9985,7 +10821,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "_clean_prompt",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -10016,7 +10852,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -10047,7 +10883,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -10078,7 +10914,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -10109,7 +10945,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 82,
+        "line": 98,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -10140,7 +10976,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10171,7 +11007,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10202,7 +11038,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10233,7 +11069,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10264,7 +11100,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10295,7 +11131,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10326,7 +11162,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10357,7 +11193,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10388,7 +11224,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10419,7 +11255,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10450,7 +11286,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10481,7 +11317,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10512,7 +11348,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10543,7 +11379,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10574,7 +11410,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10605,7 +11441,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10636,7 +11472,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10667,7 +11503,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10698,7 +11534,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10729,7 +11565,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10760,7 +11596,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 100,
+        "line": 116,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -10791,7 +11627,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 123,
+        "line": 139,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -10822,7 +11658,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 123,
+        "line": 139,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -10853,7 +11689,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 127,
+        "line": 143,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -10884,7 +11720,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 127,
+        "line": 143,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -10915,7 +11751,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 127,
+        "line": 143,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -10946,7 +11782,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -10977,7 +11813,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11008,7 +11844,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11039,7 +11875,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11070,7 +11906,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11101,7 +11937,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11132,7 +11968,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11163,7 +11999,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11194,7 +12030,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11225,7 +12061,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11256,7 +12092,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11287,7 +12123,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11318,7 +12154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11349,7 +12185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11380,7 +12216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 132,
+        "line": 148,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -11411,7 +12247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11442,7 +12278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11473,7 +12309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11504,7 +12340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11535,7 +12371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11566,7 +12402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11597,7 +12433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11628,7 +12464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 149,
+        "line": 165,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -11659,7 +12495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 159,
+        "line": 175,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -11690,7 +12526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 159,
+        "line": 175,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -11721,7 +12557,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 163,
+        "line": 179,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -11752,7 +12588,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 163,
+        "line": 179,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -11783,7 +12619,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 164,
+        "line": 180,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -11814,7 +12650,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 165,
+        "line": 181,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -11845,7 +12681,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 165,
+        "line": 181,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -11876,7 +12712,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 165,
+        "line": 181,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -11907,7 +12743,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 170,
+        "line": 186,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -11938,7 +12774,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 170,
+        "line": 186,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -11969,7 +12805,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12000,7 +12836,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12031,7 +12867,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12062,7 +12898,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12093,7 +12929,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12124,7 +12960,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12155,7 +12991,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12186,7 +13022,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12217,7 +13053,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12248,7 +13084,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12279,7 +13115,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12310,7 +13146,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12341,7 +13177,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12372,7 +13208,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12403,7 +13239,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12434,7 +13270,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12465,7 +13301,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12496,7 +13332,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 171,
+        "line": 187,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -12515,7 +13351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12530,7 +13366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 192,
+        "line": 208,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -12549,7 +13385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12564,7 +13400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 192,
+        "line": 208,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -12583,7 +13419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12598,7 +13434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 192,
+        "line": 208,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -12617,7 +13453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12632,7 +13468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12651,7 +13487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12666,7 +13502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12685,7 +13521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12700,7 +13536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12719,7 +13555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12734,7 +13570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12753,7 +13589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12768,7 +13604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -12787,7 +13623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12802,7 +13638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -12821,7 +13657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12836,7 +13672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -12855,7 +13691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12870,7 +13706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -12889,7 +13725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12904,7 +13740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -12912,6 +13748,414 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": "DEFAULT_QUALITY_TAGS",
+        "bound_name": "DEFAULT_QUALITY_TAGS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_QUALITY_TAGS",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 226,
+        "name": "DEFAULT_QUALITY_TAGS",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "DEFAULT_TRAILING_QUALITY_TAGS",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 226,
+        "name": "DEFAULT_TRAILING_QUALITY_TAGS",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_HASH_COMMENT_RE",
+        "bound_name": "_HASH_COMMENT_RE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_HASH_COMMENT_RE",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_HASH_COMMENT_RE",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_INLINE_SPACE_RE",
+        "bound_name": "_INLINE_SPACE_RE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_INLINE_SPACE_RE",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_INLINE_SPACE_RE",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_WEIGHTED_TOKEN_RE",
+        "bound_name": "_WEIGHTED_TOKEN_RE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_WEIGHTED_TOKEN_RE",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_WEIGHTED_TOKEN_RE",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_bind_prompt_fields_runtime",
+        "bound_name": "_bind_prompt_fields_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_prompt_fields_runtime",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_bind_prompt_fields_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_correct_builder_prompt",
+        "bound_name": "_correct_builder_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_correct_builder_prompt",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_correct_builder_prompt",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_filter_metadata_prompt",
+        "bound_name": "_filter_metadata_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_filter_metadata_prompt",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_filter_metadata_prompt",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_join_prompt_tokens",
+        "bound_name": "_join_prompt_tokens",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_join_prompt_tokens",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_join_prompt_tokens",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_metadata_filter_key",
+        "bound_name": "_metadata_filter_key",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_metadata_filter_key",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_metadata_filter_key",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_metadata_filter_keys",
+        "bound_name": "_metadata_filter_keys",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_metadata_filter_keys",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_metadata_filter_keys",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "_prompt_tokens",
+        "bound_name": "_prompt_tokens",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_prompt_tokens",
+          "target": "easyuse_anima/prompt/fields.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
+        "kind": "static_from",
+        "line": 226,
+        "name": "_prompt_tokens",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.fields",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
       },
       {
         "alias": "_align_down",
@@ -12923,7 +14167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12938,7 +14182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -12957,7 +14201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -12972,7 +14216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -12991,7 +14235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13006,7 +14250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -13025,7 +14269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13040,7 +14284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -13059,7 +14303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13074,7 +14318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -13093,7 +14337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13108,7 +14352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 217,
+        "line": 247,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -13127,7 +14371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13142,7 +14386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -13161,7 +14405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13176,7 +14420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -13195,7 +14439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13210,7 +14454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -13229,7 +14473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13244,7 +14488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -13263,7 +14507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13278,7 +14522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -13297,7 +14541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13312,7 +14556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -13331,7 +14575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13346,7 +14590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -13365,7 +14609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13380,7 +14624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -13399,7 +14643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13414,7 +14658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -13433,7 +14677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13448,7 +14692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -13467,7 +14711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13482,7 +14726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -13501,7 +14745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13516,7 +14760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -13535,7 +14779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13550,7 +14794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -13569,7 +14813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13584,7 +14828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 237,
+        "line": 267,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -13603,7 +14847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13618,7 +14862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 237,
+        "line": 267,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -13637,7 +14881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13652,7 +14896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 237,
+        "line": 267,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -13671,7 +14915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13686,7 +14930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13705,7 +14949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13720,7 +14964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13739,7 +14983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13754,7 +14998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13773,7 +15017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13788,7 +15032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13807,7 +15051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13822,7 +15066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13841,7 +15085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13856,7 +15100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -13875,7 +15119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13890,7 +15134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 250,
+        "line": 280,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -13909,7 +15153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13924,7 +15168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 250,
+        "line": 280,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -13932,6 +15176,40 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptBuilder",
+        "bound_name": "EasyUseAnimaPromptBuilder",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptBuilder",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
+        "kind": "static_from",
+        "line": 284,
+        "name": "EasyUseAnimaPromptBuilder",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
       },
       {
         "alias": "EasyUseAnimaPromptCorrector",
@@ -13943,7 +15221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13958,7 +15236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 254,
+        "line": 284,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -13977,7 +15255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -13992,8 +15270,42 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 254,
+        "line": 284,
         "name": "EasyUseAnimaPromptCorrectorSimple",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.prompt_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptStudio",
+        "bound_name": "EasyUseAnimaPromptStudio",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptStudio",
+          "target": "easyuse_anima/nodes/prompt_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
+        "kind": "static_from",
+        "line": 284,
+        "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
         "role": "compatibility_fallback",
@@ -14011,7 +15323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14026,7 +15338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 254,
+        "line": 284,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -14045,7 +15357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14060,7 +15372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14079,7 +15391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14094,7 +15406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14113,7 +15425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14128,7 +15440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14147,7 +15459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14162,7 +15474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14181,7 +15493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14196,7 +15508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14215,7 +15527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14230,7 +15542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14249,7 +15561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14264,7 +15576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14283,7 +15595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14298,7 +15610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14317,7 +15629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14332,7 +15644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14351,7 +15663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14366,7 +15678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14385,7 +15697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14400,7 +15712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14419,7 +15731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14434,7 +15746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14453,7 +15765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14468,7 +15780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14487,7 +15799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14502,7 +15814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14521,7 +15833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14536,7 +15848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14555,7 +15867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14570,7 +15882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -14589,7 +15901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14604,7 +15916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14623,7 +15935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14638,7 +15950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14657,7 +15969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14672,7 +15984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14691,7 +16003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14706,7 +16018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14725,7 +16037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14740,7 +16052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14759,7 +16071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14774,7 +16086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14793,7 +16105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14808,7 +16120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14827,7 +16139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14842,7 +16154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14861,7 +16173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14876,7 +16188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14895,7 +16207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14910,7 +16222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14929,7 +16241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14944,7 +16256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14963,7 +16275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -14978,7 +16290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -14997,7 +16309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15012,7 +16324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15031,7 +16343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15046,7 +16358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15065,7 +16377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15080,7 +16392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15099,7 +16411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15114,7 +16426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15133,7 +16445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15148,7 +16460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15167,7 +16479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15182,7 +16494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15201,7 +16513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15216,7 +16528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15235,7 +16547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15250,7 +16562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15269,7 +16581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15284,7 +16596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -15303,7 +16615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15318,7 +16630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 300,
+        "line": 332,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -15337,7 +16649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15352,7 +16664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 300,
+        "line": 332,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -15371,7 +16683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15386,7 +16698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 304,
+        "line": 336,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -15405,7 +16717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15420,7 +16732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 304,
+        "line": 336,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -15439,7 +16751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15454,7 +16766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 304,
+        "line": 336,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -15473,7 +16785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15488,7 +16800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15507,7 +16819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15522,7 +16834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15541,7 +16853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15556,7 +16868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15575,7 +16887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15590,7 +16902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15609,7 +16921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15624,7 +16936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15643,7 +16955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15658,7 +16970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15677,7 +16989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15692,7 +17004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15711,7 +17023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15726,7 +17038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15745,7 +17057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15760,7 +17072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15779,7 +17091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15794,7 +17106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15813,7 +17125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15828,7 +17140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15847,7 +17159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15862,7 +17174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15881,7 +17193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15896,7 +17208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15915,7 +17227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15930,7 +17242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15949,7 +17261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15964,7 +17276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -15983,7 +17295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -15998,7 +17310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16017,7 +17329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16032,7 +17344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16051,7 +17363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16066,7 +17378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16085,7 +17397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16100,7 +17412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16119,7 +17431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16134,7 +17446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16153,7 +17465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16168,7 +17480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16187,7 +17499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16202,7 +17514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16221,7 +17533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16236,7 +17548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -16255,7 +17567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16270,7 +17582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 336,
+        "line": 368,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -16289,7 +17601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16304,7 +17616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 336,
+        "line": 368,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -16323,7 +17635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16338,7 +17650,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 340,
+        "line": 372,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -16357,7 +17669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16372,7 +17684,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 340,
+        "line": 372,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -16391,7 +17703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16406,7 +17718,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 341,
+        "line": 373,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -16425,7 +17737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16440,7 +17752,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 342,
+        "line": 374,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -16459,7 +17771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16474,7 +17786,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 342,
+        "line": 374,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -16493,7 +17805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16508,7 +17820,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 342,
+        "line": 374,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -16527,7 +17839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16542,7 +17854,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 347,
+        "line": 379,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -16561,7 +17873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16576,7 +17888,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 347,
+        "line": 379,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -16595,7 +17907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16610,7 +17922,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16629,7 +17941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16644,7 +17956,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16663,7 +17975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16678,7 +17990,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16697,7 +18009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16712,7 +18024,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16731,7 +18043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16746,7 +18058,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16765,7 +18077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16780,7 +18092,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16799,7 +18111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16814,7 +18126,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16833,7 +18145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16848,7 +18160,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16867,7 +18179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16882,7 +18194,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16901,7 +18213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16916,7 +18228,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16935,7 +18247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16950,7 +18262,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -16969,7 +18281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -16984,7 +18296,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17003,7 +18315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -17018,7 +18330,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17037,7 +18349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -17052,7 +18364,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17071,7 +18383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -17086,7 +18398,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17105,7 +18417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -17120,7 +18432,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17139,7 +18451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -17154,7 +18466,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17173,7 +18485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -17188,7 +18500,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -17206,7 +18518,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2029
+            "line": 2051
           }
         ],
         "classification": "external",
@@ -17214,7 +18526,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2030,
+        "line": 2052,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -17231,7 +18543,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2094
+            "line": 2116
           }
         ],
         "classification": "external",
@@ -17239,7 +18551,7 @@
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2095,
+        "line": 2117,
         "name": null,
         "optional": true,
         "requested": "impact.core",
@@ -17256,7 +18568,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2100
+            "line": 2122
           }
         ],
         "classification": "external",
@@ -17264,7 +18576,7 @@
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2101,
+        "line": 2123,
         "name": "core",
         "optional": true,
         "requested": "modules.impact",
@@ -17281,7 +18593,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2116
+            "line": 2138
           }
         ],
         "classification": "external",
@@ -17289,7 +18601,7 @@
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2117,
+        "line": 2139,
         "name": null,
         "optional": true,
         "requested": "comfy.samplers",
@@ -17306,7 +18618,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2125
+            "line": 2147
           }
         ],
         "classification": "external",
@@ -17314,7 +18626,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2126,
+        "line": 2148,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -17331,7 +18643,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2141
+            "line": 2163
           }
         ],
         "classification": "external",
@@ -17339,7 +18651,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2142,
+        "line": 2164,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -17356,7 +18668,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2147
+            "line": 2169
           }
         ],
         "classification": "external",
@@ -17364,7 +18676,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2148,
+        "line": 2170,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -17381,7 +18693,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2161
+            "line": 2183
           }
         ],
         "classification": "external",
@@ -17389,7 +18701,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2162,
+        "line": 2184,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -17406,7 +18718,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2260
+            "line": 2282
           }
         ],
         "classification": "external",
@@ -17414,7 +18726,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2261,
+        "line": 2283,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
@@ -17431,7 +18743,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2284
+            "line": 2306
           }
         ],
         "classification": "external",
@@ -17439,7 +18751,7 @@
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2285,
+        "line": 2307,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.segs_nodes",
@@ -17456,7 +18768,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2290
+            "line": 2312
           }
         ],
         "classification": "external",
@@ -17464,7 +18776,7 @@
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2291,
+        "line": 2313,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.segs_nodes",
@@ -17481,7 +18793,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2296
+            "line": 2318
           }
         ],
         "classification": "external",
@@ -17489,7 +18801,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2297,
+        "line": 2319,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -17506,7 +18818,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2302
+            "line": 2324
           }
         ],
         "classification": "external",
@@ -17514,7 +18826,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2303,
+        "line": 2325,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -17531,7 +18843,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2737
+            "line": 2759
           }
         ],
         "classification": "external",
@@ -17539,7 +18851,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2738,
+        "line": 2760,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -17556,7 +18868,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2777
+            "line": 2799
           }
         ],
         "classification": "external",
@@ -17564,7 +18876,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2778,
+        "line": 2800,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -17579,7 +18891,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3210,
+            "line": 3232,
             "type_checking": false
           },
           {
@@ -17587,7 +18899,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3211
+            "line": 3233
           }
         ],
         "classification": "external",
@@ -17595,7 +18907,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3212,
+        "line": 3234,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -17612,7 +18924,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4011
+            "line": 4033
           }
         ],
         "classification": "external",
@@ -17620,7 +18932,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4012,
+        "line": 4034,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -17637,7 +18949,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4073
+            "line": 4095
           }
         ],
         "classification": "external",
@@ -17645,7 +18957,7 @@
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4074,
+        "line": 4096,
         "name": "PromptServer",
         "optional": true,
         "requested": "server",
@@ -17662,7 +18974,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
@@ -17670,7 +18982,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4101,
+        "line": 4123,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -17687,7 +18999,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
@@ -17695,7 +19007,7 @@
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4102,
+        "line": 4124,
         "name": null,
         "optional": true,
         "requested": "numpy",
@@ -17712,7 +19024,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
@@ -17720,7 +19032,7 @@
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4103,
+        "line": 4125,
         "name": "Image",
         "optional": true,
         "requested": "PIL",
@@ -17737,7 +19049,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4294
+            "line": 4316
           }
         ],
         "classification": "external",
@@ -17745,7 +19057,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4295,
+        "line": 4317,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17762,7 +19074,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5120
+            "line": 5080
           }
         ],
         "classification": "external",
@@ -17770,7 +19082,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5121,
+        "line": 5081,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17787,7 +19099,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5137
+            "line": 5097
           }
         ],
         "classification": "external",
@@ -17795,7 +19107,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5138,
+        "line": 5098,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17812,7 +19124,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5158
+            "line": 5118
           }
         ],
         "classification": "external",
@@ -17820,7 +19132,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5159,
+        "line": 5119,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17837,7 +19149,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5235
+            "line": 5195
           }
         ],
         "classification": "external",
@@ -17845,7 +19157,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5236,
+        "line": 5196,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17862,7 +19174,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6034
+            "line": 5994
           }
         ],
         "classification": "external",
@@ -17870,7 +19182,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6035,
+        "line": 5995,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17887,7 +19199,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7059
+            "line": 7019
           }
         ],
         "classification": "external",
@@ -17895,7 +19207,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7060,
+        "line": 7020,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -17912,7 +19224,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7093
+            "line": 7053
           }
         ],
         "classification": "external",
@@ -17920,7 +19232,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7094,
+        "line": 7054,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -19611,7 +20923,19 @@
       },
       {
         "from": "easyuse_anima/nodes/prompt_nodes.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_nodes.py",
         "to": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_nodes.py",
+        "to": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_nodes.py",
+        "to": "settings.py"
       },
       {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
@@ -19636,6 +20960,14 @@
       {
         "from": "easyuse_anima/prompt/correction.py",
         "to": "settings.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/fields.py",
+        "to": "anima_prompt/__init__.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/fields.py",
+        "to": "anima_prompt/parser.py"
       },
       {
         "from": "nodes.py",
@@ -19716,6 +21048,10 @@
       {
         "from": "nodes.py",
         "to": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/prompt/fields.py"
       },
       {
         "from": "nodes.py",
@@ -20018,6 +21354,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/prompt/fields.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "nodes.py"
         ]
       },
@@ -20048,7 +21390,7 @@
     ]
   },
   "inventory": {
-    "module_count": 48,
+    "module_count": 49,
     "modules": [
       {
         "is_package": true,
@@ -20484,12 +21826,12 @@
       },
       {
         "is_package": false,
-        "loc": 167,
+        "loc": 421,
         "module": "easyuse_anima.nodes.prompt_nodes",
-        "normalized_git_blob_sha1": "862e46cc2e24e18d00c71732258f9538a46fc9c1",
+        "normalized_git_blob_sha1": "780e6d6ec323bc5c74e9daa9d1130b4a14f95c8f",
         "path": "easyuse_anima/nodes/prompt_nodes.py",
         "top_level": {
-          "class_count": 2,
+          "class_count": 4,
           "function_count": 2,
           "global_count": 1
         }
@@ -20568,14 +21910,26 @@
       },
       {
         "is_package": false,
-        "loc": 10664,
+        "loc": 114,
+        "module": "easyuse_anima.prompt.fields",
+        "normalized_git_blob_sha1": "1ae653d37fbbc341c9e778c26a79ad183c3c226a",
+        "path": "easyuse_anima/prompt/fields.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 8,
+          "global_count": 7
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 10395,
         "module": "nodes",
-        "normalized_git_blob_sha1": "d968590df0342a380a1103bdf95b0b942fab8fb2",
+        "normalized_git_blob_sha1": "1355064c0bdec0350aab793134f3e4ee00eef42b",
         "path": "nodes.py",
         "top_level": {
-          "class_count": 17,
-          "function_count": 216,
-          "global_count": 104
+          "class_count": 15,
+          "function_count": 210,
+          "global_count": 99
         }
       },
       {
@@ -21464,16 +22818,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 16,
+            "handler_line": 25,
             "kind": "try",
-            "line": 14
+            "line": 22
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 17,
+        "line": 26,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/prompt_nodes.py",
@@ -21487,20 +22841,43 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 16,
+            "handler_line": 25,
             "kind": "try",
-            "line": 14
+            "line": 22
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 17,
+        "line": 26,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/nodes/prompt_nodes.py",
         "target": "anima_prompt/__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 25,
+            "kind": "try",
+            "line": 22
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 27,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/nodes/prompt_nodes.py",
+        "target": "settings.py"
       },
       {
         "branch_context": [
@@ -21970,7 +23347,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 10,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt:correct_prompt",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 10,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt:load_knowledge_base",
+        "kind": "static_from",
+        "line": 11,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 10,
+            "kind": "try",
+            "line": 7
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "anima_prompt.parser:parse_prompt",
+        "kind": "static_from",
+        "line": 12,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/fields.py",
+        "target": "anima_prompt/parser.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -21979,7 +23425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 192,
+        "line": 208,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -21993,7 +23439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22002,7 +23448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 192,
+        "line": 208,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22016,7 +23462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22025,7 +23471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 192,
+        "line": 208,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22039,7 +23485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22048,7 +23494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22062,7 +23508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22071,7 +23517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22085,7 +23531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22094,7 +23540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22108,7 +23554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22117,7 +23563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22131,7 +23577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22140,7 +23586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 197,
+        "line": 213,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22154,7 +23600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22163,7 +23609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22177,7 +23623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22186,7 +23632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22200,7 +23646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22209,7 +23655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22223,7 +23669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22232,7 +23678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 204,
+        "line": 220,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22246,7 +23692,283 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
+        "kind": "static_from",
+        "line": 226,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22255,7 +23977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22269,7 +23991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22278,7 +24000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22292,7 +24014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22301,7 +24023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22315,7 +24037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22324,7 +24046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22338,7 +24060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22347,7 +24069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 210,
+        "line": 240,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22361,7 +24083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22370,7 +24092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 217,
+        "line": 247,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22384,7 +24106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22393,7 +24115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22407,7 +24129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22416,7 +24138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22430,7 +24152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22439,7 +24161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22453,7 +24175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22462,7 +24184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22476,7 +24198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22485,7 +24207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22499,7 +24221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22508,7 +24230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 220,
+        "line": 250,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22522,7 +24244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22531,7 +24253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22545,7 +24267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22554,7 +24276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22568,7 +24290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22577,7 +24299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22591,7 +24313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22600,7 +24322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22614,7 +24336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22623,7 +24345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22637,7 +24359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22646,7 +24368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22660,7 +24382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22669,7 +24391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 228,
+        "line": 258,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22683,7 +24405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22692,7 +24414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 237,
+        "line": 267,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22706,7 +24428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22715,7 +24437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 237,
+        "line": 267,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22729,7 +24451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22738,7 +24460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 237,
+        "line": 267,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22752,7 +24474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22761,7 +24483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22775,7 +24497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22784,7 +24506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22798,7 +24520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22807,7 +24529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22821,7 +24543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22830,7 +24552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22844,7 +24566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22853,7 +24575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22867,7 +24589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22876,7 +24598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 242,
+        "line": 272,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22890,7 +24612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22899,7 +24621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 250,
+        "line": 280,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22913,7 +24635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22922,7 +24644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 250,
+        "line": 280,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22936,7 +24658,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
+        "kind": "static_from",
+        "line": 284,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22945,7 +24690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 254,
+        "line": 284,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22959,7 +24704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22968,7 +24713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 254,
+        "line": 284,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -22982,7 +24727,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
+        "kind": "static_from",
+        "line": 284,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -22991,7 +24759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 254,
+        "line": 284,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23005,7 +24773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23014,7 +24782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23028,7 +24796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23037,7 +24805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23051,7 +24819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23060,7 +24828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23074,7 +24842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23083,7 +24851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23097,7 +24865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23106,7 +24874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23120,7 +24888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23129,7 +24897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23143,7 +24911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23152,7 +24920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23166,7 +24934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23175,7 +24943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23189,7 +24957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23198,7 +24966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23212,7 +24980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23221,7 +24989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23235,7 +25003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23244,7 +25012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23258,7 +25026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23267,7 +25035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23281,7 +25049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23290,7 +25058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23304,7 +25072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23313,7 +25081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23327,7 +25095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23336,7 +25104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23350,7 +25118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23359,7 +25127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 259,
+        "line": 291,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23373,7 +25141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23382,7 +25150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23396,7 +25164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23405,7 +25173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23419,7 +25187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23428,7 +25196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23442,7 +25210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23451,7 +25219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23465,7 +25233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23474,7 +25242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23488,7 +25256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23497,7 +25265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23511,7 +25279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23520,7 +25288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23534,7 +25302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23543,7 +25311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23557,7 +25325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23566,7 +25334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23580,7 +25348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23589,7 +25357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23603,7 +25371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23612,7 +25380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23626,7 +25394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23635,7 +25403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23649,7 +25417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23658,7 +25426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23672,7 +25440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23681,7 +25449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23695,7 +25463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23704,7 +25472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23718,7 +25486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23727,7 +25495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23741,7 +25509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23750,7 +25518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23764,7 +25532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23773,7 +25541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23787,7 +25555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23796,7 +25564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23810,7 +25578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23819,7 +25587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23833,7 +25601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23842,7 +25610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 277,
+        "line": 309,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23856,7 +25624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23865,7 +25633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 300,
+        "line": 332,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23879,7 +25647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23888,7 +25656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 300,
+        "line": 332,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23902,7 +25670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23911,7 +25679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 304,
+        "line": 336,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23925,7 +25693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23934,7 +25702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 304,
+        "line": 336,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23948,7 +25716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23957,7 +25725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 304,
+        "line": 336,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23971,7 +25739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -23980,7 +25748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -23994,7 +25762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24003,7 +25771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24017,7 +25785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24026,7 +25794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24040,7 +25808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24049,7 +25817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24063,7 +25831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24072,7 +25840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24086,7 +25854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24095,7 +25863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24109,7 +25877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24118,7 +25886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24132,7 +25900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24141,7 +25909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24155,7 +25923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24164,7 +25932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24178,7 +25946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24187,7 +25955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24201,7 +25969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24210,7 +25978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24224,7 +25992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24233,7 +26001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24247,7 +26015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24256,7 +26024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24270,7 +26038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24279,7 +26047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24293,7 +26061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24302,7 +26070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 309,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24316,7 +26084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24325,7 +26093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24339,7 +26107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24348,7 +26116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24362,7 +26130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24371,7 +26139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24385,7 +26153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24394,7 +26162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24408,7 +26176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24417,7 +26185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24431,7 +26199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24440,7 +26208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24454,7 +26222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24463,7 +26231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24477,7 +26245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24486,7 +26254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 326,
+        "line": 358,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24500,7 +26268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24509,7 +26277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 336,
+        "line": 368,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24523,7 +26291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24532,7 +26300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 336,
+        "line": 368,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24546,7 +26314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24555,7 +26323,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 340,
+        "line": 372,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24569,7 +26337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24578,7 +26346,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 340,
+        "line": 372,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24592,7 +26360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24601,7 +26369,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 341,
+        "line": 373,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24615,7 +26383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24624,7 +26392,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 342,
+        "line": 374,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24638,7 +26406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24647,7 +26415,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 342,
+        "line": 374,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24661,7 +26429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24670,7 +26438,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 342,
+        "line": 374,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24684,7 +26452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24693,7 +26461,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 347,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24707,7 +26475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24716,7 +26484,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 347,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24730,7 +26498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24739,7 +26507,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24753,7 +26521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24762,7 +26530,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24776,7 +26544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24785,7 +26553,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24799,7 +26567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24808,7 +26576,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24822,7 +26590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24831,7 +26599,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24845,7 +26613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24854,7 +26622,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24868,7 +26636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24877,7 +26645,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24891,7 +26659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24900,7 +26668,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24914,7 +26682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24923,7 +26691,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24937,7 +26705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24946,7 +26714,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24960,7 +26728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24969,7 +26737,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -24983,7 +26751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -24992,7 +26760,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -25006,7 +26774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -25015,7 +26783,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -25029,7 +26797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -25038,7 +26806,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -25052,7 +26820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -25061,7 +26829,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -25075,7 +26843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -25084,7 +26852,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -25098,7 +26866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -25107,7 +26875,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -25121,7 +26889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 191,
+            "handler_line": 207,
             "kind": "try",
             "line": 14
           }
@@ -25130,7 +26898,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 348,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -27026,6 +28794,28 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "optional": false,
         "role": "ordinary",
@@ -27170,52 +28960,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2029
+            "line": 2051
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2030,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2094
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.core",
-        "kind": "static_import",
-        "line": 2095,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2100
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact:core",
-        "kind": "static_from",
-        "line": 2101,
+        "line": 2052,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27232,7 +28984,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "comfy.samplers",
+        "imported": "impact.core",
         "kind": "static_import",
         "line": 2117,
         "optional": true,
@@ -27246,14 +28998,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2125
+            "line": 2122
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2126,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2123,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27265,14 +29017,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2141
+            "line": 2138
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2142,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2139,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27289,8 +29041,8 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
+        "imported": "nodes",
+        "kind": "static_import",
         "line": 2148,
         "optional": true,
         "role": "optional_dependency",
@@ -27303,14 +29055,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2161
+            "line": 2163
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2164,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2169
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2170,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2183
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2162,
+        "line": 2184,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27322,14 +29112,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2260
+            "line": 2282
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2261,
+        "line": 2283,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27341,14 +29131,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2284
+            "line": 2306
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2285,
+        "line": 2307,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27360,14 +29150,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2290
+            "line": 2312
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2291,
+        "line": 2313,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27379,14 +29169,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2296
+            "line": 2318
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2297,
+        "line": 2319,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27398,14 +29188,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2302
+            "line": 2324
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2303,
+        "line": 2325,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27417,14 +29207,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2737
+            "line": 2759
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2738,
+        "line": 2760,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27436,14 +29226,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2777
+            "line": 2799
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2778,
+        "line": 2800,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27453,7 +29243,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3210,
+            "line": 3232,
             "type_checking": false
           },
           {
@@ -27461,14 +29251,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3211
+            "line": 3233
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3212,
+        "line": 3234,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27480,14 +29270,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4011
+            "line": 4033
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4012,
+        "line": 4034,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27499,14 +29289,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4073
+            "line": 4095
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4074,
+        "line": 4096,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27518,14 +29308,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4101,
+        "line": 4123,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27537,14 +29327,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4102,
+        "line": 4124,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27556,14 +29346,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4103,
+        "line": 4125,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27575,14 +29365,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4294
+            "line": 4316
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4295,
+        "line": 4317,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27594,14 +29384,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5120
+            "line": 5080
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5121,
+        "line": 5081,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27613,14 +29403,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5137
+            "line": 5097
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5138,
+        "line": 5098,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27632,14 +29422,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5158
+            "line": 5118
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5159,
+        "line": 5119,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27651,14 +29441,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5235
+            "line": 5195
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5236,
+        "line": 5196,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27670,14 +29460,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6034
+            "line": 5994
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6035,
+        "line": 5995,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27689,14 +29479,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7059
+            "line": 7019
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7060,
+        "line": 7020,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -27708,14 +29498,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7093
+            "line": 7053
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7094,
+        "line": 7054,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28598,52 +30388,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2029
+            "line": 2051
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2030,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2094
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "impact.core",
-        "kind": "static_import",
-        "line": 2095,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2100
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "modules.impact:core",
-        "kind": "static_from",
-        "line": 2101,
+        "line": 2052,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28660,7 +30412,7 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "comfy.samplers",
+        "imported": "impact.core",
         "kind": "static_import",
         "line": 2117,
         "optional": true,
@@ -28674,14 +30426,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2125
+            "line": 2122
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 2126,
+        "imported": "modules.impact:core",
+        "kind": "static_from",
+        "line": 2123,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28693,14 +30445,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2141
+            "line": 2138
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
-        "line": 2142,
+        "imported": "comfy.samplers",
+        "kind": "static_import",
+        "line": 2139,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28717,8 +30469,8 @@
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "modules.impact.impact_pack:DetailerForEach",
-        "kind": "static_from",
+        "imported": "nodes",
+        "kind": "static_import",
         "line": 2148,
         "optional": true,
         "role": "optional_dependency",
@@ -28731,14 +30483,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2161
+            "line": 2163
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2164,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2169
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "modules.impact.impact_pack:DetailerForEach",
+        "kind": "static_from",
+        "line": 2170,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2183
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2162,
+        "line": 2184,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28750,14 +30540,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2260
+            "line": 2282
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2261,
+        "line": 2283,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28769,14 +30559,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2284
+            "line": 2306
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2285,
+        "line": 2307,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28788,14 +30578,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2290
+            "line": 2312
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2291,
+        "line": 2313,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28807,14 +30597,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2296
+            "line": 2318
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2297,
+        "line": 2319,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28826,14 +30616,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2302
+            "line": 2324
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2303,
+        "line": 2325,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28845,14 +30635,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2737
+            "line": 2759
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2738,
+        "line": 2760,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28864,14 +30654,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2777
+            "line": 2799
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2778,
+        "line": 2800,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28881,7 +30671,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3210,
+            "line": 3232,
             "type_checking": false
           },
           {
@@ -28889,14 +30679,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3211
+            "line": 3233
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3212,
+        "line": 3234,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28908,14 +30698,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4011
+            "line": 4033
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4012,
+        "line": 4034,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28927,14 +30717,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4073
+            "line": 4095
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4074,
+        "line": 4096,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28946,14 +30736,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4101,
+        "line": 4123,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28965,14 +30755,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4102,
+        "line": 4124,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -28984,14 +30774,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4100
+            "line": 4122
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4103,
+        "line": 4125,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29003,14 +30793,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4294
+            "line": 4316
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4295,
+        "line": 4317,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29022,14 +30812,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5120
+            "line": 5080
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5121,
+        "line": 5081,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29041,14 +30831,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5137
+            "line": 5097
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5138,
+        "line": 5098,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29060,14 +30850,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5158
+            "line": 5118
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5159,
+        "line": 5119,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29079,14 +30869,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5235
+            "line": 5195
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5236,
+        "line": 5196,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29098,14 +30888,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 6034
+            "line": 5994
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 6035,
+        "line": 5995,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29117,14 +30907,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7059
+            "line": 7019
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7060,
+        "line": 7020,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29136,14 +30926,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 7093
+            "line": 7053
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 7094,
+        "line": 7054,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -29307,6 +31097,7 @@
       "easyuse_anima/profiles/mutation.py",
       "easyuse_anima/prompt/__init__.py",
       "easyuse_anima/prompt/correction.py",
+      "easyuse_anima/prompt/fields.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -29357,6 +31148,7 @@
       "easyuse_anima/profiles/mutation.py",
       "easyuse_anima/prompt/__init__.py",
       "easyuse_anima/prompt/correction.py",
+      "easyuse_anima/prompt/fields.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -30109,11 +31901,38 @@
         "scope": "<module>"
       },
       {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:_HASH_COMMENT_RE",
+        "kind": "import_time_call",
+        "line": 23,
+        "module": "easyuse_anima/prompt/fields.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 19,
+        "context": "assign:_INLINE_SPACE_RE",
+        "kind": "import_time_call",
+        "line": 24,
+        "module": "easyuse_anima/prompt/fields.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "re.compile",
+        "column": 21,
+        "context": "assign:_WEIGHTED_TOKEN_RE",
+        "kind": "import_time_call",
+        "line": 25,
+        "module": "easyuse_anima/prompt/fields.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "logging.getLogger",
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 369,
+        "line": 401,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30122,34 +31941,7 @@
         "column": 62,
         "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "import_time_call",
-        "line": 512,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 19,
-        "context": "assign:_HASH_COMMENT_RE",
-        "kind": "import_time_call",
-        "line": 1017,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 19,
-        "context": "assign:_INLINE_SPACE_RE",
-        "kind": "import_time_call",
-        "line": 1018,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "re.compile",
-        "column": 21,
-        "context": "assign:_WEIGHTED_TOKEN_RE",
-        "kind": "import_time_call",
-        "line": 1019,
+        "line": 537,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30158,7 +31950,7 @@
         "column": 22,
         "context": "assign:_WEIGHTED_ARTIST_RE",
         "kind": "import_time_call",
-        "line": 1020,
+        "line": 1042,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30167,7 +31959,7 @@
         "column": 19,
         "context": "assign:_ARTIST_GROUP_RE",
         "kind": "import_time_call",
-        "line": 1023,
+        "line": 1045,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30176,7 +31968,7 @@
         "column": 24,
         "context": "assign:_SECTION_SEPARATOR_RE",
         "kind": "import_time_call",
-        "line": 1027,
+        "line": 1049,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30185,7 +31977,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 1030,
+        "line": 1052,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30194,7 +31986,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1049,
+        "line": 1071,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30203,7 +31995,16 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1229,
+        "line": 1251,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_prompt_fields_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 7218,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30212,7 +32013,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7258,
+        "line": 7221,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30221,7 +32022,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7261,
+        "line": 7224,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30230,7 +32031,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7264,
+        "line": 7227,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30239,7 +32040,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7274,
+        "line": 7237,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30248,7 +32049,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7280,
+        "line": 7243,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30257,7 +32058,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7285,
+        "line": 7248,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30266,7 +32067,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 7289,
+        "line": 7252,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -30654,85 +32455,85 @@
       },
       {
         "kind": "dict",
-        "line": 380,
+        "line": 405,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 379,
+        "line": 404,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 378,
+        "line": 403,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "dict",
-        "line": 532,
+        "line": 557,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 521,
+        "line": 546,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 3983,
+        "line": 4005,
         "module": "nodes.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
         "kind": "set",
-        "line": 516,
+        "line": 541,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "dict",
-        "line": 958,
+        "line": 983,
         "module": "nodes.py",
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
       },
       {
         "kind": "list",
-        "line": 989,
+        "line": 1014,
         "module": "nodes.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 392,
+        "line": 417,
         "module": "nodes.py",
         "name": "REGIONAL_FIELD_TYPES"
       },
       {
         "kind": "set",
-        "line": 1228,
+        "line": 1250,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
       {
         "kind": "dict",
-        "line": 3996,
+        "line": 4018,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 3997,
+        "line": 4019,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
       {
         "kind": "set",
-        "line": 512,
+        "line": 537,
         "module": "nodes.py",
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
       },
@@ -30925,7 +32726,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 3996,
+        "line": 4018,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -30935,7 +32736,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 3997,
+        "line": 4019,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -32,6 +32,7 @@ from easyuse_anima.naia import client as naia_client
 from easyuse_anima.naia import resolution as naia_resolution
 from easyuse_anima.nodes import image_nodes, lora_nodes, naia_nodes, prompt_nodes, wildcard_nodes
 from easyuse_anima.prompt import correction as prompt_correction
+from easyuse_anima.prompt import fields as prompt_fields
 
 
 PACKAGE_INIT = ROOT / "__init__.py"
@@ -1033,6 +1034,191 @@ print(json.dumps({{
             payload["class_modules"],
             ["easyuse_anima.nodes.prompt_nodes", "easyuse_anima.nodes.prompt_nodes"],
         )
+        self.assertFalse(payload["root_nodes_loaded"])
+
+
+class PromptBuilderStudioMoveContractTests(unittest.TestCase):
+    FIELD_OBJECTS = (
+        "DEFAULT_QUALITY_TAGS",
+        "DEFAULT_TRAILING_QUALITY_TAGS",
+        "_HASH_COMMENT_RE",
+        "_INLINE_SPACE_RE",
+        "_WEIGHTED_TOKEN_RE",
+        "_prompt_tokens",
+        "_join_prompt_tokens",
+        "_correct_builder_prompt",
+        "_metadata_filter_key",
+        "_metadata_filter_keys",
+        "_filter_metadata_prompt",
+    )
+    NODE_CLASSES = (
+        "EasyUseAnimaPromptBuilder",
+        "EasyUseAnimaPromptStudio",
+    )
+
+    def test_root_prompt_builder_studio_objects_are_direct_canonical_aliases(self):
+        for name in self.FIELD_OBJECTS:
+            with self.subTest(module="fields", name=name):
+                self.assertIs(getattr(nodes, name), getattr(prompt_fields, name))
+        for name in self.NODE_CLASSES:
+            with self.subTest(module="prompt_nodes", name=name):
+                self.assertIs(getattr(nodes, name), getattr(prompt_nodes, name))
+
+    def test_package_loaded_root_prompt_builder_studio_objects_are_direct_aliases(self):
+        with _loaded_package_entrypoint() as (_, package_nodes):
+            package_name = package_nodes.__package__
+            package_fields = sys.modules[f"{package_name}.easyuse_anima.prompt.fields"]
+            package_prompt_nodes = sys.modules[
+                f"{package_name}.easyuse_anima.nodes.prompt_nodes"
+            ]
+
+            for name in self.FIELD_OBJECTS:
+                with self.subTest(module="fields", name=name):
+                    self.assertIs(getattr(package_nodes, name), getattr(package_fields, name))
+            for name in self.NODE_CLASSES:
+                with self.subTest(module="prompt_nodes", name=name):
+                    self.assertIs(
+                        getattr(package_nodes, name),
+                        getattr(package_prompt_nodes, name),
+                    )
+
+    def test_classic_studio_directly_inherits_the_canonical_builder(self):
+        self.assertEqual(
+            prompt_nodes.EasyUseAnimaPromptStudio.__bases__,
+            (prompt_nodes.EasyUseAnimaPromptBuilder,),
+        )
+        self.assertTrue(
+            issubclass(
+                nodes.EasyUseAnimaPromptStudio,
+                nodes.EasyUseAnimaPromptBuilder,
+            )
+        )
+
+    def test_root_parser_and_correction_monkeypatches_drive_canonical_fields(self):
+        parsed = types.SimpleNamespace(tokens=("  bound_token  ",))
+        correction_result = types.SimpleNamespace(text="bound correction")
+
+        with patch.object(nodes, "parse_prompt", return_value=parsed) as parser:
+            tokens = prompt_fields._prompt_tokens("source")
+
+        self.assertEqual(tokens, ["bound_token"])
+        parser.assert_called_once_with("source", profile="prompt")
+
+        with (
+            patch.object(nodes, "_prompt_tokens", return_value=["bound_artist"]) as tokens,
+            patch.object(nodes, "load_knowledge_base", return_value="bound kb") as load_kb,
+            patch.object(nodes, "correct_prompt", return_value=correction_result) as correct,
+        ):
+            corrected = prompt_fields._correct_builder_prompt("prompt", "artist")
+
+        self.assertEqual(corrected, "bound correction")
+        tokens.assert_called_once_with("artist")
+        load_kb.assert_called_once_with(allow_missing=True)
+        correct.assert_called_once_with(
+            "prompt",
+            profile="prompt",
+            knowledge_base="bound kb",
+            validate_artist_tags=False,
+            artist_overrides=["bound_artist"],
+        )
+
+    def test_root_monkeypatches_drive_canonical_builder_order_and_change_key(self):
+        with (
+            patch.object(nodes, "_stable_change_key", side_effect=lambda value: value) as stable,
+            patch.object(
+                nodes,
+                "_prompt_translation_change_key",
+                return_value={"bound": "translation"},
+            ) as translation_key,
+            patch.object(
+                nodes,
+                "resolve_metadata_filter_words",
+                return_value="bound filters",
+            ) as resolve_filter,
+        ):
+            change_key = prompt_nodes.EasyUseAnimaPromptBuilder.IS_CHANGED(prompt="source")
+
+        self.assertEqual(change_key["mode"], "prompt_builder")
+        self.assertEqual(change_key["metadata_filter_words"], "bound filters")
+        self.assertEqual(change_key["prompt_translation"], {"bound": "translation"})
+        self.assertEqual(change_key["prompt"], "source")
+        stable.assert_called_once_with(change_key)
+        translation_key.assert_called_once_with()
+        resolve_filter.assert_called_once_with()
+
+        with (
+            patch.object(nodes, "_as_bool", side_effect=(True, False)),
+            patch.object(nodes, "_translate_prompt_text", side_effect=lambda value: f"t:{value}"),
+            patch.object(nodes, "_join_prompt_tokens", side_effect=lambda *parts: "|".join(parts)),
+            patch.object(
+                nodes,
+                "_correct_builder_prompt",
+                side_effect=lambda value, artist_overrides="": f"c:{value}:{artist_overrides}",
+            ),
+            patch.object(
+                nodes,
+                "_filter_metadata_prompt",
+                side_effect=lambda prompt, words: f"f:{prompt}:{words}",
+            ),
+            patch.object(nodes, "resolve_metadata_filter_words", return_value="filters"),
+        ):
+            result = prompt_nodes.EasyUseAnimaPromptBuilder().build(
+                True,
+                False,
+                "quality",
+                "trigger",
+                "lora",
+                "body",
+                "trailing",
+            )
+
+        self.assertEqual(
+            result,
+            (
+                "c:t:trigger|t:lora|t:body:t:trigger|t:lora|t:trailing",
+                "t:quality",
+                True,
+                (
+                    "f:c:t:quality|t:trigger|t:lora|t:body:"
+                    "t:trigger|t:lora|t:trailing:filters"
+                ),
+            ),
+        )
+
+    def test_fresh_process_direct_imports_do_not_load_root_nodes(self):
+        script = f"""
+import importlib
+import json
+import sys
+sys.path.insert(0, {str(ROOT)!r})
+sys.dont_write_bytecode = True
+fields = importlib.import_module("easyuse_anima.prompt.fields")
+prompt_nodes = importlib.import_module("easyuse_anima.nodes.prompt_nodes")
+print(json.dumps({{
+    "class_modules": [
+        prompt_nodes.EasyUseAnimaPromptBuilder.__module__,
+        prompt_nodes.EasyUseAnimaPromptStudio.__module__,
+    ],
+    "helper_module": fields._prompt_tokens.__module__,
+    "root_nodes_loaded": "nodes" in sys.modules,
+}}))
+"""
+        result = subprocess.run(
+            [sys.executable, "-I", "-B", "-c", script],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["class_modules"],
+            ["easyuse_anima.nodes.prompt_nodes", "easyuse_anima.nodes.prompt_nodes"],
+        )
+        self.assertEqual(payload["helper_module"], "easyuse_anima.prompt.fields")
         self.assertFalse(payload["root_nodes_loaded"])
 
 

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,11 +73,11 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "d968590df0342a380a1103bdf95b0b942fab8fb2")
-        # Issue #184 B-07a moved the Prompt Corrector vertical slice as direct aliases.
-        self.assertEqual(report["top_level"]["function_count"], 216)
-        self.assertEqual(report["top_level"]["class_count"], 17)
-        self.assertEqual(report["line_count"], 10_664)
+        self.assertEqual(report["git_blob_sha1"], "1355064c0bdec0350aab793134f3e4ee00eef42b")
+        # Issue #184 B-07b moved Prompt Builder and classic Prompt Studio as direct aliases.
+        self.assertEqual(report["top_level"]["function_count"], 210)
+        self.assertEqual(report["top_level"]["class_count"], 15)
+        self.assertEqual(report["line_count"], 10_395)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)
@@ -88,6 +88,8 @@ def load_dynamic():
         self.assertNotIn("EasyUseAnimaLoraPreset", class_names)
         self.assertNotIn("EasyUseAnimaPromptCorrector", class_names)
         self.assertNotIn("EasyUseAnimaPromptCorrectorSimple", class_names)
+        self.assertNotIn("EasyUseAnimaPromptBuilder", class_names)
+        self.assertNotIn("EasyUseAnimaPromptStudio", class_names)
 
     def test_external_source_label_does_not_expose_parent_directories(self):
         label = analyzer._source_label(Path("Z:/private/user/data/example.py"))

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 48)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 48)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 47)
+        self.assertEqual(report["inventory"]["module_count"], 49)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 49)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 48)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
@@ -726,6 +726,7 @@ ignored/
                 "easyuse_anima/profiles/mutation.py",
                 "easyuse_anima/prompt/__init__.py",
                 "easyuse_anima/prompt/correction.py",
+                "easyuse_anima/prompt/fields.py",
             }.issubset(report["registry"]["shipped_python_modules"])
         )
         self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
@@ -753,6 +754,7 @@ ignored/
                 "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/prompt/__init__.py",
                 "easyuse_anima/prompt/correction.py",
+                "easyuse_anima/prompt/fields.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -47,6 +47,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/profiles/mutation.py",
     "easyuse_anima/prompt/__init__.py",
     "easyuse_anima/prompt/correction.py",
+    "easyuse_anima/prompt/fields.py",
 }
 STATIC_IMPORT_FROM_RE = re.compile(
     r"""
@@ -156,6 +157,7 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "easyuse_anima/nodes/prompt_nodes.py",
             "easyuse_anima/nodes/wildcard_nodes.py",
             "easyuse_anima/prompt/correction.py",
+            "easyuse_anima/prompt/fields.py",
             "nodes.py",
             "prompt_translation.py",
             "settings.py",


### PR DESCRIPTION
## 변경 요약

- Issue #184 B-07b 범위로 `EasyUseAnimaPromptBuilder`와 classic `EasyUseAnimaPromptStudio`를 canonical `easyuse_anima` package로 이동했습니다.
- `easyuse_anima/prompt/fields.py`에 두 기본 상수, 세 정규식, prompt field helper와 lazy runtime binding을 분리했습니다.
- 루트 `nodes.py`는 canonical class/helper를 직접 import/re-export하며 wrapper나 subclass를 추가하지 않습니다.
- 기존 root monkeypatch seam, LoRA의 root `_prompt_tokens` / `_correct_builder_prompt` binding, Builder 출력 순서와 Studio UI envelope를 결정적 회귀 테스트로 고정했습니다.
- backend analyzer baseline과 Registry package surface를 새 module에 맞게 갱신했습니다.

## 주요 파일

- `easyuse_anima/prompt/fields.py`
- `easyuse_anima/nodes/prompt_nodes.py`
- `nodes.py`
- `tests/test_node_contracts.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_backend_analyzer.py`
- `tests/fixtures/python_backend_baseline.json`
- `tests/test_registry_scanner_safety.py`

## 검토

- 메인 통합 검토: actual diff, root/canonical alias, lazy monkeypatch resolution, binder 순서, LoRA helper binding, analyzer/Registry closure 확인 — 차단점 없음
- 독립 재검토: 최종 HEAD `6bcc351a424bf4f1abd0ee008298b6c3311731a7`, base `814e3d66eb9c8e46acc7385feb6481d25d288219` 기준 P0–P2 없음
- 요청 범위 8파일 외 변경 없음, worktree clean, `git diff --check` 통과

## 검증

- `python -m py_compile nodes.py easyuse_anima/prompt/fields.py easyuse_anima/nodes/prompt_nodes.py` — 통과
- focused backend/contracts/analyzer — 209 tests 통과
- 공식 full validation:
  - Python unittest: 698 tests 통과
  - frontend semantic/syntax smoke: 111 JavaScript files 통과
  - TypeScript: 6.0.3 통과
  - compile 및 diff checks 통과
- `tests/fixtures/node_contracts_0_5_2.json` — 변경 없음

## 분석기 결과

- root `nodes.py`: blob `1355064c0bdec0350aab793134f3e4ee00eef42b`, 10,395 lines, top-level functions 210, classes 15
- Python backend: inventory 49, Registry shipped 49, runtime import closure 48, missing internal imports 0
- intentional unreachable shipped module: `easyuse_anima/aio/__init__.py` 1개

## ComfyUI 검증 표면

- ComfyUI 0.27.0 / frontend 1.45.20 / Python 3.12.13
- `/object_info`: Builder와 Studio의 7개 required input 순서, 4개 output 이름/순서, display/category/module 확인
- Legacy canvas: 두 노드가 누락 없이 워크플로에 로드되고 노드 목록 및 입력값이 복원됨
- Node 2.0: Builder와 classic Studio가 각각 Vue 노드로 렌더링되고 7개 입력, 4개 출력, 저장된 prompt 값이 복원됨
- 검증 후 Node 2.0 설정을 비활성 상태로 복원
- GPU queue 실행: 실행하지 않음 — 이번 PR은 Python ownership 이동이며 노드 실행 계약은 focused/full unittest로 검증
