### PR TITLE
fix: 와일드카드 시드 재현성과 모드 제어 정렬

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -317,6 +317,7 @@ try:
         WILDCARD_MODE_POPULATE,
         WILDCARD_MODE_REPRODUCE,
         WILDCARD_MODE_SEQUENTIAL,
+        expand_wildcard_texts,
         expand_wildcards,
         has_wildcard_syntax,
         next_seed,
@@ -630,6 +631,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         WILDCARD_MODE_POPULATE,
         WILDCARD_MODE_REPRODUCE,
         WILDCARD_MODE_SEQUENTIAL,
+        expand_wildcard_texts,
         expand_wildcards,
         has_wildcard_syntax,
         next_seed,
@@ -4573,15 +4575,13 @@ def _preserve_expanded_connected_field_texts(
     }
     for field in saved_fields:
         socket_name = _advanced_field_socket_name(field)
-        if socket_name not in connected_values:
-            continue
         source_field = source_by_socket.get(socket_name)
         expanded_field = expanded_by_socket.get(socket_name)
         if source_field is None or expanded_field is None:
             continue
         source_text = str(source_field.get("text") or "")
         expanded_text = str(expanded_field.get("text") or "")
-        if expanded_text != source_text:
+        if socket_name not in connected_values or expanded_text != source_text:
             field["text"] = expanded_text
 
 
@@ -4757,14 +4757,28 @@ def _expand_advanced_wildcard_fields(
             "missing_keys": (),
         }
 
+    wildcard_fields = []
+    wildcard_texts = []
+    for field in expanded_fields:
+        text = str(field.get("text") or "")
+        if has_wildcard_syntax(text):
+            wildcard_fields.append(field)
+            wildcard_texts.append(text)
+
+    expansions = expand_wildcard_texts(
+        wildcard_texts,
+        seed=seed,
+        mode=mode_key,
+    )
     changed = False
     used_keys: list[str] = []
     missing_keys: list[str] = []
