### PR TITLE
refactor: Regional Prompt Studio vertical slice 이동

### DIFF
--- a/easyuse_anima/nodes/regional_nodes.py
+++ b/easyuse_anima/nodes/regional_nodes.py
@@ -1,0 +1,569 @@
+"""ComfyUI adapters for Regional Prompt Studio."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..naia.resolution import (
+    DEFAULT_ADVANCED_RESOLUTION_BUCKET,
+    DEFAULT_ADVANCED_RESOLUTION_SIZE,
+)
+from ..prompt.regional import (
+    REGIONAL_CONFIG_WORKFLOW_PROPERTY,
+    REGIONAL_FIELDS_WORKFLOW_PROPERTY,
+    REGIONAL_PROMPT_DATA_TYPE,
+)
+
+
+WILDCARD_MODE_SEQUENTIAL = "sequential"
+PROMPT_STUDIO_WILDCARD_MODE_LABELS = ("일반", "순차")
+SEED_CONTROL_FIXED = "fixed"
+SEED_CONTROL_RANDOMIZE = "randomize"
+SEED_CONTROL_INCREMENT = "increment"
+SEED_CONTROL_DECREMENT = "decrement"
+SEED_CONTROL_MODES = (
+    SEED_CONTROL_FIXED,
+    SEED_CONTROL_RANDOMIZE,
+    SEED_CONTROL_INCREMENT,
+    SEED_CONTROL_DECREMENT,
+)
+MAX_SEED = 0xFFFFFFFFFFFFFFFF
+PUBLIC_MAX_SEED = (1 << 53) - 1
+WILDCARD_SEED_RANGE_NOTE = (
+    f"Browser/public editing and next-seed range: 0..{PUBLIC_MAX_SEED}. The Python "
+    "backend continues accepting uint64 values for legacy workflow validation, but "
+    "values above the public maximum are best-effort in the browser because JavaScript "
+    "may already have lost integer precision. Fixed does not intentionally advance a "
+    "legacy value; increment, decrement, and randomize return the next seed to the "
+    "public range."
+)
+
+
+class _FlexibleOptionalInputType(dict):
+    def __init__(self, input_type):
+        self.input_type = input_type
+
+    def __getitem__(self, key):
+        return (self.input_type,)
+
+    def __contains__(self, key):
+        return True
+
+
+def _unbound_runtime(*_args, **_kwargs):
+    raise RuntimeError("Regional node runtime dependencies are not bound.")
+
+
+_regional_fields_json = _unbound_runtime
+_regional_config_json = _unbound_runtime
+_advanced_resolution_from_selection = _unbound_runtime
+_normalize_regional_fields = _unbound_runtime
+_normalize_regional_config = _unbound_runtime
+_apply_regional_field_inputs = _unbound_runtime
+normalize_prompt_studio_wildcard_mode = _unbound_runtime
+_normalize_prompt_studio_wildcard_seed_control = _unbound_runtime
+_stable_change_key = _unbound_runtime
+resolve_metadata_filter_words = _unbound_runtime
+_prompt_translation_change_key = _unbound_runtime
+wildcard_sources_signature = _unbound_runtime
+normalize_seed = _unbound_runtime
+_single_value = _unbound_runtime
+_get_workflow_node = _unbound_runtime
+_advanced_field_input_values = _unbound_runtime
+_clone_regional_fields = _unbound_runtime
+_consume_reserved_wildcard_next_seed = _unbound_runtime
+_expand_advanced_wildcard_fields = _unbound_runtime
+_translate_prompt_fields = _unbound_runtime
+next_seed = _unbound_runtime
+_build_regional_outputs = _unbound_runtime
+_parse_json_object = _unbound_runtime
+_regional_payload_canvas = _unbound_runtime
+_encode_with_comfy_clip = _unbound_runtime
+_as_bool = _unbound_runtime
+_normalize_mask_ids = _unbound_runtime
+_regional_union_mask_for_ids = _unbound_runtime
+_as_float = _unbound_runtime
+_regional_mask_bounds_area = _unbound_runtime
+_conditioning_set_values = _unbound_runtime
+
+
+def _bind_regional_node_runtime(*, resolve_helper, flexible_optional_input_type) -> None:
+    global _FlexibleOptionalInputType
+    global _regional_fields_json, _regional_config_json, _advanced_resolution_from_selection
+    global _normalize_regional_fields, _normalize_regional_config
+    global _apply_regional_field_inputs, normalize_prompt_studio_wildcard_mode
+    global _normalize_prompt_studio_wildcard_seed_control
+    global _stable_change_key, resolve_metadata_filter_words
+    global _prompt_translation_change_key, wildcard_sources_signature, normalize_seed
+    global _single_value, _get_workflow_node, _advanced_field_input_values
+    global _clone_regional_fields
+    global _consume_reserved_wildcard_next_seed, _expand_advanced_wildcard_fields
+    global _translate_prompt_fields, next_seed
+    global _build_regional_outputs, _parse_json_object, _regional_payload_canvas
+    global _encode_with_comfy_clip, _as_bool, _normalize_mask_ids
+    global _regional_union_mask_for_ids, _as_float, _regional_mask_bounds_area
+    global _conditioning_set_values
+
+    def runtime_helper(name):
+        def call(*args, **kwargs):
+            return resolve_helper(name)(*args, **kwargs)
+
+        return call
+
+    _FlexibleOptionalInputType = flexible_optional_input_type
+    for name in (
+        "_regional_fields_json",
+        "_regional_config_json",
+        "_advanced_resolution_from_selection",
+        "_normalize_regional_fields",
+        "_normalize_regional_config",
+        "_apply_regional_field_inputs",
+        "normalize_prompt_studio_wildcard_mode",
+        "_normalize_prompt_studio_wildcard_seed_control",
+        "_stable_change_key",
+        "resolve_metadata_filter_words",
+        "_prompt_translation_change_key",
+        "wildcard_sources_signature",
+        "normalize_seed",
+        "_single_value",
+        "_get_workflow_node",
+        "_advanced_field_input_values",
+        "_clone_regional_fields",
+        "_consume_reserved_wildcard_next_seed",
+        "_expand_advanced_wildcard_fields",
+        "_translate_prompt_fields",
+        "next_seed",
+        "_build_regional_outputs",
+        "_parse_json_object",
+        "_regional_payload_canvas",
+        "_encode_with_comfy_clip",
+        "_as_bool",
+        "_normalize_mask_ids",
+        "_regional_union_mask_for_ids",
+        "_as_float",
+        "_regional_mask_bounds_area",
+        "_conditioning_set_values",
+    ):
+        globals()[name] = runtime_helper(name)
+
+
+class EasyUseAnimaPromptStudioRegional:
+    """Mask-scoped Prompt Studio with serialized prompt fields and mask config."""
+
+    DESCRIPTION = (
+        "Regional Prompt Studio that stores numbered user masks and applies selected "
+        "positive prompt fields only inside those masks. Connect regional_prompt_data "
+        "to Anima Regional Conditioning to create KSampler-ready conditionings."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Metadata positive prompt with global and mask-scoped prompt fields included.",
+        "Metadata negative prompt with metadata filters applied.",
+        "Selected latent width used by the mask editor canvas.",
+        "Selected latent height used by the mask editor canvas.",
+        "Bundled regional prompt, mask, and model-patch data for Anima Regional Conditioning.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "regional_fields": ("STRING", {
+                    "multiline": True,
+                    "default": _regional_fields_json(),
+                    "tooltip": "Internal JSON payload for Regional Prompt Studio fields.",
+                }),
+                "regional_config": ("STRING", {
+                    "multiline": True,
+                    "default": _regional_config_json(),
+                    "tooltip": "Internal JSON payload for numbered masks and mask editor settings.",
+                }),
+                "resolution_bucket": ("STRING", {
+                    "default": DEFAULT_ADVANCED_RESOLUTION_BUCKET,
+                    "tooltip": "Internal selected latent resolution bucket.",
+                }),
+                "resolution_size": ("STRING", {
+                    "default": DEFAULT_ADVANCED_RESOLUTION_SIZE,
+                    "tooltip": "Internal selected latent resolution, formatted as width * height (ratio).",
+                }),
+                "resolution_custom_width": ("INT", {
+                    "default": 1024,
+                    "min": 32,
+                    "max": 8192,
+                    "step": 32,
+                    "tooltip": "Internal custom latent width. Values are snapped to multiples of 32.",
+                }),
+                "resolution_custom_height": ("INT", {
+                    "default": 1024,
+                    "min": 32,
+                    "max": 8192,
+                    "step": 32,
+                    "tooltip": "Internal custom latent height. Values are snapped to multiples of 32.",
+                }),
+                "wildcard_mode": (PROMPT_STUDIO_WILDCARD_MODE_LABELS, {
+                    "default": PROMPT_STUDIO_WILDCARD_MODE_LABELS[0],
+                    "tooltip": "General expands deterministically; Sequential uses seed % option_count. Seed control independently decides the next seed.",
+                }),
+                "wildcard_seed": ("INT", {
+                    "default": 0,
+                    "min": 0,
+                    "max": MAX_SEED,
+                    "tooltip": (
+                        "Wildcard seed used by Regional Prompt Studio fields. "
+                        f"{WILDCARD_SEED_RANGE_NOTE}"
+                    ),
+                }),
+                "wildcard_seed_after_generate": (SEED_CONTROL_MODES, {
+                    "default": SEED_CONTROL_FIXED,
+                    "tooltip": "After an accepted queue: keep the seed fixed, randomize it, or increment it by one.",
+                }),
+            },
+            "optional": _FlexibleOptionalInputType("STRING"),
+            "hidden": {
+                "workflow_prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+                "unique_id": "UNIQUE_ID",
+            },
+        }
+
+    RETURN_TYPES = (
+        "STRING",
+        "STRING",
+        "INT",
+        "INT",
+        REGIONAL_PROMPT_DATA_TYPE,
+    )
+    RETURN_NAMES = (
+        "metadata_prompt",
+        "metadata_negative_prompt",
+        "width",
+        "height",
+        "regional_prompt_data",
+    )
+    FUNCTION = "build"
+    CATEGORY = "EasyUse Anima/Prompt"
+
+    @classmethod
+    def _widget_input_names(cls) -> list[str]:
+        return list(cls.INPUT_TYPES()["required"].keys())
+
+    @classmethod
+    def IS_CHANGED(
+        cls,
+        regional_fields: str = "",
+        regional_config: str = "",
+        resolution_bucket: str = DEFAULT_ADVANCED_RESOLUTION_BUCKET,
+        resolution_size: str = DEFAULT_ADVANCED_RESOLUTION_SIZE,
+        resolution_custom_width: int = 1024,
+        resolution_custom_height: int = 1024,
+        wildcard_mode: str = PROMPT_STUDIO_WILDCARD_MODE_LABELS[0],
+        wildcard_seed: int = 0,
+        wildcard_seed_after_generate: str = SEED_CONTROL_FIXED,
+        **kwargs,
+    ):
+        width, height = _advanced_resolution_from_selection(
+            resolution_bucket,
+            resolution_size,
+            resolution_custom_width,
+            resolution_custom_height,
+        )
+        fields = _normalize_regional_fields(regional_fields)
+        effective_fields = _apply_regional_field_inputs(fields, kwargs)
+        config = _normalize_regional_config(regional_config, width, height)
+        wildcard_mode_key = normalize_prompt_studio_wildcard_mode(wildcard_mode)
+        wildcard_active = True
+        wildcard_seed_control = _normalize_prompt_studio_wildcard_seed_control(
+            wildcard_seed_after_generate,
+            wildcard_mode,
+        )
+        return _stable_change_key({
+            "mode": "prompt_studio_regional",
+            "metadata_filter_words": resolve_metadata_filter_words(),
+            "prompt_translation": _prompt_translation_change_key(),
+            "wildcard_sources": wildcard_sources_signature() if wildcard_active else {},
+            "wildcard_mode": wildcard_mode_key,
+            "wildcard_seed": normalize_seed(wildcard_seed),
+            "wildcard_seed_after_generate": wildcard_seed_control,
+            "resolution": (width, height),
+            "regional_fields": _regional_fields_json(effective_fields),
+            "regional_config": _regional_config_json(config),
+        })
+
+    @classmethod
+    def _update_metadata_fields(
+        cls,
+        workflow_prompt,
+        extra_pnginfo,
+        unique_id,
+        regional_fields: str,
+        regional_config: str,
+        extra_updates: dict[str, Any] | None = None,
+    ) -> None:
+        node_id = _single_value(unique_id)
+        if node_id is None:
+            return
+        node_id = str(node_id)
+        updates = {
+            "regional_fields": regional_fields,
+            "regional_config": regional_config,
+        }
+        if extra_updates:
+            updates.update(extra_updates)
+
+        if isinstance(workflow_prompt, dict):
+            prompt_node = workflow_prompt.get(node_id)
+            if isinstance(prompt_node, dict):
+                inputs = prompt_node.setdefault("inputs", {})
+                for name, value in updates.items():
+                    inputs[name] = value
+
+        workflow_node = _get_workflow_node(extra_pnginfo, node_id)
+        if workflow_node is None:
+            return
+
+        properties = workflow_node.setdefault("properties", {})
+        if not isinstance(properties, dict):
+            properties = {}
+            workflow_node["properties"] = properties
+        properties[REGIONAL_FIELDS_WORKFLOW_PROPERTY] = regional_fields
+        properties[REGIONAL_CONFIG_WORKFLOW_PROPERTY] = regional_config
+
+        input_names = cls._widget_input_names()
+        widgets_values = workflow_node.setdefault("widgets_values", [])
+        for name, value in updates.items():
+            if name not in input_names:
+                continue
+            index = input_names.index(name)
+            while len(widgets_values) <= index:
+                widgets_values.append(None)
+            widgets_values[index] = value
+
+    @staticmethod
+    def _ui(
+        regional_fields: str,
+        regional_config: str,
+        field_inputs: dict | None = None,
+        extra_payload: dict[str, Any] | None = None,
+    ):
+        payload = {
+            "prompt_studio_regional": [{
+                "regional_fields": regional_fields,
+                "regional_config": regional_config,
+                "field_inputs": field_inputs or {},
+            }]
+        }
+        if extra_payload:
+            payload["prompt_studio_regional"][0].update(extra_payload)
+        return payload
+
+    def build(
+        self,
+        regional_fields: str,
+        regional_config: str,
+        resolution_bucket: str = DEFAULT_ADVANCED_RESOLUTION_BUCKET,
+        resolution_size: str = DEFAULT_ADVANCED_RESOLUTION_SIZE,
+        resolution_custom_width: int = 1024,
+        resolution_custom_height: int = 1024,
+        wildcard_mode: str = PROMPT_STUDIO_WILDCARD_MODE_LABELS[0],
+        wildcard_seed: int = 0,
+        wildcard_seed_after_generate: str = SEED_CONTROL_FIXED,
+        workflow_prompt=None,
+        extra_pnginfo=None,
+        unique_id=None,
+        **field_inputs,
+    ):
+        width, height = _advanced_resolution_from_selection(
+            resolution_bucket,
+            resolution_size,
+            resolution_custom_width,
+            resolution_custom_height,
+        )
+        fields = _normalize_regional_fields(regional_fields)
+        saved_fields = _clone_regional_fields(fields)
+        effective_field_inputs = _advanced_field_input_values(field_inputs)
+        config = _normalize_regional_config(regional_config, width, height)
+
+        wildcard_mode_key = normalize_prompt_studio_wildcard_mode(wildcard_mode)
+        wildcard_mode_label = (
+            PROMPT_STUDIO_WILDCARD_MODE_LABELS[1]
+            if wildcard_mode_key == WILDCARD_MODE_SEQUENTIAL
+            else PROMPT_STUDIO_WILDCARD_MODE_LABELS[0]
+        )
+        effective_fields = _apply_regional_field_inputs(fields, effective_field_inputs)
+        wildcard_seed_value = normalize_seed(wildcard_seed)
+        wildcard_effective_seed_control = _normalize_prompt_studio_wildcard_seed_control(
+            wildcard_seed_after_generate,
+            wildcard_mode,
+        )
+        reserved_next_wildcard_seed = _consume_reserved_wildcard_next_seed(
+            field_inputs,
+            workflow_prompt,
+            unique_id,
+            wildcard_seed_value,
+            wildcard_mode_key,
+            wildcard_effective_seed_control,
+        )
+        ui_updates: dict[str, Any] = {}
+        metadata_updates: dict[str, Any] = {}
+
+        effective_fields, effective_wildcard = _expand_advanced_wildcard_fields(
+            effective_fields,
+            wildcard_seed_value,
+            wildcard_mode_key,
+        )
+        effective_fields = _translate_prompt_fields(effective_fields)
+        next_wildcard_seed = (
+            reserved_next_wildcard_seed
+            if reserved_next_wildcard_seed is not None
+            else next_seed(wildcard_seed_value, wildcard_effective_seed_control)
+        )
+        ui_updates.update({
+            "wildcard_mode": wildcard_mode_label,
+            "wildcard_seed": next_wildcard_seed,
+            "wildcard_seed_after_generate": wildcard_effective_seed_control,
+            "wildcard_used_keys": list(effective_wildcard["used_keys"]),
+            "wildcard_missing_keys": list(effective_wildcard["missing_keys"]),
+        })
+        metadata_updates.update({
+            "wildcard_mode": wildcard_mode_label,
+            "wildcard_seed": wildcard_seed_value,
+            "wildcard_seed_after_generate": SEED_CONTROL_FIXED,
+        })
+
+        fields_json = _regional_fields_json(saved_fields)
+        config_json = _regional_config_json(config)
+        self._update_metadata_fields(
+            workflow_prompt,
+            extra_pnginfo,
+            unique_id,
+            fields_json,
+            config_json,
+            metadata_updates,
+        )
+
+        (
+            positive_prompt,
+            negative_prompt,
+            metadata_prompt,
+            metadata_negative_prompt,
+            regional_prompt_data,
+        ) = _build_regional_outputs(effective_fields, config, width, height)
+
+        return {
+            "ui": self._ui(fields_json, config_json, effective_field_inputs, ui_updates),
+            "result": (
+                metadata_prompt,
+                metadata_negative_prompt,
+                width,
+                height,
+                regional_prompt_data,
+            ),
+        }
+
+
+class EasyUseAnimaRegionalConditioning:
+    """Convert Regional Prompt Studio JSON into KSampler-ready conditionings."""
+
+    DESCRIPTION = (
+        "Encodes Anima Prompt Studio Regional data with CLIP and attaches mask metadata "
+        "to mask-scoped positive conditioning entries."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Positive conditioning containing the global prompt plus mask-scoped regional entries.",
+        "Negative conditioning encoded from the bundled negative prompt.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "clip": ("CLIP", {
+                    "tooltip": "CLIP model used to encode the bundled global and regional prompts.",
+                }),
+                "regional_prompt_data": (REGIONAL_PROMPT_DATA_TYPE, {
+                    "forceInput": True,
+                    "tooltip": "Bundled structured data from Anima Prompt Studio Regional.",
+                }),
+                "mask_strength": ("FLOAT", {
+                    "default": 1.0,
+                    "min": 0.0,
+                    "max": 10.0,
+                    "step": 0.01,
+                    "tooltip": "Strength applied to mask-scoped conditioning entries.",
+                }),
+                "set_cond_area": (["mask bounds", "default"], {
+                    "default": "mask bounds",
+                    "tooltip": "mask bounds mirrors ComfyUI ConditioningSetMask area behavior.",
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("CONDITIONING", "CONDITIONING")
+    RETURN_NAMES = ("positive", "negative")
+    FUNCTION = "encode"
+    CATEGORY = "EasyUse Anima/Prompt"
+
+    @classmethod
+    def IS_CHANGED(
+        cls,
+        regional_prompt_data: str | dict = "",
+        mask_strength: float = 1.0,
+        set_cond_area: str = "mask bounds",
+        **kwargs,
+    ):
+        return _stable_change_key({
+            "mode": "regional_conditioning",
+            "regional_prompt_data": (
+                regional_prompt_data
+                if isinstance(regional_prompt_data, dict)
+                else str(regional_prompt_data or "")
+            ),
+            "mask_strength": _as_float(mask_strength, 1.0),
+            "set_cond_area": str(set_cond_area or "mask bounds"),
+        })
+
+    def encode(
+        self,
+        regional_prompt_data: str | dict,
+        clip,
+        mask_strength: float = 1.0,
+        set_cond_area: str = "mask bounds",
+    ):
+        payload = _parse_json_object(regional_prompt_data)
+        width, height = _regional_payload_canvas(payload)
+        positive_prompt = str(payload.get("global_prompt") or payload.get("positive_prompt") or "")
+        negative_prompt = str(payload.get("negative_prompt") or "")
+
+        positive = list(_encode_with_comfy_clip(clip, positive_prompt))
+        negative = _encode_with_comfy_clip(clip, negative_prompt)
+
+        if _as_bool(payload.get("regional_enabled"), False):
+            use_mask_bounds = str(set_cond_area or "mask bounds") != "default"
+            mask_prompts = payload.get("mask_prompts") if isinstance(payload.get("mask_prompts"), list) else []
+            for entry in mask_prompts:
+                if not isinstance(entry, dict):
+                    continue
+                valid_mask_ids = _normalize_mask_ids(entry.get("valid_mask_ids") or entry.get("mask_ids"))
+                prompt = str(entry.get("prompt") or entry.get("text") or "").strip()
+                if not valid_mask_ids or not prompt:
+                    continue
+                mask = _regional_union_mask_for_ids(payload, valid_mask_ids, width, height)
+                regional_conditioning = _encode_with_comfy_clip(clip, prompt)
+                conditioning_values = {
+                    "mask": mask,
+                    "set_area_to_bounds": False,
+                    "mask_strength": _as_float(mask_strength, 1.0),
+                    "easyuse_anima_region": {
+                        "field_id": str(entry.get("field_id") or ""),
+                        "mask_ids": valid_mask_ids,
+                    },
+                }
+                if use_mask_bounds:
+                    area = _regional_mask_bounds_area(mask, width, height)
+                    if area is not None:
+                        conditioning_values["area"] = area
+                positive.extend(_conditioning_set_values(regional_conditioning, conditioning_values))
+
+        return (positive, negative)
+
+
+__all__ = ()

--- a/easyuse_anima/prompt/regional.py
+++ b/easyuse_anima/prompt/regional.py
@@ -1,0 +1,586 @@
+"""Regional Prompt Studio schema and service helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+REGIONAL_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_regional_fields"
+REGIONAL_CONFIG_WORKFLOW_PROPERTY = "easyuse_anima_regional_config"
+REGIONAL_FIELD_TYPES = {"quality", "artist", "trigger", "general"}
+REGIONAL_CONFIG_VERSION = 1
+REGIONAL_PROMPT_DATA_TYPE = "EASYUSE_ANIMA_REGIONAL_PROMPT_DATA"
+REGIONAL_PROMPT_DATA_SCHEMA = "easyuse_anima_prompt_studio_regional"
+REGIONAL_PROMPT_BUNDLE_SCHEMA = "easyuse_anima_prompt_studio_regional_bundle"
+
+ADVANCED_FIELD_PANES = {"positive", "negative"}
+ADVANCED_FIELD_LABELS = {
+    "quality": "Quality Tags",
+    "artist": "Artist Tags",
+    "trigger": "Trigger Words",
+    "general": "General Tags",
+}
+
+
+def _unbound_runtime(*_args, **_kwargs):
+    raise RuntimeError("Regional Prompt Studio runtime dependencies are not bound.")
+
+
+_advanced_default_fields = _unbound_runtime
+_single_value = _unbound_runtime
+_as_int = _unbound_runtime
+_as_bool = _unbound_runtime
+_as_float = _unbound_runtime
+_as_advanced_height = _unbound_runtime
+_advanced_field_input_values = _unbound_runtime
+_advanced_field_socket_name = _unbound_runtime
+_ratio_label = _unbound_runtime
+_correct_advanced_field_sequence = _unbound_runtime
+_join_prompt_tokens = _unbound_runtime
+resolve_metadata_filter_words = _unbound_runtime
+_filter_metadata_prompt = _unbound_runtime
+
+
+def _bind_regional_runtime(*, resolve_helper) -> None:
+    global _advanced_default_fields, _single_value, _as_int, _as_bool, _as_float
+    global _as_advanced_height, _advanced_field_input_values, _advanced_field_socket_name
+    global _ratio_label, _correct_advanced_field_sequence, _join_prompt_tokens
+    global resolve_metadata_filter_words, _filter_metadata_prompt
+
+    def runtime_helper(name):
+        def call(*args, **kwargs):
+            return resolve_helper(name)(*args, **kwargs)
+
+        return call
+
+    _advanced_default_fields = runtime_helper("_advanced_default_fields")
+    _single_value = runtime_helper("_single_value")
+    _as_int = runtime_helper("_as_int")
+    _as_bool = runtime_helper("_as_bool")
+    _as_float = runtime_helper("_as_float")
+    _as_advanced_height = runtime_helper("_as_advanced_height")
+    _advanced_field_input_values = runtime_helper("_advanced_field_input_values")
+    _advanced_field_socket_name = runtime_helper("_advanced_field_socket_name")
+    _ratio_label = runtime_helper("_ratio_label")
+    _correct_advanced_field_sequence = runtime_helper("_correct_advanced_field_sequence")
+    _join_prompt_tokens = runtime_helper("_join_prompt_tokens")
+    resolve_metadata_filter_words = runtime_helper("resolve_metadata_filter_words")
+    _filter_metadata_prompt = runtime_helper("_filter_metadata_prompt")
+
+
+def _regional_default_fields() -> list[dict]:
+    fields = []
+    for field in _advanced_default_fields():
+        if field.get("type") == "naia":
+            continue
+        item = dict(field)
+        item["mask_ids"] = []
+        fields.append(item)
+    return fields
+
+
+def _regional_fields_json(fields: list[dict] | None = None) -> str:
+    return json.dumps(
+        fields if fields is not None else _regional_default_fields(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _normalize_mask_ids(value) -> list[int]:
+    value = _single_value(value)
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_values = re.split(r"[,;\s]+", value.strip())
+    elif isinstance(value, (list, tuple, set)):
+        raw_values = list(value)
+    else:
+        raw_values = [value]
+
+    mask_ids: list[int] = []
+    for raw in raw_values:
+        mask_id = _as_int(raw, 0)
+        if mask_id > 0 and mask_id not in mask_ids:
+            mask_ids.append(mask_id)
+    return mask_ids
+
+
+def _normalize_regional_fields(value: str | list | None) -> list[dict]:
+    raw = value
+    if isinstance(value, str):
+        try:
+            raw = json.loads(value or "[]")
+        except json.JSONDecodeError:
+            raw = []
+    if not isinstance(raw, list):
+        raw = []
+    if not raw:
+        raw = _regional_default_fields()
+
+    fields: list[dict] = []
+    seen_trigger = False
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            continue
+        pane = str(item.get("pane") or "positive").strip().lower()
+        if pane not in ADVANCED_FIELD_PANES:
+            pane = "positive"
+        field_type = str(item.get("type") or "general").strip().lower()
+        if field_type not in REGIONAL_FIELD_TYPES:
+            field_type = "general"
+        if pane == "negative" and field_type == "trigger":
+            field_type = "general"
+        if field_type == "trigger":
+            if seen_trigger:
+                continue
+            seen_trigger = True
+            pane = "positive"
+        default_label = ADVANCED_FIELD_LABELS.get(field_type, ADVANCED_FIELD_LABELS["general"])
+        label = str(item.get("label") or default_label).strip() or default_label
+        field_id = str(item.get("id") or f"{pane}_{field_type}_{index + 1}").strip()
+        if not field_id:
+            field_id = f"{pane}_{field_type}_{index + 1}"
+        mask_ids = _normalize_mask_ids(item.get("mask_ids"))
+        if pane != "positive":
+            mask_ids = []
+        fields.append({
+            "id": field_id,
+            "pane": pane,
+            "type": field_type,
+            "label": label,
+            "text": str(item.get("text") or ""),
+            "height": _as_advanced_height(item.get("height"), 72),
+            "enabled": _as_bool(item.get("enabled"), True),
+            "pin": _as_bool(item.get("pin"), field_type == "trigger"),
+            "collapsed": _as_bool(item.get("collapsed"), False),
+            "mask_ids": mask_ids,
+        })
+
+    return fields or _regional_default_fields()
+
+
+def _clone_regional_fields(fields: list[dict]) -> list[dict]:
+    return [
+        {
+            **dict(field),
+            "mask_ids": list(field.get("mask_ids") or []),
+        }
+        for field in fields
+    ]
+
+
+def _apply_regional_field_inputs(fields: list[dict], field_inputs: dict) -> list[dict]:
+    values = _advanced_field_input_values(field_inputs)
+    if not values:
+        return _clone_regional_fields(fields)
+
+    effective = _clone_regional_fields(fields)
+    for field in effective:
+        name = _advanced_field_socket_name(field)
+        if name in values:
+            field["text"] = values[name]
+    return effective
+
+
+def _regional_default_config(width: int = 1024, height: int = 1024) -> dict[str, Any]:
+    return {
+        "version": REGIONAL_CONFIG_VERSION,
+        "canvas": {
+            "width": int(width),
+            "height": int(height),
+            "aspect_ratio": _ratio_label(width, height),
+            "source": "resolution_fields",
+        },
+        "mask_authoring": {
+            "render_space": "image_pixels",
+            "storage_space": "normalized_canvas",
+            "preview_enabled": True,
+        },
+        "global_prompt": "",
+        "negative_prompt": "",
+        "next_mask_id": 1,
+        "masks": [],
+        "regional_enabled": False,
+        "mask_prompts": [],
+        "assignments": [],
+        "artist_mix": {},
+        "conditioning_settings": {},
+        "regional_settings": {},
+    }
+
+
+def _normalize_mask_geometry(value) -> dict[str, float]:
+    if not isinstance(value, dict):
+        value = {}
+    shape = str(value.get("type") or "rect").strip().lower()
+    if shape not in {"rect", "ellipse"}:
+        shape = "rect"
+    x = max(0.0, min(0.99, _as_float(value.get("x"), 0.1)))
+    y = max(0.0, min(0.99, _as_float(value.get("y"), 0.1)))
+    width = max(0.01, min(1.0, _as_float(value.get("width"), 0.35)))
+    height = max(0.01, min(1.0, _as_float(value.get("height"), 0.35)))
+    if x + width > 1.0:
+        width = max(0.01, 1.0 - x)
+    if y + height > 1.0:
+        height = max(0.01, 1.0 - y)
+    return {
+        "type": shape,
+        "x": round(x, 6),
+        "y": round(y, 6),
+        "width": round(width, 6),
+        "height": round(height, 6),
+    }
+
+
+def _normalize_regional_mask(value, fallback_id: int) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    mask_id = _as_int(value.get("mask_id", value.get("id")), fallback_id)
+    if mask_id <= 0:
+        return None
+    default_label = f"Mask {mask_id}"
+    name = str(value.get("name") or "").strip()
+    label = str(value.get("label") or name or default_label).strip() or default_label
+    color = str(value.get("color") or "#3b82f6").strip() or "#3b82f6"
+    if not re.fullmatch(r"#[0-9A-Fa-f]{6}", color):
+        color = "#3b82f6"
+    mask = {
+        "mask_id": mask_id,
+        "label": label,
+        "name": name,
+        "color": color,
+        "enabled": _as_bool(value.get("enabled"), True),
+        "geometry": _normalize_mask_geometry(value.get("geometry")),
+    }
+    if isinstance(value.get("strokes"), list):
+        mask["strokes"] = value["strokes"]
+    if isinstance(value.get("shapes"), list):
+        mask["shapes"] = value["shapes"]
+    return mask
+
+
+def _normalize_regional_config(
+    value: str | dict | None,
+    width: int = 1024,
+    height: int = 1024,
+) -> dict[str, Any]:
+    raw = value
+    if isinstance(value, str):
+        try:
+            raw = json.loads(value or "{}")
+        except json.JSONDecodeError:
+            raw = {}
+    if not isinstance(raw, dict):
+        raw = {}
+
+    config = _regional_default_config(width, height)
+    for key in ("artist_mix", "conditioning_settings", "regional_settings"):
+        if isinstance(raw.get(key), dict):
+            config[key] = raw[key]
+    authoring = raw.get("mask_authoring")
+    if isinstance(authoring, dict):
+        merged = dict(config["mask_authoring"])
+        merged.update({k: v for k, v in authoring.items() if isinstance(k, str)})
+        config["mask_authoring"] = merged
+
+    masks: list[dict[str, Any]] = []
+    used_ids: set[int] = set()
+    raw_masks = raw.get("masks")
+    if not isinstance(raw_masks, list):
+        raw_masks = raw.get("regions") if isinstance(raw.get("regions"), list) else []
+    for index, item in enumerate(raw_masks):
+        mask = _normalize_regional_mask(item, index + 1)
+        if mask is None or mask["mask_id"] in used_ids:
+            continue
+        used_ids.add(mask["mask_id"])
+        masks.append(mask)
+    next_mask_id = max([_as_int(raw.get("next_mask_id"), 1), 1, *(mask["mask_id"] + 1 for mask in masks)])
+    config["next_mask_id"] = next_mask_id
+    config["masks"] = masks
+    config["canvas"] = {
+        "width": int(width),
+        "height": int(height),
+        "aspect_ratio": _ratio_label(width, height),
+        "source": "resolution_fields",
+    }
+    return config
+
+
+def _regional_config_json(config: dict[str, Any] | None = None) -> str:
+    return json.dumps(
+        config if config is not None else _regional_default_config(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _regional_field_prompt(field: dict, artist_overrides: str = "") -> str:
+    return _correct_advanced_field_sequence(
+        [field],
+        include_quality=True,
+        artist_overrides=artist_overrides,
+        force_pin_triggers=True,
+    )
+
+
+def _build_regional_outputs(
+    fields: list[dict],
+    config: dict[str, Any],
+    width: int,
+    height: int,
+) -> tuple[str, str, str, str, dict[str, Any]]:
+    positive_fields = [
+        field
+        for field in fields
+        if field.get("pane") == "positive" and _as_bool(field.get("enabled"), True)
+    ]
+    negative_fields = [
+        field
+        for field in fields
+        if field.get("pane") == "negative" and _as_bool(field.get("enabled"), True)
+    ]
+    global_positive_fields = [
+        field for field in positive_fields if not _normalize_mask_ids(field.get("mask_ids"))
+    ]
+    mask_positive_fields = [
+        field for field in positive_fields if _normalize_mask_ids(field.get("mask_ids"))
+    ]
+
+    global_artist_prompt = _join_prompt_tokens(
+        *(str(field.get("text") or "") for field in global_positive_fields if field.get("type") == "artist")
+    )
+    all_artist_prompt = _join_prompt_tokens(
+        *(str(field.get("text") or "") for field in positive_fields if field.get("type") == "artist")
+    )
+    negative_artist_prompt = _join_prompt_tokens(
+        *(str(field.get("text") or "") for field in negative_fields if field.get("type") == "artist")
+    )
+
+    positive_prompt = _correct_advanced_field_sequence(
+        global_positive_fields,
+        include_quality=True,
+        artist_overrides=global_artist_prompt,
+        force_pin_triggers=True,
+    )
+    negative_prompt = _correct_advanced_field_sequence(
+        negative_fields,
+        include_quality=True,
+        artist_overrides=negative_artist_prompt,
+    )
+    metadata_prompt = _correct_advanced_field_sequence(
+        positive_fields,
+        include_quality=True,
+        artist_overrides=all_artist_prompt,
+        force_pin_triggers=True,
+    )
+
+    filter_words = resolve_metadata_filter_words()
+    metadata_prompt = _filter_metadata_prompt(metadata_prompt, filter_words)
+    metadata_negative_prompt = _filter_metadata_prompt(negative_prompt, filter_words)
+
+    masks = config.get("masks") if isinstance(config.get("masks"), list) else []
+    enabled_mask_ids = {
+        _as_int(mask.get("mask_id"), 0)
+        for mask in masks
+        if isinstance(mask, dict) and _as_bool(mask.get("enabled"), True)
+    }
+    assignments: list[dict[str, Any]] = []
+    mask_prompts: list[dict[str, Any]] = []
+    for field in mask_positive_fields:
+        mask_ids = _normalize_mask_ids(field.get("mask_ids"))
+        valid_mask_ids = [mask_id for mask_id in mask_ids if mask_id in enabled_mask_ids]
+        missing_mask_ids = [mask_id for mask_id in mask_ids if mask_id not in enabled_mask_ids]
+        prompt = _regional_field_prompt(field, all_artist_prompt)
+        assignments.append({
+            "field_id": str(field.get("id") or ""),
+            "mask_ids": mask_ids,
+            "valid_mask_ids": valid_mask_ids,
+            "missing_mask_ids": missing_mask_ids,
+        })
+        mask_prompts.append({
+            "field_id": str(field.get("id") or ""),
+            "type": str(field.get("type") or "general"),
+            "label": str(field.get("label") or ""),
+            "text": str(field.get("text") or ""),
+            "prompt": prompt,
+            "mask_ids": mask_ids,
+            "valid_mask_ids": valid_mask_ids,
+            "missing_mask_ids": missing_mask_ids,
+        })
+
+    regional_enabled = any(entry["valid_mask_ids"] for entry in mask_prompts)
+    regional_prompt_data = {
+        **config,
+        "version": REGIONAL_CONFIG_VERSION,
+        "schema": REGIONAL_PROMPT_BUNDLE_SCHEMA,
+        "canvas": {
+            "width": int(width),
+            "height": int(height),
+            "aspect_ratio": _ratio_label(width, height),
+            "source": "resolution_fields",
+        },
+        "global_prompt": positive_prompt,
+        "negative_prompt": negative_prompt,
+        "metadata_prompt": metadata_prompt,
+        "metadata_negative_prompt": metadata_negative_prompt,
+        "masks": masks,
+        "regional_enabled": regional_enabled,
+        "mask_prompts": mask_prompts,
+        "assignments": assignments,
+    }
+    model_patch_data = {
+        "version": REGIONAL_CONFIG_VERSION,
+        "regional_attention": {
+            "enabled": regional_enabled,
+            "assignments": assignments,
+            "masks": [
+                {
+                    "mask_id": mask.get("mask_id"),
+                    "label": mask.get("label"),
+                    "name": mask.get("name"),
+                    "enabled": _as_bool(mask.get("enabled"), True),
+                }
+                for mask in masks
+                if isinstance(mask, dict)
+            ],
+        },
+        "layout_control": {
+            "canvas": regional_prompt_data["canvas"],
+        },
+        "global_mod_guidance": {},
+        "artist_mix": config.get("artist_mix") if isinstance(config.get("artist_mix"), dict) else {},
+        "compatibility": {
+            "schema": REGIONAL_PROMPT_DATA_SCHEMA,
+            "version": REGIONAL_CONFIG_VERSION,
+            "mask_scoped_prompts": True,
+        },
+    }
+    regional_prompt_data["model_patch_data"] = model_patch_data
+    return (
+        positive_prompt,
+        negative_prompt,
+        metadata_prompt,
+        metadata_negative_prompt,
+        regional_prompt_data,
+    )
+
+
+def _parse_json_object(value: str | dict | None) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value or "{}")
+        except json.JSONDecodeError as exc:
+            raise ValueError("[EasyUseAnima] regional_prompt_data is not valid JSON.") from exc
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _regional_payload_canvas(payload: dict[str, Any]) -> tuple[int, int]:
+    canvas = payload.get("canvas") if isinstance(payload.get("canvas"), dict) else {}
+    width = max(8, _as_int(canvas.get("width"), 1024))
+    height = max(8, _as_int(canvas.get("height"), 1024))
+    return width, height
+
+
+def _conditioning_set_values(conditioning, values: dict[str, Any]) -> list:
+    out = []
+    for item in conditioning or []:
+        if isinstance(item, (list, tuple)) and len(item) >= 2 and isinstance(item[1], dict):
+            metadata = dict(item[1])
+            metadata.update(values)
+            out.append([item[0], metadata])
+        else:
+            out.append(item)
+    return out
+
+
+def _regional_union_mask_for_ids(
+    payload: dict[str, Any],
+    mask_ids: list[int],
+    width: int,
+    height: int,
+):
+    try:
+        import torch  # type: ignore
+    except Exception as exc:
+        raise RuntimeError("[EasyUseAnima] torch is required to convert regional masks to conditioning.") from exc
+
+    selected_ids = set(mask_ids)
+    mask_tensor = torch.zeros((height, width), dtype=torch.float32)
+    masks = payload.get("masks") if isinstance(payload.get("masks"), list) else []
+    for mask in masks:
+        if not isinstance(mask, dict) or not _as_bool(mask.get("enabled"), True):
+            continue
+        mask_id = _as_int(mask.get("mask_id"), 0)
+        if mask_id not in selected_ids:
+            continue
+        geometry = _normalize_mask_geometry(mask.get("geometry"))
+        x0 = max(0, min(width - 1, int(round(geometry["x"] * width))))
+        y0 = max(0, min(height - 1, int(round(geometry["y"] * height))))
+        x1 = max(x0 + 1, min(width, int(round((geometry["x"] + geometry["width"]) * width))))
+        y1 = max(y0 + 1, min(height, int(round((geometry["y"] + geometry["height"]) * height))))
+        if geometry["type"] == "ellipse":
+            yy = torch.arange(y0, y1, dtype=torch.float32).unsqueeze(1)
+            xx = torch.arange(x0, x1, dtype=torch.float32).unsqueeze(0)
+            cx = (x0 + x1 - 1) / 2.0
+            cy = (y0 + y1 - 1) / 2.0
+            rx = max(0.5, (x1 - x0) / 2.0)
+            ry = max(0.5, (y1 - y0) / 2.0)
+            ellipse = (((xx - cx) / rx) ** 2 + ((yy - cy) / ry) ** 2) <= 1.0
+            mask_tensor[y0:y1, x0:x1] = torch.maximum(mask_tensor[y0:y1, x0:x1], ellipse.to(torch.float32))
+        else:
+            mask_tensor[y0:y1, x0:x1] = 1.0
+    return mask_tensor.unsqueeze(0)
+
+
+def _regional_mask_bounds_area(
+    mask,
+    canvas_width: int | None = None,
+    canvas_height: int | None = None,
+) -> tuple | None:
+    try:
+        import torch  # type: ignore
+    except Exception:
+        return None
+
+    if not hasattr(mask, "shape"):
+        return None
+    if len(mask.shape) == 3:
+        mask_2d = torch.max(torch.abs(mask), dim=0).values
+    elif len(mask.shape) == 2:
+        mask_2d = mask
+    else:
+        return None
+
+    if mask_2d.numel() == 0 or torch.max(mask_2d != 0) == False:
+        return None
+    y, x = torch.where(mask_2d != 0)
+    height = max(1, int(canvas_height or mask_2d.shape[-2]))
+    width = max(1, int(canvas_width or mask_2d.shape[-1]))
+    y0 = int(torch.min(y).item())
+    y1 = int(torch.max(y).item())
+    x0 = int(torch.min(x).item())
+    x1 = int(torch.max(x).item())
+    latent_height = max(1, height // 8)
+    latent_width = max(1, width // 8)
+    area_y = max(0, min(latent_height - 1, round(y0 / height * latent_height)))
+    area_x = max(0, min(latent_width - 1, round(x0 / width * latent_width)))
+    area_height = max(1, round((y1 - y0 + 1) / height * latent_height))
+    area_width = max(1, round((x1 - x0 + 1) / width * latent_width))
+    area_height = min(area_height, latent_height - area_y)
+    area_width = min(area_width, latent_width - area_x)
+    return (
+        area_height,
+        area_width,
+        area_y,
+        area_x,
+    )
+
+
+__all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -62,6 +62,34 @@ try:
         _prompt_data_parameter_snapshot as _prompt_data_parameter_snapshot,
         _set_prompt_data_output as _set_prompt_data_output,
     )
+    from .easyuse_anima.prompt.regional import (
+        REGIONAL_CONFIG_VERSION as REGIONAL_CONFIG_VERSION,
+        REGIONAL_CONFIG_WORKFLOW_PROPERTY as REGIONAL_CONFIG_WORKFLOW_PROPERTY,
+        REGIONAL_FIELDS_WORKFLOW_PROPERTY as REGIONAL_FIELDS_WORKFLOW_PROPERTY,
+        REGIONAL_FIELD_TYPES as REGIONAL_FIELD_TYPES,
+        REGIONAL_PROMPT_BUNDLE_SCHEMA as REGIONAL_PROMPT_BUNDLE_SCHEMA,
+        REGIONAL_PROMPT_DATA_SCHEMA as REGIONAL_PROMPT_DATA_SCHEMA,
+        REGIONAL_PROMPT_DATA_TYPE as REGIONAL_PROMPT_DATA_TYPE,
+        _apply_regional_field_inputs as _apply_regional_field_inputs,
+        _bind_regional_runtime as _bind_regional_runtime,
+        _build_regional_outputs as _build_regional_outputs,
+        _clone_regional_fields as _clone_regional_fields,
+        _conditioning_set_values as _conditioning_set_values,
+        _normalize_mask_geometry as _normalize_mask_geometry,
+        _normalize_mask_ids as _normalize_mask_ids,
+        _normalize_regional_config as _normalize_regional_config,
+        _normalize_regional_fields as _normalize_regional_fields,
+        _normalize_regional_mask as _normalize_regional_mask,
+        _parse_json_object as _parse_json_object,
+        _regional_config_json as _regional_config_json,
+        _regional_default_config as _regional_default_config,
+        _regional_default_fields as _regional_default_fields,
+        _regional_field_prompt as _regional_field_prompt,
+        _regional_fields_json as _regional_fields_json,
+        _regional_mask_bounds_area as _regional_mask_bounds_area,
+        _regional_payload_canvas as _regional_payload_canvas,
+        _regional_union_mask_for_ids as _regional_union_mask_for_ids,
+    )
     from .easyuse_anima.prompt.conditioning import (
         ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE as ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE,
         ANIMA_MOD_GUIDANCE_MODES as ANIMA_MOD_GUIDANCE_MODES,
@@ -214,6 +242,11 @@ try:
         EasyUseAnimaPromptCorrectorSimple as EasyUseAnimaPromptCorrectorSimple,
         EasyUseAnimaPromptStudio as EasyUseAnimaPromptStudio,
         _bind_prompt_node_runtime as _bind_prompt_node_runtime,
+    )
+    from .easyuse_anima.nodes.regional_nodes import (
+        EasyUseAnimaPromptStudioRegional as EasyUseAnimaPromptStudioRegional,
+        EasyUseAnimaRegionalConditioning as EasyUseAnimaRegionalConditioning,
+        _bind_regional_node_runtime as _bind_regional_node_runtime,
     )
     from .easyuse_anima.naia.client import (
         DEFAULT_HOST as DEFAULT_HOST,
@@ -376,6 +409,34 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _prompt_data_parameter_snapshot as _prompt_data_parameter_snapshot,
         _set_prompt_data_output as _set_prompt_data_output,
     )
+    from easyuse_anima.prompt.regional import (
+        REGIONAL_CONFIG_VERSION as REGIONAL_CONFIG_VERSION,
+        REGIONAL_CONFIG_WORKFLOW_PROPERTY as REGIONAL_CONFIG_WORKFLOW_PROPERTY,
+        REGIONAL_FIELDS_WORKFLOW_PROPERTY as REGIONAL_FIELDS_WORKFLOW_PROPERTY,
+        REGIONAL_FIELD_TYPES as REGIONAL_FIELD_TYPES,
+        REGIONAL_PROMPT_BUNDLE_SCHEMA as REGIONAL_PROMPT_BUNDLE_SCHEMA,
+        REGIONAL_PROMPT_DATA_SCHEMA as REGIONAL_PROMPT_DATA_SCHEMA,
+        REGIONAL_PROMPT_DATA_TYPE as REGIONAL_PROMPT_DATA_TYPE,
+        _apply_regional_field_inputs as _apply_regional_field_inputs,
+        _bind_regional_runtime as _bind_regional_runtime,
+        _build_regional_outputs as _build_regional_outputs,
+        _clone_regional_fields as _clone_regional_fields,
+        _conditioning_set_values as _conditioning_set_values,
+        _normalize_mask_geometry as _normalize_mask_geometry,
+        _normalize_mask_ids as _normalize_mask_ids,
+        _normalize_regional_config as _normalize_regional_config,
+        _normalize_regional_fields as _normalize_regional_fields,
+        _normalize_regional_mask as _normalize_regional_mask,
+        _parse_json_object as _parse_json_object,
+        _regional_config_json as _regional_config_json,
+        _regional_default_config as _regional_default_config,
+        _regional_default_fields as _regional_default_fields,
+        _regional_field_prompt as _regional_field_prompt,
+        _regional_fields_json as _regional_fields_json,
+        _regional_mask_bounds_area as _regional_mask_bounds_area,
+        _regional_payload_canvas as _regional_payload_canvas,
+        _regional_union_mask_for_ids as _regional_union_mask_for_ids,
+    )
     from easyuse_anima.prompt.conditioning import (
         ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE as ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE,
         ANIMA_MOD_GUIDANCE_MODES as ANIMA_MOD_GUIDANCE_MODES,
@@ -529,6 +590,11 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaPromptStudio as EasyUseAnimaPromptStudio,
         _bind_prompt_node_runtime as _bind_prompt_node_runtime,
     )
+    from easyuse_anima.nodes.regional_nodes import (
+        EasyUseAnimaPromptStudioRegional as EasyUseAnimaPromptStudioRegional,
+        EasyUseAnimaRegionalConditioning as EasyUseAnimaRegionalConditioning,
+        _bind_regional_node_runtime as _bind_regional_node_runtime,
+    )
     from easyuse_anima.naia.client import (
         DEFAULT_HOST as DEFAULT_HOST,
         DEFAULT_PORT as DEFAULT_PORT,
@@ -670,10 +736,6 @@ PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES = {
     "reproduce",
     "재현",
 }
-REGIONAL_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_regional_fields"
-REGIONAL_CONFIG_WORKFLOW_PROPERTY = "easyuse_anima_regional_config"
-REGIONAL_FIELD_TYPES = {"quality", "artist", "trigger", "general"}
-REGIONAL_CONFIG_VERSION = 1
 EASY_USE_ANIMA_INPUT_TYPE = "EASY_USE_ANIMA_INPUT"
 EASY_USE_ANIMA_INPUT_SCHEMA = "easy_use_anima_input"
 EASY_USE_ANIMA_INPUT_SETTINGS_VERSION = 1
@@ -1158,9 +1220,6 @@ AIO_GENERATION_DEFAULT_SETTINGS = {
         "feed_count": 12,
     },
 }
-REGIONAL_PROMPT_DATA_TYPE = "EASYUSE_ANIMA_REGIONAL_PROMPT_DATA"
-REGIONAL_PROMPT_DATA_SCHEMA = "easyuse_anima_prompt_studio_regional"
-REGIONAL_PROMPT_BUNDLE_SCHEMA = "easyuse_anima_prompt_studio_regional_bundle"
 EXTEND_PROMPT_SLOT_SPECS = [
     ("quality_tags_1", "positive", "quality", "Quality Tags 1", DEFAULT_QUALITY_TAGS, 72),
     ("quality_tags_2", "positive", "quality", "Quality Tags 2", "", 72),
@@ -5071,517 +5130,6 @@ def _build_advanced_prompt_data(
     }
 
 
-def _regional_default_fields() -> list[dict]:
-    fields = []
-    for field in _advanced_default_fields():
-        if field.get("type") == "naia":
-            continue
-        item = dict(field)
-        item["mask_ids"] = []
-        fields.append(item)
-    return fields
-
-
-def _regional_fields_json(fields: list[dict] | None = None) -> str:
-    return json.dumps(
-        fields if fields is not None else _regional_default_fields(),
-        ensure_ascii=False,
-        separators=(",", ":"),
-    )
-
-
-def _normalize_mask_ids(value) -> list[int]:
-    value = _single_value(value)
-    if value is None:
-        return []
-    if isinstance(value, str):
-        raw_values = re.split(r"[,;\s]+", value.strip())
-    elif isinstance(value, (list, tuple, set)):
-        raw_values = list(value)
-    else:
-        raw_values = [value]
-
-    mask_ids: list[int] = []
-    for raw in raw_values:
-        mask_id = _as_int(raw, 0)
-        if mask_id > 0 and mask_id not in mask_ids:
-            mask_ids.append(mask_id)
-    return mask_ids
-
-
-def _normalize_regional_fields(value: str | list | None) -> list[dict]:
-    raw = value
-    if isinstance(value, str):
-        try:
-            raw = json.loads(value or "[]")
-        except json.JSONDecodeError:
-            raw = []
-    if not isinstance(raw, list):
-        raw = []
-    if not raw:
-        raw = _regional_default_fields()
-
-    fields: list[dict] = []
-    seen_trigger = False
-    for index, item in enumerate(raw):
-        if not isinstance(item, dict):
-            continue
-        pane = str(item.get("pane") or "positive").strip().lower()
-        if pane not in ADVANCED_FIELD_PANES:
-            pane = "positive"
-        field_type = str(item.get("type") or "general").strip().lower()
-        if field_type not in REGIONAL_FIELD_TYPES:
-            field_type = "general"
-        if pane == "negative" and field_type == "trigger":
-            field_type = "general"
-        if field_type == "trigger":
-            if seen_trigger:
-                continue
-            seen_trigger = True
-            pane = "positive"
-        default_label = ADVANCED_FIELD_LABELS.get(field_type, ADVANCED_FIELD_LABELS["general"])
-        label = str(item.get("label") or default_label).strip() or default_label
-        field_id = str(item.get("id") or f"{pane}_{field_type}_{index + 1}").strip()
-        if not field_id:
-            field_id = f"{pane}_{field_type}_{index + 1}"
-        mask_ids = _normalize_mask_ids(item.get("mask_ids"))
-        if pane != "positive":
-            mask_ids = []
-        fields.append({
-            "id": field_id,
-            "pane": pane,
-            "type": field_type,
-            "label": label,
-            "text": str(item.get("text") or ""),
-            "height": _as_advanced_height(item.get("height"), 72),
-            "enabled": _as_bool(item.get("enabled"), True),
-            "pin": _as_bool(item.get("pin"), field_type == "trigger"),
-            "collapsed": _as_bool(item.get("collapsed"), False),
-            "mask_ids": mask_ids,
-        })
-
-    return fields or _regional_default_fields()
-
-
-def _clone_regional_fields(fields: list[dict]) -> list[dict]:
-    return [
-        {
-            **dict(field),
-            "mask_ids": list(field.get("mask_ids") or []),
-        }
-        for field in fields
-    ]
-
-
-def _apply_regional_field_inputs(fields: list[dict], field_inputs: dict) -> list[dict]:
-    values = _advanced_field_input_values(field_inputs)
-    if not values:
-        return _clone_regional_fields(fields)
-
-    effective = _clone_regional_fields(fields)
-    for field in effective:
-        name = _advanced_field_socket_name(field)
-        if name in values:
-            field["text"] = values[name]
-    return effective
-
-
-def _regional_default_config(width: int = 1024, height: int = 1024) -> dict[str, Any]:
-    return {
-        "version": REGIONAL_CONFIG_VERSION,
-        "canvas": {
-            "width": int(width),
-            "height": int(height),
-            "aspect_ratio": _ratio_label(width, height),
-            "source": "resolution_fields",
-        },
-        "mask_authoring": {
-            "render_space": "image_pixels",
-            "storage_space": "normalized_canvas",
-            "preview_enabled": True,
-        },
-        "global_prompt": "",
-        "negative_prompt": "",
-        "next_mask_id": 1,
-        "masks": [],
-        "regional_enabled": False,
-        "mask_prompts": [],
-        "assignments": [],
-        "artist_mix": {},
-        "conditioning_settings": {},
-        "regional_settings": {},
-    }
-
-
-def _normalize_mask_geometry(value) -> dict[str, float]:
-    if not isinstance(value, dict):
-        value = {}
-    shape = str(value.get("type") or "rect").strip().lower()
-    if shape not in {"rect", "ellipse"}:
-        shape = "rect"
-    x = max(0.0, min(0.99, _as_float(value.get("x"), 0.1)))
-    y = max(0.0, min(0.99, _as_float(value.get("y"), 0.1)))
-    width = max(0.01, min(1.0, _as_float(value.get("width"), 0.35)))
-    height = max(0.01, min(1.0, _as_float(value.get("height"), 0.35)))
-    if x + width > 1.0:
-        width = max(0.01, 1.0 - x)
-    if y + height > 1.0:
-        height = max(0.01, 1.0 - y)
-    return {
-        "type": shape,
-        "x": round(x, 6),
-        "y": round(y, 6),
-        "width": round(width, 6),
-        "height": round(height, 6),
-    }
-
-
-def _normalize_regional_mask(value, fallback_id: int) -> dict[str, Any] | None:
-    if not isinstance(value, dict):
-        return None
-    mask_id = _as_int(value.get("mask_id", value.get("id")), fallback_id)
-    if mask_id <= 0:
-        return None
-    default_label = f"Mask {mask_id}"
-    name = str(value.get("name") or "").strip()
-    label = str(value.get("label") or name or default_label).strip() or default_label
-    color = str(value.get("color") or "#3b82f6").strip() or "#3b82f6"
-    if not re.fullmatch(r"#[0-9A-Fa-f]{6}", color):
-        color = "#3b82f6"
-    mask = {
-        "mask_id": mask_id,
-        "label": label,
-        "name": name,
-        "color": color,
-        "enabled": _as_bool(value.get("enabled"), True),
-        "geometry": _normalize_mask_geometry(value.get("geometry")),
-    }
-    if isinstance(value.get("strokes"), list):
-        mask["strokes"] = value["strokes"]
-    if isinstance(value.get("shapes"), list):
-        mask["shapes"] = value["shapes"]
-    return mask
-
-
-def _normalize_regional_config(
-    value: str | dict | None,
-    width: int = 1024,
-    height: int = 1024,
-) -> dict[str, Any]:
-    raw = value
-    if isinstance(value, str):
-        try:
-            raw = json.loads(value or "{}")
-        except json.JSONDecodeError:
-            raw = {}
-    if not isinstance(raw, dict):
-        raw = {}
-
-    config = _regional_default_config(width, height)
-    for key in ("artist_mix", "conditioning_settings", "regional_settings"):
-        if isinstance(raw.get(key), dict):
-            config[key] = raw[key]
-    authoring = raw.get("mask_authoring")
-    if isinstance(authoring, dict):
-        merged = dict(config["mask_authoring"])
-        merged.update({k: v for k, v in authoring.items() if isinstance(k, str)})
-        config["mask_authoring"] = merged
-
-    masks: list[dict[str, Any]] = []
-    used_ids: set[int] = set()
-    raw_masks = raw.get("masks")
-    if not isinstance(raw_masks, list):
-        raw_masks = raw.get("regions") if isinstance(raw.get("regions"), list) else []
-    for index, item in enumerate(raw_masks):
-        mask = _normalize_regional_mask(item, index + 1)
-        if mask is None or mask["mask_id"] in used_ids:
-            continue
-        used_ids.add(mask["mask_id"])
-        masks.append(mask)
-    next_mask_id = max([_as_int(raw.get("next_mask_id"), 1), 1, *(mask["mask_id"] + 1 for mask in masks)])
-    config["next_mask_id"] = next_mask_id
-    config["masks"] = masks
-    config["canvas"] = {
-        "width": int(width),
-        "height": int(height),
-        "aspect_ratio": _ratio_label(width, height),
-        "source": "resolution_fields",
-    }
-    return config
-
-
-def _regional_config_json(config: dict[str, Any] | None = None) -> str:
-    return json.dumps(
-        config if config is not None else _regional_default_config(),
-        ensure_ascii=False,
-        separators=(",", ":"),
-    )
-
-
-def _regional_field_prompt(field: dict, artist_overrides: str = "") -> str:
-    return _correct_advanced_field_sequence(
-        [field],
-        include_quality=True,
-        artist_overrides=artist_overrides,
-        force_pin_triggers=True,
-    )
-
-
-def _build_regional_outputs(
-    fields: list[dict],
-    config: dict[str, Any],
-    width: int,
-    height: int,
-) -> tuple[str, str, str, str, dict[str, Any]]:
-    positive_fields = [
-        field
-        for field in fields
-        if field.get("pane") == "positive" and _as_bool(field.get("enabled"), True)
-    ]
-    negative_fields = [
-        field
-        for field in fields
-        if field.get("pane") == "negative" and _as_bool(field.get("enabled"), True)
-    ]
-    global_positive_fields = [
-        field for field in positive_fields if not _normalize_mask_ids(field.get("mask_ids"))
-    ]
-    mask_positive_fields = [
-        field for field in positive_fields if _normalize_mask_ids(field.get("mask_ids"))
-    ]
-
-    global_artist_prompt = _join_prompt_tokens(
-        *(str(field.get("text") or "") for field in global_positive_fields if field.get("type") == "artist")
-    )
-    all_artist_prompt = _join_prompt_tokens(
-        *(str(field.get("text") or "") for field in positive_fields if field.get("type") == "artist")
-    )
-    negative_artist_prompt = _join_prompt_tokens(
-        *(str(field.get("text") or "") for field in negative_fields if field.get("type") == "artist")
-    )
-
-    positive_prompt = _correct_advanced_field_sequence(
-        global_positive_fields,
-        include_quality=True,
-        artist_overrides=global_artist_prompt,
-        force_pin_triggers=True,
-    )
-    negative_prompt = _correct_advanced_field_sequence(
-        negative_fields,
-        include_quality=True,
-        artist_overrides=negative_artist_prompt,
-    )
-    metadata_prompt = _correct_advanced_field_sequence(
-        positive_fields,
-        include_quality=True,
-        artist_overrides=all_artist_prompt,
-        force_pin_triggers=True,
-    )
-
-    filter_words = resolve_metadata_filter_words()
-    metadata_prompt = _filter_metadata_prompt(metadata_prompt, filter_words)
-    metadata_negative_prompt = _filter_metadata_prompt(negative_prompt, filter_words)
-
-    masks = config.get("masks") if isinstance(config.get("masks"), list) else []
-    enabled_mask_ids = {
-        _as_int(mask.get("mask_id"), 0)
-        for mask in masks
-        if isinstance(mask, dict) and _as_bool(mask.get("enabled"), True)
-    }
-    assignments: list[dict[str, Any]] = []
-    mask_prompts: list[dict[str, Any]] = []
-    for field in mask_positive_fields:
-        mask_ids = _normalize_mask_ids(field.get("mask_ids"))
-        valid_mask_ids = [mask_id for mask_id in mask_ids if mask_id in enabled_mask_ids]
-        missing_mask_ids = [mask_id for mask_id in mask_ids if mask_id not in enabled_mask_ids]
-        prompt = _regional_field_prompt(field, all_artist_prompt)
-        assignments.append({
-            "field_id": str(field.get("id") or ""),
-            "mask_ids": mask_ids,
-            "valid_mask_ids": valid_mask_ids,
-            "missing_mask_ids": missing_mask_ids,
-        })
-        mask_prompts.append({
-            "field_id": str(field.get("id") or ""),
-            "type": str(field.get("type") or "general"),
-            "label": str(field.get("label") or ""),
-            "text": str(field.get("text") or ""),
-            "prompt": prompt,
-            "mask_ids": mask_ids,
-            "valid_mask_ids": valid_mask_ids,
-            "missing_mask_ids": missing_mask_ids,
-        })
-
-    regional_enabled = any(entry["valid_mask_ids"] for entry in mask_prompts)
-    regional_prompt_data = {
-        **config,
-        "version": REGIONAL_CONFIG_VERSION,
-        "schema": REGIONAL_PROMPT_BUNDLE_SCHEMA,
-        "canvas": {
-            "width": int(width),
-            "height": int(height),
-            "aspect_ratio": _ratio_label(width, height),
-            "source": "resolution_fields",
-        },
-        "global_prompt": positive_prompt,
-        "negative_prompt": negative_prompt,
-        "metadata_prompt": metadata_prompt,
-        "metadata_negative_prompt": metadata_negative_prompt,
-        "masks": masks,
-        "regional_enabled": regional_enabled,
-        "mask_prompts": mask_prompts,
-        "assignments": assignments,
-    }
-    model_patch_data = {
-        "version": REGIONAL_CONFIG_VERSION,
-        "regional_attention": {
-            "enabled": regional_enabled,
-            "assignments": assignments,
-            "masks": [
-                {
-                    "mask_id": mask.get("mask_id"),
-                    "label": mask.get("label"),
-                    "name": mask.get("name"),
-                    "enabled": _as_bool(mask.get("enabled"), True),
-                }
-                for mask in masks
-                if isinstance(mask, dict)
-            ],
-        },
-        "layout_control": {
-            "canvas": regional_prompt_data["canvas"],
-        },
-        "global_mod_guidance": {},
-        "artist_mix": config.get("artist_mix") if isinstance(config.get("artist_mix"), dict) else {},
-        "compatibility": {
-            "schema": REGIONAL_PROMPT_DATA_SCHEMA,
-            "version": REGIONAL_CONFIG_VERSION,
-            "mask_scoped_prompts": True,
-        },
-    }
-    regional_prompt_data["model_patch_data"] = model_patch_data
-    return (
-        positive_prompt,
-        negative_prompt,
-        metadata_prompt,
-        metadata_negative_prompt,
-        regional_prompt_data,
-    )
-
-
-def _parse_json_object(value: str | dict | None) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value or "{}")
-        except json.JSONDecodeError as exc:
-            raise ValueError("[EasyUseAnima] regional_prompt_data is not valid JSON.") from exc
-        if isinstance(parsed, dict):
-            return parsed
-    return {}
-
-
-def _regional_payload_canvas(payload: dict[str, Any]) -> tuple[int, int]:
-    canvas = payload.get("canvas") if isinstance(payload.get("canvas"), dict) else {}
-    width = max(8, _as_int(canvas.get("width"), 1024))
-    height = max(8, _as_int(canvas.get("height"), 1024))
-    return width, height
-
-
-def _conditioning_set_values(conditioning, values: dict[str, Any]) -> list:
-    out = []
-    for item in conditioning or []:
-        if isinstance(item, (list, tuple)) and len(item) >= 2 and isinstance(item[1], dict):
-            metadata = dict(item[1])
-            metadata.update(values)
-            out.append([item[0], metadata])
-        else:
-            out.append(item)
-    return out
-
-
-def _regional_union_mask_for_ids(
-    payload: dict[str, Any],
-    mask_ids: list[int],
-    width: int,
-    height: int,
-):
-    try:
-        import torch  # type: ignore
-    except Exception as exc:
-        raise RuntimeError("[EasyUseAnima] torch is required to convert regional masks to conditioning.") from exc
-
-    selected_ids = set(mask_ids)
-    mask_tensor = torch.zeros((height, width), dtype=torch.float32)
-    masks = payload.get("masks") if isinstance(payload.get("masks"), list) else []
-    for mask in masks:
-        if not isinstance(mask, dict) or not _as_bool(mask.get("enabled"), True):
-            continue
-        mask_id = _as_int(mask.get("mask_id"), 0)
-        if mask_id not in selected_ids:
-            continue
-        geometry = _normalize_mask_geometry(mask.get("geometry"))
-        x0 = max(0, min(width - 1, int(round(geometry["x"] * width))))
-        y0 = max(0, min(height - 1, int(round(geometry["y"] * height))))
-        x1 = max(x0 + 1, min(width, int(round((geometry["x"] + geometry["width"]) * width))))
-        y1 = max(y0 + 1, min(height, int(round((geometry["y"] + geometry["height"]) * height))))
-        if geometry["type"] == "ellipse":
-            yy = torch.arange(y0, y1, dtype=torch.float32).unsqueeze(1)
-            xx = torch.arange(x0, x1, dtype=torch.float32).unsqueeze(0)
-            cx = (x0 + x1 - 1) / 2.0
-            cy = (y0 + y1 - 1) / 2.0
-            rx = max(0.5, (x1 - x0) / 2.0)
-            ry = max(0.5, (y1 - y0) / 2.0)
-            ellipse = (((xx - cx) / rx) ** 2 + ((yy - cy) / ry) ** 2) <= 1.0
-            mask_tensor[y0:y1, x0:x1] = torch.maximum(mask_tensor[y0:y1, x0:x1], ellipse.to(torch.float32))
-        else:
-            mask_tensor[y0:y1, x0:x1] = 1.0
-    return mask_tensor.unsqueeze(0)
-
-
-def _regional_mask_bounds_area(mask, canvas_width: int | None = None, canvas_height: int | None = None) -> tuple | None:
-    try:
-        import torch  # type: ignore
-    except Exception:
-        return None
-
-    if not hasattr(mask, "shape"):
-        return None
-    if len(mask.shape) == 3:
-        mask_2d = torch.max(torch.abs(mask), dim=0).values
-    elif len(mask.shape) == 2:
-        mask_2d = mask
-    else:
-        return None
-
-    if mask_2d.numel() == 0 or torch.max(mask_2d != 0) == False:
-        return None
-    y, x = torch.where(mask_2d != 0)
-    height = max(1, int(canvas_height or mask_2d.shape[-2]))
-    width = max(1, int(canvas_width or mask_2d.shape[-1]))
-    y0 = int(torch.min(y).item())
-    y1 = int(torch.max(y).item())
-    x0 = int(torch.min(x).item())
-    x1 = int(torch.max(x).item())
-    latent_height = max(1, height // 8)
-    latent_width = max(1, width // 8)
-    area_y = max(0, min(latent_height - 1, round(y0 / height * latent_height)))
-    area_x = max(0, min(latent_width - 1, round(x0 / width * latent_width)))
-    area_height = max(1, round((y1 - y0 + 1) / height * latent_height))
-    area_width = max(1, round((x1 - x0 + 1) / width * latent_width))
-    area_height = min(area_height, latent_height - area_y)
-    area_width = min(area_width, latent_width - area_x)
-    return (
-        area_height,
-        area_width,
-        area_y,
-        area_x,
-    )
-
-
-
-
 def _get_workflow_node(extra_pnginfo, node_id: str):
     pnginfo = _single_value(extra_pnginfo)
     if not isinstance(pnginfo, dict):
@@ -5716,6 +5264,13 @@ def _consume_reserved_wildcard_next_seed(
     return reservation_next_seed if reservation_next_seed == expected_next_seed else None
 
 
+_bind_regional_runtime(
+    resolve_helper=lambda name: globals()[name],
+)
+_bind_regional_node_runtime(
+    resolve_helper=lambda name: globals()[name],
+    flexible_optional_input_type=_FlexibleOptionalInputType,
+)
 _bind_conditioning_runtime(
     resolve_helper=lambda name: globals()[name],
     resolve_logger=lambda: logger,
@@ -7102,425 +6657,6 @@ class EasyUseAnimaAIOGenerator:
             "ui": ui,
             "result": (image, latent, metadata_json),
         }
-
-
-class EasyUseAnimaPromptStudioRegional:
-    """Mask-scoped Prompt Studio with serialized prompt fields and mask config."""
-
-    DESCRIPTION = (
-        "Regional Prompt Studio that stores numbered user masks and applies selected "
-        "positive prompt fields only inside those masks. Connect regional_prompt_data "
-        "to Anima Regional Conditioning to create KSampler-ready conditionings."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Metadata positive prompt with global and mask-scoped prompt fields included.",
-        "Metadata negative prompt with metadata filters applied.",
-        "Selected latent width used by the mask editor canvas.",
-        "Selected latent height used by the mask editor canvas.",
-        "Bundled regional prompt, mask, and model-patch data for Anima Regional Conditioning.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "regional_fields": ("STRING", {
-                    "multiline": True,
-                    "default": _regional_fields_json(),
-                    "tooltip": "Internal JSON payload for Regional Prompt Studio fields.",
-                }),
-                "regional_config": ("STRING", {
-                    "multiline": True,
-                    "default": _regional_config_json(),
-                    "tooltip": "Internal JSON payload for numbered masks and mask editor settings.",
-                }),
-                "resolution_bucket": ("STRING", {
-                    "default": DEFAULT_ADVANCED_RESOLUTION_BUCKET,
-                    "tooltip": "Internal selected latent resolution bucket.",
-                }),
-                "resolution_size": ("STRING", {
-                    "default": DEFAULT_ADVANCED_RESOLUTION_SIZE,
-                    "tooltip": "Internal selected latent resolution, formatted as width * height (ratio).",
-                }),
-                "resolution_custom_width": ("INT", {
-                    "default": 1024,
-                    "min": 32,
-                    "max": 8192,
-                    "step": 32,
-                    "tooltip": "Internal custom latent width. Values are snapped to multiples of 32.",
-                }),
-                "resolution_custom_height": ("INT", {
-                    "default": 1024,
-                    "min": 32,
-                    "max": 8192,
-                    "step": 32,
-                    "tooltip": "Internal custom latent height. Values are snapped to multiples of 32.",
-                }),
-                "wildcard_mode": (PROMPT_STUDIO_WILDCARD_MODE_LABELS, {
-                    "default": PROMPT_STUDIO_WILDCARD_MODE_LABELS[0],
-                    "tooltip": "General expands deterministically; Sequential uses seed % option_count. Seed control independently decides the next seed.",
-                }),
-                "wildcard_seed": ("INT", {
-                    "default": 0,
-                    "min": 0,
-                    "max": MAX_SEED,
-                    "tooltip": (
-                        "Wildcard seed used by Regional Prompt Studio fields. "
-                        f"{WILDCARD_SEED_RANGE_NOTE}"
-                    ),
-                }),
-                "wildcard_seed_after_generate": (SEED_CONTROL_MODES, {
-                    "default": SEED_CONTROL_FIXED,
-                    "tooltip": "After an accepted queue: keep the seed fixed, randomize it, or increment it by one.",
-                }),
-            },
-            "optional": _FlexibleOptionalInputType("STRING"),
-            "hidden": {
-                "workflow_prompt": "PROMPT",
-                "extra_pnginfo": "EXTRA_PNGINFO",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    RETURN_TYPES = (
-        "STRING",
-        "STRING",
-        "INT",
-        "INT",
-        REGIONAL_PROMPT_DATA_TYPE,
-    )
-    RETURN_NAMES = (
-        "metadata_prompt",
-        "metadata_negative_prompt",
-        "width",
-        "height",
-        "regional_prompt_data",
-    )
-    FUNCTION = "build"
-    CATEGORY = "EasyUse Anima/Prompt"
-
-    @classmethod
-    def _widget_input_names(cls) -> list[str]:
-        return list(cls.INPUT_TYPES()["required"].keys())
-
-    @classmethod
-    def IS_CHANGED(
-        cls,
-        regional_fields: str = "",
-        regional_config: str = "",
-        resolution_bucket: str = DEFAULT_ADVANCED_RESOLUTION_BUCKET,
-        resolution_size: str = DEFAULT_ADVANCED_RESOLUTION_SIZE,
-        resolution_custom_width: int = 1024,
-        resolution_custom_height: int = 1024,
-        wildcard_mode: str = PROMPT_STUDIO_WILDCARD_MODE_LABELS[0],
-        wildcard_seed: int = 0,
-        wildcard_seed_after_generate: str = SEED_CONTROL_FIXED,
-        **kwargs,
-    ):
-        width, height = _advanced_resolution_from_selection(
-            resolution_bucket,
-            resolution_size,
-            resolution_custom_width,
-            resolution_custom_height,
-        )
-        fields = _normalize_regional_fields(regional_fields)
-        effective_fields = _apply_regional_field_inputs(fields, kwargs)
-        config = _normalize_regional_config(regional_config, width, height)
-        wildcard_mode_key = normalize_prompt_studio_wildcard_mode(wildcard_mode)
-        wildcard_active = True
-        wildcard_seed_control = _normalize_prompt_studio_wildcard_seed_control(
-            wildcard_seed_after_generate,
-            wildcard_mode,
-        )
-        return _stable_change_key({
-            "mode": "prompt_studio_regional",
-            "metadata_filter_words": resolve_metadata_filter_words(),
-            "prompt_translation": _prompt_translation_change_key(),
-            "wildcard_sources": wildcard_sources_signature() if wildcard_active else {},
-            "wildcard_mode": wildcard_mode_key,
-            "wildcard_seed": normalize_seed(wildcard_seed),
-            "wildcard_seed_after_generate": wildcard_seed_control,
-            "resolution": (width, height),
-            "regional_fields": _regional_fields_json(effective_fields),
-            "regional_config": _regional_config_json(config),
-        })
-
-    @classmethod
-    def _update_metadata_fields(
-        cls,
-        workflow_prompt,
-        extra_pnginfo,
-        unique_id,
-        regional_fields: str,
-        regional_config: str,
-        extra_updates: dict[str, Any] | None = None,
-    ) -> None:
-        node_id = _single_value(unique_id)
-        if node_id is None:
-            return
-        node_id = str(node_id)
-        updates = {
-            "regional_fields": regional_fields,
-            "regional_config": regional_config,
-        }
-        if extra_updates:
-            updates.update(extra_updates)
-
-        if isinstance(workflow_prompt, dict):
-            prompt_node = workflow_prompt.get(node_id)
-            if isinstance(prompt_node, dict):
-                inputs = prompt_node.setdefault("inputs", {})
-                for name, value in updates.items():
-                    inputs[name] = value
-
-        workflow_node = _get_workflow_node(extra_pnginfo, node_id)
-        if workflow_node is None:
-            return
-
-        properties = workflow_node.setdefault("properties", {})
-        if not isinstance(properties, dict):
-            properties = {}
-            workflow_node["properties"] = properties
-        properties[REGIONAL_FIELDS_WORKFLOW_PROPERTY] = regional_fields
-        properties[REGIONAL_CONFIG_WORKFLOW_PROPERTY] = regional_config
-
-        input_names = cls._widget_input_names()
-        widgets_values = workflow_node.setdefault("widgets_values", [])
-        for name, value in updates.items():
-            if name not in input_names:
-                continue
-            index = input_names.index(name)
-            while len(widgets_values) <= index:
-                widgets_values.append(None)
-            widgets_values[index] = value
-
-    @staticmethod
-    def _ui(
-        regional_fields: str,
-        regional_config: str,
-        field_inputs: dict | None = None,
-        extra_payload: dict[str, Any] | None = None,
-    ):
-        payload = {
-            "prompt_studio_regional": [{
-                "regional_fields": regional_fields,
-                "regional_config": regional_config,
-                "field_inputs": field_inputs or {},
-            }]
-        }
-        if extra_payload:
-            payload["prompt_studio_regional"][0].update(extra_payload)
-        return payload
-
-    def build(
-        self,
-        regional_fields: str,
-        regional_config: str,
-        resolution_bucket: str = DEFAULT_ADVANCED_RESOLUTION_BUCKET,
-        resolution_size: str = DEFAULT_ADVANCED_RESOLUTION_SIZE,
-        resolution_custom_width: int = 1024,
-        resolution_custom_height: int = 1024,
-        wildcard_mode: str = PROMPT_STUDIO_WILDCARD_MODE_LABELS[0],
-        wildcard_seed: int = 0,
-        wildcard_seed_after_generate: str = SEED_CONTROL_FIXED,
-        workflow_prompt=None,
-        extra_pnginfo=None,
-        unique_id=None,
-        **field_inputs,
-    ):
-        width, height = _advanced_resolution_from_selection(
-            resolution_bucket,
-            resolution_size,
-            resolution_custom_width,
-            resolution_custom_height,
-        )
-        fields = _normalize_regional_fields(regional_fields)
-        saved_fields = _clone_regional_fields(fields)
-        effective_field_inputs = _advanced_field_input_values(field_inputs)
-        config = _normalize_regional_config(regional_config, width, height)
-
-        wildcard_mode_key = normalize_prompt_studio_wildcard_mode(wildcard_mode)
-        wildcard_mode_label = (
-            PROMPT_STUDIO_WILDCARD_MODE_LABELS[1]
-            if wildcard_mode_key == WILDCARD_MODE_SEQUENTIAL
-            else PROMPT_STUDIO_WILDCARD_MODE_LABELS[0]
-        )
-        effective_fields = _apply_regional_field_inputs(fields, effective_field_inputs)
-        wildcard_seed_value = normalize_seed(wildcard_seed)
-        wildcard_effective_seed_control = _normalize_prompt_studio_wildcard_seed_control(
-            wildcard_seed_after_generate,
-            wildcard_mode,
-        )
-        reserved_next_wildcard_seed = _consume_reserved_wildcard_next_seed(
-            field_inputs,
-            workflow_prompt,
-            unique_id,
-            wildcard_seed_value,
-            wildcard_mode_key,
-            wildcard_effective_seed_control,
-        )
-        ui_updates: dict[str, Any] = {}
-        metadata_updates: dict[str, Any] = {}
-
-        effective_fields, effective_wildcard = _expand_advanced_wildcard_fields(
-            effective_fields,
-            wildcard_seed_value,
-            wildcard_mode_key,
-        )
-        effective_fields = _translate_prompt_fields(effective_fields)
-        next_wildcard_seed = (
-            reserved_next_wildcard_seed
-            if reserved_next_wildcard_seed is not None
-            else next_seed(wildcard_seed_value, wildcard_effective_seed_control)
-        )
-        ui_updates.update({
-            "wildcard_mode": wildcard_mode_label,
-            "wildcard_seed": next_wildcard_seed,
-            "wildcard_seed_after_generate": wildcard_effective_seed_control,
-            "wildcard_used_keys": list(effective_wildcard["used_keys"]),
-            "wildcard_missing_keys": list(effective_wildcard["missing_keys"]),
-        })
-        metadata_updates.update({
-            "wildcard_mode": wildcard_mode_label,
-            "wildcard_seed": wildcard_seed_value,
-            "wildcard_seed_after_generate": SEED_CONTROL_FIXED,
-        })
-
-        fields_json = _regional_fields_json(saved_fields)
-        config_json = _regional_config_json(config)
-        self._update_metadata_fields(
-            workflow_prompt,
-            extra_pnginfo,
-            unique_id,
-            fields_json,
-            config_json,
-            metadata_updates,
-        )
-
-        (
-            positive_prompt,
-            negative_prompt,
-            metadata_prompt,
-            metadata_negative_prompt,
-            regional_prompt_data,
-        ) = _build_regional_outputs(effective_fields, config, width, height)
-
-        return {
-            "ui": self._ui(fields_json, config_json, effective_field_inputs, ui_updates),
-            "result": (
-                metadata_prompt,
-                metadata_negative_prompt,
-                width,
-                height,
-                regional_prompt_data,
-            ),
-        }
-
-
-class EasyUseAnimaRegionalConditioning:
-    """Convert Regional Prompt Studio JSON into KSampler-ready conditionings."""
-
-    DESCRIPTION = (
-        "Encodes Anima Prompt Studio Regional data with CLIP and attaches mask metadata "
-        "to mask-scoped positive conditioning entries."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Positive conditioning containing the global prompt plus mask-scoped regional entries.",
-        "Negative conditioning encoded from the bundled negative prompt.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "clip": ("CLIP", {
-                    "tooltip": "CLIP model used to encode the bundled global and regional prompts.",
-                }),
-                "regional_prompt_data": (REGIONAL_PROMPT_DATA_TYPE, {
-                    "forceInput": True,
-                    "tooltip": "Bundled structured data from Anima Prompt Studio Regional.",
-                }),
-                "mask_strength": ("FLOAT", {
-                    "default": 1.0,
-                    "min": 0.0,
-                    "max": 10.0,
-                    "step": 0.01,
-                    "tooltip": "Strength applied to mask-scoped conditioning entries.",
-                }),
-                "set_cond_area": (["mask bounds", "default"], {
-                    "default": "mask bounds",
-                    "tooltip": "mask bounds mirrors ComfyUI ConditioningSetMask area behavior.",
-                }),
-            },
-        }
-
-    RETURN_TYPES = ("CONDITIONING", "CONDITIONING")
-    RETURN_NAMES = ("positive", "negative")
-    FUNCTION = "encode"
-    CATEGORY = "EasyUse Anima/Prompt"
-
-    @classmethod
-    def IS_CHANGED(
-        cls,
-        regional_prompt_data: str | dict = "",
-        mask_strength: float = 1.0,
-        set_cond_area: str = "mask bounds",
-        **kwargs,
-    ):
-        return _stable_change_key({
-            "mode": "regional_conditioning",
-            "regional_prompt_data": (
-                regional_prompt_data
-                if isinstance(regional_prompt_data, dict)
-                else str(regional_prompt_data or "")
-            ),
-            "mask_strength": _as_float(mask_strength, 1.0),
-            "set_cond_area": str(set_cond_area or "mask bounds"),
-        })
-
-    def encode(
-        self,
-        regional_prompt_data: str | dict,
-        clip,
-        mask_strength: float = 1.0,
-        set_cond_area: str = "mask bounds",
-    ):
-        payload = _parse_json_object(regional_prompt_data)
-        width, height = _regional_payload_canvas(payload)
-        positive_prompt = str(payload.get("global_prompt") or payload.get("positive_prompt") or "")
-        negative_prompt = str(payload.get("negative_prompt") or "")
-
-        positive = list(_encode_with_comfy_clip(clip, positive_prompt))
-        negative = _encode_with_comfy_clip(clip, negative_prompt)
-
-        if _as_bool(payload.get("regional_enabled"), False):
-            use_mask_bounds = str(set_cond_area or "mask bounds") != "default"
-            mask_prompts = payload.get("mask_prompts") if isinstance(payload.get("mask_prompts"), list) else []
-            for entry in mask_prompts:
-                if not isinstance(entry, dict):
-                    continue
-                valid_mask_ids = _normalize_mask_ids(entry.get("valid_mask_ids") or entry.get("mask_ids"))
-                prompt = str(entry.get("prompt") or entry.get("text") or "").strip()
-                if not valid_mask_ids or not prompt:
-                    continue
-                mask = _regional_union_mask_for_ids(payload, valid_mask_ids, width, height)
-                regional_conditioning = _encode_with_comfy_clip(clip, prompt)
-                conditioning_values = {
-                    "mask": mask,
-                    "set_area_to_bounds": False,
-                    "mask_strength": _as_float(mask_strength, 1.0),
-                    "easyuse_anima_region": {
-                        "field_id": str(entry.get("field_id") or ""),
-                        "mask_ids": valid_mask_ids,
-                    },
-                }
-                if use_mask_bounds:
-                    area = _regional_mask_bounds_area(mask, width, height)
-                    if area is not None:
-                        conditioning_values["area"] = area
-                positive.extend(_conditioning_set_values(regional_conditioning, conditioning_values))
-
-        return (positive, negative)
 
 
 class EasyUseAnimaPromptStudioExtend:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -7322,6 +7322,130 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "kind": "static_from",
+        "line": 7,
+        "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "kind": "static_from",
+        "line": 7,
+        "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 11,
+        "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 11,
+        "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "REGIONAL_PROMPT_DATA_TYPE",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
+        "kind": "static_from",
+        "line": 11,
+        "name": "REGIONAL_PROMPT_DATA_TYPE",
+        "optional": false,
+        "requested": "..prompt.regional",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/regional_nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
@@ -9074,6 +9198,124 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "json",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "json",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "re",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "name": null,
+        "optional": false,
+        "requested": "re",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 509
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 510,
+        "name": null,
+        "optional": true,
+        "requested": "torch",
+        "role": "optional_dependency",
+        "scope": "_regional_union_mask_for_ids",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "torch",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 547
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 548,
+        "name": null,
+        "optional": true,
+        "requested": "torch",
+        "role": "optional_dependency",
+        "scope": "_regional_mask_bounds_area",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "name": "annotations",
         "optional": false,
@@ -10527,6 +10769,812 @@
         "target": "easyuse_anima/prompt/data.py"
       },
       {
+        "alias": "REGIONAL_CONFIG_VERSION",
+        "bound_name": "REGIONAL_CONFIG_VERSION",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_CONFIG_VERSION",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
+        "kind": "static_from",
+        "line": 65,
+        "name": "REGIONAL_CONFIG_VERSION",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "bound_name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 65,
+        "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "bound_name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 65,
+        "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_FIELD_TYPES",
+        "bound_name": "REGIONAL_FIELD_TYPES",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_FIELD_TYPES",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
+        "kind": "static_from",
+        "line": 65,
+        "name": "REGIONAL_FIELD_TYPES",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "bound_name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "kind": "static_from",
+        "line": 65,
+        "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_PROMPT_DATA_SCHEMA",
+        "bound_name": "REGIONAL_PROMPT_DATA_SCHEMA",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_PROMPT_DATA_SCHEMA",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
+        "kind": "static_from",
+        "line": 65,
+        "name": "REGIONAL_PROMPT_DATA_SCHEMA",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_PROMPT_DATA_TYPE",
+        "bound_name": "REGIONAL_PROMPT_DATA_TYPE",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_PROMPT_DATA_TYPE",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
+        "kind": "static_from",
+        "line": 65,
+        "name": "REGIONAL_PROMPT_DATA_TYPE",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_apply_regional_field_inputs",
+        "bound_name": "_apply_regional_field_inputs",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_regional_field_inputs",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_apply_regional_field_inputs",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_bind_regional_runtime",
+        "bound_name": "_bind_regional_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_regional_runtime",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_bind_regional_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_build_regional_outputs",
+        "bound_name": "_build_regional_outputs",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_build_regional_outputs",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_build_regional_outputs",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_clone_regional_fields",
+        "bound_name": "_clone_regional_fields",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_clone_regional_fields",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_clone_regional_fields",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_conditioning_set_values",
+        "bound_name": "_conditioning_set_values",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_conditioning_set_values",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_conditioning_set_values",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_mask_geometry",
+        "bound_name": "_normalize_mask_geometry",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_mask_geometry",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_normalize_mask_geometry",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_normalize_mask_geometry",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_mask_ids",
+        "bound_name": "_normalize_mask_ids",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_mask_ids",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_normalize_mask_ids",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_regional_config",
+        "bound_name": "_normalize_regional_config",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_regional_config",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_normalize_regional_config",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_regional_fields",
+        "bound_name": "_normalize_regional_fields",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_regional_fields",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_normalize_regional_fields",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_regional_mask",
+        "bound_name": "_normalize_regional_mask",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_regional_mask",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_normalize_regional_mask",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_normalize_regional_mask",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_parse_json_object",
+        "bound_name": "_parse_json_object",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_json_object",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_parse_json_object",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_config_json",
+        "bound_name": "_regional_config_json",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_config_json",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_config_json",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_default_config",
+        "bound_name": "_regional_default_config",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_default_config",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_default_config",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_default_config",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_default_fields",
+        "bound_name": "_regional_default_fields",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_default_fields",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_default_fields",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_default_fields",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_field_prompt",
+        "bound_name": "_regional_field_prompt",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_field_prompt",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_field_prompt",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_field_prompt",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_fields_json",
+        "bound_name": "_regional_fields_json",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_fields_json",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_fields_json",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_mask_bounds_area",
+        "bound_name": "_regional_mask_bounds_area",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_mask_bounds_area",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_mask_bounds_area",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_payload_canvas",
+        "bound_name": "_regional_payload_canvas",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_payload_canvas",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_payload_canvas",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_union_mask_for_ids",
+        "bound_name": "_regional_union_mask_for_ids",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_union_mask_for_ids",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
+        "kind": "static_from",
+        "line": 65,
+        "name": "_regional_union_mask_for_ids",
+        "optional": false,
+        "requested": ".easyuse_anima.prompt.regional",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
         "alias": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "branch_context": [
@@ -10548,7 +11596,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10579,7 +11627,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10610,7 +11658,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10641,7 +11689,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10672,7 +11720,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10703,7 +11751,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10734,7 +11782,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10765,7 +11813,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10796,7 +11844,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10827,7 +11875,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10858,7 +11906,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10889,7 +11937,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10920,7 +11968,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10951,7 +11999,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 65,
+        "line": 93,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -10982,7 +12030,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11013,7 +12061,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11044,7 +12092,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11075,7 +12123,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11106,7 +12154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11137,7 +12185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11168,7 +12216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11199,7 +12247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11230,7 +12278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11261,7 +12309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11292,7 +12340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11323,7 +12371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11354,7 +12402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11385,7 +12433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11416,7 +12464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11447,7 +12495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11478,7 +12526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11509,7 +12557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11540,7 +12588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11571,7 +12619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11602,7 +12650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11633,7 +12681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11664,7 +12712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11695,7 +12743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11726,7 +12774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11757,7 +12805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11788,7 +12836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11819,7 +12867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11850,7 +12898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11881,7 +12929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11912,7 +12960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11943,7 +12991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -11974,7 +13022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12005,7 +13053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_group_token",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12036,7 +13084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12067,7 +13115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12098,7 +13146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12129,7 +13177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12160,7 +13208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12191,7 +13239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12222,7 +13270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12253,7 +13301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12284,7 +13332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12315,7 +13363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12346,7 +13394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12377,7 +13425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12408,7 +13456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12439,7 +13487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12470,7 +13518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12501,7 +13549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12532,7 +13580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12563,7 +13611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12594,7 +13642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12625,7 +13673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12656,7 +13704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12687,7 +13735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12718,7 +13766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12749,7 +13797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12780,7 +13828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12811,7 +13859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12842,7 +13890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12873,7 +13921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12904,7 +13952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12935,7 +13983,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12966,7 +14014,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -12997,7 +14045,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13028,7 +14076,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13059,7 +14107,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13090,7 +14138,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13121,7 +14169,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13152,7 +14200,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13183,7 +14231,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13214,7 +14262,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13245,7 +14293,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13276,7 +14324,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13307,7 +14355,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13338,7 +14386,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13369,7 +14417,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 81,
+        "line": 109,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -13400,7 +14448,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 161,
+        "line": 189,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -13431,7 +14479,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 161,
+        "line": 189,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -13462,7 +14510,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 161,
+        "line": 189,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -13493,7 +14541,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 161,
+        "line": 189,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -13524,7 +14572,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 167,
+        "line": 195,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -13555,7 +14603,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 167,
+        "line": 195,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -13586,7 +14634,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 167,
+        "line": 195,
         "name": "_align_up",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -13617,7 +14665,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 167,
+        "line": 195,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -13648,7 +14696,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 167,
+        "line": 195,
         "name": "_alignment_value",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -13679,7 +14727,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 174,
+        "line": 202,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": ".easyuse_anima.image.detailer",
@@ -13710,7 +14758,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 177,
+        "line": 205,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -13741,7 +14789,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 177,
+        "line": 205,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -13772,7 +14820,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 177,
+        "line": 205,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -13803,7 +14851,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 177,
+        "line": 205,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -13834,7 +14882,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 177,
+        "line": 205,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -13865,7 +14913,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 177,
+        "line": 205,
         "name": "_scale_by_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -13896,7 +14944,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 185,
+        "line": 213,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -13927,7 +14975,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 185,
+        "line": 213,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -13958,7 +15006,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 185,
+        "line": 213,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -13989,7 +15037,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 185,
+        "line": 213,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -14020,7 +15068,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 185,
+        "line": 213,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -14051,7 +15099,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 185,
+        "line": 213,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -14082,7 +15130,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 185,
+        "line": 213,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -14113,7 +15161,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 194,
+        "line": 222,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -14144,7 +15192,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 194,
+        "line": 222,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -14175,7 +15223,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 194,
+        "line": 222,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -14206,7 +15254,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 199,
+        "line": 227,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -14237,7 +15285,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 199,
+        "line": 227,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -14268,7 +15316,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 199,
+        "line": 227,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -14299,7 +15347,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 199,
+        "line": 227,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -14330,7 +15378,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 199,
+        "line": 227,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -14361,7 +15409,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 199,
+        "line": 227,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -14392,7 +15440,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 207,
+        "line": 235,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -14423,7 +15471,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 207,
+        "line": 235,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -14454,7 +15502,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 211,
+        "line": 239,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -14485,7 +15533,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 211,
+        "line": 239,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -14516,7 +15564,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 211,
+        "line": 239,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -14547,7 +15595,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 211,
+        "line": 239,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -14578,7 +15626,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 211,
+        "line": 239,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -14586,6 +15634,99 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptStudioRegional",
+        "bound_name": "EasyUseAnimaPromptStudioRegional",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptStudioRegional",
+          "target": "easyuse_anima/nodes/regional_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
+        "kind": "static_from",
+        "line": 246,
+        "name": "EasyUseAnimaPromptStudioRegional",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.regional_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaRegionalConditioning",
+        "bound_name": "EasyUseAnimaRegionalConditioning",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaRegionalConditioning",
+          "target": "easyuse_anima/nodes/regional_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
+        "kind": "static_from",
+        "line": 246,
+        "name": "EasyUseAnimaRegionalConditioning",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.regional_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "alias": "_bind_regional_node_runtime",
+        "bound_name": "_bind_regional_node_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_regional_node_runtime",
+          "target": "easyuse_anima/nodes/regional_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
+        "kind": "static_from",
+        "line": 246,
+        "name": "_bind_regional_node_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.regional_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
       },
       {
         "alias": "DEFAULT_HOST",
@@ -14609,7 +15750,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14640,7 +15781,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14671,7 +15812,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14702,7 +15843,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14733,7 +15874,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14764,7 +15905,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14795,7 +15936,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14826,7 +15967,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "NAI_1MP",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14857,7 +15998,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14888,7 +16029,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14919,7 +16060,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14950,7 +16091,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "_clean_prompt",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -14981,7 +16122,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -15012,7 +16153,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -15043,7 +16184,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -15074,7 +16215,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 218,
+        "line": 251,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -15105,7 +16246,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15136,7 +16277,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15167,7 +16308,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15198,7 +16339,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15229,7 +16370,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15260,7 +16401,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15291,7 +16432,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15322,7 +16463,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15353,7 +16494,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15384,7 +16525,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15415,7 +16556,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15446,7 +16587,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15477,7 +16618,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15508,7 +16649,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15539,7 +16680,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15570,7 +16711,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15601,7 +16742,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15632,7 +16773,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15663,7 +16804,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15694,7 +16835,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15725,7 +16866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 236,
+        "line": 269,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -15756,7 +16897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 259,
+        "line": 292,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -15787,7 +16928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 259,
+        "line": 292,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -15818,7 +16959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 263,
+        "line": 296,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -15849,7 +16990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 263,
+        "line": 296,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -15880,7 +17021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 263,
+        "line": 296,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -15911,7 +17052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -15942,7 +17083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -15973,7 +17114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16004,7 +17145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16035,7 +17176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16066,7 +17207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16097,7 +17238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16128,7 +17269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16159,7 +17300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16190,7 +17331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16221,7 +17362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16252,7 +17393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16283,7 +17424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16314,7 +17455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16345,7 +17486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 268,
+        "line": 301,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -16376,7 +17517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16407,7 +17548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16438,7 +17579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16469,7 +17610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16500,7 +17641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16531,7 +17672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16562,7 +17703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16593,7 +17734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 285,
+        "line": 318,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -16624,7 +17765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 295,
+        "line": 328,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -16655,7 +17796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 295,
+        "line": 328,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -16686,7 +17827,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 299,
+        "line": 332,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -16717,7 +17858,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 299,
+        "line": 332,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -16748,7 +17889,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 300,
+        "line": 333,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -16779,7 +17920,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 301,
+        "line": 334,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -16810,7 +17951,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 301,
+        "line": 334,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -16841,7 +17982,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 301,
+        "line": 334,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -16872,7 +18013,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 306,
+        "line": 339,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -16903,7 +18044,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 306,
+        "line": 339,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -16934,7 +18075,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -16965,7 +18106,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -16996,7 +18137,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17027,7 +18168,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17058,7 +18199,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17089,7 +18230,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17120,7 +18261,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17151,7 +18292,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17182,7 +18323,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17213,7 +18354,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17244,7 +18385,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17275,7 +18416,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17306,7 +18447,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17337,7 +18478,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17368,7 +18509,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17399,7 +18540,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17430,7 +18571,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17461,7 +18602,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17492,7 +18633,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 307,
+        "line": 340,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -17511,7 +18652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17526,7 +18667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 329,
+        "line": 362,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -17545,7 +18686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17560,7 +18701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 329,
+        "line": 362,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -17579,7 +18720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17594,7 +18735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 329,
+        "line": 362,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -17613,7 +18754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17628,7 +18769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -17647,7 +18788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17662,7 +18803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -17681,7 +18822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17696,7 +18837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -17715,7 +18856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17730,7 +18871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -17749,7 +18890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17764,7 +18905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -17783,7 +18924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17798,7 +18939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -17817,7 +18958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17832,7 +18973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -17851,7 +18992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17866,7 +19007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -17885,7 +19026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17900,7 +19041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -17919,7 +19060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17934,7 +19075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -17953,7 +19094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -17968,7 +19109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -17987,7 +19128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18002,7 +19143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18021,7 +19162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18036,7 +19177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18055,7 +19196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18070,7 +19211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18089,7 +19230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18104,7 +19245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18123,7 +19264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18138,7 +19279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18157,7 +19298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18172,7 +19313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18191,7 +19332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18206,7 +19347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18225,7 +19366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18240,7 +19381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18259,7 +19400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18274,7 +19415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18293,7 +19434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18308,7 +19449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18327,7 +19468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18342,7 +19483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18361,7 +19502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18376,7 +19517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18395,7 +19536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18410,7 +19551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18429,7 +19570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18444,7 +19585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18463,7 +19604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18478,7 +19619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18497,7 +19638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18512,7 +19653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18531,7 +19672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18546,7 +19687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18565,7 +19706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18580,7 +19721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18599,7 +19740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18614,7 +19755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18633,7 +19774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18648,7 +19789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18667,7 +19808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18682,7 +19823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18701,7 +19842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18716,7 +19857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18735,7 +19876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18750,7 +19891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18769,7 +19910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18784,7 +19925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18803,7 +19944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18818,7 +19959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18837,7 +19978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18852,7 +19993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18860,6 +20001,890 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": "REGIONAL_CONFIG_VERSION",
+        "bound_name": "REGIONAL_CONFIG_VERSION",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_CONFIG_VERSION",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
+        "kind": "static_from",
+        "line": 412,
+        "name": "REGIONAL_CONFIG_VERSION",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "bound_name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 412,
+        "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "bound_name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 412,
+        "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_FIELD_TYPES",
+        "bound_name": "REGIONAL_FIELD_TYPES",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_FIELD_TYPES",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
+        "kind": "static_from",
+        "line": 412,
+        "name": "REGIONAL_FIELD_TYPES",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "bound_name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "kind": "static_from",
+        "line": 412,
+        "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_PROMPT_DATA_SCHEMA",
+        "bound_name": "REGIONAL_PROMPT_DATA_SCHEMA",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_PROMPT_DATA_SCHEMA",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
+        "kind": "static_from",
+        "line": 412,
+        "name": "REGIONAL_PROMPT_DATA_SCHEMA",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "REGIONAL_PROMPT_DATA_TYPE",
+        "bound_name": "REGIONAL_PROMPT_DATA_TYPE",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "REGIONAL_PROMPT_DATA_TYPE",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
+        "kind": "static_from",
+        "line": 412,
+        "name": "REGIONAL_PROMPT_DATA_TYPE",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_apply_regional_field_inputs",
+        "bound_name": "_apply_regional_field_inputs",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_regional_field_inputs",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_apply_regional_field_inputs",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_bind_regional_runtime",
+        "bound_name": "_bind_regional_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_regional_runtime",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_bind_regional_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_build_regional_outputs",
+        "bound_name": "_build_regional_outputs",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_build_regional_outputs",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_build_regional_outputs",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_clone_regional_fields",
+        "bound_name": "_clone_regional_fields",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_clone_regional_fields",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_clone_regional_fields",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_conditioning_set_values",
+        "bound_name": "_conditioning_set_values",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_conditioning_set_values",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_conditioning_set_values",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_mask_geometry",
+        "bound_name": "_normalize_mask_geometry",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_mask_geometry",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_normalize_mask_geometry",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_mask_ids",
+        "bound_name": "_normalize_mask_ids",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_mask_ids",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_normalize_mask_ids",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_regional_config",
+        "bound_name": "_normalize_regional_config",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_regional_config",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_normalize_regional_config",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_regional_fields",
+        "bound_name": "_normalize_regional_fields",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_regional_fields",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_normalize_regional_fields",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_normalize_regional_mask",
+        "bound_name": "_normalize_regional_mask",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_normalize_regional_mask",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_normalize_regional_mask",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_parse_json_object",
+        "bound_name": "_parse_json_object",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_parse_json_object",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_parse_json_object",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_parse_json_object",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_config_json",
+        "bound_name": "_regional_config_json",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_config_json",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_config_json",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_config_json",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_default_config",
+        "bound_name": "_regional_default_config",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_default_config",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_default_config",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_default_config",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_default_fields",
+        "bound_name": "_regional_default_fields",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_default_fields",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_default_fields",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_field_prompt",
+        "bound_name": "_regional_field_prompt",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_field_prompt",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_field_prompt",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_fields_json",
+        "bound_name": "_regional_fields_json",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_fields_json",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_fields_json",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_mask_bounds_area",
+        "bound_name": "_regional_mask_bounds_area",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_mask_bounds_area",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_mask_bounds_area",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_payload_canvas",
+        "bound_name": "_regional_payload_canvas",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_payload_canvas",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_payload_canvas",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "alias": "_regional_union_mask_for_ids",
+        "bound_name": "_regional_union_mask_for_ids",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_regional_union_mask_for_ids",
+          "target": "easyuse_anima/prompt/regional.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
+        "kind": "static_from",
+        "line": 412,
+        "name": "_regional_union_mask_for_ids",
+        "optional": false,
+        "requested": "easyuse_anima.prompt.regional",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
       },
       {
         "alias": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
@@ -18871,7 +20896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18886,7 +20911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -18905,7 +20930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18920,7 +20945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -18939,7 +20964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18954,7 +20979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -18973,7 +20998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -18988,7 +21013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19007,7 +21032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19022,7 +21047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19041,7 +21066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19056,7 +21081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19075,7 +21100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19090,7 +21115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19109,7 +21134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19124,7 +21149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19143,7 +21168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19158,7 +21183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19177,7 +21202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19192,7 +21217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19211,7 +21236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19226,7 +21251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19245,7 +21270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19260,7 +21285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19279,7 +21304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19294,7 +21319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19313,7 +21338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19328,7 +21353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19347,7 +21372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19362,7 +21387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19381,7 +21406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19396,7 +21421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19415,7 +21440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19430,7 +21455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19449,7 +21474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19464,7 +21489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19483,7 +21508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19498,7 +21523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19517,7 +21542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19532,7 +21557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19551,7 +21576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19566,7 +21591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19585,7 +21610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19600,7 +21625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19619,7 +21644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19634,7 +21659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19653,7 +21678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19668,7 +21693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19687,7 +21712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19702,7 +21727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19721,7 +21746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19736,7 +21761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19755,7 +21780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19770,7 +21795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19789,7 +21814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19804,7 +21829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19823,7 +21848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19838,7 +21863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19857,7 +21882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19872,7 +21897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19891,7 +21916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19906,7 +21931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19925,7 +21950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19940,7 +21965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19959,7 +21984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -19974,7 +21999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19993,7 +22018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20008,7 +22033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20027,7 +22052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20042,7 +22067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20061,7 +22086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20076,7 +22101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20095,7 +22120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20110,7 +22135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20129,7 +22154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20144,7 +22169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20163,7 +22188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20178,7 +22203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20197,7 +22222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20212,7 +22237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20231,7 +22256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20246,7 +22271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20265,7 +22290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20280,7 +22305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20299,7 +22324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20314,7 +22339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20333,7 +22358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20348,7 +22373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20367,7 +22392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20382,7 +22407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20401,7 +22426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20416,7 +22441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20435,7 +22460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20450,7 +22475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20469,7 +22494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20484,7 +22509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_group_token",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20503,7 +22528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20518,7 +22543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20537,7 +22562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20552,7 +22577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20571,7 +22596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20586,7 +22611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20605,7 +22630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20620,7 +22645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20639,7 +22664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20654,7 +22679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20673,7 +22698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20688,7 +22713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20707,7 +22732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20722,7 +22747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20741,7 +22766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20756,7 +22781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20775,7 +22800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20790,7 +22815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20809,7 +22834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20824,7 +22849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20843,7 +22868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20858,7 +22883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20877,7 +22902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20892,7 +22917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20911,7 +22936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20926,7 +22951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20945,7 +22970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20960,7 +22985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20979,7 +23004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -20994,7 +23019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21013,7 +23038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21028,7 +23053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21047,7 +23072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21062,7 +23087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21081,7 +23106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21096,7 +23121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21115,7 +23140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21130,7 +23155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21149,7 +23174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21164,7 +23189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21183,7 +23208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21198,7 +23223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21217,7 +23242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21232,7 +23257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21251,7 +23276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21266,7 +23291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21285,7 +23310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21300,7 +23325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21319,7 +23344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21334,7 +23359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21353,7 +23378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21368,7 +23393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21387,7 +23412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21402,7 +23427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21421,7 +23446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21436,7 +23461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21455,7 +23480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21470,7 +23495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21489,7 +23514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21504,7 +23529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21523,7 +23548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21538,7 +23563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21557,7 +23582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21572,7 +23597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21591,7 +23616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21606,7 +23631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21625,7 +23650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21640,7 +23665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21659,7 +23684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21674,7 +23699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21693,7 +23718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21708,7 +23733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21727,7 +23752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21742,7 +23767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21761,7 +23786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21776,7 +23801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21795,7 +23820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21810,7 +23835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21829,7 +23854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21844,7 +23869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21863,7 +23888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21878,7 +23903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21897,7 +23922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21912,7 +23937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21931,7 +23956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21946,7 +23971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21965,7 +23990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -21980,7 +24005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21999,7 +24024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22014,7 +24039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22033,7 +24058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22048,7 +24073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22067,7 +24092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22082,7 +24107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22101,7 +24126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22116,7 +24141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22135,7 +24160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22150,7 +24175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22169,7 +24194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22184,7 +24209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22203,7 +24228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22218,7 +24243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22237,7 +24262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22252,7 +24277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22271,7 +24296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22286,7 +24311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22305,7 +24330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22320,7 +24345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 488,
+        "line": 549,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -22339,7 +24364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22354,7 +24379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22373,7 +24398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22388,7 +24413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22407,7 +24432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22422,7 +24447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22441,7 +24466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22456,7 +24481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22475,7 +24500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22490,7 +24515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22509,7 +24534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22524,7 +24549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22543,7 +24568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22558,7 +24583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -22577,7 +24602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22592,7 +24617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -22611,7 +24636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22626,7 +24651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -22645,7 +24670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22660,7 +24685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -22679,7 +24704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22694,7 +24719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -22713,7 +24738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22728,7 +24753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -22747,7 +24772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22762,7 +24787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -22781,7 +24806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22796,7 +24821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 508,
+        "line": 569,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -22815,7 +24840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22830,7 +24855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 508,
+        "line": 569,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -22849,7 +24874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22864,7 +24889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 508,
+        "line": 569,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -22883,7 +24908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22898,7 +24923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -22917,7 +24942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22932,7 +24957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -22951,7 +24976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -22966,7 +24991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -22985,7 +25010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23000,7 +25025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23019,7 +25044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23034,7 +25059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23053,7 +25078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23068,7 +25093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23087,7 +25112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23102,7 +25127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 521,
+        "line": 582,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -23121,7 +25146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23136,7 +25161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 521,
+        "line": 582,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -23155,7 +25180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23170,7 +25195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23189,7 +25214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23204,7 +25229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23223,7 +25248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23238,7 +25263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23257,7 +25282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23272,7 +25297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23291,7 +25316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23306,7 +25331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23314,6 +25339,108 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/prompt_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaPromptStudioRegional",
+        "bound_name": "EasyUseAnimaPromptStudioRegional",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaPromptStudioRegional",
+          "target": "easyuse_anima/nodes/regional_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
+        "kind": "static_from",
+        "line": 593,
+        "name": "EasyUseAnimaPromptStudioRegional",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.regional_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaRegionalConditioning",
+        "bound_name": "EasyUseAnimaRegionalConditioning",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaRegionalConditioning",
+          "target": "easyuse_anima/nodes/regional_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
+        "kind": "static_from",
+        "line": 593,
+        "name": "EasyUseAnimaRegionalConditioning",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.regional_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "alias": "_bind_regional_node_runtime",
+        "bound_name": "_bind_regional_node_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_regional_node_runtime",
+          "target": "easyuse_anima/nodes/regional_nodes.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
+        "kind": "static_from",
+        "line": 593,
+        "name": "_bind_regional_node_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.regional_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
       },
       {
         "alias": "DEFAULT_HOST",
@@ -23325,7 +25452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23340,7 +25467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23359,7 +25486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23374,7 +25501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23393,7 +25520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23408,7 +25535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23427,7 +25554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23442,7 +25569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23461,7 +25588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23476,7 +25603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23495,7 +25622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23510,7 +25637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23529,7 +25656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23544,7 +25671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23563,7 +25690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23578,7 +25705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23597,7 +25724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23612,7 +25739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23631,7 +25758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23646,7 +25773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23665,7 +25792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23680,7 +25807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23699,7 +25826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23714,7 +25841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23733,7 +25860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23748,7 +25875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23767,7 +25894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23782,7 +25909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23801,7 +25928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23816,7 +25943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23835,7 +25962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23850,7 +25977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23869,7 +25996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23884,7 +26011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -23903,7 +26030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23918,7 +26045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -23937,7 +26064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23952,7 +26079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -23971,7 +26098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -23986,7 +26113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24005,7 +26132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24020,7 +26147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24039,7 +26166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24054,7 +26181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24073,7 +26200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24088,7 +26215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24107,7 +26234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24122,7 +26249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24141,7 +26268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24156,7 +26283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24175,7 +26302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24190,7 +26317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24209,7 +26336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24224,7 +26351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24243,7 +26370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24258,7 +26385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24277,7 +26404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24292,7 +26419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24311,7 +26438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24326,7 +26453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24345,7 +26472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24360,7 +26487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24379,7 +26506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24394,7 +26521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24413,7 +26540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24428,7 +26555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24447,7 +26574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24462,7 +26589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24481,7 +26608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24496,7 +26623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24515,7 +26642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24530,7 +26657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24549,7 +26676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24564,7 +26691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24583,7 +26710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24598,7 +26725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 573,
+        "line": 639,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -24617,7 +26744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24632,7 +26759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 639,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -24651,7 +26778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24666,7 +26793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 577,
+        "line": 643,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -24685,7 +26812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24700,7 +26827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 577,
+        "line": 643,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -24719,7 +26846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24734,7 +26861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 643,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -24753,7 +26880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24768,7 +26895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -24787,7 +26914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24802,7 +26929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -24821,7 +26948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24836,7 +26963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -24855,7 +26982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24870,7 +26997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -24889,7 +27016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24904,7 +27031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -24923,7 +27050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24938,7 +27065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -24957,7 +27084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -24972,7 +27099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -24991,7 +27118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25006,7 +27133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25025,7 +27152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25040,7 +27167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25059,7 +27186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25074,7 +27201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25093,7 +27220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25108,7 +27235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25127,7 +27254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25142,7 +27269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25161,7 +27288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25176,7 +27303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25195,7 +27322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25210,7 +27337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25229,7 +27356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25244,7 +27371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25263,7 +27390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25278,7 +27405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25297,7 +27424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25312,7 +27439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25331,7 +27458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25346,7 +27473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25365,7 +27492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25380,7 +27507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25399,7 +27526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25414,7 +27541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25433,7 +27560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25448,7 +27575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25467,7 +27594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25482,7 +27609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25501,7 +27628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25516,7 +27643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25535,7 +27662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25550,7 +27677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 609,
+        "line": 675,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -25569,7 +27696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25584,7 +27711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 675,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -25603,7 +27730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25618,7 +27745,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 613,
+        "line": 679,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -25637,7 +27764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25652,7 +27779,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 613,
+        "line": 679,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -25671,7 +27798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25686,7 +27813,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 614,
+        "line": 680,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -25705,7 +27832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25720,7 +27847,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 615,
+        "line": 681,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -25739,7 +27866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25754,7 +27881,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 615,
+        "line": 681,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -25773,7 +27900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25788,7 +27915,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 615,
+        "line": 681,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -25807,7 +27934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25822,7 +27949,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 620,
+        "line": 686,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -25841,7 +27968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25856,7 +27983,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 620,
+        "line": 686,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -25875,7 +28002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25890,7 +28017,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -25909,7 +28036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25924,7 +28051,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -25943,7 +28070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25958,7 +28085,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -25977,7 +28104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -25992,7 +28119,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26011,7 +28138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26026,7 +28153,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26045,7 +28172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26060,7 +28187,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26079,7 +28206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26094,7 +28221,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26113,7 +28240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26128,7 +28255,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26147,7 +28274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26162,7 +28289,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26181,7 +28308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26196,7 +28323,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26215,7 +28342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26230,7 +28357,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26249,7 +28376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26264,7 +28391,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26283,7 +28410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26298,7 +28425,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26317,7 +28444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26332,7 +28459,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26351,7 +28478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26366,7 +28493,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26385,7 +28512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26400,7 +28527,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26419,7 +28546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26434,7 +28561,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26453,7 +28580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26468,7 +28595,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26487,7 +28614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -26502,7 +28629,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26520,7 +28647,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2193
+            "line": 2252
           }
         ],
         "classification": "external",
@@ -26528,7 +28655,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2194,
+        "line": 2253,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -26545,7 +28672,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2258
+            "line": 2317
           }
         ],
         "classification": "external",
