### PR TITLE
fix: 와일드카드 PRNG를 NumPy PCG64로 고정

### DIFF
--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -28833,25 +28833,17 @@
       {
         "alias": "np",
         "bound_name": "np",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 17
-          }
-        ],
+        "branch_context": [],
         "classification": "external",
-        "column": 4,
-        "conditional": true,
+        "column": 0,
+        "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 18,
+        "line": 19,
         "name": null,
-        "optional": true,
+        "optional": false,
         "requested": "numpy",
-        "role": "optional_dependency",
+        "role": "ordinary",
         "scope": "<module>",
         "source": "wildcard_engine.py"
       },
@@ -28864,7 +28856,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 22
+            "line": 21
           }
         ],
         "classification": "external",
@@ -28872,7 +28864,7 @@
         "conditional": true,
         "imported": "yaml",
         "kind": "static_import",
-        "line": 23,
+        "line": 22,
         "name": null,
         "optional": true,
         "requested": "yaml",
@@ -28889,7 +28881,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 27
+            "line": 26
           }
         ],
         "classification": "internal",
@@ -28897,12 +28889,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 27
+          "try_line": 26
         },
         "conditional": true,
         "imported": ".storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 28,
+        "line": 27,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": ".storage",
@@ -28921,9 +28913,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 29,
+            "handler_line": 28,
             "kind": "try",
-            "line": 27
+            "line": 26
           }
         ],
         "classification": "compatibility_fallback",
@@ -28931,12 +28923,12 @@
         "compatibility_pair": {
           "bound_name": "USER_DATA_DIR",
           "target": "storage.py",
-          "try_line": 27
+          "try_line": 26
         },
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 30,
+        "line": 29,
         "name": "USER_DATA_DIR",
         "optional": false,
         "requested": "storage",
@@ -28954,7 +28946,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 533
+            "line": 532
           }
         ],
         "classification": "external",
@@ -28962,7 +28954,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 534,
+        "line": 533,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -28977,7 +28969,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 553,
+            "line": 552,
             "type_checking": false
           },
           {
@@ -28985,7 +28977,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 554
+            "line": 553
           }
         ],
         "classification": "internal",
@@ -28993,12 +28985,12 @@
         "compatibility_pair": {
           "bound_name": "get_settings",
           "target": "settings.py",
-          "try_line": 554
+          "try_line": 553
         },
         "conditional": true,
         "imported": ".settings:get_settings",
         "kind": "static_from",
-        "line": 555,
+        "line": 554,
         "name": "get_settings",
         "optional": false,
         "requested": ".settings",
@@ -29014,7 +29006,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 553,
+            "line": 552,
             "type_checking": false
           },
           {
@@ -29023,9 +29015,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 556,
+            "handler_line": 555,
             "kind": "try",
-            "line": 554
+            "line": 553
           }
         ],
         "classification": "compatibility_fallback",
@@ -29033,12 +29025,12 @@
         "compatibility_pair": {
           "bound_name": "get_settings",
           "target": "settings.py",
-          "try_line": 554
+          "try_line": 553
         },
         "conditional": true,
         "imported": "settings:get_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 556,
         "name": "get_settings",
         "optional": false,
         "requested": "settings",
@@ -30426,14 +30418,14 @@
       },
       {
         "is_package": false,
-        "loc": 1169,
+        "loc": 1155,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "a015c07bedfd6e630e1cd90899734b6d85304b57",
+        "normalized_git_blob_sha1": "da6c507859a6a0df78bd1308d413c717f4b6d9a5",
         "path": "wildcard_engine.py",
         "top_level": {
           "class_count": 12,
           "function_count": 39,
-          "global_count": 40
+          "global_count": 39
         }
       }
     ]
@@ -38128,16 +38120,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 29,
+            "handler_line": 28,
             "kind": "try",
-            "line": 27
+            "line": 26
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "storage:USER_DATA_DIR",
         "kind": "static_from",