-    for field in expanded_fields:
-        text = str(field.get("text") or "")
-        if not has_wildcard_syntax(text):
-            continue
-        result = expand_wildcards(text, seed=seed, mode=mode_key)
+    for field, text, result in zip(
+        wildcard_fields,
+        wildcard_texts,
+        expansions,
+        strict=True,
+    ):
         if result.text != text:
             field["text"] = result.text
             changed = True

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -17806,6 +17806,37 @@
       },
       {
         "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": ".wildcard_engine:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 307,
+        "name": "expand_wildcard_texts",
+        "optional": false,
+        "requested": ".wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
         "bound_name": "expand_wildcards",
         "branch_context": [
           {
@@ -18000,7 +18031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18015,7 +18046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -18034,7 +18065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18049,7 +18080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -18068,7 +18099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18083,7 +18114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -18102,7 +18133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18117,7 +18148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -18136,7 +18167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18151,7 +18182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -18170,7 +18201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18185,7 +18216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -18204,7 +18235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18219,7 +18250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -18238,7 +18269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18253,7 +18284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -18272,7 +18303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18287,7 +18318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -18306,7 +18337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18321,7 +18352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -18340,7 +18371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18355,7 +18386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -18374,7 +18405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18389,7 +18420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -18408,7 +18439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18423,7 +18454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18442,7 +18473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18457,7 +18488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18476,7 +18507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18491,7 +18522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18510,7 +18541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18525,7 +18556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18544,7 +18575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18559,7 +18590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18578,7 +18609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18593,7 +18624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18612,7 +18643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18627,7 +18658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18646,7 +18677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18661,7 +18692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18680,7 +18711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18695,7 +18726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18714,7 +18745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18729,7 +18760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18748,7 +18779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18763,7 +18794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18782,7 +18813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18797,7 +18828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -18816,7 +18847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18831,7 +18862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18850,7 +18881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18865,7 +18896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18884,7 +18915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18899,7 +18930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18918,7 +18949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18933,7 +18964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18952,7 +18983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -18967,7 +18998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -18986,7 +19017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19020,7 +19051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19035,7 +19066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19054,7 +19085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19069,7 +19100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19088,7 +19119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19103,7 +19134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19122,7 +19153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19137,7 +19168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19156,7 +19187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19171,7 +19202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19190,7 +19221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19205,7 +19236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19224,7 +19255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19239,7 +19270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19258,7 +19289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19273,7 +19304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19292,7 +19323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19307,7 +19338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19326,7 +19357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19341,7 +19372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -19360,7 +19391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19375,7 +19406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19394,7 +19425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19409,7 +19440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19428,7 +19459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19443,7 +19474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19462,7 +19493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19477,7 +19508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19496,7 +19527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19511,7 +19542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19530,7 +19561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19545,7 +19576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19564,7 +19595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19579,7 +19610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19598,7 +19629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19613,7 +19644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19632,7 +19663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19647,7 +19678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19666,7 +19697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19681,7 +19712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19700,7 +19731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19715,7 +19746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19734,7 +19765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19749,7 +19780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19768,7 +19799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19783,7 +19814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19802,7 +19833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19817,7 +19848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -19836,7 +19867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19851,7 +19882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19870,7 +19901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19885,7 +19916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19904,7 +19935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19919,7 +19950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19938,7 +19969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19953,7 +19984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -19972,7 +20003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -19987,7 +20018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20006,7 +20037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20021,7 +20052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20040,7 +20071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20074,7 +20105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20089,7 +20120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20108,7 +20139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20123,7 +20154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20142,7 +20173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20157,7 +20188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20176,7 +20207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20191,7 +20222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20225,7 +20256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20244,7 +20275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20259,7 +20290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20278,7 +20309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20293,7 +20324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20312,7 +20343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20327,7 +20358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20346,7 +20377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20361,7 +20392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20380,7 +20411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20395,7 +20426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20414,7 +20445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20429,7 +20460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20448,7 +20479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20463,7 +20494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20482,7 +20513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20497,7 +20528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20516,7 +20547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20531,7 +20562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20550,7 +20581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20565,7 +20596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20584,7 +20615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20599,7 +20630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20618,7 +20649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20633,7 +20664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20652,7 +20683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20667,7 +20698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20686,7 +20717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20701,7 +20732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20720,7 +20751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20735,7 +20766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20754,7 +20785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20769,7 +20800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20788,7 +20819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20803,7 +20834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20822,7 +20853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20837,7 +20868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20856,7 +20887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20871,7 +20902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20890,7 +20921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20905,7 +20936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20924,7 +20955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20939,7 +20970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20958,7 +20989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -20973,7 +21004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_group_token",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -20992,7 +21023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21007,7 +21038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21026,7 +21057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21041,7 +21072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21060,7 +21091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21075,7 +21106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21094,7 +21125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21128,7 +21159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21143,7 +21174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21162,7 +21193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21177,7 +21208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21196,7 +21227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21211,7 +21242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21230,7 +21261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21245,7 +21276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21264,7 +21295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21279,7 +21310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21298,7 +21329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21313,7 +21344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21332,7 +21363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21347,7 +21378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21366,7 +21397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21381,7 +21412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21400,7 +21431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21415,7 +21446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21434,7 +21465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21449,7 +21480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21468,7 +21499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21483,7 +21514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21502,7 +21533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21517,7 +21548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21536,7 +21567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21551,7 +21582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21570,7 +21601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21585,7 +21616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21604,7 +21635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21619,7 +21650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21638,7 +21669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21653,7 +21684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21672,7 +21703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21687,7 +21718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21706,7 +21737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21721,7 +21752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21740,7 +21771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21755,7 +21786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21774,7 +21805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21789,7 +21820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21808,7 +21839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21823,7 +21854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21842,7 +21873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21857,7 +21888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21876,7 +21907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21891,7 +21922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21910,7 +21941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21925,7 +21956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21944,7 +21975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21959,7 +21990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -21978,7 +22009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -21993,7 +22024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22012,7 +22043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22027,7 +22058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22046,7 +22077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22061,7 +22092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22080,7 +22111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22095,7 +22126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22114,7 +22145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22129,7 +22160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22148,7 +22179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22182,7 +22213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22197,7 +22228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22216,7 +22247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22231,7 +22262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22250,7 +22281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22265,7 +22296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22284,7 +22315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22299,7 +22330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22318,7 +22349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22333,7 +22364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22352,7 +22383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22367,7 +22398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22386,7 +22417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22401,7 +22432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22420,7 +22451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22435,7 +22466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22454,7 +22485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22469,7 +22500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -22488,7 +22519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22503,7 +22534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22522,7 +22553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22537,7 +22568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22556,7 +22587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22571,7 +22602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22590,7 +22621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22605,7 +22636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -22624,7 +22655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22639,7 +22670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22658,7 +22689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22673,7 +22704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22692,7 +22723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22707,7 +22738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22726,7 +22757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22741,7 +22772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22760,7 +22791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22775,7 +22806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -22794,7 +22825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22809,7 +22840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -22828,7 +22859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22843,7 +22874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22862,7 +22893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22877,7 +22908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22896,7 +22927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22911,7 +22942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22930,7 +22961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22945,7 +22976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22964,7 +22995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -22979,7 +23010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -22998,7 +23029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23013,7 +23044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -23032,7 +23063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23047,7 +23078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -23066,7 +23097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23081,7 +23112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -23100,7 +23131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23115,7 +23146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -23134,7 +23165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23149,7 +23180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -23168,7 +23199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23183,7 +23214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -23202,7 +23233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -23236,7 +23267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23251,7 +23282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -23270,7 +23301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23285,7 +23316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -23304,7 +23335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23319,7 +23350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -23338,7 +23369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23353,7 +23384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -23372,7 +23403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23387,7 +23418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23406,7 +23437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23421,7 +23452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23440,7 +23471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23455,7 +23486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23474,7 +23505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23489,7 +23520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23508,7 +23539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23523,7 +23554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23542,7 +23573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23557,7 +23588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -23576,7 +23607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23591,7 +23622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -23610,7 +23641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23625,7 +23656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -23644,7 +23675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23659,7 +23690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23678,7 +23709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23693,7 +23724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23712,7 +23743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23727,7 +23758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23746,7 +23777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23761,7 +23792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23780,7 +23811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23795,7 +23826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -23814,7 +23845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23829,7 +23860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23848,7 +23879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23863,7 +23894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23882,7 +23913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23897,7 +23928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23916,7 +23947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23931,7 +23962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23950,7 +23981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23965,7 +23996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -23984,7 +24015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -23999,7 +24030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24018,7 +24049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24033,7 +24064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24052,7 +24083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24067,7 +24098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24086,7 +24117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24101,7 +24132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24120,7 +24151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24135,7 +24166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24154,7 +24185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24169,7 +24200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24188,7 +24219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24203,7 +24234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24222,7 +24253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24237,7 +24268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24256,7 +24287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24290,7 +24321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24305,7 +24336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24324,7 +24355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24339,7 +24370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -24358,7 +24389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24373,7 +24404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24392,7 +24423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24407,7 +24438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24426,7 +24457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24441,7 +24472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24460,7 +24491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24475,7 +24506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24494,7 +24525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24509,7 +24540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24528,7 +24559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24543,7 +24574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24562,7 +24593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24577,7 +24608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24596,7 +24627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24611,7 +24642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24630,7 +24661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24645,7 +24676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24664,7 +24695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24679,7 +24710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24698,7 +24729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24713,7 +24744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24732,7 +24763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24747,7 +24778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24766,7 +24797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24781,7 +24812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24800,7 +24831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24815,7 +24846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24834,7 +24865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24849,7 +24880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24868,7 +24899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24883,7 +24914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24902,7 +24933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24917,7 +24948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24936,7 +24967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24951,7 +24982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -24970,7 +25001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -24985,7 +25016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -25004,7 +25035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25019,7 +25050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -25038,7 +25069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25053,7 +25084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -25072,7 +25103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25087,7 +25118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -25106,7 +25137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25121,7 +25152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -25140,7 +25171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25155,7 +25186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -25174,7 +25205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25189,7 +25220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -25208,7 +25239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25223,7 +25254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -25242,7 +25273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25257,7 +25288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25276,7 +25307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25291,7 +25322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25310,7 +25341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25325,7 +25356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25344,7 +25375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25359,7 +25390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25378,7 +25409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25393,7 +25424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25412,7 +25443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25427,7 +25458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25446,7 +25477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25461,7 +25492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25480,7 +25511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25495,7 +25526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25514,7 +25545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25529,7 +25560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25548,7 +25579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25563,7 +25594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25582,7 +25613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25597,7 +25628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25616,7 +25647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25631,7 +25662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25650,7 +25681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25665,7 +25696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25684,7 +25715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25699,7 +25730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25718,7 +25749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25733,7 +25764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -25752,7 +25783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25767,7 +25798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25786,7 +25817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25801,7 +25832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25820,7 +25851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25835,7 +25866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25854,7 +25885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25869,7 +25900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25888,7 +25919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25903,7 +25934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25922,7 +25953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25937,7 +25968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25956,7 +25987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -25971,7 +26002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -25990,7 +26021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26005,7 +26036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -26024,7 +26055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26039,7 +26070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -26058,7 +26089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26073,7 +26104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -26092,7 +26123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26107,7 +26138,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -26126,7 +26157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26141,7 +26172,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -26160,7 +26191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26175,7 +26206,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -26194,7 +26225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26209,7 +26240,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -26228,7 +26259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26243,7 +26274,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -26262,7 +26293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26277,7 +26308,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -26296,7 +26327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26311,7 +26342,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 619,
+        "line": 620,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -26330,7 +26361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26345,7 +26376,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 619,
+        "line": 620,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -26364,7 +26395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26379,7 +26410,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26398,7 +26429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26413,7 +26444,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26432,7 +26463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26447,7 +26478,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26466,7 +26497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26481,7 +26512,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26500,7 +26531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26515,7 +26546,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26534,7 +26565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26549,7 +26580,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26568,7 +26599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26583,7 +26614,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26602,7 +26633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26617,7 +26648,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26636,7 +26667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26651,7 +26682,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26670,7 +26701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26685,7 +26716,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26704,7 +26735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26719,7 +26750,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "WILDCARD_MODE_REPRODUCE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26738,7 +26769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26753,8 +26784,42 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "WILDCARD_MODE_SEQUENTIAL",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 328,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "wildcard_engine.py",
+          "try_line": 14
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 621,
+        "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
         "role": "compatibility_fallback",
@@ -26772,7 +26837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26787,7 +26852,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26806,7 +26871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26821,7 +26886,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26840,7 +26905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26855,7 +26920,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26874,7 +26939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26889,7 +26954,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26908,7 +26973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26923,7 +26988,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26942,7 +27007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -26957,7 +27022,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -26975,7 +27040,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2175
+            "line": 2177
           }
         ],
         "classification": "external",
@@ -26983,7 +27048,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2176,
+        "line": 2178,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -27000,7 +27065,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2240
+            "line": 2242
           }
         ],
         "classification": "external",
@@ -27008,7 +27073,7 @@
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2241,
+        "line": 2243,
         "name": null,
         "optional": true,
         "requested": "impact.core",
@@ -27025,7 +27090,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2246
+            "line": 2248
           }
         ],
         "classification": "external",
@@ -27033,7 +27098,7 @@
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2247,
+        "line": 2249,
         "name": "core",
         "optional": true,
         "requested": "modules.impact",
@@ -27050,7 +27115,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2262
+            "line": 2264
           }
         ],
         "classification": "external",
@@ -27058,7 +27123,7 @@
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2263,
+        "line": 2265,
         "name": null,
         "optional": true,
         "requested": "comfy.samplers",
@@ -27075,7 +27140,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2271
+            "line": 2273
           }
         ],
         "classification": "external",
@@ -27083,7 +27148,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2272,
+        "line": 2274,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -27100,7 +27165,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2287
+            "line": 2289
           }
         ],
         "classification": "external",
@@ -27108,7 +27173,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2288,
+        "line": 2290,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -27125,7 +27190,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2293
+            "line": 2295
           }
         ],
         "classification": "external",
@@ -27133,7 +27198,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2294,
+        "line": 2296,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -27150,7 +27215,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2307
+            "line": 2309
           }
         ],
         "classification": "external",
@@ -27158,7 +27223,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2308,
+        "line": 2310,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -27175,7 +27240,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2406
+            "line": 2408
           }
         ],
         "classification": "external",
@@ -27183,7 +27248,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2407,
+        "line": 2409,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
@@ -27200,7 +27265,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2430
+            "line": 2432
           }
         ],
         "classification": "external",
