### PR TITLE
fix: 연결된 와일드카드 Reproduce 값 보존

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -4545,6 +4545,38 @@ def _apply_advanced_field_inputs(fields: list[dict], field_inputs: dict) -> list
     return effective
 
 
+def _preserve_expanded_connected_field_texts(
+    saved_fields: list[dict],
+    source_fields: list[dict],
+    expanded_fields: list[dict],
+    field_inputs: dict,
+) -> None:
+    connected_values = _advanced_field_input_values(field_inputs)
+    if not connected_values:
+        return
+
+    source_by_socket = {
+        _advanced_field_socket_name(field): field
+        for field in source_fields
+    }
+    expanded_by_socket = {
+        _advanced_field_socket_name(field): field
+        for field in expanded_fields
+    }
+    for field in saved_fields:
+        socket_name = _advanced_field_socket_name(field)
+        if socket_name not in connected_values:
+            continue
+        source_field = source_by_socket.get(socket_name)
+        expanded_field = expanded_by_socket.get(socket_name)
+        if source_field is None or expanded_field is None:
+            continue
+        source_text = str(source_field.get("text") or "")
+        expanded_text = str(expanded_field.get("text") or "")
+        if expanded_text != source_text:
+            field["text"] = expanded_text
+
+
 def _advanced_enabled_naia_panes(fields: list[dict]) -> set[str]:
     return {
         str(field.get("pane") or "positive")
@@ -6014,7 +6046,6 @@ class EasyUseAnimaPromptStudioAdvanced:
     ):
         fields = _normalize_advanced_fields(advanced_fields)
         saved_fields = _clone_advanced_fields(fields)
-        effective_fields = _apply_advanced_field_inputs(fields, field_inputs)
         effective_field_inputs = _advanced_field_input_values(field_inputs)
         requested_use_naia = _as_bool(use_naia, False)
         enabled_naia_panes = _advanced_enabled_naia_panes(fields)
@@ -6024,6 +6055,11 @@ class EasyUseAnimaPromptStudioAdvanced:
         metadata_updates: dict[str, Any] = {}
         ui_updates: dict[str, Any] = {}
         wildcard_mode_key = normalize_wildcard_mode(wildcard_mode)
+        effective_fields = (
+            _clone_advanced_fields(saved_fields)
+            if wildcard_mode_key == WILDCARD_MODE_REPRODUCE
+            else _apply_advanced_field_inputs(fields, effective_field_inputs)
+        )
         wildcard_seed_value = normalize_seed(wildcard_seed)
         wildcard_effective_seed_control = (
             SEED_CONTROL_INCREMENT
@@ -6085,6 +6121,7 @@ class EasyUseAnimaPromptStudioAdvanced:
             metadata_use_naia = False
 
         ui_fields = _clone_advanced_fields(saved_fields)
+        effective_source_fields = _clone_advanced_fields(effective_fields)
         saved_fields, saved_wildcard = _expand_advanced_wildcard_fields(
             saved_fields,
             wildcard_seed_value,
@@ -6094,6 +6131,12 @@ class EasyUseAnimaPromptStudioAdvanced:
             effective_fields,
             wildcard_seed_value,
             wildcard_mode_key,
+        )
+        _preserve_expanded_connected_field_texts(
+            saved_fields,
+            effective_source_fields,
+            effective_fields,
+            effective_field_inputs,
         )
         effective_fields = _translate_prompt_fields(effective_fields)
         wildcard_changed = bool(saved_wildcard["changed"] or effective_wildcard["changed"])
@@ -6417,12 +6460,16 @@ class EasyUseAnimaPromptStudioAdvancedV2(EasyUseAnimaPromptStudioAdvanced):
             })
         saved_fields = _normalize_advanced_fields(ui_payload.get("advanced_fields", advanced_fields))
         effective_field_inputs = _advanced_field_input_values(ui_payload.get("field_inputs") or field_inputs)