@@ -26553,7 +28680,7 @@
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2259,
+        "line": 2318,
         "name": null,
         "optional": true,
         "requested": "impact.core",
@@ -26570,7 +28697,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2264
+            "line": 2323
           }
         ],
         "classification": "external",
@@ -26578,7 +28705,7 @@
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2265,
+        "line": 2324,
         "name": "core",
         "optional": true,
         "requested": "modules.impact",
@@ -26595,7 +28722,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2280
+            "line": 2339
           }
         ],
         "classification": "external",
@@ -26603,7 +28730,7 @@
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2281,
+        "line": 2340,
         "name": null,
         "optional": true,
         "requested": "comfy.samplers",
@@ -26620,7 +28747,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2289
+            "line": 2348
           }
         ],
         "classification": "external",
@@ -26628,7 +28755,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2290,
+        "line": 2349,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -26645,7 +28772,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2305
+            "line": 2364
           }
         ],
         "classification": "external",
@@ -26653,7 +28780,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2306,
+        "line": 2365,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -26670,7 +28797,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2311
+            "line": 2370
           }
         ],
         "classification": "external",
@@ -26678,7 +28805,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2312,
+        "line": 2371,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -26695,7 +28822,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2325
+            "line": 2384
           }
         ],
         "classification": "external",