-        "line": 30,
+        "line": 29,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -38148,7 +38140,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 553,
+            "line": 552,
             "type_checking": false
           },
           {
@@ -38157,16 +38149,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 556,
+            "handler_line": 555,
             "kind": "try",
-            "line": 554
+            "line": 553
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:get_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 556,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "wildcard_engine.py",
@@ -41139,22 +41131,14 @@
         "source": "wildcard_engine.py"
       },
       {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 17
-          }
-        ],
+        "branch_context": [],
         "classification": "external",
-        "conditional": true,
+        "conditional": false,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 18,
-        "optional": true,
-        "role": "optional_dependency",
+        "line": 19,
+        "optional": false,
+        "role": "ordinary",
         "source": "wildcard_engine.py"
       },
       {
@@ -41164,14 +41148,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 22
+            "line": 21
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "yaml",
         "kind": "static_import",
-        "line": 23,
+        "line": 22,
         "optional": true,
         "role": "optional_dependency",
         "source": "wildcard_engine.py"
@@ -41183,14 +41167,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 533
+            "line": 532
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 534,
+        "line": 533,
         "optional": true,
         "role": "optional_dependency",
         "source": "wildcard_engine.py"
@@ -42144,33 +42128,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 17
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "numpy",
-        "kind": "static_import",
-        "line": 18,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 22
+            "line": 21
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "yaml",
         "kind": "static_import",
-        "line": 23,
+        "line": 22,
         "optional": true,
         "role": "optional_dependency",
         "source": "wildcard_engine.py"
@@ -42182,14 +42147,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 533
+            "line": 532
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 534,
+        "line": 533,
         "optional": true,
         "role": "optional_dependency",
         "source": "wildcard_engine.py"
@@ -43352,7 +43317,7 @@
         "column": 13,
         "context": "assign:COMMENT_RE",
         "kind": "import_time_call",
-        "line": 93,
+        "line": 92,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43361,7 +43326,7 @@
         "column": 13,
         "context": "assign:DYNAMIC_RE",
         "kind": "import_time_call",
-        "line": 94,
+        "line": 93,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43370,7 +43335,7 @@
         "column": 14,
         "context": "assign:WILDCARD_RE",
         "kind": "import_time_call",
-        "line": 95,
+        "line": 94,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43379,7 +43344,7 @@
         "column": 19,
         "context": "assign:WILDCARD_FULL_RE",
         "kind": "import_time_call",
-        "line": 96,
+        "line": 95,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43388,7 +43353,7 @@
         "column": 25,
         "context": "assign:WILDCARD_QUANTIFIER_RE",
         "kind": "import_time_call",
-        "line": 97,
+        "line": 96,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43397,7 +43362,7 @@
         "column": 19,
         "context": "assign:WEIGHT_PREFIX_RE",
         "kind": "import_time_call",
-        "line": 101,
+        "line": 100,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43406,7 +43371,7 @@
         "column": 16,
         "context": "assign:COUNT_SPEC_RE",
         "kind": "import_time_call",
-        "line": 102,
+        "line": 101,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43415,7 +43380,7 @@
         "column": 1,
         "context": "decorator:WildcardOption",
         "kind": "import_time_call",
-        "line": 107,
+        "line": 106,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43424,7 +43389,7 @@
         "column": 1,
         "context": "decorator:_WildcardSourceFile",
         "kind": "import_time_call",
-        "line": 113,
+        "line": 112,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43433,7 +43398,7 @@
         "column": 1,
         "context": "decorator:_WildcardSourceState",
         "kind": "import_time_call",
-        "line": 127,
+        "line": 126,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43442,7 +43407,7 @@
         "column": 1,
         "context": "decorator:_WildcardSnapshot",
         "kind": "import_time_call",
-        "line": 142,
+        "line": 141,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43451,7 +43416,7 @@
         "column": 22,
         "context": "assign:_SNAPSHOT_CONDITION",
         "kind": "import_time_call",
-        "line": 167,
+        "line": 166,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43460,7 +43425,7 @@
         "column": 57,
         "context": "assign:_SNAPSHOT_CACHE",
         "kind": "import_time_call",
-        "line": 168,
+        "line": 167,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43469,7 +43434,7 @@
         "column": 33,
         "context": "assign:_SNAPSHOT_BUILDING",
         "kind": "import_time_call",
-        "line": 169,
+        "line": 168,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43478,7 +43443,7 @@
         "column": 1,
         "context": "decorator:WildcardExpansionBudget",
         "kind": "import_time_call",
-        "line": 190,
+        "line": 189,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43487,7 +43452,7 @@
         "column": 1,
         "context": "decorator:WildcardExpansionResult",
         "kind": "import_time_call",
-        "line": 235,
+        "line": 234,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43496,7 +43461,7 @@
         "column": 1,
         "context": "decorator:_ExpansionSegment",
         "kind": "import_time_call",
-        "line": 260,
+        "line": 259,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       },
@@ -43505,7 +43470,7 @@
         "column": 1,
         "context": "decorator:_Replacement",
         "kind": "import_time_call",