@@ -27208,7 +27273,7 @@
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2431,
+        "line": 2433,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.segs_nodes",
@@ -27225,7 +27290,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2436
+            "line": 2438
           }
         ],
         "classification": "external",
@@ -27233,7 +27298,7 @@
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2437,
+        "line": 2439,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.segs_nodes",
@@ -27250,7 +27315,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2442
+            "line": 2444
           }
         ],
         "classification": "external",
@@ -27258,7 +27323,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2443,
+        "line": 2445,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -27275,7 +27340,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2448
+            "line": 2450
           }
         ],
         "classification": "external",
@@ -27283,7 +27348,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2449,
+        "line": 2451,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -27300,7 +27365,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2786
+            "line": 2788
           }
         ],
         "classification": "external",
@@ -27308,7 +27373,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2787,
+        "line": 2789,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -27325,7 +27390,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2826
+            "line": 2828
           }
         ],
         "classification": "external",
@@ -27333,7 +27398,7 @@
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2827,
+        "line": 2829,
         "name": null,
         "optional": true,
         "requested": "comfy.model_management",
@@ -27348,7 +27413,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3259,
+            "line": 3261,
             "type_checking": false
           },
           {
@@ -27356,7 +27421,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3260
+            "line": 3262
           }
         ],
         "classification": "external",
@@ -27364,7 +27429,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3261,
+        "line": 3263,
         "name": "UpscaleModelLoader",
         "optional": true,
         "requested": "comfy_extras.nodes_upscale_model",
@@ -27381,7 +27446,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4060
+            "line": 4062
           }
         ],
         "classification": "external",
@@ -27389,7 +27454,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4061,
+        "line": 4063,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -27406,7 +27471,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4122
+            "line": 4124
           }
         ],
         "classification": "external",
@@ -27414,7 +27479,7 @@
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4123,
+        "line": 4125,
         "name": "PromptServer",
         "optional": true,
         "requested": "server",
@@ -27431,7 +27496,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4149
+            "line": 4151
           }
         ],
         "classification": "external",
@@ -27439,7 +27504,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4150,
+        "line": 4152,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -27456,7 +27521,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4149
+            "line": 4151
           }
         ],
         "classification": "external",
@@ -27464,7 +27529,7 @@
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 4151,
+        "line": 4153,
         "name": null,
         "optional": true,
         "requested": "numpy",
@@ -27481,7 +27546,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4149
+            "line": 4151
           }
         ],
         "classification": "external",
@@ -27489,7 +27554,7 @@
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 4152,
+        "line": 4154,
         "name": "Image",
         "optional": true,
         "requested": "PIL",
@@ -27506,7 +27571,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4343
+            "line": 4345
           }
         ],
         "classification": "external",
@@ -27514,7 +27579,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 4344,
+        "line": 4346,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -27531,7 +27596,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5524
+            "line": 5538
           }
         ],
         "classification": "external",
@@ -27539,7 +27604,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5525,
+        "line": 5539,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -27556,7 +27621,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5558
+            "line": 5572
           }
         ],
         "classification": "external",