@@ -26703,7 +28830,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2326,
+        "line": 2385,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -26720,7 +28847,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2424
+            "line": 2483
           }
         ],
         "classification": "external",
@@ -26728,7 +28855,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2425,
+        "line": 2484,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
@@ -26745,7 +28872,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2448
+            "line": 2507
           }
         ],
         "classification": "external",
@@ -26753,7 +28880,7 @@
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2449,
+        "line": 2508,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.segs_nodes",
@@ -26770,7 +28897,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2454
+            "line": 2513
           }
         ],
         "classification": "external",
@@ -26778,7 +28905,7 @@
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2455,
+        "line": 2514,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.segs_nodes",
@@ -26795,7 +28922,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2460
+            "line": 2519
           }
         ],
         "classification": "external",
@@ -26803,7 +28930,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2461,
+        "line": 2520,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -26820,7 +28947,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2466
+            "line": 2525
           }
         ],
         "classification": "external",
@@ -26828,7 +28955,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2467,
+        "line": 2526,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -26845,7 +28972,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2804
+            "line": 2863
           }
         ],
         "classification": "external",
@@ -26853,7 +28980,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2805,
+        "line": 2864,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -26870,7 +28997,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2844
+            "line": 2903
           }
         ],
         "classification": "external",
@@ -26878,7 +29005,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2845,
+        "line": 2904,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -26893,7 +29020,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3277,
+            "line": 3336,
             "type_checking": false
           },
           {
@@ -26901,7 +29028,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3278
+            "line": 3337
           }
         ],
         "classification": "external",