-        "line": 333,
+        "line": 332,
         "module": "wildcard_engine.py",
         "scope": "<module>"
       }
@@ -43827,25 +43792,25 @@
       },
       {
         "kind": "set",
-        "line": 91,
+        "line": 90,
         "module": "wildcard_engine.py",
         "name": "WILDCARD_EXTENSIONS"
       },
       {
         "kind": "dict",
-        "line": 52,
+        "line": 51,
         "module": "wildcard_engine.py",
         "name": "WILDCARD_MODE_ALIASES"
       },
       {
         "kind": "set",
-        "line": 169,
+        "line": 168,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
       {
         "kind": "dict",
-        "line": 168,
+        "line": 167,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }
@@ -43982,7 +43947,7 @@
           "single_flight"
         ],
         "initializer": "set",
-        "line": 169,
+        "line": 168,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_BUILDING"
       },
@@ -43992,7 +43957,7 @@
           "mutable_container"
         ],
         "initializer": "OrderedDict",
-        "line": 168,
+        "line": 167,
         "module": "wildcard_engine.py",
         "name": "_SNAPSHOT_CACHE"
       }

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -64,6 +64,8 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(result.used_keys, ("style",))
 
     def test_sequential_mode_uses_seed_modulo_option_count(self):
+        self.assertIsNone(wildcard_engine._Selector(4, sequential=True).rng)
+
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "color.txt").write_text("red\nblue\ngreen\n", encoding="utf-8")
@@ -277,40 +279,74 @@ class WildcardEngineTests(unittest.TestCase):
         self.assertEqual(growth_limited.limit_reason, "max_growth_per_pass")
         self.assertEqual(growth_limited.replacement_count, 0)
 
-    def test_existing_seeded_expansion_result_is_preserved(self):
-        source = "{2$$red|blue|green}, {soft|hard}"
+    def test_random_mode_uses_numpy_pcg64_golden_outputs(self):
+        selector = wildcard_engine._Selector(7, sequential=False)
+        self.assertIsInstance(selector.rng.bit_generator, wildcard_engine.np.random.PCG64)
 
-        first = expand_wildcards(source, seed=7)
-        second = expand_wildcards(source, seed=7)
+        cases = (
+            ("option_count_one", "{only}", "only"),
+            ("option_count_two", "{red|blue}", "blue"),
+            (
+                "larger_option_count",
+                "{" + "|".join(f"item-{index:02d}" for index in range(16)) + "}",
+                "item-10",
+            ),
+            (
+                "existing_combined_expansion",
+                "{2$$red|blue|green}, {soft|hard}",
+                "blue, green, hard",
+            ),
+        )
 