@@ -27564,7 +27629,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5559,
+        "line": 5573,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -30370,9 +30435,9 @@
       },
       {
         "is_package": false,
-        "loc": 8331,
+        "loc": 8345,
         "module": "nodes",
-        "normalized_git_blob_sha1": "c0bf17e90bd1399601d461dc50508fffb454406c",
+        "normalized_git_blob_sha1": "78a1e81379028951fea6f3b040136f049d68247d",
         "path": "nodes.py",
         "top_level": {
           "class_count": 12,
@@ -30418,13 +30483,13 @@
       },
       {
         "is_package": false,
-        "loc": 1155,
+        "loc": 1262,
         "module": "wildcard_engine",
-        "normalized_git_blob_sha1": "da6c507859a6a0df78bd1308d413c717f4b6d9a5",
+        "normalized_git_blob_sha1": "02e1ad129406b9badccd52e635d40c35c1ceb747",
         "path": "wildcard_engine.py",
         "top_level": {
-          "class_count": 12,
-          "function_count": 39,
+          "class_count": 13,
+          "function_count": 40,
           "global_count": 39
         }
       }
@@ -31864,7 +31929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -31873,7 +31938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31887,7 +31952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -31896,7 +31961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31910,7 +31975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -31919,7 +31984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 328,
+        "line": 329,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31933,7 +31998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -31942,7 +32007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31956,7 +32021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -31965,7 +32030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -31979,7 +32044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -31988,7 +32053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32002,7 +32067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32011,7 +32076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32025,7 +32090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32034,7 +32099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 333,
+        "line": 334,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32048,7 +32113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32057,7 +32122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32071,7 +32136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32080,7 +32145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32094,7 +32159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32103,7 +32168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32117,7 +32182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32126,7 +32191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 340,
+        "line": 341,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32140,7 +32205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32149,7 +32214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32163,7 +32228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32172,7 +32237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32186,7 +32251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32195,7 +32260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32209,7 +32274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32218,7 +32283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32232,7 +32297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32241,7 +32306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32255,7 +32320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32264,7 +32329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32278,7 +32343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32287,7 +32352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32301,7 +32366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32310,7 +32375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32324,7 +32389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32333,7 +32398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32347,7 +32412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32356,7 +32421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32370,7 +32435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32379,7 +32444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32393,7 +32458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32402,7 +32467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 346,
+        "line": 347,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32416,7 +32481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32425,7 +32490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32439,7 +32504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32448,7 +32513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32462,7 +32527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32471,7 +32536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32485,7 +32550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32494,7 +32559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32508,7 +32573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32517,7 +32582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32531,7 +32596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32540,7 +32605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32554,7 +32619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32563,7 +32628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32577,7 +32642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32586,7 +32651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32600,7 +32665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32609,7 +32674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32623,7 +32688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32632,7 +32697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32646,7 +32711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32655,7 +32720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32669,7 +32734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32678,7 +32743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32692,7 +32757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32701,7 +32766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32715,7 +32780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32724,7 +32789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32738,7 +32803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32747,7 +32812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32761,7 +32826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32770,7 +32835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32784,7 +32849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32793,7 +32858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32807,7 +32872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32816,7 +32881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32830,7 +32895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32839,7 +32904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32853,7 +32918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32862,7 +32927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32876,7 +32941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32885,7 +32950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32899,7 +32964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32908,7 +32973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32922,7 +32987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32931,7 +32996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32945,7 +33010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32954,7 +33019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32968,7 +33033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -32977,7 +33042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -32991,7 +33056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33000,7 +33065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33014,7 +33079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33023,7 +33088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33037,7 +33102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33046,7 +33111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33060,7 +33125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33069,7 +33134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33083,7 +33148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33092,7 +33157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33106,7 +33171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33115,7 +33180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33129,7 +33194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33138,7 +33203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33152,7 +33217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33161,7 +33226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33175,7 +33240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33184,7 +33249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33198,7 +33263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33207,7 +33272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33221,7 +33286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33230,7 +33295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33244,7 +33309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33253,7 +33318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33267,7 +33332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33276,7 +33341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33290,7 +33355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33299,7 +33364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33313,7 +33378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33322,7 +33387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33336,7 +33401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33345,7 +33410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33359,7 +33424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33368,7 +33433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33382,7 +33447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33391,7 +33456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33405,7 +33470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33414,7 +33479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33428,7 +33493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33437,7 +33502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33451,7 +33516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33460,7 +33525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33474,7 +33539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33483,7 +33548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33497,7 +33562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33506,7 +33571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33520,7 +33585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33529,7 +33594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33543,7 +33608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33552,7 +33617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33566,7 +33631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33575,7 +33640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33589,7 +33654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33598,7 +33663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33612,7 +33677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33621,7 +33686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33635,7 +33700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33644,7 +33709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33658,7 +33723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33667,7 +33732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33681,7 +33746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33690,7 +33755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33704,7 +33769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33713,7 +33778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33727,7 +33792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33736,7 +33801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33750,7 +33815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33759,7 +33824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33773,7 +33838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33782,7 +33847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33796,7 +33861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33805,7 +33870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33819,7 +33884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33828,7 +33893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33842,7 +33907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33851,7 +33916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33865,7 +33930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33874,7 +33939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33888,7 +33953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33897,7 +33962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33911,7 +33976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33920,7 +33985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33934,7 +33999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33943,7 +34008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33957,7 +34022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33966,7 +34031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -33980,7 +34045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -33989,7 +34054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34003,7 +34068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34012,7 +34077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34026,7 +34091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34035,7 +34100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34049,7 +34114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34058,7 +34123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34072,7 +34137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34081,7 +34146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34095,7 +34160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34104,7 +34169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34118,7 +34183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34127,7 +34192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34141,7 +34206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34150,7 +34215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34164,7 +34229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34173,7 +34238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34187,7 +34252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34196,7 +34261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34210,7 +34275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34219,7 +34284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34233,7 +34298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34242,7 +34307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34256,7 +34321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34265,7 +34330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34279,7 +34344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34288,7 +34353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34302,7 +34367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34311,7 +34376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34325,7 +34390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34334,7 +34399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34348,7 +34413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34357,7 +34422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34371,7 +34436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34380,7 +34445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34394,7 +34459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34403,7 +34468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34417,7 +34482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34426,7 +34491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34440,7 +34505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34449,7 +34514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34463,7 +34528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34472,7 +34537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34486,7 +34551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34495,7 +34560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34509,7 +34574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34518,7 +34583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34532,7 +34597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34541,7 +34606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34555,7 +34620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34564,7 +34629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34578,7 +34643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34587,7 +34652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34601,7 +34666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34610,7 +34675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34624,7 +34689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34633,7 +34698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34647,7 +34712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34656,7 +34721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34670,7 +34735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34679,7 +34744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34693,7 +34758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34702,7 +34767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34716,7 +34781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34725,7 +34790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34739,7 +34804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34748,7 +34813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34762,7 +34827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34771,7 +34836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34785,7 +34850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34794,7 +34859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34808,7 +34873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34817,7 +34882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34831,7 +34896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34840,7 +34905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34854,7 +34919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34863,7 +34928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34877,7 +34942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34886,7 +34951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 394,
+        "line": 395,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34900,7 +34965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34909,7 +34974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34923,7 +34988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34932,7 +34997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34946,7 +35011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34955,7 +35020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34969,7 +35034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -34978,7 +35043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -34992,7 +35057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35001,7 +35066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35015,7 +35080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35024,7 +35089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35038,7 +35103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35047,7 +35112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35061,7 +35126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35070,7 +35135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35084,7 +35149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35093,7 +35158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 480,
+        "line": 481,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35107,7 +35172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35116,7 +35181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 487,
+        "line": 488,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35130,7 +35195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35139,7 +35204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35153,7 +35218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35162,7 +35227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35176,7 +35241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35185,7 +35250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35199,7 +35264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35208,7 +35273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35222,7 +35287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35231,7 +35296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35245,7 +35310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35254,7 +35319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 490,
+        "line": 491,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35268,7 +35333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35277,7 +35342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35291,7 +35356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35300,7 +35365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35314,7 +35379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35323,7 +35388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35337,7 +35402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35346,7 +35411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35360,7 +35425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35369,7 +35434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35383,7 +35448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35392,7 +35457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35406,7 +35471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35415,7 +35480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35429,7 +35494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35438,7 +35503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35452,7 +35517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35461,7 +35526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35475,7 +35540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35484,7 +35549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35498,7 +35563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35507,7 +35572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35521,7 +35586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35530,7 +35595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35544,7 +35609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35553,7 +35618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35567,7 +35632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35576,7 +35641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35590,7 +35655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35599,7 +35664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35613,7 +35678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35622,7 +35687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 512,
+        "line": 513,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35636,7 +35701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35645,7 +35710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35659,7 +35724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35668,7 +35733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 520,
+        "line": 521,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35682,7 +35747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35691,7 +35756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35705,7 +35770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35714,7 +35779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35728,7 +35793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35737,7 +35802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35751,7 +35816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35760,7 +35825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35774,7 +35839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35783,7 +35848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35797,7 +35862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35806,7 +35871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35820,7 +35885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35829,7 +35894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35843,7 +35908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35852,7 +35917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35866,7 +35931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35875,7 +35940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35889,7 +35954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35898,7 +35963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35912,7 +35977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35921,7 +35986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35935,7 +36000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35944,7 +36009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35958,7 +36023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35967,7 +36032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -35981,7 +36046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -35990,7 +36055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36004,7 +36069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36013,7 +36078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36027,7 +36092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36036,7 +36101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36050,7 +36115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36059,7 +36124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36073,7 +36138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36082,7 +36147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36096,7 +36161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36105,7 +36170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36119,7 +36184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36128,7 +36193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36142,7 +36207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36151,7 +36216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 531,
+        "line": 532,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36165,7 +36230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36174,7 +36239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36188,7 +36253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36197,7 +36262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36211,7 +36276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36220,7 +36285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36234,7 +36299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36243,7 +36308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36257,7 +36322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36266,7 +36331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36280,7 +36345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36289,7 +36354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36303,7 +36368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36312,7 +36377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36326,7 +36391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36335,7 +36400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36349,7 +36414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36358,7 +36423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36372,7 +36437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36381,7 +36446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36395,7 +36460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36404,7 +36469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36418,7 +36483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36427,7 +36492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36441,7 +36506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36450,7 +36515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36464,7 +36529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36473,7 +36538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36487,7 +36552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36496,7 +36561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36510,7 +36575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36519,7 +36584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36533,7 +36598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36542,7 +36607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36556,7 +36621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36565,7 +36630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36579,7 +36644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36588,7 +36653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36602,7 +36667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36611,7 +36676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36625,7 +36690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36634,7 +36699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36648,7 +36713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36657,7 +36722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36671,7 +36736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36680,7 +36745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36694,7 +36759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36703,7 +36768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36717,7 +36782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36726,7 +36791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36740,7 +36805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36749,7 +36814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 576,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36763,7 +36828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36772,7 +36837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36786,7 +36851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36795,7 +36860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36809,7 +36874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36818,7 +36883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36832,7 +36897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36841,7 +36906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36855,7 +36920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36864,7 +36929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36878,7 +36943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36887,7 +36952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36901,7 +36966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36910,7 +36975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36924,7 +36989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36933,7 +36998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36947,7 +37012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36956,7 +37021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36970,7 +37035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -36979,7 +37044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -36993,7 +37058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37002,7 +37067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37016,7 +37081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37025,7 +37090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37039,7 +37104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37048,7 +37113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37062,7 +37127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37071,7 +37136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37085,7 +37150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37094,7 +37159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37108,7 +37173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37117,7 +37182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37131,7 +37196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37140,7 +37205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37154,7 +37219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37163,7 +37228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37177,7 +37242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37186,7 +37251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37200,7 +37265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37209,7 +37274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37223,7 +37288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37232,7 +37297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37246,7 +37311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37255,7 +37320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37269,7 +37334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37278,7 +37343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 598,
+        "line": 599,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37292,7 +37357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37301,7 +37366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37315,7 +37380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37324,7 +37389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37338,7 +37403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37347,7 +37412,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37361,7 +37426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37370,7 +37435,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37384,7 +37449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37393,7 +37458,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37407,7 +37472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37416,7 +37481,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37430,7 +37495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37439,7 +37504,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37453,7 +37518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37462,7 +37527,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 614,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37476,7 +37541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37485,7 +37550,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 619,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37499,7 +37564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37508,7 +37573,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 619,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37522,7 +37587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37531,7 +37596,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37545,7 +37610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37554,7 +37619,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37568,7 +37633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37577,7 +37642,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37591,7 +37656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37600,7 +37665,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37614,7 +37679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37623,7 +37688,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37637,7 +37702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37646,7 +37711,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37660,7 +37725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37669,7 +37734,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37683,7 +37748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37692,7 +37757,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37706,7 +37771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37715,7 +37780,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37729,7 +37794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37738,7 +37803,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37752,7 +37817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37761,7 +37826,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_REPRODUCE",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37775,7 +37840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37784,7 +37849,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37798,7 +37863,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
+            "kind": "try",
+            "line": 14
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 621,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37807,7 +37895,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37821,7 +37909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37830,7 +37918,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37844,7 +37932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37853,7 +37941,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37867,7 +37955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37876,7 +37964,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37890,7 +37978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37899,7 +37987,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -37913,7 +38001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 327,
+            "handler_line": 328,
             "kind": "try",
             "line": 14
           }