@@ -26909,7 +29036,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3279,
+        "line": 3338,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -26926,7 +29053,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4137
           }
         ],
         "classification": "external",
@@ -26934,7 +29061,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4079,
+        "line": 4138,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -26951,7 +29078,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4140
+            "line": 4199
           }
         ],
         "classification": "external",
@@ -26959,7 +29086,7 @@
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4141,
+        "line": 4200,
         "name": "PromptServer",
         "optional": true,
         "requested": "server",
@@ -26976,7 +29103,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
@@ -26984,7 +29111,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4168,
+        "line": 4227,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -27001,7 +29128,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
@@ -27009,7 +29136,7 @@
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4169,
+        "line": 4228,
         "name": null,
         "optional": true,
         "requested": "numpy",
@@ -27026,7 +29153,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
@@ -27034,7 +29161,7 @@
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4170,
+        "line": 4229,
         "name": "Image",
         "optional": true,
         "requested": "PIL",
@@ -27051,7 +29178,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4361
+            "line": 4420
           }
         ],
         "classification": "external",
@@ -27059,62 +29186,12 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4362,
+        "line": 4421,
         "name": null,
         "optional": true,
         "requested": "torch",
         "role": "optional_dependency",
         "scope": "_empty_mask_for_image",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "torch",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 5510
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5511,
-        "name": null,
-        "optional": true,
-        "requested": "torch",
-        "role": "optional_dependency",
-        "scope": "_regional_union_mask_for_ids",
-        "source": "nodes.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "torch",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 5544
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5545,
-        "name": null,
-        "optional": true,
-        "requested": "torch",
-        "role": "optional_dependency",
-        "scope": "_regional_mask_bounds_area",
         "source": "nodes.py"
       },
       {
@@ -28827,6 +30904,14 @@
         "to": "settings.py"
       },
       {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/regional_nodes.py",
+        "to": "easyuse_anima/prompt/regional.py"
+      },
+      {
         "from": "easyuse_anima/nodes/wildcard_nodes.py",
         "to": "easyuse_anima/common/serialization.py"
       },