-        effective_fields = _apply_advanced_field_inputs(saved_fields, effective_field_inputs)
-        effective_fields, _wildcard = _expand_advanced_wildcard_fields(
-            effective_fields,
-            normalize_seed(wildcard_seed),
-            normalize_wildcard_mode(wildcard_mode),
-        )
+        wildcard_mode_key = normalize_wildcard_mode(wildcard_mode)
+        if wildcard_mode_key == WILDCARD_MODE_REPRODUCE:
+            effective_fields = _clone_advanced_fields(saved_fields)
+        else:
+            effective_fields = _apply_advanced_field_inputs(saved_fields, effective_field_inputs)
+            effective_fields, _wildcard = _expand_advanced_wildcard_fields(
+                effective_fields,
+                normalize_seed(wildcard_seed),
+                wildcard_mode_key,
+            )
         effective_fields = _translate_prompt_fields(effective_fields)
         prompt_data_parameters = _prompt_data_parameter_snapshot(
             self.INPUT_TYPES().get("required", {}),
@@ -7305,11 +7352,15 @@ class EasyUseAnimaPromptStudioRegional:
         )
         fields = _normalize_regional_fields(regional_fields)
         saved_fields = _clone_regional_fields(fields)
-        effective_fields = _apply_regional_field_inputs(fields, field_inputs)
         effective_field_inputs = _advanced_field_input_values(field_inputs)
         config = _normalize_regional_config(regional_config, width, height)
 
         wildcard_mode_key = normalize_wildcard_mode(wildcard_mode)
+        effective_fields = (
+            _clone_regional_fields(saved_fields)
+            if wildcard_mode_key == WILDCARD_MODE_REPRODUCE
+            else _apply_regional_field_inputs(fields, effective_field_inputs)
+        )
         wildcard_seed_value = normalize_seed(wildcard_seed)
         wildcard_effective_seed_control = (
             SEED_CONTROL_INCREMENT
@@ -7327,6 +7378,7 @@ class EasyUseAnimaPromptStudioRegional:
         ui_updates: dict[str, Any] = {}
         metadata_updates: dict[str, Any] = {}
 
+        effective_source_fields = _clone_regional_fields(effective_fields)
         saved_fields, saved_wildcard = _expand_advanced_wildcard_fields(
             saved_fields,
             wildcard_seed_value,
@@ -7336,6 +7388,12 @@ class EasyUseAnimaPromptStudioRegional:
             effective_fields,
             wildcard_seed_value,
             wildcard_mode_key,
+        )
+        _preserve_expanded_connected_field_texts(
+            saved_fields,
+            effective_source_fields,
+            effective_fields,
+            effective_field_inputs,
         )
         effective_fields = _translate_prompt_fields(effective_fields)
         wildcard_changed = bool(saved_wildcard["changed"] or effective_wildcard["changed"])

--- a/nodes.py
+++ b/nodes.py
@@ -4545,6 +4545,14 @@ def _apply_advanced_field_inputs(fields: list[dict], field_inputs: dict) -> list
     return effective
 
 
+def _reproduce_connected_field_inputs(field_inputs: dict) -> dict[str, str]:
+    return {
+        name: value
+        for name, value in _advanced_field_input_values(field_inputs).items()
+        if not has_wildcard_syntax(value)
+    }
+
+
 def _preserve_expanded_connected_field_texts(
     saved_fields: list[dict],
     source_fields: list[dict],
@@ -6056,7 +6064,10 @@ class EasyUseAnimaPromptStudioAdvanced:
         ui_updates: dict[str, Any] = {}
         wildcard_mode_key = normalize_wildcard_mode(wildcard_mode)
         effective_fields = (
-            _clone_advanced_fields(saved_fields)
+            _apply_advanced_field_inputs(
+                saved_fields,
+                _reproduce_connected_field_inputs(effective_field_inputs),
+            )
             if wildcard_mode_key == WILDCARD_MODE_REPRODUCE
             else _apply_advanced_field_inputs(fields, effective_field_inputs)
         )
@@ -6462,7 +6473,10 @@ class EasyUseAnimaPromptStudioAdvancedV2(EasyUseAnimaPromptStudioAdvanced):
         effective_field_inputs = _advanced_field_input_values(ui_payload.get("field_inputs") or field_inputs)
         wildcard_mode_key = normalize_wildcard_mode(wildcard_mode)
         if wildcard_mode_key == WILDCARD_MODE_REPRODUCE:
-            effective_fields = _clone_advanced_fields(saved_fields)
+            effective_fields = _apply_advanced_field_inputs(
+                saved_fields,
+                _reproduce_connected_field_inputs(effective_field_inputs),
+            )
         else:
             effective_fields = _apply_advanced_field_inputs(saved_fields, effective_field_inputs)
             effective_fields, _wildcard = _expand_advanced_wildcard_fields(
@@ -7357,7 +7371,10 @@ class EasyUseAnimaPromptStudioRegional:
 
         wildcard_mode_key = normalize_wildcard_mode(wildcard_mode)
         effective_fields = (
-            _clone_regional_fields(saved_fields)
+            _apply_regional_field_inputs(
+                saved_fields,
+                _reproduce_connected_field_inputs(effective_field_inputs),
+            )
             if wildcard_mode_key == WILDCARD_MODE_REPRODUCE
             else _apply_regional_field_inputs(fields, effective_field_inputs)
         )

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -27531,7 +27531,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5484
+            "line": 5524
           }
         ],
         "classification": "external",
@@ -27539,7 +27539,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5485,
+        "line": 5525,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -27556,7 +27556,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5518
+            "line": 5558
           }
         ],
         "classification": "external",