@@ -37922,7 +38010,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 620,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40189,14 +40277,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2175
+            "line": 2177
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2176,
+        "line": 2178,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40208,14 +40296,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2240
+            "line": 2242
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2241,
+        "line": 2243,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40227,14 +40315,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2246
+            "line": 2248
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2247,
+        "line": 2249,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40246,14 +40334,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2262
+            "line": 2264
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2263,
+        "line": 2265,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40265,14 +40353,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2271
+            "line": 2273
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2272,
+        "line": 2274,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40284,14 +40372,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2287
+            "line": 2289
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2288,
+        "line": 2290,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40303,14 +40391,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2293
+            "line": 2295
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2294,
+        "line": 2296,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40322,14 +40410,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2307
+            "line": 2309
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2308,
+        "line": 2310,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40341,14 +40429,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2406
+            "line": 2408
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2407,
+        "line": 2409,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40360,14 +40448,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2430
+            "line": 2432
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2431,
+        "line": 2433,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40379,14 +40467,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2436
+            "line": 2438
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2437,
+        "line": 2439,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40398,14 +40486,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2442
+            "line": 2444
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2443,
+        "line": 2445,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40417,14 +40505,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2448
+            "line": 2450
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2449,
+        "line": 2451,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40436,14 +40524,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2786
+            "line": 2788
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2787,
+        "line": 2789,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40455,14 +40543,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2826
+            "line": 2828
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2827,
+        "line": 2829,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40472,7 +40560,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3259,
+            "line": 3261,
             "type_checking": false
           },
           {
@@ -40480,14 +40568,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3260
+            "line": 3262
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3261,
+        "line": 3263,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40499,14 +40587,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4060
+            "line": 4062
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4061,
+        "line": 4063,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40518,14 +40606,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4122
+            "line": 4124
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4123,
+        "line": 4125,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40537,51 +40625,13 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4149
+            "line": 4151
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4150,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 4149
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "numpy",
-        "kind": "static_import",
-        "line": 4151,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 4149
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "PIL:Image",
-        "kind": "static_from",
         "line": 4152,
         "optional": true,
         "role": "optional_dependency",
@@ -40594,14 +40644,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4343
+            "line": 4151
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "torch",
+        "imported": "numpy",
         "kind": "static_import",
-        "line": 4344,
+        "line": 4153,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40613,14 +40663,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5524
+            "line": 4151
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5525,
+        "imported": "PIL:Image",
+        "kind": "static_from",
+        "line": 4154,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -40632,14 +40682,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5558
+            "line": 4345
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5559,
+        "line": 4346,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5538
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5539,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5572
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5573,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41609,14 +41697,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2175
+            "line": 2177
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2176,
+        "line": 2178,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41628,14 +41716,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2240
+            "line": 2242
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.core",
         "kind": "static_import",
-        "line": 2241,
+        "line": 2243,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41647,14 +41735,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2246
+            "line": 2248
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact:core",
         "kind": "static_from",
-        "line": 2247,
+        "line": 2249,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41666,14 +41754,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2262
+            "line": 2264
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.samplers",
         "kind": "static_import",
-        "line": 2263,
+        "line": 2265,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41685,14 +41773,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2271
+            "line": 2273
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2272,
+        "line": 2274,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41704,14 +41792,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2287
+            "line": 2289
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2288,
+        "line": 2290,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41723,14 +41811,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2293
+            "line": 2295
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 2294,
+        "line": 2296,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41742,14 +41830,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2307
+            "line": 2309
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 2308,
+        "line": 2310,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41761,14 +41849,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2406
+            "line": 2408
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 2407,
+        "line": 2409,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41780,14 +41868,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2430
+            "line": 2432
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2431,
+        "line": 2433,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41799,14 +41887,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2436
+            "line": 2438
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 2437,
+        "line": 2439,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41818,14 +41906,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2442
+            "line": 2444
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2443,
+        "line": 2445,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41837,14 +41925,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2448
+            "line": 2450
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 2449,
+        "line": 2451,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41856,14 +41944,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2786
+            "line": 2788
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2787,
+        "line": 2789,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41875,14 +41963,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2826
+            "line": 2828
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy.model_management",
         "kind": "static_import",
-        "line": 2827,
+        "line": 2829,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41892,7 +41980,7 @@
           {
             "branch": "body",
             "kind": "if",
-            "line": 3259,
+            "line": 3261,
             "type_checking": false
           },
           {
@@ -41900,14 +41988,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3260
+            "line": 3262
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_upscale_model:UpscaleModelLoader",
         "kind": "static_from",
-        "line": 3261,
+        "line": 3263,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41919,14 +42007,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4060
+            "line": 4062
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4061,
+        "line": 4063,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41938,14 +42026,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4122
+            "line": 4124
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 4123,
+        "line": 4125,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -41957,51 +42045,13 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4149
+            "line": 4151
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 4150,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 4149
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "numpy",
-        "kind": "static_import",
-        "line": 4151,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 4149
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "PIL:Image",
-        "kind": "static_from",
         "line": 4152,
         "optional": true,
         "role": "optional_dependency",
@@ -42014,14 +42064,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 4343
+            "line": 4151
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "torch",
+        "imported": "numpy",
         "kind": "static_import",
-        "line": 4344,
+        "line": 4153,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -42033,14 +42083,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5524
+            "line": 4151
           }
         ],
         "classification": "external",
         "conditional": true,