@@ -28952,6 +31037,10 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
@@ -28973,6 +31062,10 @@
       {
         "from": "nodes.py",
         "to": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/prompt/regional.py"
       },
       {
         "from": "nodes.py",
@@ -29245,6 +31338,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/nodes/regional_nodes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/nodes/wildcard_nodes.py"
         ]
       },
@@ -29305,6 +31404,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/prompt/regional.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "nodes.py"
         ]
       },
@@ -29335,7 +31440,7 @@
     ]
   },
   "inventory": {
-    "module_count": 53,
+    "module_count": 55,
     "modules": [
       {
         "is_package": true,
@@ -29795,6 +31900,18 @@
       },
       {
         "is_package": false,
+        "loc": 569,
+        "module": "easyuse_anima.nodes.regional_nodes",
+        "normalized_git_blob_sha1": "e471ddb34eddaf21afad4921cfb59799d038f9f4",
+        "path": "easyuse_anima/nodes/regional_nodes.py",
+        "top_level": {
+          "class_count": 3,
+          "function_count": 2,
+          "global_count": 42
+        }
+      },
+      {
+        "is_package": false,
         "loc": 259,
         "module": "easyuse_anima.nodes.wildcard_nodes",
         "normalized_git_blob_sha1": "165137535f108fa23574497e362c6ba3d3286fc4",
@@ -29915,14 +32032,26 @@
       },
       {
         "is_package": false,
-        "loc": 8283,
+        "loc": 586,
+        "module": "easyuse_anima.prompt.regional",
+        "normalized_git_blob_sha1": "9c170e8906905c204b876861faa26f8661a53363",
+        "path": "easyuse_anima/prompt/regional.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 20,
+          "global_count": 23
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 7419,
         "module": "nodes",
-        "normalized_git_blob_sha1": "9f98bc738d3e88d8c08455f096ec512aff6ea8b0",
+        "normalized_git_blob_sha1": "c6a41def5246e8889bb6846c002c5a1fee755009",
         "path": "nodes.py",
         "top_level": {
-          "class_count": 12,
-          "function_count": 150,
-          "global_count": 56
+          "class_count": 10,
+          "function_count": 132,
+          "global_count": 49
         }
       },
       {
@@ -31225,7 +33354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31234,7 +33363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 329,
+        "line": 362,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31248,7 +33377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31257,7 +33386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 329,
+        "line": 362,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31271,7 +33400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31280,7 +33409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 329,
+        "line": 362,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31294,7 +33423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31303,7 +33432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31317,7 +33446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31326,7 +33455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31340,7 +33469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31349,7 +33478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31363,7 +33492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31372,7 +33501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31386,7 +33515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31395,7 +33524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 334,
+        "line": 367,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31409,7 +33538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31418,7 +33547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31432,7 +33561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31441,7 +33570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31455,7 +33584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31464,7 +33593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31478,7 +33607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31487,7 +33616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 341,
+        "line": 374,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31501,7 +33630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31510,7 +33639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31524,7 +33653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31533,7 +33662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31547,7 +33676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31556,7 +33685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31570,7 +33699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31579,7 +33708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31593,7 +33722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31602,7 +33731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31616,7 +33745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31625,7 +33754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31639,7 +33768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31648,7 +33777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31662,7 +33791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31671,7 +33800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31685,7 +33814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31694,7 +33823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31708,7 +33837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31717,7 +33846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31731,7 +33860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31740,7 +33869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31754,7 +33883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31763,7 +33892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 347,
+        "line": 380,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31777,7 +33906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31786,7 +33915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31800,7 +33929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31809,7 +33938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31823,7 +33952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31832,7 +33961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31846,7 +33975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31855,7 +33984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31869,7 +33998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31878,7 +34007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31892,7 +34021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31901,7 +34030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31915,7 +34044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31924,7 +34053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31938,7 +34067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31947,7 +34076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31961,7 +34090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31970,7 +34099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31984,7 +34113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -31993,7 +34122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32007,7 +34136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32016,7 +34145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32030,7 +34159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32039,7 +34168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32053,7 +34182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32062,7 +34191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32076,7 +34205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32085,7 +34214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32099,7 +34228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32108,7 +34237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32122,7 +34251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32131,7 +34260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 361,
+        "line": 394,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32145,7 +34274,605 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_parse_json_object",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_config_json",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_default_config",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
+        "kind": "static_from",
+        "line": 412,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32154,7 +34881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32168,7 +34895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32177,7 +34904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32191,7 +34918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32200,7 +34927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32214,7 +34941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32223,7 +34950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32237,7 +34964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32246,7 +34973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32260,7 +34987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32269,7 +34996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32283,7 +35010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32292,7 +35019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32306,7 +35033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32315,7 +35042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32329,7 +35056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32338,7 +35065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32352,7 +35079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32361,7 +35088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32375,7 +35102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32384,7 +35111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32398,7 +35125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32407,7 +35134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32421,7 +35148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32430,7 +35157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32444,7 +35171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32453,7 +35180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 379,
+        "line": 440,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32467,7 +35194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32476,7 +35203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32490,7 +35217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32499,7 +35226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32513,7 +35240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32522,7 +35249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32536,7 +35263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32545,7 +35272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32559,7 +35286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32568,7 +35295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32582,7 +35309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32591,7 +35318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32605,7 +35332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32614,7 +35341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32628,7 +35355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32637,7 +35364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32651,7 +35378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32660,7 +35387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32674,7 +35401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32683,7 +35410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32697,7 +35424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32706,7 +35433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32720,7 +35447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32729,7 +35456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32743,7 +35470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32752,7 +35479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32766,7 +35493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32775,7 +35502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32789,7 +35516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32798,7 +35525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32812,7 +35539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32821,7 +35548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32835,7 +35562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32844,7 +35571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32858,7 +35585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32867,7 +35594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32881,7 +35608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32890,7 +35617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32904,7 +35631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32913,7 +35640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32927,7 +35654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32936,7 +35663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32950,7 +35677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32959,7 +35686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32973,7 +35700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -32982,7 +35709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32996,7 +35723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33005,7 +35732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33019,7 +35746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33028,7 +35755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33042,7 +35769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33051,7 +35778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33065,7 +35792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33074,7 +35801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33088,7 +35815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33097,7 +35824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33111,7 +35838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33120,7 +35847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33134,7 +35861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33143,7 +35870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33157,7 +35884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33166,7 +35893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33180,7 +35907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33189,7 +35916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33203,7 +35930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33212,7 +35939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33226,7 +35953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33235,7 +35962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33249,7 +35976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33258,7 +35985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33272,7 +35999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33281,7 +36008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33295,7 +36022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33304,7 +36031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33318,7 +36045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33327,7 +36054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33341,7 +36068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33350,7 +36077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33364,7 +36091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33373,7 +36100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33387,7 +36114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33396,7 +36123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33410,7 +36137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33419,7 +36146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33433,7 +36160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33442,7 +36169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33456,7 +36183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33465,7 +36192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33479,7 +36206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33488,7 +36215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33502,7 +36229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33511,7 +36238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33525,7 +36252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33534,7 +36261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33548,7 +36275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33557,7 +36284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33571,7 +36298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33580,7 +36307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33594,7 +36321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33603,7 +36330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33617,7 +36344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33626,7 +36353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33640,7 +36367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33649,7 +36376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33663,7 +36390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33672,7 +36399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33686,7 +36413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33695,7 +36422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33709,7 +36436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33718,7 +36445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33732,7 +36459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33741,7 +36468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33755,7 +36482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33764,7 +36491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33778,7 +36505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33787,7 +36514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33801,7 +36528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33810,7 +36537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33824,7 +36551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33833,7 +36560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33847,7 +36574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33856,7 +36583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33870,7 +36597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33879,7 +36606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33893,7 +36620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33902,7 +36629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33916,7 +36643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33925,7 +36652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33939,7 +36666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33948,7 +36675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33962,7 +36689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33971,7 +36698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33985,7 +36712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -33994,7 +36721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34008,7 +36735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34017,7 +36744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34031,7 +36758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34040,7 +36767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34054,7 +36781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34063,7 +36790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34077,7 +36804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34086,7 +36813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34100,7 +36827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34109,7 +36836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34123,7 +36850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34132,7 +36859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34146,7 +36873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34155,7 +36882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34169,7 +36896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34178,7 +36905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34192,7 +36919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34201,7 +36928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34215,7 +36942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34224,7 +36951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34238,7 +36965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34247,7 +36974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 395,
+        "line": 456,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34261,7 +36988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34270,7 +36997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34284,7 +37011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34293,7 +37020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34307,7 +37034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34316,7 +37043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34330,7 +37057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34339,7 +37066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 475,
+        "line": 536,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34353,7 +37080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34362,7 +37089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34376,7 +37103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34385,7 +37112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34399,7 +37126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34408,7 +37135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34422,7 +37149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34431,7 +37158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34445,7 +37172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34454,7 +37181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 481,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34468,7 +37195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34477,7 +37204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 488,
+        "line": 549,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34491,7 +37218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34500,7 +37227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34514,7 +37241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34523,7 +37250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34537,7 +37264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34546,7 +37273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34560,7 +37287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34569,7 +37296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34583,7 +37310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34592,7 +37319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34606,7 +37333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34615,7 +37342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 491,
+        "line": 552,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34629,7 +37356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34638,7 +37365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34652,7 +37379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34661,7 +37388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34675,7 +37402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34684,7 +37411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34698,7 +37425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34707,7 +37434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34721,7 +37448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34730,7 +37457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34744,7 +37471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34753,7 +37480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34767,7 +37494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34776,7 +37503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 499,
+        "line": 560,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34790,7 +37517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34799,7 +37526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 508,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34813,7 +37540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34822,7 +37549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 508,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34836,7 +37563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34845,7 +37572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 508,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34859,7 +37586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34868,7 +37595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34882,7 +37609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34891,7 +37618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34905,7 +37632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34914,7 +37641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34928,7 +37655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34937,7 +37664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34951,7 +37678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34960,7 +37687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34974,7 +37701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -34983,7 +37710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 513,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34997,7 +37724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35006,7 +37733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 521,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35020,7 +37747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35029,7 +37756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 521,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35043,7 +37770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35052,7 +37779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35066,7 +37793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35075,7 +37802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35089,7 +37816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35098,7 +37825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35112,7 +37839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35121,7 +37848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35135,7 +37862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35144,7 +37871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35158,7 +37885,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
+        "kind": "static_from",
+        "line": 593,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
+        "kind": "static_from",
+        "line": 593,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
+        "kind": "static_from",
+        "line": 593,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35167,7 +37963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35181,7 +37977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35190,7 +37986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35204,7 +38000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35213,7 +38009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35227,7 +38023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35236,7 +38032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35250,7 +38046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35259,7 +38055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35273,7 +38069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35282,7 +38078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35296,7 +38092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35305,7 +38101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35319,7 +38115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35328,7 +38124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35342,7 +38138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35351,7 +38147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35365,7 +38161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35374,7 +38170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35388,7 +38184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35397,7 +38193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35411,7 +38207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35420,7 +38216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35434,7 +38230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35443,7 +38239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35457,7 +38253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35466,7 +38262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35480,7 +38276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35489,7 +38285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35503,7 +38299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35512,7 +38308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 532,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35526,7 +38322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35535,7 +38331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35549,7 +38345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35558,7 +38354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35572,7 +38368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35581,7 +38377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35595,7 +38391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35604,7 +38400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35618,7 +38414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35627,7 +38423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35641,7 +38437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35650,7 +38446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35664,7 +38460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35673,7 +38469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35687,7 +38483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35696,7 +38492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35710,7 +38506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35719,7 +38515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35733,7 +38529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35742,7 +38538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35756,7 +38552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35765,7 +38561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35779,7 +38575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35788,7 +38584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35802,7 +38598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35811,7 +38607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35825,7 +38621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35834,7 +38630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35848,7 +38644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35857,7 +38653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35871,7 +38667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35880,7 +38676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35894,7 +38690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35903,7 +38699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35917,7 +38713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35926,7 +38722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35940,7 +38736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35949,7 +38745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35963,7 +38759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35972,7 +38768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35986,7 +38782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -35995,7 +38791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 550,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36009,7 +38805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36018,7 +38814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 573,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36032,7 +38828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36041,7 +38837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36055,7 +38851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36064,7 +38860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 577,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36078,7 +38874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36087,7 +38883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 577,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36101,7 +38897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36110,7 +38906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36124,7 +38920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36133,7 +38929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36147,7 +38943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36156,7 +38952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36170,7 +38966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36179,7 +38975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36193,7 +38989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36202,7 +38998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36216,7 +39012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36225,7 +39021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36239,7 +39035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36248,7 +39044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36262,7 +39058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36271,7 +39067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36285,7 +39081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36294,7 +39090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36308,7 +39104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36317,7 +39113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36331,7 +39127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36340,7 +39136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36354,7 +39150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36363,7 +39159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36377,7 +39173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36386,7 +39182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36400,7 +39196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36409,7 +39205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36423,7 +39219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36432,7 +39228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36446,7 +39242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36455,7 +39251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 582,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36469,7 +39265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36478,7 +39274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36492,7 +39288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36501,7 +39297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36515,7 +39311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36524,7 +39320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36538,7 +39334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36547,7 +39343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36561,7 +39357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36570,7 +39366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36584,7 +39380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36593,7 +39389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36607,7 +39403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36616,7 +39412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36630,7 +39426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36639,7 +39435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 599,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36653,7 +39449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36662,7 +39458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 609,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36676,7 +39472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36685,7 +39481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36699,7 +39495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36708,7 +39504,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 613,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36722,7 +39518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36731,7 +39527,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 613,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36745,7 +39541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36754,7 +39550,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 614,
+        "line": 680,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36768,7 +39564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36777,7 +39573,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 615,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36791,7 +39587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36800,7 +39596,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 615,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36814,7 +39610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36823,7 +39619,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 615,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36837,7 +39633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36846,7 +39642,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 620,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36860,7 +39656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36869,7 +39665,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 620,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36883,7 +39679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36892,7 +39688,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36906,7 +39702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36915,7 +39711,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36929,7 +39725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36938,7 +39734,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36952,7 +39748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36961,7 +39757,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36975,7 +39771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -36984,7 +39780,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36998,7 +39794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37007,7 +39803,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37021,7 +39817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37030,7 +39826,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37044,7 +39840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37053,7 +39849,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37067,7 +39863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37076,7 +39872,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37090,7 +39886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37099,7 +39895,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37113,7 +39909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37122,7 +39918,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37136,7 +39932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37145,7 +39941,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37159,7 +39955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37168,7 +39964,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37182,7 +39978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37191,7 +39987,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37205,7 +40001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37214,7 +40010,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37228,7 +40024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37237,7 +40033,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37251,7 +40047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37260,7 +40056,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37274,7 +40070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37283,7 +40079,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37297,7 +40093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 328,
+            "handler_line": 361,
             "kind": "try",
             "line": 14
           }
@@ -37306,7 +40102,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 621,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -39051,6 +41847,28 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/regional_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/nodes/wildcard_nodes.py"
       },
       {
@@ -39429,6 +42247,88 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "json",
+        "kind": "static_import",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "re",
+        "kind": "static_import",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 509
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 510,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 547
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 548,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 2,
         "optional": false,
         "role": "ordinary",
@@ -39573,14 +42473,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2193
+            "line": 2252
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2194,
+        "line": 2253,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39592,14 +42492,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2258
+            "line": 2317
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2259,
+        "line": 2318,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39611,14 +42511,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2264
+            "line": 2323
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2265,
+        "line": 2324,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39630,14 +42530,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2280
+            "line": 2339
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2281,
+        "line": 2340,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39649,14 +42549,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2289
+            "line": 2348
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2290,
+        "line": 2349,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39668,14 +42568,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2305
+            "line": 2364
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2306,
+        "line": 2365,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39687,14 +42587,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2311
+            "line": 2370
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2312,
+        "line": 2371,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39706,14 +42606,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2325
+            "line": 2384
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2326,
+        "line": 2385,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39725,14 +42625,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2424
+            "line": 2483
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2425,
+        "line": 2484,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39744,14 +42644,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2448
+            "line": 2507
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2449,
+        "line": 2508,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39763,14 +42663,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2454
+            "line": 2513
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2455,
+        "line": 2514,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39782,14 +42682,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2460
+            "line": 2519
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2461,
+        "line": 2520,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39801,14 +42701,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2466
+            "line": 2525
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2467,
+        "line": 2526,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39820,14 +42720,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2804
+            "line": 2863
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2805,
+        "line": 2864,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39839,14 +42739,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2844
+            "line": 2903
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2845,
+        "line": 2904,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39856,7 +42756,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3277,
+            "line": 3336,
             "type_checking": false
           },
           {
@@ -39864,14 +42764,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3278
+            "line": 3337
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3279,
+        "line": 3338,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39883,14 +42783,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4137
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4079,
+        "line": 4138,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39902,14 +42802,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4140
+            "line": 4199
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4141,
+        "line": 4200,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39921,14 +42821,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4168,
+        "line": 4227,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39940,14 +42840,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4169,
+        "line": 4228,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39959,14 +42859,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4170,
+        "line": 4229,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -39978,52 +42878,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4361
+            "line": 4420
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4362,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 5510
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5511,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 5544
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5545,
+        "line": 4421,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40993,14 +43855,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2193
+            "line": 509
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 510,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 547
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 548,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2252
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2194,
+        "line": 2253,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41012,14 +43912,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2258
+            "line": 2317
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2259,
+        "line": 2318,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41031,14 +43931,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2264
+            "line": 2323
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2265,
+        "line": 2324,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41050,14 +43950,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2280
+            "line": 2339
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2281,
+        "line": 2340,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41069,14 +43969,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2289
+            "line": 2348
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2290,
+        "line": 2349,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41088,14 +43988,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2305
+            "line": 2364
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2306,
+        "line": 2365,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41107,14 +44007,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2311
+            "line": 2370
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2312,
+        "line": 2371,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41126,14 +44026,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2325
+            "line": 2384
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2326,
+        "line": 2385,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41145,14 +44045,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2424
+            "line": 2483
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2425,
+        "line": 2484,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41164,14 +44064,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2448
+            "line": 2507
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2449,
+        "line": 2508,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41183,14 +44083,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2454
+            "line": 2513
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2455,
+        "line": 2514,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41202,14 +44102,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2460
+            "line": 2519
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2461,
+        "line": 2520,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41221,14 +44121,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2466
+            "line": 2525
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2467,
+        "line": 2526,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41240,14 +44140,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2804
+            "line": 2863
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2805,
+        "line": 2864,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41259,14 +44159,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2844
+            "line": 2903
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2845,
+        "line": 2904,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41276,7 +44176,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3277,
+            "line": 3336,
             "type_checking": false
           },
           {
@@ -41284,14 +44184,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3278
+            "line": 3337
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3279,
+        "line": 3338,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41303,14 +44203,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4078
+            "line": 4137
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4079,
+        "line": 4138,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41322,14 +44222,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4140
+            "line": 4199
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4141,
+        "line": 4200,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41341,14 +44241,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4168,
+        "line": 4227,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41360,14 +44260,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4169,
+        "line": 4228,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41379,14 +44279,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4167
+            "line": 4226
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4170,
+        "line": 4229,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41398,52 +44298,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4361
+            "line": 4420
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4362,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 5510
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5511,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 5544
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5545,
+        "line": 4421,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41583,6 +44445,7 @@
       "easyuse_anima/nodes/naia_nodes.py",
       "easyuse_anima/nodes/prompt_data_nodes.py",
       "easyuse_anima/nodes/prompt_nodes.py",
+      "easyuse_anima/nodes/regional_nodes.py",
       "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
@@ -41593,6 +44456,7 @@
       "easyuse_anima/prompt/correction.py",
       "easyuse_anima/prompt/data.py",
       "easyuse_anima/prompt/fields.py",
+      "easyuse_anima/prompt/regional.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -41638,6 +44502,7 @@
       "easyuse_anima/nodes/naia_nodes.py",
       "easyuse_anima/nodes/prompt_data_nodes.py",
       "easyuse_anima/nodes/prompt_nodes.py",
+      "easyuse_anima/nodes/regional_nodes.py",
       "easyuse_anima/nodes/wildcard_nodes.py",
       "easyuse_anima/profiles/__init__.py",
       "easyuse_anima/profiles/contract.py",
@@ -41648,6 +44513,7 @@
       "easyuse_anima/prompt/correction.py",
       "easyuse_anima/prompt/data.py",
       "easyuse_anima/prompt/fields.py",
+      "easyuse_anima/prompt/regional.py",
       "nodes.py",
       "prompt_translation.py",
       "settings.py",
@@ -42476,7 +45342,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 643,
+        "line": 709,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42485,7 +45351,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 1194,
+        "line": 1253,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42494,7 +45360,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1213,
+        "line": 1272,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42503,7 +45369,25 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1393,
+        "line": 1452,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_regional_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 5267,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_regional_node_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 5270,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42512,7 +45396,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5719,
+        "line": 5274,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42521,7 +45405,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5723,
+        "line": 5278,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42530,7 +45414,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5726,
+        "line": 5281,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42539,7 +45423,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5729,
+        "line": 5284,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42548,7 +45432,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5732,
+        "line": 5287,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42557,7 +45441,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5735,
+        "line": 5290,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42566,7 +45450,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5738,
+        "line": 5293,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42575,7 +45459,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5745,
+        "line": 5300,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42584,7 +45468,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5751,
+        "line": 5306,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42593,7 +45477,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5756,
+        "line": 5311,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -42602,7 +45486,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5760,
+        "line": 5315,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43014,85 +45898,97 @@
       },
       {
         "kind": "dict",
-        "line": 647,
+        "line": 19,
+        "module": "easyuse_anima/prompt/regional.py",
+        "name": "ADVANCED_FIELD_LABELS"
+      },
+      {
+        "kind": "set",
+        "line": 18,
+        "module": "easyuse_anima/prompt/regional.py",
+        "name": "ADVANCED_FIELD_PANES"
+      },
+      {
+        "kind": "set",
+        "line": 12,
+        "module": "easyuse_anima/prompt/regional.py",
+        "name": "REGIONAL_FIELD_TYPES"
+      },
+      {
+        "kind": "dict",
+        "line": 713,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 646,
+        "line": 712,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 645,
+        "line": 711,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "dict",
-        "line": 743,
+        "line": 805,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 732,
+        "line": 794,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 4050,
+        "line": 4109,
         "module": "nodes.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
         "kind": "set",
-        "line": 727,
+        "line": 789,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "list",
-        "line": 1164,
+        "line": 1223,
         "module": "nodes.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 667,
+        "line": 733,
         "module": "nodes.py",
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES"
       },
       {
         "kind": "dict",
-        "line": 657,
+        "line": 723,
         "module": "nodes.py",
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES"
       },
       {
         "kind": "set",
-        "line": 675,
-        "module": "nodes.py",
-        "name": "REGIONAL_FIELD_TYPES"
-      },
-      {
-        "kind": "set",
-        "line": 1392,
+        "line": 1451,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
       {
         "kind": "dict",
-        "line": 4063,
+        "line": 4122,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 4064,
+        "line": 4123,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -43285,7 +46181,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 4063,
+        "line": 4122,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -43295,7 +46191,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 4064,
+        "line": 4123,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,11 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "9f98bc738d3e88d8c08455f096ec512aff6ea8b0")
-        # Prompt Studio preserves source fields and separates wildcard mode from seed control.
-        self.assertEqual(report["top_level"]["function_count"], 150)
-        self.assertEqual(report["top_level"]["class_count"], 12)
-        self.assertEqual(report["line_count"], 8_283)
+        self.assertEqual(report["git_blob_sha1"], "c6a41def5246e8889bb6846c002c5a1fee755009")
+        # Issue #184 B-07d moved the Regional Prompt Studio vertical slice while
+        # preserving the current Prompt Studio wildcard seed-control contract.
+        self.assertEqual(report["top_level"]["function_count"], 132)
+        self.assertEqual(report["top_level"]["class_count"], 10)
+        self.assertEqual(report["line_count"], 7_419)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)
@@ -90,6 +91,8 @@ def load_dynamic():
         self.assertNotIn("EasyUseAnimaPromptCorrectorSimple", class_names)
         self.assertNotIn("EasyUseAnimaPromptBuilder", class_names)
         self.assertNotIn("EasyUseAnimaPromptStudio", class_names)
+        self.assertNotIn("EasyUseAnimaPromptStudioRegional", class_names)
+        self.assertNotIn("EasyUseAnimaRegionalConditioning", class_names)
         self.assertNotIn("EasyUseAnimaPromptDataUnpack", class_names)
         self.assertNotIn("EasyUseAnimaArtistMixConditioning", class_names)
         self.assertNotIn("EasyUseAnimaPromptDataConditioning", class_names)

--- a/tests/test_prompt_studio_regional.py
+++ b/tests/test_prompt_studio_regional.py
@@ -5,6 +5,8 @@ import unittest
 from unittest.mock import patch
 
 import nodes as easy_nodes
+from easyuse_anima.nodes import regional_nodes
+from easyuse_anima.prompt import regional as regional_service
 from nodes import (
     EasyUseAnimaRegionalConditioning,
     EasyUseAnimaPromptStudioRegional,
@@ -15,6 +17,24 @@ from nodes import (
 
 
 class PromptStudioRegionalTests(unittest.TestCase):
+    def test_root_exports_are_canonical_regional_identities(self):
+        self.assertIs(
+            EasyUseAnimaPromptStudioRegional,
+            regional_nodes.EasyUseAnimaPromptStudioRegional,
+        )
+        self.assertIs(
+            EasyUseAnimaRegionalConditioning,
+            regional_nodes.EasyUseAnimaRegionalConditioning,
+        )
+        self.assertIs(
+            easy_nodes._normalize_regional_fields,
+            regional_service._normalize_regional_fields,
+        )
+        self.assertIs(
+            easy_nodes._build_regional_outputs,
+            regional_service._build_regional_outputs,
+        )
+
     def test_defaults_return_global_prompts_and_regional_payload(self):
         result = EasyUseAnimaPromptStudioRegional().build(
             "",

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 53)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 53)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 52)
+        self.assertEqual(report["inventory"]["module_count"], 55)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 55)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 54)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(
             report["registry"]["unreachable_shipped_python_modules"],
@@ -721,6 +721,7 @@ ignored/
                 "easyuse_anima/nodes/naia_nodes.py",
                 "easyuse_anima/nodes/prompt_data_nodes.py",
                 "easyuse_anima/nodes/prompt_nodes.py",
+                "easyuse_anima/nodes/regional_nodes.py",
                 "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
@@ -731,6 +732,7 @@ ignored/
                 "easyuse_anima/prompt/conditioning.py",
                 "easyuse_anima/prompt/data.py",
                 "easyuse_anima/prompt/fields.py",
+                "easyuse_anima/prompt/regional.py",
             }.issubset(report["registry"]["shipped_python_modules"])
         )
         self.assertIn("nodes.py", report["registry"]["shipped_python_modules"])