-        self.assertEqual(first.text, "blue, green, hard")
-        self.assertEqual(first, second)
-        self.assertIsNone(first.limit_reason)
-
-    def test_random_multiselect_excludes_zero_weight_options_in_both_backends(self):
-        numpy_module = wildcard_engine.np
-        self.assertIsNotNone(numpy_module)
-
-        for backend_name, backend in (("numpy", numpy_module), ("python", None)):
-            with self.subTest(backend=backend_name), patch.object(wildcard_engine, "np", backend):
-                result = expand_wildcards("{2$$0::zero|1::positive}", seed=0)
-
-            self.assertEqual(result.text, "positive")
-
-    def test_all_zero_weights_use_the_full_pool_deterministically_in_both_backends(self):
-        numpy_module = wildcard_engine.np
-        self.assertIsNotNone(numpy_module)
-        source = "{5$$0::red|0::blue|0::green}"
-
-        for backend_name, backend in (("numpy", numpy_module), ("python", None)):
-            with self.subTest(backend=backend_name), patch.object(wildcard_engine, "np", backend):
+        for name, source, expected in cases:
+            with self.subTest(name=name):
                 first = expand_wildcards(source, seed=7)
                 second = expand_wildcards(source, seed=7)
 
-            self.assertEqual(first.text, second.text)
-            values = [part.strip() for part in first.text.split(",")]
-            self.assertEqual(len(values), 3)
-            self.assertEqual(set(values), {"red", "blue", "green"})
+                self.assertEqual(first.text, expected)
+                self.assertEqual(first, second)
+                self.assertIsNone(first.limit_reason)
+
+    def test_random_mode_weighted_and_multiselect_golden_outputs(self):
+        cases = (
+            ("weighted", "{1::red|3::blue|6::green}", "green"),
+            (
+                "multiselect_without_replacement",
+                "{3$$red|blue|green|gold|silver}",
+                "gold, silver, red",
+            ),
+            (
+                "all_zero_weights_use_full_pool",
+                "{5$$0::red|0::blue|0::green}",
+                "red, blue, green",
+            ),
+        )
+
+        for name, source, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(expand_wildcards(source, seed=7).text, expected)
+
+    def test_random_mode_nested_wildcard_has_golden_output(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "outer.txt").write_text(
+                "__inner__ red\n__inner__ blue\n",
+                encoding="utf-8",
+            )
+            (root / "inner.txt").write_text(
+                "circle\nsquare\ntriangle\n",
+                encoding="utf-8",
+            )
+
+            result = expand_wildcards("__outer__", seed=7, roots=[root])
+
+        self.assertEqual(result.text, "triangle blue")
+        self.assertEqual(result.replacement_count, 2)
+
+    def test_random_multiselect_excludes_zero_weight_options(self):
+        result = expand_wildcards("{2$$0::zero|1::positive}", seed=0)
+
+        self.assertEqual(result.text, "positive")
 
     def test_sequential_multiselect_keeps_zero_weight_candidates(self):
         result = expand_wildcards(

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -14,10 +14,9 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Iterable, Mapping, Sequence
 
-try:
-    import numpy as np
-except Exception:  # pragma: no cover - ComfyUI normally provides numpy.
-    np = None
+# NumPy is mandatory in supported ComfyUI runtimes and defines the seeded
+# wildcard sampling contract. A stdlib fallback would produce different results.
+import numpy as np
 
 try:
     import yaml
@@ -828,10 +827,11 @@ class _Selector:
     def __init__(self, seed: int, sequential: bool):
         self.seed = normalize_seed(seed)
         self.sequential = sequential
-        if np is not None:
-            self.rng = np.random.default_rng(self.seed)
-        else:
-            self.rng = random.Random(self.seed)
+        self.rng = (
+            None
+            if self.sequential
+            else np.random.Generator(np.random.PCG64(self.seed))
+        )
 
     def count_from_range(self, minimum: int, maximum: int) -> int:
         minimum = max(0, minimum)
@@ -840,9 +840,7 @@ class _Selector:
             return minimum
         if self.sequential:
             return minimum + (self.seed % (maximum - minimum + 1))
-        if np is not None:
-            return int(self.rng.integers(minimum, maximum + 1))
-        return self.rng.randint(minimum, maximum)
+        return int(self.rng.integers(minimum, maximum + 1))
 
     def choose_one(self, options: Sequence[WildcardOption]) -> WildcardOption | None:
         selected = self.choose_many(options, 1)
@@ -874,24 +872,12 @@ class _Selector:
             pool_weights = None
 
         count = min(count, len(pool))
-        if np is not None:
-            probabilities = None
-            if pool_weights is not None:
-                total = sum(pool_weights)
-                probabilities = [weight / total for weight in pool_weights]
-            indices = self.rng.choice(len(pool), size=count, replace=False, p=probabilities)
-            return [pool[int(index)] for index in indices]
-
+        probabilities = None
         if pool_weights is not None:
-            selected = []
-            for _ in range(count):
-                choice = self.rng.choices(pool, weights=pool_weights, k=1)[0]
-                index = pool.index(choice)
-                selected.append(choice)
-                pool.pop(index)
-                pool_weights.pop(index)
-            return selected
-        return self.rng.sample(pool, count)
+            total = sum(pool_weights)
+            probabilities = [weight / total for weight in pool_weights]
+        indices = self.rng.choice(len(pool), size=count, replace=False, p=probabilities)
+        return [pool[int(index)] for index in indices]
 
 
 class _WildcardLibrary:


### PR DESCRIPTION
## 변경 요약

- 지원 ComfyUI 런타임의 와일드카드 random 모드를 NumPy `Generator(PCG64)` 계약으로 고정했습니다.
- NumPy 유무에 따라 stdlib `random.Random`으로 바뀌던 fallback과 backend 분기를 제거했습니다.
- Sequential은 기존 `seed % option_count` 선택을 유지하며 PRNG를 생성하지 않습니다.
- 지원 ComfyUI 결과가 바뀌지 않으므로 workflow 필드, 알고리즘 버전, migration, UI 설정은 추가하지 않았습니다.

## 원인과 지원 런타임 근거

기존 코드는 NumPy가 있으면 `default_rng`, 없으면 stdlib `random.Random`을 사용해 같은 source/seed에서도 선택 결과가 달랐습니다.

ComfyUI v0.27.0의 필수 requirements 구간에는 `numpy>=1.25.0`가 선언되어 있고, 확인한 v0.27.0 환경의 설치 메타데이터는 NumPy 2.4.4였습니다. 따라서 지원 런타임은 현재 `default_rng`가 사용하는 PCG64을 명시적으로 고정하고, NumPy 없는 standalone import는 다른 알고리즘으로 조용히 동작시키지 않는 비지원 경계로 정의했습니다.

## 주요 파일

- `wildcard_engine.py`: 필수 NumPy import, PCG64 selector, fallback/backend 분기 제거
- `tests/test_wildcards.py`: option count 1/2/큰 목록, weighted, multiselect without replacement, nesting, zero-weight, Sequential 분리 golden 회귀
- `tests/fixtures/python_backend_baseline.json`: 공식 analyzer로 required NumPy import와 제거된 fallback 분기 inventory 갱신

## 검증

- `python -m py_compile wildcard_engine.py tests/test_wildcards.py` — 통과
- `python -m unittest discover -s tests -p test_wildcards.py -q` — 55 tests, 통과
- focused backend analyzer fixture 회귀 — 1 test, 통과
- `tools/check_project.ps1 -Profile quick` — 통과
- `tools/check_project.ps1 -Profile full` — 통과
  - Python unittest 715 tests
  - frontend 111 JavaScript files
  - TypeScript 6.0.3
  - Python compile 및 Git diff check
- ComfyUI v0.27.0: 필수 의존성 선언 및 설치 메타데이터 확인
- Live ComfyUI/browser smoke: 실행하지 않음

## 호환성과 남은 위험

- 지원 ComfyUI의 기존 NumPy random golden 출력과 Sequential 결과는 유지됩니다.
- 저장 workflow/API/UI schema 변경과 migration은 없습니다.
- NumPy가 없는 standalone import는 의도적으로 비지원이며 즉시 import 오류가 납니다.
- NumPy 1.25부터 2.4까지의 별도 버전 행렬은 실행하지 않았고, golden 테스트가 지원 환경의 알고리즘 drift를 탐지합니다.

Closes #222