### PR TITLE
chore: Autocomplete root entry checkJs debt 제거 (#166)

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -19,6 +19,7 @@
     "web/js/lifecycle/**/*.js",
     "web/js/settings/**/*.js",
     "web/js/easyuse_anima_api.js",
+    "web/js/easyuse_anima_autocomplete.js",
     "web/js/easyuse_anima_i18n.js",
     "web/js/easyuse_anima_naia.js",
     "web/js/easyuse_anima_prompt_rules.js",

--- a/tests/frontend_autocomplete_input_binding_smoke.mjs
+++ b/tests/frontend_autocomplete_input_binding_smoke.mjs
@@ -423,6 +423,61 @@ const { createAutocompleteInputBinding } = bindingModule;
   assert.equal(noCanvas.defaultPrevented, false);
 }
 
+{
+  const strictStart = entrySource.indexOf("function strictAutocompleteResults");
+  const strictEnd = entrySource.indexOf("\nfunction copyCaretMirrorStyle", strictStart);
+  assert.ok(strictStart >= 0 && strictEnd > strictStart);
+  const strictAutocompleteResults = new Function(
+    `"use strict";\n${entrySource.slice(strictStart, strictEnd)}\nreturn strictAutocompleteResults;`,
+  )();
+  assert.equal(
+    strictAutocompleteResults.length,
+    4,
+    "the unused state slot must preserve the positional four-argument contract",
+  );
+}
+
+{
+  const bracketStart = entrySource.indexOf("function insertBracketPair");
+  const bracketEnd = entrySource.indexOf("\nfunction widgetValueSetterCallsCallback", bracketStart);
+  assert.ok(bracketStart >= 0 && bracketEnd > bracketStart);
+  const handleBracketPreviewKeydown = new Function(
+    "replaceInputRange",
+    "syncWidgetValue",
+    `"use strict";\nconst autocompletePreviewClosingBrackets = true;\n${entrySource.slice(bracketStart, bracketEnd)}\nreturn handleBracketPreviewKeydown;`,
+  )(
+    (input, start, end, replacement, caretOffset) => {
+      input.value = `${input.value.slice(0, start)}${replacement}${input.value.slice(end)}`;
+      input.setSelectionRange(start + caretOffset, start + caretOffset);
+    },
+    (state) => { state.syncCalls += 1; },
+  );
+
+  const input = {
+    value: "tag",
+    selectionStart: 0,
+    selectionEnd: 3,
+    setSelectionRange(start, end) {
+      this.selectionStart = start;
+      this.selectionEnd = end;
+    },
+  };
+  const state = { input, syncCalls: 0 };
+  const openEvent = createEvent({ key: "(" });
+  assert.equal(handleBracketPreviewKeydown(state, openEvent), true);
+  assert.equal(input.value, "(tag)");
+  assert.equal(input.selectionStart, 4);
+  assert.equal(state.syncCalls, 1);
+
+  input.selectionStart = 4;
+  input.selectionEnd = 4;
+  const closeEvent = createEvent({ key: ")" });
+  assert.equal(handleBracketPreviewKeydown(state, closeEvent), true);
+  assert.equal(input.value, "(tag)", "typing an existing closer must not duplicate it");
+  assert.equal(input.selectionStart, 5);
+  assert.equal(state.syncCalls, 1, "skipping an existing closer must not rewrite widget state");
+}
+
 function noOpController(disposeCall) {
   return {
     beginComposition() {},
@@ -623,6 +678,37 @@ function replacementBinding(input, state, owner, registry, controller) {
   assert.deepEqual(
     autocompleteGraphNodesFor({ graph: { _nodes_by_id: { 1: legacyNode, empty: null } } }),
     [legacyNode],
+  );
+
+  class FakeElement {
+    constructor(root = null) {
+      this.root = root || this;
+      this.dataset = {};
+      this.id = "";
+    }
+
+    closest() {
+      return this.root;
+    }
+
+    getAttribute() {
+      return null;
+    }
+  }
+  const nodeFromDomStart = entrySource.indexOf("function nodeFromDomElement");
+  const nodeFromDomEnd = entrySource.indexOf("\nfunction isAutocompleteDomInput", nodeFromDomStart);
+  assert.ok(nodeFromDomStart >= 0 && nodeFromDomEnd > nodeFromDomStart);
+  const nodeFromDomElement = new Function(
+    "Element",
+    "findGraphNodeById",
+    `"use strict";\n${entrySource.slice(nodeFromDomStart, nodeFromDomEnd)}\nreturn nodeFromDomElement;`,
+  )(FakeElement, (id) => id);
+  const datasetRoot = new FakeElement();
+  datasetRoot.dataset.nodeId = "42";
+  assert.equal(
+    nodeFromDomElement(new FakeElement(datasetRoot)),
+    "42",
+    "DOM ownership lookup must retain the dataset fallback when the attribute path is empty",
   );
 
   let graphNodes = [];

--- a/tests/test_autocomplete_frontend.py
+++ b/tests/test_autocomplete_frontend.py
@@ -51,6 +51,16 @@ FRONTEND_CHECK_SCRIPT = ROOT / "tools" / "check_frontend.ps1"
 
 
 class AutocompleteFrontendBoundaryTests(unittest.TestCase):
+    def test_root_entry_checkjs_cleanup_preserves_runtime_contracts(self):
+        entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")
+
+        self.assertRegex(
+            entry_source,
+            r"function strictAutocompleteResults\(context, token, _state, results\)",
+        )
+        self.assertNotIn("function closingBracketPreview", entry_source)
+        self.assertIn("function handleBracketPreviewKeydown", entry_source)
+
     def test_input_controller_has_exact_lifecycle_boundary(self):
         module_source = AUTOCOMPLETE_INPUT_CONTROLLER.read_text(encoding="utf-8")
         entry_source = AUTOCOMPLETE_ENTRY.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -3374,7 +3374,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
         }
         debt_root_entries = {
             "web/js/easyuse_anima_aio.js",
-            "web/js/easyuse_anima_autocomplete.js",
             "web/js/easyuse_anima_lora_preset.js",
         }
         actual_root_entries = {

--- a/web/js/easyuse_anima_autocomplete.js
+++ b/web/js/easyuse_anima_autocomplete.js
@@ -1,3 +1,4 @@
+// @ts-expect-error ComfyUI provides this host module outside the custom-node typecheck root.
 import { app } from "../../../scripts/app.js";
 import {
   normalizePromptTagText,
@@ -765,7 +766,7 @@ function autocompleteStateSignature(token, context, state) {
   });
 }
 
-function strictAutocompleteResults(context, token, state, results) {
+function strictAutocompleteResults(context, token, _state, results) {
   if (!autocompletePreviewCompletion) {
     return results;
   }
@@ -1067,7 +1068,10 @@ function forwardMiddlePanFromAutocompleteInput(event) {
   if (middlePanForwardCleanup) {
     return middlePanForwardCleanup;
   }
-  document.activeElement?.blur?.();
+  const activeElement = document.activeElement;
+  if (activeElement && "blur" in activeElement && typeof activeElement.blur === "function") {
+    activeElement.blur();
+  }
   dispatchAutocompleteCanvasPointerEvent("pointerdown", event, { button: 1, buttons: 4 });
   dispatchAutocompleteCanvasMouseEvent("mousedown", event, { button: 1, buttons: 4 });
 
@@ -1156,24 +1160,6 @@ function completionText(token, entry, forceArtistOnly = false) {
     return `@${tag}`;
   }
   return tag;
-}
-
-function closingBracketPreview(token) {
-  if (!autocompletePreviewClosingBrackets || !token) {
-    return "";
-  }
-  const before = token.value.slice(token.segmentStart, token.start);
-  const after = token.value.slice(token.end, token.segmentEnd);
-  if (before.includes("[[") && !after.includes("]]")) {
-    return "]]";
-  }
-  if (before.includes("(") && !after.includes(")")) {
-    return ")";
-  }
-  if (before.includes("{") && !after.includes("}")) {
-    return "}";
-  }
-  return "";
 }
 
 function autocompletePreviewStyle(category) {
@@ -1624,8 +1610,9 @@ function nodeFromDomElement(element) {
     return null;
   }
   const root = element.closest?.("[data-node-id], .lg-node");
+  const rootElement = /** @type {HTMLElement | SVGElement | null} */ (root);
   const id = root?.getAttribute?.("data-node-id")
-    || root?.dataset?.nodeId
+    || rootElement?.dataset?.nodeId
     || root?.id?.match?.(/\d+/)?.[0];
   return findGraphNodeById(id);
 }


### PR DESCRIPTION
## 변경 요약

- Autocomplete root entry를 `jsconfig.json` checkJs 범위에 포함했습니다.
- 단독 TypeScript 6.0.3 오류 5개를 runtime 의미를 유지하는 타입 주석, 좁은 DOM narrowing, unused binding 정리로 제거했습니다.
- root-entry debt ledger를 3개에서 2개로 줄였고, typecheck coverage를 8/11에서 9/11로 올렸습니다.
- 남은 두 root debt의 직접 측정 오류 수는 26개로, 기존 31개에서 5개 감소했습니다.

Refs #166

## 주요 파일

- `web/js/easyuse_anima_autocomplete.js`
  - ComfyUI host import에 근거가 좁은 `@ts-expect-error` 적용
  - `strictAutocompleteResults`의 4-argument positional contract 유지
  - active element blur 및 node dataset 접근을 실제 DOM 경계에 맞게 narrowing
  - 호출과 side effect가 없는 `closingBracketPreview` dead function 제거
- `jsconfig.json`
  - Autocomplete root entry 추가
- `tests/test_frontend_modules.py`
  - 명시적 root debt ledger 갱신
- `tests/test_autocomplete_frontend.py`, `tests/frontend_autocomplete_input_binding_smoke.mjs`
  - 함수 arity, bracket pair/closer skip, dataset fallback 의미 보존 regression 추가

## 검증

- `npx --yes --package "typescript@6.0.3" -- tsc -p jsconfig.json` — 통과
- Autocomplete root 단독 TypeScript 6.0.3 checkJs — 0 errors
- `node --check web/js/easyuse_anima_autocomplete.js` — 통과
- `node tests/frontend_autocomplete_input_binding_smoke.mjs` — 통과
- `python -m unittest tests.test_autocomplete_frontend` — 12 tests, OK
- `python -m unittest tests.test_frontend_modules` — 48 tests, OK
- 관련 AiO source regression 4건 — OK
- `tools/check_project.ps1 -Profile quick` — 111 JavaScript files, TypeScript 6.0.3, 전체 quick 통과
- `git diff --check` — 통과

## 메인 검토 및 공식 full

- actual diff 5파일과 호출 주변 코드를 검토했으며 P0–P2 차단점 없음
- exact HEAD `0bdcab5c3b58791e0aff3f86534ec66fa34ac2fe` 공식 full validation:
  - Python unittest 699 tests, OK
  - frontend syntax/semantic smoke 111 JavaScript files, OK
  - TypeScript 6.0.3, OK
  - compile 및 git diff checks, OK
- runtime 실행 의미와 DOM lifecycle/serialization이 바뀌지 않아 live browser는 반복하지 않음

## 영향과 미검증 범위

실행 경로, DOM lifecycle, function arity, event flow, serialization은 변경하지 않았습니다. 실제 bracket preview 경로의 pair 삽입과 기존 closer skip 동작은 semantic smoke로 고정했습니다.

- ComfyUI Codex test surface: frontend syntax, semantic smoke, TypeScript, focused unittest
- Live ComfyUI browser smoke: 실행하지 않음
- 공식 full validation: exact HEAD에서 실행 완료