@@ -756,6 +758,7 @@ ignored/
                 "easyuse_anima/nodes/naia_nodes.py",
                 "easyuse_anima/nodes/prompt_data_nodes.py",
                 "easyuse_anima/nodes/prompt_nodes.py",
+                "easyuse_anima/nodes/regional_nodes.py",
                 "easyuse_anima/nodes/wildcard_nodes.py",
                 "easyuse_anima/prompt/__init__.py",
                 "easyuse_anima/prompt/correction.py",
@@ -763,6 +766,7 @@ ignored/
                 "easyuse_anima/prompt/conditioning.py",
                 "easyuse_anima/prompt/data.py",
                 "easyuse_anima/prompt/fields.py",
+                "easyuse_anima/prompt/regional.py",
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -25,6 +25,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.naia",
     "easyuse_anima.nodes",
     "easyuse_anima.nodes.prompt_data_nodes",
+    "easyuse_anima.nodes.regional_nodes",
     "easyuse_anima.profiles",
     "easyuse_anima.profiles.contract",
     "easyuse_anima.profiles.mutation",
@@ -32,6 +33,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.prompt.artist_mix",
     "easyuse_anima.prompt.conditioning",
     "easyuse_anima.prompt.data",
+    "easyuse_anima.prompt.regional",
 )
 
 