@@ -27564,7 +27564,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5519,
+        "line": 5559,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -30378,13 +30378,13 @@
       },
       {
         "is_package": false,
-        "loc": 8256,
+        "loc": 8331,
         "module": "nodes",
-        "normalized_git_blob_sha1": "67e3d13782951ce0541a50f2b05bc353e1ae1611",
+        "normalized_git_blob_sha1": "c0bf17e90bd1399601d461dc50508fffb454406c",
         "path": "nodes.py",
         "top_level": {
           "class_count": 12,
-          "function_count": 149,
+          "function_count": 151,
           "global_count": 54
         }
       },
@@ -40621,14 +40621,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5484
+            "line": 5524
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5485,
+        "line": 5525,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40640,14 +40640,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5518
+            "line": 5558
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5519,
+        "line": 5559,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -42049,14 +42049,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5484
+            "line": 5524
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5485,
+        "line": 5525,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -42068,14 +42068,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5518
+            "line": 5558
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5519,
+        "line": 5559,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -43163,7 +43163,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5683,
+        "line": 5723,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43172,7 +43172,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5687,
+        "line": 5727,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43181,7 +43181,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5690,
+        "line": 5730,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43190,7 +43190,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5693,
+        "line": 5733,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43199,7 +43199,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5696,
+        "line": 5736,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43208,7 +43208,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5699,
+        "line": 5739,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43217,7 +43217,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5702,
+        "line": 5742,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43226,7 +43226,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5712,
+        "line": 5752,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43235,7 +43235,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5718,
+        "line": 5758,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43244,7 +43244,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5723,
+        "line": 5763,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43253,7 +43253,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5727,
+        "line": 5767,
         "module": "nodes.py",
         "scope": "<module>"
       },

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,11 +73,11 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "67e3d13782951ce0541a50f2b05bc353e1ae1611")
-        # Issue #184 B-07c moved prompt-data and conditioning helpers/adapters.
-        self.assertEqual(report["top_level"]["function_count"], 149)
+        self.assertEqual(report["git_blob_sha1"], "c0bf17e90bd1399601d461dc50508fffb454406c")
+        # Issue #220 added connected wildcard snapshot/reproduce helpers.
+        self.assertEqual(report["top_level"]["function_count"], 151)
         self.assertEqual(report["top_level"]["class_count"], 12)
-        self.assertEqual(report["line_count"], 8_256)
+        self.assertEqual(report["line_count"], 8_331)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -1143,6 +1143,39 @@ class WildcardNodeTests(unittest.TestCase):
     def test_prompt_studio_advanced_v2_connected_wildcard_round_trip_preserves_expansion(self):
         self._assert_advanced_connected_wildcard_round_trip(EasyUseAnimaPromptStudioAdvancedV2)
 
