### PR TITLE
fix: wildcard seed popup의 stale commit 방지 (#221)

### DIFF
--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -1006,17 +1006,22 @@ for (const [surface, createNode] of [
   assert.equal(seedWidget.value, 17, `${surface} rejected queue must keep canonical seed`);
   assert.deepEqual(popupPublishes, [], `${surface} rejected queue must not trigger popup publish`);
 
+  let acceptedCount = 0;
   const accepted = fixture.runtime.wrapQueuePrompt(() => ({
-    prompt_id: `${surface.toLowerCase()}-popup-open`,
+    prompt_id: `${surface.toLowerCase()}-popup-open-${++acceptedCount}`,
     node_errors: {},
   }));
-  await accepted(0, promptFor([node]));
-  assert.equal(seedWidget.value, 18, `${surface} accepted queue must advance canonical seed`);
+  await Promise.all([
+    accepted(0, promptFor([node])),
+    accepted(0, promptFor([node])),
+    accepted(0, promptFor([node])),
+  ]);
+  assert.equal(seedWidget.value, 20, `${surface} three rapid queues must advance canonical seed`);
   assert.equal(popupInput.value, "17", `${surface} open popup starts with its prior snapshot`);
 
   popupInput.dispatch("blur");
-  assert.equal(popupInput.value, "18", `${surface} untouched blur must refresh from canonical seed`);
-  assert.equal(seedWidget.value, 18, `${surface} untouched blur must not roll back canonical seed`);
+  assert.equal(popupInput.value, "20", `${surface} untouched blur must refresh from canonical seed`);
+  assert.equal(seedWidget.value, 20, `${surface} untouched blur must not roll back canonical seed`);
   assert.deepEqual(popupPublishes, [], `${surface} untouched popup must not publish a stale seed`);
 
   popupInput.value = "23";

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -979,6 +979,54 @@ function reservedSeedState(prompt, nodeId) {
   assert.equal(queued.every((entry) => entry.options === options), true);
 }
 
+for (const [surface, createNode] of [
+  ["Advanced", () => advancedNode(10, ADVANCED, 17)],
+  ["Regional", () => regionalNode(30, 17)],
+]) {
+  const node = createNode();
+  const seedWidget = node.widgets.find((widget) => widget.name === "wildcard_seed");
+  const fixture = createFixture({ nodes: [node] });
+  const popupPublishes = [];
+  const popupInput = seedInputFixture("17");
+  seedContract.bindWildcardSeedInput(
+    popupInput,
+    () => seedWidget.value,
+    (seed) => {
+      popupPublishes.push(seed);
+      seedWidget.value = seed;
+    },
+  );
+  popupInput.dispatch("blur");
+  assert.equal(seedWidget.value, 17, `${surface} untouched close must not invent a seed advance`);
+  assert.deepEqual(popupPublishes, [], `${surface} untouched close must not publish`);
+
+  const rejected = fixture.runtime.wrapQueuePrompt(() => ({ node_errors: {} }));
+  await rejected(0, promptFor([node]));
+  popupInput.dispatch("blur");
+  assert.equal(seedWidget.value, 17, `${surface} rejected queue must keep canonical seed`);
+  assert.deepEqual(popupPublishes, [], `${surface} rejected queue must not trigger popup publish`);
+
+  const accepted = fixture.runtime.wrapQueuePrompt(() => ({
+    prompt_id: `${surface.toLowerCase()}-popup-open`,
+    node_errors: {},
+  }));
+  await accepted(0, promptFor([node]));
+  assert.equal(seedWidget.value, 18, `${surface} accepted queue must advance canonical seed`);
+  assert.equal(popupInput.value, "17", `${surface} open popup starts with its prior snapshot`);
+
+  popupInput.dispatch("blur");
+  assert.equal(popupInput.value, "18", `${surface} untouched blur must refresh from canonical seed`);
+  assert.equal(seedWidget.value, 18, `${surface} untouched blur must not roll back canonical seed`);
+  assert.deepEqual(popupPublishes, [], `${surface} untouched popup must not publish a stale seed`);
+
+  popupInput.value = "23";
+  popupInput.dispatch("input");
+  popupInput.dispatch("change");
+  popupInput.dispatch("blur");
+  assert.equal(seedWidget.value, 23, `${surface} real popup edit must update canonical seed`);
+  assert.deepEqual(popupPublishes, [23], `${surface} real edit must publish exactly once`);
+}
+
 {
   const node = advancedNode(10, ADVANCED, 7);
   node.widgets[0].value = "일반 채우기";

--- a/web/js/prompt_studio/wildcard_seed_contract.js
+++ b/web/js/prompt_studio/wildcard_seed_contract.js
@@ -58,17 +58,35 @@ function bindWildcardSeedInput(input, getCurrentSeed, publishSeed, afterPublish)
   input.min = "0";
   input.max = String(WILDCARD_SEED_MAX);
   input.step = "1";
+  // An untouched open control must yield to queue/executed widget updates,
+  // while any real input event keeps ownership of the user's pending edit.
+  let baselineValue = String(input.value ?? "");
+  let dirty = false;
+  const restoreCurrentSeed = () => {
+    input.value = String(getCurrentSeed() ?? "0");
+    baselineValue = input.value;
+    dirty = false;
+  };
   const syncSeed = () => {
+    if (!dirty && input.value === baselineValue) {
+      restoreCurrentSeed();
+      return false;
+    }
     const seed = normalizeWildcardSeedInput(input.value);
     if (seed == null) {
-      input.value = String(getCurrentSeed() ?? "0");
+      restoreCurrentSeed();
       return false;
     }
     input.value = String(seed);
     publishSeed(seed);
     afterPublish?.(seed);
+    baselineValue = input.value;
+    dirty = false;
     return true;
   };
+  input.addEventListener("input", () => {
+    dirty = true;
+  });
   input.addEventListener("change", syncSeed);
   input.addEventListener("blur", syncSeed);
   return syncSeed;


### PR DESCRIPTION
## 변경 요약

- 열린 wildcard seed 입력이 생성 당시 값을 baseline으로 기억하고, 실제 `input` 이벤트가 있을 때만 사용자 편집 소유권을 갖도록 수정했습니다.
- 외부 queue/executed 경로가 canonical hidden seed를 갱신한 뒤 untouched popup이 blur되면 최신 canonical 값을 복원하고 stale 값을 publish하지 않습니다.
- 실제 사용자 편집은 change 시 한 번만 publish되며, 이어지는 blur는 중복 commit하지 않습니다.

## 원인

Advanced와 Regional이 공유하는 seed 입력 binding은 `change`와 `blur`마다 현재 DOM 값을 무조건 canonical widget으로 publish했습니다. 그 결과 seed 17에서 popup을 연 채 accepted queue가 hidden seed를 전진시켜도, 남아 있던 DOM 값 17이 blur 시 다시 publish되어 canonical seed를 롤백할 수 있었습니다.

## 주요 파일

- `web/js/prompt_studio/wildcard_seed_contract.js`
  - baseline/dirty 기반 commit ownership 추가
  - untouched/invalid commit에서 canonical seed 복원
- `tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs`
  - Advanced/Regional 공통 회귀 추가
  - popup open 17 → rejected queue 유지
  - 3개 rapid accepted queue → canonical 20 → untouched blur 20 유지
  - 실제 edit 23은 정확히 한 번 commit

## 검증

- Focused Node syntax 및 queue seed runtime smoke 통과
- 새 HEAD `5847ff0f086d905a8eb4f2afde726745da30e498`에서 Advanced/Regional 3개 rapid queue popup 회귀 통과
- 공식 full profile 통과(동일 production code HEAD)
  - Python unittest: 709 tests
  - Frontend: 111 JavaScript files
  - TypeScript 6.0.3
  - Python compile 및 diff checks
- `git diff --check origin/dev...HEAD` 통과

## 라이브 테스트 표면

- ComfyUI Codex test instance
- Legacy canvas
  - Advanced fixed/increment seed의 승인 queue 전진 `17 → 18`
  - Regional rejected queue와 untouched blur에서 `17` 유지
  - 실제 seed/control UI 로드 및 편집 commit 확인
- Node 2.0
  - Regional seed/control `17 · increment` workflow 복원 및 UI 표시 확인
  - 검증 후 Nodes 2.0 설정을 원래 OFF로 복원
- Advanced 설정 popup은 실행 버튼 클릭 시 닫히므로, 열린 popup에 대한 3개 rapid accepted queue → untouched blur의 정확한 순서는 결정적 semantic smoke가 담당합니다.

## 남은 위험

- non-dirty popup은 외부 변경 즉시 값을 push 받는 구독형 UI가 아니라 다음 change/blur commit 경계에서 canonical 값을 복원합니다.
- 이 PR의 목표인 stale rollback 방지는 충족하며, listener/observer lifecycle은 추가하지 않았습니다.

Closes #221