### PR DESCRIPTION
## 변경 요약

- Issue #184 B-07d로 Regional Prompt Studio의 순수 서비스 로직을 `easyuse_anima/prompt/regional.py`로 이동했습니다.
- Regional Prompt Studio와 Regional Conditioning 노드 어댑터를 `easyuse_anima/nodes/regional_nodes.py`로 이동했습니다.
- `nodes.py`는 기존 공개 심볼과 클래스 identity를 그대로 재노출하고 런타임 의존성을 바인딩합니다.
- 최신 `dev`의 Prompt Studio 와일드카드 계약(`일반/순차` 모드와 독립적인 시드 제어)을 보존한 상태로 충돌을 해소했습니다.
- Python backend analyzer 기준선과 패키지/import 계약 테스트를 현재 구조에서 다시 생성·갱신했습니다.

## 주요 파일

- `easyuse_anima/prompt/regional.py`
- `easyuse_anima/nodes/regional_nodes.py`
- `nodes.py`
- `tests/test_prompt_studio_regional.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_backend_analyzer.py`
- `tests/test_python_package_skeleton.py`

## 검증

- `python -m unittest tests.test_prompt_studio_regional tests.test_nodes_module_analyzer tests.test_python_backend_analyzer tests.test_python_package_skeleton tests.test_node_contracts`
  - 69 tests passed
- `powershell -ExecutionPolicy Bypass -File tools/check_project.ps1 -Profile quick`
  - passed
- `powershell -ExecutionPolicy Bypass -File D:\\ComfyUI\\custom_nodes_workplace\\tools\\check_custom_node.ps1 -Project <PR absolute worktree> -Profile full`
  - Python unittest 728 tests passed
  - frontend checks passed (112 JavaScript files, TypeScript 6.0.3)
  - compile 및 `git diff --check` passed

## 테스트 표면

- ComfyUI Codex test instance: repository full validation
- Regional pure-data/runtime lifecycle 및 wildcard serialization smoke
- Live ComfyUI/browser smoke: 미실행 (백엔드 구조 이동이며 공개 노드 계약은 회귀 테스트로 검증)

## 위험 및 호환성

- 사용자 노드 이름, 입출력, 워크플로우 저장 속성, 루트 공개 심볼 identity는 유지됩니다.
- 새 모듈은 루트 런타임 helper를 명시적으로 바인딩하므로 직접 package import는 부작용 없는 빈 package surface 계약을 유지합니다.

Related to #184.