+    def test_prompt_studio_advanced_reproduce_keeps_plain_connected_input(self):
+        fields_json = json.dumps([{
+            "id": "positive_general",
+            "pane": "positive",
+            "type": "general",
+            "label": "General Tags",
+            "text": "stored fallback",
+            "height": 120,
+            "enabled": True,
+        }])
+
+        for node_class in (
+            EasyUseAnimaPromptStudioAdvanced,
+            EasyUseAnimaPromptStudioAdvancedV2,
+        ):
+            with self.subTest(node_class=node_class.__name__):
+                reproduced = node_class().build(
+                    False,
+                    True,
+                    False,
+                    False,
+                    fields_json,
+                    wildcard_mode="재현",
+                    wildcard_seed=17,
+                    wildcard_seed_after_generate="fixed",
+                    field_positive_general="plain connected",
+                )
+
+                reproduced_output = reproduced["result"][0]
+                if isinstance(reproduced_output, dict):
+                    reproduced_output = reproduced_output["positive_prompt"]
+                self.assertEqual(reproduced_output, "plain connected")
+
     def test_prompt_studio_regional_connected_wildcard_round_trip_preserves_expansion(self):
         source_text = "{cat|dog|fox}"
         fields = [{
@@ -1227,6 +1260,29 @@ class WildcardNodeTests(unittest.TestCase):
 
         expand.assert_not_called()
         self.assertEqual(reproduced["result"][0], "fox")
+
+    def test_prompt_studio_regional_reproduce_keeps_plain_connected_input(self):
+        fields_json = json.dumps([{
+            "id": "positive_general",
+            "pane": "positive",
+            "type": "general",
+            "label": "General Tags",
+            "text": "stored fallback",
+            "height": 120,
+            "enabled": True,
+            "mask_ids": [],
+        }])
+
+        reproduced = EasyUseAnimaPromptStudioRegional().build(
+            fields_json,
+            json.dumps({}),
+            wildcard_mode="재현",
+            wildcard_seed=17,
+            wildcard_seed_after_generate="fixed",
+            field_positive_general="plain connected",
+        )
+
+        self.assertEqual(reproduced["result"][0], "plain connected")
 
     def test_public_settings_include_wildcard_extra_paths(self):
         self.assertIn("wildcard.extra_paths", public_settings())

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from nodes import (
     EasyUseAnimaPromptStudioAdvanced,
+    EasyUseAnimaPromptStudioAdvancedV2,
     EasyUseAnimaPromptStudioRegional,
     EasyUseAnimaWildcard,
 )
@@ -1036,6 +1037,196 @@ class WildcardNodeTests(unittest.TestCase):
             json.loads(payload["advanced_fields"])[0]["text"],
             "expanded style",
         )
+
+    def _assert_advanced_connected_wildcard_round_trip(self, node_class):
+        source_text = "{cat|dog|fox}"
+        fields = [{
+            "id": "positive_general",
+            "pane": "positive",
+            "type": "general",
+            "label": "General Tags",
+            "text": "stored fallback",
+            "height": 120,
+            "enabled": True,
+        }]
+        fields_json = json.dumps(fields)
+        workflow_prompt = {
+            "9": {
+                "inputs": {
+                    "advanced_fields": fields_json,
+                    "wildcard_mode": "고정",
+                    "wildcard_seed": 17,
+                    "wildcard_seed_after_generate": "fixed",
+                    "field_positive_general": ["8", 0],
+                }
+            }
+        }
+        extra_pnginfo = {
+            "workflow": {
+                "nodes": [{
+                    "id": 9,
+                    "widgets_values": [
+                        False,
+                        True,
+                        False,
+                        "1024",
+                        "1024 * 1024 (1:1)",
+                        1024,
+                        1024,
+                        False,
+                        fields_json,
+                        False,
+                        "고정",
+                        17,
+                        "fixed",
+                    ],
+                }]
+            }
+        }
+
+        initial = node_class().build(
+            False,
+            True,
+            False,
+            False,
+            fields_json,
+            wildcard_mode="고정",
+            wildcard_seed=17,
+            wildcard_seed_after_generate="fixed",
+            workflow_prompt=workflow_prompt,
+            extra_pnginfo=extra_pnginfo,
+            unique_id="9",
+            field_positive_general=source_text,
+        )
+
+        ui_payload = initial["ui"]["prompt_studio_advanced"][0]
+        effective_output = initial["result"][0]
+        if isinstance(effective_output, dict):
+            effective_output = effective_output["positive_prompt"]
+        saved_prompt_fields = json.loads(workflow_prompt["9"]["inputs"]["advanced_fields"])
+        saved_image_fields = json.loads(extra_pnginfo["workflow"]["nodes"][0]["widgets_values"][8])
+        saved_property_fields = json.loads(
+            extra_pnginfo["workflow"]["nodes"][0]["properties"]["easyuse_anima_advanced_fields"]
+        )
+
+        self.assertEqual(ui_payload["field_inputs"]["field_positive_general"], source_text)
+        self.assertEqual(effective_output, "fox")
+        self.assertEqual(saved_prompt_fields[0]["text"], "fox")
+        self.assertEqual(saved_image_fields[0]["text"], "fox")
+        self.assertEqual(saved_property_fields[0]["text"], "fox")
+        self.assertEqual(workflow_prompt["9"]["inputs"]["field_positive_general"], ["8", 0])
+        self.assertEqual(workflow_prompt["9"]["inputs"]["wildcard_mode"], "재현")
+
+        with patch("nodes.expand_wildcards") as expand:
+            reproduced = node_class().build(
+                False,
+                True,
+                False,
+                False,
+                json.dumps(saved_prompt_fields),
+                wildcard_mode="재현",
+                wildcard_seed=17,
+                wildcard_seed_after_generate="fixed",
+                field_positive_general=source_text,
+            )
+
+        expand.assert_not_called()
+        reproduced_output = reproduced["result"][0]
+        if isinstance(reproduced_output, dict):
+            self.assertEqual(reproduced_output["fields"][0]["text"], "fox")
+            reproduced_output = reproduced_output["positive_prompt"]
+        self.assertEqual(reproduced_output, "fox")
+
+    def test_prompt_studio_advanced_connected_wildcard_round_trip_preserves_expansion(self):
+        self._assert_advanced_connected_wildcard_round_trip(EasyUseAnimaPromptStudioAdvanced)
+
+    def test_prompt_studio_advanced_v2_connected_wildcard_round_trip_preserves_expansion(self):
+        self._assert_advanced_connected_wildcard_round_trip(EasyUseAnimaPromptStudioAdvancedV2)
+
+    def test_prompt_studio_regional_connected_wildcard_round_trip_preserves_expansion(self):
+        source_text = "{cat|dog|fox}"
+        fields = [{
+            "id": "positive_general",
+            "pane": "positive",
+            "type": "general",
+            "label": "General Tags",
+            "text": "stored fallback",
+            "height": 120,
+            "enabled": True,
+            "mask_ids": [],
+        }]
+        fields_json = json.dumps(fields)
+        config_json = json.dumps({})
+        workflow_prompt = {
+            "42": {
+                "inputs": {
+                    "regional_fields": fields_json,
+                    "regional_config": config_json,
+                    "wildcard_mode": "고정",
+                    "wildcard_seed": 17,
+                    "wildcard_seed_after_generate": "fixed",
+                    "field_positive_general": ["41", 0],
+                }
+            }
+        }
+        extra_pnginfo = {
+            "workflow": {
+                "nodes": [{
+                    "id": 42,
+                    "widgets_values": [
+                        fields_json,
+                        config_json,
+                        "1024",
+                        "1024 * 1024 (1:1)",
+                        1024,
+                        1024,
+                        "고정",
+                        17,
+                        "fixed",
+                    ],
+                    "properties": {},
+                }]
+            }
+        }
+
+        initial = EasyUseAnimaPromptStudioRegional().build(
+            fields_json,
+            config_json,
+            wildcard_mode="고정",
+            wildcard_seed=17,
+            wildcard_seed_after_generate="fixed",
+            workflow_prompt=workflow_prompt,
+            extra_pnginfo=extra_pnginfo,
+            unique_id="42",
+            field_positive_general=source_text,
+        )
+
+        ui_payload = initial["ui"]["prompt_studio_regional"][0]
+        saved_prompt_fields = json.loads(workflow_prompt["42"]["inputs"]["regional_fields"])
+        saved_image_fields = json.loads(extra_pnginfo["workflow"]["nodes"][0]["widgets_values"][0])
+        saved_property_fields = json.loads(
+            extra_pnginfo["workflow"]["nodes"][0]["properties"]["easyuse_anima_regional_fields"]
+        )
+        self.assertEqual(ui_payload["field_inputs"]["field_positive_general"], source_text)
+        self.assertEqual(initial["result"][0], "fox")
+        self.assertEqual(saved_prompt_fields[0]["text"], "fox")
+        self.assertEqual(saved_image_fields[0]["text"], "fox")
+        self.assertEqual(saved_property_fields[0]["text"], "fox")
+        self.assertEqual(workflow_prompt["42"]["inputs"]["field_positive_general"], ["41", 0])
+        self.assertEqual(workflow_prompt["42"]["inputs"]["wildcard_mode"], "재현")
+
+        with patch("nodes.expand_wildcards") as expand:
+            reproduced = EasyUseAnimaPromptStudioRegional().build(
+                json.dumps(saved_prompt_fields),
+                config_json,
+                wildcard_mode="재현",
+                wildcard_seed=17,
+                wildcard_seed_after_generate="fixed",
+                field_positive_general=source_text,
+            )
+
+        expand.assert_not_called()
+        self.assertEqual(reproduced["result"][0], "fox")
 
     def test_public_settings_include_wildcard_extra_paths(self):
         self.assertIn("wildcard.extra_paths", public_settings())


### PR DESCRIPTION
## 변경 요약

- Advanced, Advanced v2, Regional의 연결 필드에서 와일드카드로 실제 확장된 값을 saved workflow/Reproduce snapshot에 보존합니다.
- Reproduce 모드에서 연결 원문에 와일드카드 문법이 있으면 저장 snapshot을 사용해 재확장하지 않습니다.
- 와일드카드가 없는 일반 연결 텍스트는 Reproduce에서도 기존처럼 현재 연결값을 따르도록 호환성을 유지합니다.
- standalone Wildcard 노드의 seed/PRNG/cache 경로와 비연결 필드 계약은 변경하지 않습니다.

## 원인

저장용 필드와 연결 입력이 적용된 실행용 필드를 별도로 확장했지만, saved workflow에는 저장용 필드만 기록했습니다. 따라서 연결 입력 `{cat|dog|fox}`가 seed 17에서 `fox`로 실행되어도 저장 payload에는 그 유효값이 남지 않았고, Reproduce 시 연결 원본 리터럴이 다시 적용되었습니다.

## 주요 파일

- `nodes.py`: 연결 필드의 확장 결과를 저장 snapshot에 병합하고, Reproduce에서 와일드카드 연결과 일반 연결을 구분
- `tests/test_wildcards.py`: Advanced, Advanced v2, Regional의 source/effective/saved payload/Reproduce 및 일반 연결 호환 회귀
- `tests/fixtures/python_backend_baseline.json`, `tests/test_nodes_module_analyzer.py`: 공식 analyzer/shape ratchet 갱신

## 검증

- 연결 wildcard/Reproduce 집중 회귀 5개 — OK
- `python -m unittest discover -s tests -p test_wildcards.py -v` — 54 tests, OK
- `python -m unittest -v tests.test_nodes_module_analyzer tests.test_python_backend_analyzer` — 22 tests, OK
- 공식 full runner — Python 714 tests OK, frontend 111 JS files, TypeScript 6.0.3, compile/diff 통과
- 실제 ComfyUI API queue graph:
  - fixed + connected `{cat|dog|fox}` → `fox`
  - Reproduce + saved `fox` + connected 원문 → `fox`
  - Reproduce + 일반 연결 → `plain connected`
- `git diff --check origin/dev...HEAD` — 통과

## 검증 표면 및 남은 위험

- ComfyUI v0.27.0 Codex test instance: 실제 API queue 및 Legacy/Node 2.0 Advanced UI 렌더 확인
- Node 2.0 설정은 검증 후 원래 OFF 상태로 복원
- 결정론적 테스트가 workflow prompt, PNG workflow widgets/properties의 snapshot을 검증합니다.
- 실제 저장 이미지 파일을 브라우저에서 다시 import하는 수동 E2E는 별도로 실행하지 않았습니다.
- 새 persistent workflow field 또는 migration은 추가하지 않았습니다.

Closes #220