-        "imported": "torch",
-        "kind": "static_import",
-        "line": 5525,
+        "imported": "PIL:Image",
+        "kind": "static_from",
+        "line": 4154,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -42052,14 +42102,52 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 5558
+            "line": 4345
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 5559,
+        "line": 4346,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5538
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5539,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 5572
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "torch",
+        "kind": "static_import",
+        "line": 5573,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -43092,7 +43180,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 641,
+        "line": 643,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43101,7 +43189,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 1176,
+        "line": 1178,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43110,7 +43198,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1195,
+        "line": 1197,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43119,7 +43207,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1375,
+        "line": 1377,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43128,7 +43216,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5723,
+        "line": 5737,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43137,7 +43225,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5727,
+        "line": 5741,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43146,7 +43234,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5730,
+        "line": 5744,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43155,7 +43243,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5733,
+        "line": 5747,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43164,7 +43252,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5736,
+        "line": 5750,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43173,7 +43261,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5739,
+        "line": 5753,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43182,7 +43270,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5742,
+        "line": 5756,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43191,7 +43279,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5752,
+        "line": 5766,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43200,7 +43288,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5758,
+        "line": 5772,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43209,7 +43297,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5763,
+        "line": 5777,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43218,7 +43306,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 5767,
+        "line": 5781,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -43630,73 +43718,73 @@
       },
       {
         "kind": "dict",
-        "line": 645,
+        "line": 647,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 644,
+        "line": 646,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 643,
+        "line": 645,
         "module": "nodes.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "dict",
-        "line": 725,
+        "line": 727,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 714,
+        "line": 716,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 4032,
+        "line": 4034,
         "module": "nodes.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
         "kind": "set",
-        "line": 709,
+        "line": 711,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "list",
-        "line": 1146,
+        "line": 1148,
         "module": "nodes.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 657,
+        "line": 659,
         "module": "nodes.py",
         "name": "REGIONAL_FIELD_TYPES"
       },
       {
         "kind": "set",
-        "line": 1374,
+        "line": 1376,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
       {
         "kind": "dict",
-        "line": 4045,
+        "line": 4047,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 4046,
+        "line": 4048,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -43889,7 +43977,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 4045,
+        "line": 4047,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -43899,7 +43987,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 4046,
+        "line": 4048,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
+++ b/tests/frontend_prompt_studio_advanced_queue_seed_runtime_smoke.mjs
@@ -46,6 +46,7 @@ assert.deepEqual(
     "normalizeWildcardSeedInput",
     "optionalWildcardSeed",
     "randomWildcardSeed",
+    "wildcardSeedControlForMode",
   ],
 );
 assert.equal(seedContract.WILDCARD_SEED_MAX, Number.MAX_SAFE_INTEGER);
@@ -87,6 +88,51 @@ assert.equal(
   seedContract.randomWildcardSeed(() => 1),
   Number.MAX_SAFE_INTEGER,
 );
+
+for (const surface of ["advanced", "regional"]) {
+  const node = {
+    surface,
+    widgets: {
+      wildcard_mode: "일반 채우기",
+      wildcard_seed: 42,
+      wildcard_seed_after_generate: "randomize",
+    },
+  };
+  const selectMode = (target, mode) => {
+    target.widgets.wildcard_mode = mode;
+    target.widgets.wildcard_seed_after_generate = seedContract.wildcardSeedControlForMode(
+      mode,
+      target.widgets.wildcard_seed_after_generate,
+    );
+  };
+
+  selectMode(node, "재현");
+  assert.equal(node.widgets.wildcard_seed_after_generate, "fixed");
+  assert.equal(
+    seedContract.nextWildcardSeed(
+      node.widgets.wildcard_seed,
+      node.widgets.wildcard_seed_after_generate,
+    ),
+    42,
+    `${surface} Reproduce changed a fixed seed`,
+  );
+
+  const reopened = clone(node);
+  assert.equal(reopened.widgets.wildcard_mode, "재현");
+  assert.equal(reopened.widgets.wildcard_seed_after_generate, "fixed");
+
+  reopened.widgets.wildcard_seed_after_generate = "decrement";
+  selectMode(reopened, "일반 채우기");
+  assert.equal(reopened.widgets.wildcard_seed_after_generate, "decrement");
+  assert.equal(
+    seedContract.wildcardSeedControlForMode("고정", "randomize"),
+    "randomize",
+  );
+  assert.equal(
+    seedContract.wildcardSeedControlForMode("순차", "fixed"),
+    "increment",
+  );
+}
 
 function seedInputFixture(value) {
   const listeners = new Map();

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -2664,6 +2664,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertIn("bindWildcardSeedInput", contract_source)
         self.assertIn("normalizeWildcardSeedInput", contract_source)
         self.assertIn("nextWildcardSeed", contract_source)
+        self.assertIn("wildcardSeedControlForMode", contract_source)
         self.assertIn("./wildcard_seed_contract.js", queue_source)
         self.assertIn("nextWildcardSeed", queue_source)
         self.assertIn("./wildcard_seed_contract.js", extension_source)
@@ -2678,6 +2679,18 @@ class FrontendModuleStructureTests(unittest.TestCase):
             with self.subTest(module="seed-control"):
                 self.assertIn("wildcard_seed_contract.js", source)
                 self.assertIn("bindWildcardSeedInput", source)
+                self.assertGreaterEqual(
+                    source.count("wildcardSeedControlForMode"),
+                    2,
+                )
+        self.assertIn(
+            'setAdvancedWidgetValue(node, "wildcard_seed_after_generate", nextControl);',
+            advanced_source,
+        )
+        self.assertIn(
+            '"wildcard_seed_after_generate",\n          nextControl,',
+            regional_source,
+        )
 
     def test_prompt_studio_wildcard_tooltips_follow_the_selected_mode(self):
         constants_source = (PROMPT_STUDIO_MODULES / "constants.js").read_text(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,11 +73,11 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "c0bf17e90bd1399601d461dc50508fffb454406c")
-        # Issue #220 added connected wildcard snapshot/reproduce helpers.
+        self.assertEqual(report["git_blob_sha1"], "78a1e81379028951fea6f3b040136f049d68247d")
+        # Issue #226 aligned Prompt Studio fields on one wildcard RNG stream.
         self.assertEqual(report["top_level"]["function_count"], 151)
         self.assertEqual(report["top_level"]["class_count"], 12)
-        self.assertEqual(report["line_count"], 8_331)
+        self.assertEqual(report["line_count"], 8_345)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import patch
 
+import nodes as nodes_module
 from nodes import (
     EasyUseAnimaPromptStudioAdvanced,
     EasyUseAnimaPromptStudioAdvancedV2,
@@ -21,6 +22,7 @@ from wildcard_engine import (
     WildcardExpansionBudget,
     WildcardExpansionResult,
     ensure_default_wildcard_root,
+    expand_wildcard_texts,
     expand_wildcards,
     list_wildcards,
 )
@@ -325,6 +327,63 @@ class WildcardEngineTests(unittest.TestCase):
         for name, source, expected in cases:
             with self.subTest(name=name):
                 self.assertEqual(expand_wildcards(source, seed=7).text, expected)
+
+    def test_ordered_texts_share_one_deterministic_selector_stream(self):
+        first = expand_wildcard_texts(
+            ["{red|blue|green}", "{red|blue|green}"],
+            seed=7,
+        )
+        second = expand_wildcard_texts(
+            ["{red|blue|green}", "{red|blue|green}"],
+            seed=7,
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual([result.text for result in first], ["blue", "green"])
+        self.assertEqual(
+            expand_wildcard_texts(["{red|blue|green}"], seed=7)[0],
+            expand_wildcards("{red|blue|green}", seed=7),
+        )
+        nested = expand_wildcard_texts(
+            ["{{red|blue}|green}", "{circle|square|triangle}"],
+            seed=7,
+        )
+        self.assertEqual(
+            [result.text for result in nested],
+            ["green", "triangle"],
+        )
+
+    def test_ordered_file_wildcards_share_seed_stream_and_metadata(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "inner.txt").write_text(
+                "circle\nsquare\ntriangle\n",
+                encoding="utf-8",
+            )
+            (root / "outer.txt").write_text(
+                "__inner__ red\n__inner__ blue\n",
+                encoding="utf-8",
+            )
+
+            first = expand_wildcard_texts(
+                ["__outer__", "__outer__"],
+                seed=7,
+                roots=[root],
+            )
+            second = expand_wildcard_texts(
+                ["__outer__", "__outer__"],
+                seed=7,
+                roots=[root],
+            )
+
+        self.assertEqual(first, second)
+        self.assertEqual(
+            [result.text for result in first],
+            ["triangle blue", "circle blue"],
+        )
+        for result in first:
+            self.assertEqual(result.used_keys, ("outer", "inner"))
+            self.assertEqual(result.replacement_count, 2)
 
     def test_random_mode_nested_wildcard_has_golden_output(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -865,6 +924,87 @@ class WildcardSeedContractTests(unittest.TestCase):
 
 
 class WildcardNodeTests(unittest.TestCase):
+    def test_prompt_studio_fields_share_one_seed_stream(self):
+        fields = [
+            {
+                "id": "positive_first",
+                "pane": "positive",
+                "type": "general",
+                "text": "{red|blue|green}",
+                "enabled": True,
+            },
+            {
+                "id": "positive_second",
+                "pane": "positive",
+                "type": "general",
+                "text": "{red|blue|green}",
+                "enabled": True,
+            },
+        ]
+
+        expanded, metadata = nodes_module._expand_advanced_wildcard_fields(
+            fields,
+            7,
+            "일반 채우기",
+        )
+
+        self.assertEqual(
+            [field["text"] for field in expanded],
+            ["blue", "green"],
+        )
+        self.assertTrue(metadata["changed"])
+
+    def test_connected_field_rng_consumption_is_saved_for_reproduce(self):
+        saved_source = [
+            {
+                "id": "positive_connected",
+                "pane": "positive",
+                "type": "general",
+                "text": "stored fallback",
+                "enabled": True,
+            },
+            {
+                "id": "positive_local",
+                "pane": "positive",
+                "type": "general",
+                "text": "{red|blue|green}",
+                "enabled": True,
+            },
+        ]
+        field_inputs = {
+            "field_positive_connected": "{cat|dog|fox}",
+        }
+        effective_source = nodes_module._apply_advanced_field_inputs(
+            saved_source,
+            field_inputs,
+        )
+        saved_fields, _saved_metadata = nodes_module._expand_advanced_wildcard_fields(
+            saved_source,
+            17,
+            "고정",
+        )
+        effective_fields, _effective_metadata = nodes_module._expand_advanced_wildcard_fields(
+            effective_source,
+            17,
+            "고정",
+        )
+
+        nodes_module._preserve_expanded_connected_field_texts(
+            saved_fields,
+            effective_source,
+            effective_fields,
+            field_inputs,
+        )
+
+        self.assertEqual(
+            [field["text"] for field in effective_fields],
+            ["fox", "red"],
+        )
+        self.assertEqual(
+            [field["text"] for field in saved_fields],
+            ["fox", "red"],
+        )
+
     def test_input_tooltips_cover_syntax_cache_and_actual_mode_lifecycle(self):
         inputs = EasyUseAnimaWildcard.INPUT_TYPES()["required"]
         text_tooltip = inputs["text"][1]["tooltip"]
@@ -1073,16 +1213,26 @@ class WildcardNodeTests(unittest.TestCase):
         expand.assert_called_once_with("", seed=5, mode="reproduce")
         self.assertEqual(result["result"], ("", 5))
 
-    def test_native_reproduce_expands_file_wildcard_from_populated_text(self):
+    def test_native_reproduce_repeats_file_selection_with_the_same_seed(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            (root / "style.txt").write_text("resolved from file\n", encoding="utf-8")
+            (root / "style.txt").write_text(
+                "first file option\nsecond file option\nthird file option\n",
+                encoding="utf-8",
+            )
 
             def expand_from_test_root(text, *, seed, mode):
                 return expand_wildcards(text, seed=seed, mode=mode, roots=[root])
 
             with patch("nodes.expand_wildcards", side_effect=expand_from_test_root) as expand:
-                result = EasyUseAnimaWildcard().generate(
+                first = EasyUseAnimaWildcard().generate(
+                    "ignored source",
+                    "__style__",
+                    "재현",
+                    5,
+                    "fixed",
+                )
+                second = EasyUseAnimaWildcard().generate(
                     "ignored source",
                     "__style__",
                     "재현",
@@ -1090,9 +1240,13 @@ class WildcardNodeTests(unittest.TestCase):
                     "fixed",
                 )
 
-        expand.assert_called_once_with("__style__", seed=5, mode="reproduce")
-        self.assertEqual(result["result"], ("resolved from file", 5))
-        self.assertEqual(result["ui"]["wildcard"][0]["used_keys"], ["style"])
+        self.assertEqual(expand.call_count, 2)
+        for call in expand.call_args_list:
+            self.assertEqual(call.args, ("__style__",))
+            self.assertEqual(call.kwargs, {"seed": 5, "mode": "reproduce"})
+        self.assertEqual(first["result"], second["result"])
+        self.assertEqual(first["result"][1], 5)
+        self.assertEqual(first["ui"]["wildcard"][0]["used_keys"], ["style"])
 
     def test_prompt_studio_reproduce_keeps_saved_fields_and_does_not_advance_seed(self):
         fields = [{
@@ -1430,13 +1584,13 @@ class WildcardNodeTests(unittest.TestCase):
         }
 
         with patch(
-            "nodes.expand_wildcards",
-            return_value=WildcardExpansionResult(
+            "nodes.expand_wildcard_texts",
+            return_value=(WildcardExpansionResult(
                 text="expanded style",
                 changed=True,
                 used_keys=("style",),
                 missing_keys=(),
-            ),
+            ),),
         ):
             result = EasyUseAnimaPromptStudioAdvanced().build(
                 False,

--- a/web/js/prompt_studio/advanced_controls.js
+++ b/web/js/prompt_studio/advanced_controls.js
@@ -40,6 +40,7 @@ import {
 } from "./widgets.js";
 import {
   bindWildcardSeedInput,
+  wildcardSeedControlForMode,
 } from "./wildcard_seed_contract.js";
 
 function setAdvancedControlValue(node, name, value) {
@@ -590,10 +591,14 @@ function createAdvancedWildcardSettingsBody(node) {
   const syncMode = () => {
     const nextMode = normalizeAdvancedWildcardMode(modeSelect.value);
     setAdvancedWidgetValue(node, "wildcard_mode", nextMode);
-    if (nextMode === "순차") {
-      setAdvancedWidgetValue(node, "wildcard_seed_after_generate", "increment");
-      controlSelect.value = "increment";
+    const nextControl = wildcardSeedControlForMode(
+      nextMode,
+      normalizeAdvancedSeedControl(controlWidget.value),
+    );
+    if (nextControl !== controlWidget.value) {
+      setAdvancedWidgetValue(node, "wildcard_seed_after_generate", nextControl);
     }
+    controlSelect.value = nextControl;
     controlSelect.disabled = nextMode === "순차";
     applyAdvancedWildcardModeTitle(modeRow, modeSelect, nextMode);
     refreshSummary();

--- a/web/js/prompt_studio/regional/field_editor.js
+++ b/web/js/prompt_studio/regional/field_editor.js
@@ -26,6 +26,7 @@ import {
 } from "./lifecycle.js";
 import {
   bindWildcardSeedInput,
+  wildcardSeedControlForMode,
 } from "../wildcard_seed_contract.js";
 import { disposeExternalAutocompleteInputs } from "../../autocomplete/entry_lifecycle.js";
 
@@ -158,11 +159,15 @@ function createRegionalFieldEditor(runtime, layout, maskEditor, hooks) {
     const syncMode = () => {
       const nextMode = normalizeWildcardMode(modeSelect.value);
       runtime.setRegionalWidgetValue(node, "wildcard_mode", nextMode);
-      if (nextMode === "순차") {
+      const nextControl = wildcardSeedControlForMode(
+        nextMode,
+        normalizeSeedControl(controlWidget.value),
+      );
+      if (nextControl !== controlWidget.value) {
         runtime.setRegionalWidgetValue(
           node,
           "wildcard_seed_after_generate",
-          "increment",
+          nextControl,
         );
       }
       renderRegionalEditor(node);

--- a/web/js/prompt_studio/wildcard_seed_contract.js
+++ b/web/js/prompt_studio/wildcard_seed_contract.js
@@ -2,6 +2,27 @@
 
 const WILDCARD_SEED_MAX = Number.MAX_SAFE_INTEGER;
 const WILDCARD_SEED_MAX_BIGINT = BigInt(WILDCARD_SEED_MAX);
+const WILDCARD_MODE_CONTROL_OVERRIDES = new Map([
+  ["sequential", "increment"],
+  ["순차", "increment"],
+  ["reproduce", "fixed"],
+  ["재현", "fixed"],
+]);
+
+/**
+ * Return the seed control implied by a mode selection. Populate and Fixed
+ * preserve the user's current control; Sequential and Reproduce apply their
+ * explicit lifecycle defaults at the moment the user selects the mode.
+ *
+ * @param {any} mode
+ * @param {any} currentControl
+ */
+function wildcardSeedControlForMode(mode, currentControl) {
+  return WILDCARD_MODE_CONTROL_OVERRIDES.get(
+    String(mode || "").trim().toLowerCase(),
+  )
+    || String(currentControl || "fixed");
+}
 
 /** @param {any} value */
 function normalizeWildcardSeed(value) {
@@ -127,4 +148,5 @@ export {
   normalizeWildcardSeedInput,
   optionalWildcardSeed,
   randomWildcardSeed,
+  wildcardSeedControlForMode,
 };

--- a/wildcard_engine.py
+++ b/wildcard_engine.py
@@ -881,8 +881,15 @@ class _Selector:
 
 
 class _WildcardLibrary:
-    def __init__(self, roots: Iterable[Path]):
-        self.mapping = _wildcard_snapshot(roots).mapping
+    def __init__(
+        self,
+        roots: Iterable[Path] | None = None,
+        *,
+        snapshot: _WildcardSnapshot | None = None,
+    ):
+        if snapshot is None:
+            snapshot = _wildcard_snapshot(roots or ())
+        self.mapping = snapshot.mapping
         self.used: list[str] = []
         self.missing: list[str] = []
 
@@ -1093,6 +1100,149 @@ def _expansion_state_signature(text: str) -> tuple[int, bytes]:
     return len(text), digest.digest()
 
 
+@dataclass
+class _ExpansionLane:
+    source: str
+    current: _ExpansionText
+    state: _ExpansionState
+    library: _WildcardLibrary
+
+
+def expand_wildcard_texts(
+    texts: Sequence[str],
+    seed=0,
+    mode: str = WILDCARD_MODE_POPULATE,
+    extra_paths: str | None = None,
+    roots: Iterable[Path] | None = None,
+    budget: WildcardExpansionBudget | None = None,
+) -> tuple[WildcardExpansionResult, ...]:
+    """Expand ordered texts through one deterministic selector stream.
+
+    Each text keeps its existing recursion and safety budget, while expansion
+    stages run across the texts in order. This matches expanding one Prompt
+    Studio prompt without joining fields through a lossy delimiter.
+    """
+    sources = tuple(str(text or "") for text in texts)
+    if not sources:
+        return ()
+
+    mode = normalize_wildcard_mode(mode)
+    selector = _Selector(
+        normalize_seed(seed),
+        sequential=mode == WILDCARD_MODE_SEQUENTIAL,
+    )
+    resolved_roots = tuple(
+        Path(root)
+        for root in (
+            roots if roots is not None else resolve_wildcard_roots(extra_paths)
+        )
+    )
+    snapshot = _wildcard_snapshot(resolved_roots)
+    expansion_budget = (
+        budget
+        if isinstance(budget, WildcardExpansionBudget)
+        else WildcardExpansionBudget()
+    )
+    lanes: list[_ExpansionLane] = []
+    for source in sources:
+        state = _ExpansionState(expansion_budget)
+        cleaned = COMMENT_RE.sub("", source)
+        if (
+            len(cleaned) > expansion_budget.max_output_chars
+            or _utf8_length(cleaned) > expansion_budget.max_output_chars
+        ):
+            cleaned = _bounded_output_prefix(
+                cleaned,
+                expansion_budget.max_output_chars,
+            )
+            state.stop("max_output_chars")
+        current = _ExpansionText.from_text(cleaned)
+        lanes.append(
+            _ExpansionLane(
+                source=source,
+                current=current,
+                state=state,
+                library=_WildcardLibrary(snapshot=snapshot),
+            )
+        )
+
+    seen_batch_states = {
+        tuple(_expansion_state_signature(lane.current.text) for lane in lanes)
+    }
+    if expansion_budget.max_depth == 0:
+        for lane in lanes:
+            if lane.state.limit_reason is None and has_wildcard_syntax(lane.current.text):
+                lane.state.stop("max_depth")
+    else:
+        for depth in range(expansion_budget.max_depth):
+            active_lanes = [
+                lane for lane in lanes if lane.state.limit_reason is None
+            ]
+            if not active_lanes:
+                break
+            replacements_before_pass = sum(
+                lane.state.replacement_count for lane in lanes
+            )
+            for lane in active_lanes:
+                lane.state.begin_pass(lane.current)
+
+            for replace_stage in (
+                _replace_dynamic,
+                _replace_quantified_wildcards,
+                _replace_file_wildcards,
+            ):
+                for lane in active_lanes:
+                    if lane.state.limit_reason is None:
+                        lane.current = replace_stage(
+                            lane.current,
+                            lane.state,
+                            selector,
+                            lane.library,
+                        )
+
+            replacements_after_pass = sum(
+                lane.state.replacement_count for lane in lanes
+            )
+            if replacements_after_pass == replacements_before_pass:
+                break
+            unresolved_lanes = [
+                lane
+                for lane in lanes
+                if lane.state.limit_reason is None
+                and has_wildcard_syntax(lane.current.text)
+            ]
+            if not unresolved_lanes:
+                break
+            batch_signature = tuple(
+                _expansion_state_signature(lane.current.text)
+                for lane in lanes
+            )
+            if batch_signature in seen_batch_states:
+                for lane in unresolved_lanes:
+                    lane.state.stop("repeated_state")
+                break
+            seen_batch_states.add(batch_signature)
+            if depth + 1 >= expansion_budget.max_depth:
+                for lane in unresolved_lanes:
+                    lane.state.stop("max_depth")
+                break
+
+    return tuple(
+        WildcardExpansionResult(
+            text=lane.current.text,
+            changed=lane.current.text != lane.source,
+            used_keys=tuple(lane.library.used),
+            missing_keys=tuple(lane.library.missing),
+            replacement_count=lane.state.replacement_count,
+            limit_reason=(
+                lane.state.limit_reason
+                or ("cycle" if lane.state.cycle_detected else None)
+            ),
+        )
+        for lane in lanes
+    )
+
+
 
 def expand_wildcards(
     text: str,
@@ -1102,54 +1252,11 @@ def expand_wildcards(
     roots: Iterable[Path] | None = None,
     budget: WildcardExpansionBudget | None = None,
 ) -> WildcardExpansionResult:
-    source = str(text or "")
-    mode = normalize_wildcard_mode(mode)
-    selector = _Selector(normalize_seed(seed), sequential=mode == WILDCARD_MODE_SEQUENTIAL)
-    library = _WildcardLibrary(roots if roots is not None else resolve_wildcard_roots(extra_paths))
-    budget = budget if isinstance(budget, WildcardExpansionBudget) else WildcardExpansionBudget()
-    state = _ExpansionState(budget)
-
-    cleaned = COMMENT_RE.sub("", source)
-    if len(cleaned) > budget.max_output_chars or _utf8_length(cleaned) > budget.max_output_chars:
-        cleaned = _bounded_output_prefix(cleaned, budget.max_output_chars)
-        state.stop("max_output_chars")
-    current = _ExpansionText.from_text(cleaned)
-    # Key stacks stop file recursion before append; stable pass signatures are
-    # a separate fallback for keyless fixed points and oscillating expressions.
-    seen_states = {_expansion_state_signature(current.text)}
-
-    if state.limit_reason is None:
-        for depth in range(budget.max_depth):
-            state.begin_pass(current)
-            replacements_before_pass = state.replacement_count
-            current = _replace_dynamic(current, state, selector, library)
-            if state.limit_reason is None:
-                current = _replace_quantified_wildcards(current, state, selector, library)
-            if state.limit_reason is None:
-                current = _replace_file_wildcards(current, state, selector, library)
-            if state.limit_reason is not None:
-                break
-            if state.replacement_count == replacements_before_pass:
-                break
-            if not has_wildcard_syntax(current.text):
-                break
-            signature = _expansion_state_signature(current.text)
-            if signature in seen_states:
-                state.stop("repeated_state")
-                break
-            seen_states.add(signature)
-            if depth + 1 >= budget.max_depth:
-                state.stop("max_depth")
-                break
-        else:
-            if budget.max_depth == 0 and has_wildcard_syntax(current.text):
-                state.stop("max_depth")
-
-    return WildcardExpansionResult(
-        text=current.text,
-        changed=current.text != source,
-        used_keys=tuple(library.used),
-        missing_keys=tuple(library.missing),
-        replacement_count=state.replacement_count,
-        limit_reason=state.limit_reason or ("cycle" if state.cycle_detected else None),
-    )
+    return expand_wildcard_texts(
+        (text,),
+        seed=seed,
+        mode=mode,
+        extra_paths=extra_paths,
+        roots=roots,
+        budget=budget,
+    )[0]


### PR DESCRIPTION
## 변경 요약

- Prompt Studio의 여러 와일드카드 필드가 Impact Pack처럼 하나의 ordered PCG64 시드 스트림을 공유하도록 수정했습니다.
- Advanced/V2/Regional에서 같은 입력과 같은 seed가 동적·중첩·파일 와일드카드에 동일한 결과를 재현합니다.
- 연결 필드가 앞에서 RNG를 소비해도 저장되는 Reproduce snapshot과 실제 출력의 뒤 필드 결과가 일치합니다.
- Prompt Studio에서 `재현` 모드를 선택하면 생성 후 시드 제어가 즉시 `fixed`로 바뀌고, `순차 → increment` 및 다른 모드의 기존 제어값 보존은 유지됩니다.

## 주요 파일

- `wildcard_engine.py`: ordered multi-text wildcard expansion API와 shared selector stream
- `nodes.py`: Prompt Studio field batch expansion 및 connected-field snapshot 동기화
- `web/js/prompt_studio/wildcard_seed_contract.js`: 모드별 seed-control 연동 계약
- `web/js/prompt_studio/advanced_controls.js`
- `web/js/prompt_studio/regional/field_editor.js`
- wildcard/frontend/analyzer 회귀 테스트와 공식 fixture

## 검증

- 공식 full profile: Python unittest 721/721 통과
- Frontend: 111 JavaScript 파일 smoke 통과
- TypeScript 6.0.3 통과
- Python compile 및 `git diff --check` 통과
- 동적·중첩·파일 와일드카드의 동일 seed 반복 결과와 저장/재열기 회귀 통과

## 남은 확인

- 병합 후 최신 `dev`를 Codex test instance에 반영해 Legacy/Node 2.0 실제 UI와 wildcard 실행을 별도로 확인합니다.

Closes #226
