### PR TITLE
fix: AiO 의존성 팝업을 명시적 기능 선택으로 제한

### DIFF
--- a/tests/frontend_aio_advanced_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_advanced_settings_dialog_smoke.mjs
@@ -151,6 +151,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   const dialogs = [];
   const loadCalls = [];
   const loadResolvers = [];
+  const notifications = [];
   const mergeCalls = [];
   const clampCalls = [];
   const writes = [];
@@ -334,6 +335,15 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
         dependencyCalls += 1;
         return `pack:${key}`;
       },
+      markMissingControl(control, missing, message = "") {
+        control.disabled = false;
+        control.parentElement?.classList.toggle("easyuse-anima-aio-unsupported", missing);
+        control.title = missing ? message : "";
+      },
+      notifyMissing(backend, keys) {
+        notifications.push({ backend, keys: [...keys] });
+        return true;
+      },
       load(options) {
         dependencyCalls += 1;
         loadCalls.push(options);
@@ -353,6 +363,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     dialogs,
     loadCalls,
     availabilityState,
+    notifications,
     mergeCalls,
     clampCalls,
     writes,
@@ -705,10 +716,9 @@ for (const dependencyCase of [
   await flushPromises();
 
   for (const [groupKey, controls] of Object.entries(controlGroups)) {
-    assertDisabled(
-      controls,
-      groupKey === dependencyCase.key,
-    );
+    const [primary, ...details] = controls;
+    assertDisabled([primary], false);
+    assertDisabled(details, groupKey === dependencyCase.key);
   }
   assert.equal(warning.hidden, false);
   assert.equal(
@@ -719,6 +729,25 @@ for (const dependencyCase of [
     })}`,
     `Only ${dependencyCase.key} must contribute its warning`,
   );
+  assert.deepEqual(fixture.notifications, [], "Async dependency refresh must stay silent");
+  const primaryControls = {
+    dave: controlIn(dave, "Use DAVE"),
+    safePag: controlIn(safePag, "Use Safe PAG"),
+    kjFp16: controlIn(kj, "KJNodes FP16 accum"),
+    kjSage: controlIn(sage, "Mode"),
+    kjTorchCompile: controlIn(torch, "Use Torch compile"),
+  };
+  const primary = primaryControls[dependencyCase.key];
+  if (dependencyCase.key === "kjSage") {
+    primary.value = "auto";
+  } else {
+    primary.checked = true;
+  }
+  primary.emit("change");
+  assert.deepEqual(fixture.notifications, [{
+    backend: dependencyCase.backend,
+    keys: [dependencyCase.key],
+  }]);
 }
 
 {
@@ -766,10 +795,15 @@ for (const dependencyCase of [
 
   assertDisabled([
     [dave, "Use DAVE"],
+    [safePag, "Use Safe PAG"],
+    [kj, "KJNodes FP16 accum"],
+    [sage, "Mode"],
+    [torch, "Use Torch compile"],
+  ], false);
+  assertDisabled([
     [dave, "Mask"],
     [dave, "DAVE strength"],
     [dave, "DAVE tau"],
-    [safePag, "Use Safe PAG"],
     [safePag, "Safe PAG scale"],
     [safePag, "Safe PAG blocks"],
     [safePag, "PAG perturbation"],
@@ -778,10 +812,7 @@ for (const dependencyCase of [
     [safePag, "PAG end percent"],
     [safePag, "PAG rescale"],
     [safePag, "PAG rescale mode"],
-    [kj, "KJNodes FP16 accum"],
-    [sage, "Mode"],
     [sage, "Allow compile"],
-    [torch, "Use Torch compile"],
     [torchDetails, "Backend"],
     [torchDetails, "Fullgraph"],
     [torchDetails, "Mode"],
@@ -790,7 +821,7 @@ for (const dependencyCase of [
     [torchDetails, "Dynamo cache limit"],
     [torchDetails, "Debug keys"],
     [torchDetails, "Disable dynamic VRAM"],
-  ]);
+  ], true);
   assertChecked([
     [dave, "Use DAVE", false],
     [safePag, "Use Safe PAG", false],

--- a/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_detailer_settings_dialog_smoke.mjs
@@ -92,6 +92,7 @@ function createFixture({
   const dialogs = [];
   const loadResolvers = [];
   const loadCalls = [];
+  const notifications = [];
   const writes = [];
   const renders = [];
   const stageCalls = [];
@@ -438,6 +439,15 @@ function createFixture({
         dependencyCalls += 1;
         return `pack:${key}`;
       },
+      markMissingControl(control, missing, message = "") {
+        control.disabled = false;
+        control.parentElement?.classList.toggle("easyuse-anima-aio-unsupported", missing);
+        control.title = missing ? message : "";
+      },
+      notifyMissing(backend, keys) {
+        notifications.push({ backend, keys: [...keys] });
+        return true;
+      },
       load(options) {
         dependencyCalls += 1;
         loadCalls.push(options);
@@ -458,6 +468,7 @@ function createFixture({
     dialogs,
     loadCalls,
     availabilityState,
+    notifications,
     writes,
     renders,
     stageCalls,
@@ -770,13 +781,21 @@ function createFixture({
     "legacy-missing.safetensors",
     "SAM3 hydration must preserve a saved value missing from the current catalog",
   );
-  assert.equal(enabled.disabled, true, "Missing dependencies must lock Detailer after async refresh");
+  assert.equal(enabled.disabled, false, "Detailer must remain interactive for an explicit notice");
   assert.equal(enabled.checked, false, "Missing dependencies must clear an enabled Detailer toggle");
   assert.equal(warning.hidden, false);
   assert.equal(
     warning.textContent,
     'format:warning.optionalDependencyMissing:{"backend":"Detailer","pack":"pack:impactDetailer, pack:impactMaskToSegs"}',
   );
+  assert.deepEqual(fixture.notifications, [], "Async dependency refresh must stay silent");
+  enabled.checked = true;
+  enabled.emit("change");
+  assert.deepEqual(fixture.notifications, [{
+    backend: "Detailer",
+    keys: ["impactDetailer", "impactMaskToSegs"],
+  }]);
+  assert.equal(enabled.checked, false);
 
   action(dialog, "button.apply").emit("click");
   assert.deepEqual(dialog.trace.slice(-3), ["write", "render", "remove"]);

--- a/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_sampler_settings_dialog_smoke.mjs
@@ -108,6 +108,7 @@ function createFixture({
   const mergeVisibleCalls = [];
   const optionCalls = [];
   const supportedCalls = [];
+  const notifications = [];
   const writes = [];
   const renders = [];
   const applyVisibleCalls = [];
@@ -416,6 +417,15 @@ function createFixture({
         }
         return !Object.hasOwn(availabilityState, key) || !!availabilityState[key];
       },
+      markMissingControl(control, missing, message = "") {
+        control.disabled = false;
+        control.parentElement?.classList.toggle("easyuse-anima-aio-unsupported", missing);
+        control.title = missing ? message : "";
+      },
+      notifyMissing(backend, keys) {
+        notifications.push({ backend, keys: [...keys] });
+        return true;
+      },
       load(options) {
         dependencyCalls += 1;
         loadCalls.push(options);
@@ -438,6 +448,7 @@ function createFixture({
     mergeVisibleCalls,
     optionCalls,
     supportedCalls,
+    notifications,
     writes,
     renders,
     applyVisibleCalls,
@@ -518,7 +529,7 @@ function createFixture({
   assert.equal(dialog.title, "Sampler Details");
   assert.equal(
     dialog.subtitle,
-    "Choose one of three sampler paths. Missing optional node packs are locked before queue execution.",
+    "Choose one of three sampler paths. Selecting an unavailable path shows its required node pack.",
   );
   const base = sectionByHeading(dialog, "Base Parameters");
   const sampler = sectionByHeading(dialog, "Sampler Backend");
@@ -840,12 +851,12 @@ for (const testCase of [
   fixture.resolveLoads();
   await flushPromises();
 
-  assert.equal(advancedOption.disabled, true);
+  assert.equal(advancedOption.disabled, false, "Missing backends must remain selectable for an explicit notice");
   assert.equal(advancedOption.textContent, "spectrum_mod_guidance_advanced (pack:spectrumAdvanced missing)");
   assert.equal(backend.value, "comfy_ksampler", "Missing selected backend must fall back to Comfy KSampler");
-  assert.equal(controlIn(spectrum, "Use Spectrum patch").disabled, true);
+  assert.equal(controlIn(spectrum, "Use Spectrum patch").disabled, false);
   assert.equal(controlIn(spectrum, "Use Spectrum patch").checked, false);
-  assert.equal(controlIn(corrections, "Use corrections").disabled, true);
+  assert.equal(controlIn(corrections, "Use corrections").disabled, false);
   assert.equal(controlIn(corrections, "Use corrections").checked, false);
   assert.equal(
     warningIn(dialog).textContent,
@@ -853,6 +864,22 @@ for (const testCase of [
       + 'format:warning.optionalDependencyMissing:{"backend":"Spectrum Patch","pack":"pack:spectrumPatch"}',
   );
   assertBackendVisibility(dialog, "comfy_ksampler");
+  assert.deepEqual(fixture.notifications, [], "Async dependency refresh must stay silent");
+  setSelectValue(backend, "spectrum_mod_guidance_advanced");
+  backend.emit("change");
+  assert.deepEqual(fixture.notifications, [{
+    backend: "spectrum_mod_guidance_advanced",
+    keys: ["spectrumAdvanced"],
+  }]);
+  assert.equal(backend.value, "comfy_ksampler");
+  const spectrumToggle = controlIn(spectrum, "Use Spectrum patch");
+  spectrumToggle.checked = true;
+  spectrumToggle.emit("change");
+  assert.deepEqual(fixture.notifications.at(-1), {
+    backend: "Spectrum Patch",
+    keys: ["spectrumPatch"],
+  });
+  assert.equal(spectrumToggle.checked, false);
   const latestInputInfo = fixture.supportedCalls.slice(-17);
   assert.deepEqual(
     latestInputInfo.slice(0, 7).map(({ key }) => key),

--- a/tests/frontend_aio_save_settings_dialog_smoke.mjs
+++ b/tests/frontend_aio_save_settings_dialog_smoke.mjs
@@ -138,6 +138,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   const dialogs = [];
   const loadCalls = [];
   const loadResolvers = [];
+  const notifications = [];
   const writes = [];
   const renders = [];
   const visibleApplies = [];
@@ -347,6 +348,15 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
         dependencyCalls += 1;
         return `pack:${key}`;
       },
+      markMissingControl(control, missing, message = "") {
+        control.disabled = false;
+        control.parentElement?.classList.toggle("easyuse-anima-aio-unsupported", missing);
+        control.title = missing ? message : "";
+      },
+      notifyMissing(backend, keys) {
+        notifications.push({ backend, keys: [...keys] });
+        return true;
+      },
       load(options) {
         dependencyCalls += 1;
         loadCalls.push(options);
@@ -366,6 +376,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     dialogs,
     loadCalls,
     availabilityState,
+    notifications,
     writes,
     renders,
     visibleApplies,
@@ -395,7 +406,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   assert.equal(dialog.title, "Save Options");
   assert.equal(
     dialog.subtitle,
-    "Image Saver requires ComfyUI-Image-Saver. Missing node packs are reported during queue execution.",
+    "Image Saver requires ComfyUI-Image-Saver. Selecting an unavailable backend shows its required node pack.",
   );
   assert.ok(dialog.body.classList.contains("easyuse-anima-aio-save-body"));
   const main = sectionByHeading(dialog.body, "Save Backend");
@@ -498,7 +509,7 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
   fixture.availabilityState.imageSaver = false;
   fixture.resolveLoads();
   await flushPromises();
-  assert.equal(imageSaverOption.disabled, true, "Deferred dependency refresh must disable Image Saver");
+  assert.equal(imageSaverOption.disabled, false, "Missing backend remains selectable for an explicit notice");
   assert.equal(imageSaverOption.textContent, "image_saver (pack:imageSaver missing)");
   assert.equal(backend.value, "comfy_save_image", "Missing Image Saver must select the built-in fallback");
   assert.equal(warning.hidden, false);
@@ -506,6 +517,14 @@ function createFixture({ settings = {}, available = {}, deferLoads = false } = {
     warning.textContent,
     'format:warning.optionalDependencyMissing:{"backend":"image_saver","pack":"pack:imageSaver"}',
   );
+  assert.deepEqual(fixture.notifications, [], "Async dependency refresh must stay silent");
+  backend.value = "image_saver";
+  backend.emit("change");
+  assert.deepEqual(fixture.notifications, [{
+    backend: "image_saver",
+    keys: ["imageSaver"],
+  }]);
+  assert.equal(backend.value, "comfy_save_image");
 
   controlIn(main, "Save image").checked = false;
   controlIn(files, "Filename").value = "";

--- a/tests/frontend_aio_stage_settings_dialogs_smoke.mjs
+++ b/tests/frontend_aio_stage_settings_dialogs_smoke.mjs
@@ -81,6 +81,7 @@ function createFixture({
   const loadResolvers = [];
   const optionCalls = [];
   const choiceCalls = [];
+  const notifications = [];
   let catalogLoaded = !deferLoads;
   const writes = [];
   const renders = [];
@@ -328,6 +329,18 @@ function createFixture({
         dependencyCalls += 1;
         return [...(missingByBackendState[backend] || [])];
       },
+      upscaleBackendMissingKeys(backend) {
+        return (missingByBackendState[backend] || []).length ? [`${backend}Dependency`] : [];
+      },
+      markMissingControl(control, missing, message = "") {
+        control.disabled = false;
+        control.parentElement?.classList.toggle("easyuse-anima-aio-unsupported", missing);
+        control.title = missing ? message : "";
+      },
+      notifyMissing(backend, keys) {
+        notifications.push({ backend, keys: [...keys] });
+        return true;
+      },
       load(options) {
         dependencyCalls += 1;
         loadCalls.push(options);
@@ -351,6 +364,7 @@ function createFixture({
     missingByBackendState,
     optionCalls,
     choiceCalls,
+    notifications,
     writes,
     renders,
     trace,
@@ -443,14 +457,23 @@ function createFixture({
   assert.equal(control(dialog, "CFG").parentElement.style.display, "none");
   assert.equal(control(dialog, "Sampler").parentElement.style.display, "none");
   assert.equal(control(dialog, "Scheduler").parentElement.style.display, "none");
-  assert.equal(control(dialog, "Spectrum patch").disabled, true);
+  assert.equal(control(dialog, "Spectrum patch").disabled, false);
   assert.equal(control(dialog, "Spectrum patch").checked, false);
-  assert.equal(control(dialog, "Use corrections").disabled, true);
+  assert.equal(control(dialog, "Use corrections").disabled, false);
   assert.equal(control(dialog, "Use corrections").checked, false);
   const warnings = findAll(dialog.body, (element) => element.classList.contains("easyuse-anima-aio-warning"));
   const spdWarning = warnings.find((element) => element.textContent === "text:text.highresSpdManualRequired");
   assert.ok(spdWarning);
   assert.ok(warnings.some((element) => element.textContent.includes("pack:spectrumPatch")));
+  assert.deepEqual(fixture.notifications, [], "Dependency refresh must not notify by itself");
+  const spectrumToggle = control(dialog, "Spectrum patch");
+  spectrumToggle.checked = true;
+  spectrumToggle.emit("change");
+  assert.deepEqual(fixture.notifications, [{
+    backend: "Highres Optimization",
+    keys: ["spectrumPatch"],
+  }]);
+  assert.equal(spectrumToggle.checked, false);
 
   const inheritSampler = control(dialog, "Follow main sampler");
   inheritSampler.checked = false;
@@ -550,7 +573,7 @@ function createFixture({
     new Set(fixture.choiceCalls.map(({ dependencyKey, inputName }) => `${dependencyKey}:${inputName}`)),
     new Set(["upscaleModelLoader:model_name", "resShiftLoader:student_name"]),
   );
-  assert.equal(resshiftOption.disabled, true);
+  assert.equal(resshiftOption.disabled, false, "Missing backend remains selectable for an explicit notice");
   assert.ok(resshiftOption.textContent.includes("ComfyUI-ResShift"));
   assert.equal(control(dialog, "Enable upscale").checked, false, "Missing selected backend must disable upscale");
   assert.deepEqual(
@@ -583,6 +606,14 @@ function createFixture({
   assert.equal(control(dialog, "Chop").value, "768");
   assert.equal(control(dialog, "Overlap").value, "96");
   assert.equal(control(dialog, "Tile batch", 1).value, "3");
+
+  assert.deepEqual(fixture.notifications, [], "Async backend refresh must stay silent");
+  backend.emit("change");
+  assert.deepEqual(fixture.notifications, [{
+    backend: "resshift",
+    keys: ["resshiftDependency"],
+  }]);
+  assert.equal(backend.value, "usdu", "Rejected backend selection must restore an available fallback");
 
   setSelectValue(backend, "usdu");
   backend.emit("change");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -748,14 +748,17 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertIn("upscaleBackendMissingPacks(next.upscale.backend).length", body)
         self.assertIn("next.upscale.enabled = false", body)
 
-    def test_optional_dependency_query_adapter_updates_cache_and_reports_results(self):
+    def test_optional_dependency_query_is_silent_until_explicit_missing_selection(self):
         source = AIO_JS.read_text(encoding="utf-8")
         fetch_start = source.index("async function fetchGeneratorOptionalDependencies")
-        fetch_end = source.index("\nfunction optionalDependencyResultLabel", fetch_start)
+        fetch_end = source.index("\nfunction notifyGeneratorMissingDependencies", fetch_start)
         fetch_body = source[fetch_start:fetch_end]
-        report_start = source.index("function reportGeneratorOptionalDependencyStatus")
-        report_end = source.index("\nfunction loadGeneratorOptionalDependencies", report_start)
-        report_body = source[report_start:report_end]
+        notify_start = source.index("function notifyGeneratorMissingDependencies")
+        notify_end = source.index("\nfunction loadGeneratorOptionalDependencies", notify_start)
+        notify_body = source[notify_start:notify_end]
+        load_start = source.index("function loadGeneratorOptionalDependencies")
+        load_end = source.index("\nfunction optionalDependencyStatus", load_start)
+        load_body = source[load_start:load_end]
 
         self.assertIn("aioQueryOptionalDependencies(", fetch_body)
         self.assertIn("AIO_OPTIONAL_DEPENDENCY_SPECS", fetch_body)
@@ -770,9 +773,13 @@ class AIOFrontendSourceTests(unittest.TestCase):
                     f"generatorOptionalDependencyState.{cache_name} = next.{cache_name}",
                     fetch_body,
                 )
-        self.assertIn('console.info("[EasyUseAnima] AiO optional dependency query result", rows)', report_body)
-        self.assertIn('severity: failed.length ? "warn" : "info"', report_body)
-        self.assertIn("app.ui.dialog.show", report_body)
+        self.assertNotIn("toast.add", load_body)
+        self.assertNotIn("app.ui.dialog.show", load_body)
+        self.assertIn('optionalDependencyStatus(key) === "missing"', notify_body)
+        self.assertIn('severity: "warn"', notify_body)
+        self.assertIn("toast.add", notify_body)
+        self.assertIn("app.ui.dialog.show", notify_body)
+        self.assertNotIn("reportGeneratorOptionalDependencyStatus", source)
 
     def test_optional_dependency_query_retries_errors_before_queueing(self):
         source = AIO_JS.read_text(encoding="utf-8")

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -1646,6 +1646,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 "aioOptionalDependencyPack",
                 "aioOptionalDependencyStatus",
                 "aioQueryOptionalDependencies",
+                "aioUpscaleBackendDependencyKeys",
                 "aioUpscaleBackendMissingPacks",
             },
         )

--- a/web/js/aio/advanced_settings_dialog.js
+++ b/web/js/aio/advanced_settings_dialog.js
@@ -37,6 +37,8 @@
  * @typedef {object} AioAdvancedDialogDependencyAdapter
  * @property {(key: string) => boolean} available
  * @property {(key: string) => string} pack
+ * @property {(control: any, missing: boolean, message?: string) => void} markMissingControl
+ * @property {(backend: string, keys: string[]) => boolean} notifyMissing
  * @property {(options?: Record<string, any>) => Promise<any>} load
  */
 
@@ -95,6 +97,8 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
   const {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyMissingDependency,
     load: loadGeneratorOptionalDependencies,
   } = dependencyAdapter;
 
@@ -301,7 +305,12 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
       const messages = [];
 
       const daveMissing = !optionalDependencyAvailable("dave");
-      setControlsDisabled([daveEnabled, daveMask, daveStrength, daveTau], daveMissing);
+      setControlsDisabled([daveMask, daveStrength, daveTau], daveMissing);
+      const daveMessage = aioFormat("warning.optionalDependencyMissing", {
+        backend: "Anima DAVE",
+        pack: optionalDependencyPack("dave"),
+      });
+      aioMarkMissingDependencyControl(daveEnabled, daveMissing, daveMessage);
       if (daveMissing && daveEnabled.checked) {
         daveEnabled.checked = false;
       }
@@ -314,7 +323,6 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
 
       const safePagMissing = !optionalDependencyAvailable("safePag");
       setControlsDisabled([
-        safePagEnabled,
         safePagScale,
         safePagBlocks,
         safePagPerturbation,
@@ -324,6 +332,11 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
         safePagRescale,
         safePagRescaleMode,
       ], safePagMissing);
+      const safePagMessage = aioFormat("warning.optionalDependencyMissing", {
+        backend: "Anima Safe PAG",
+        pack: optionalDependencyPack("safePag"),
+      });
+      aioMarkMissingDependencyControl(safePagEnabled, safePagMissing, safePagMessage);
       if (safePagMissing && safePagEnabled.checked) {
         safePagEnabled.checked = false;
       }
@@ -335,7 +348,11 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
       }
 
       const kjFp16Missing = !optionalDependencyAvailable("kjFp16");
-      fp16Accum.disabled = kjFp16Missing;
+      const kjFp16Message = aioFormat("warning.optionalDependencyMissing", {
+        backend: "KJNodes FP16 accum",
+        pack: optionalDependencyPack("kjFp16"),
+      });
+      aioMarkMissingDependencyControl(fp16Accum, kjFp16Missing, kjFp16Message);
       if (kjFp16Missing && fp16Accum.checked) {
         fp16Accum.checked = false;
       }
@@ -347,7 +364,12 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
       }
 
       const kjSageMissing = !optionalDependencyAvailable("kjSage");
-      setControlsDisabled([sageAttention, sageAllowCompile], kjSageMissing);
+      setControlsDisabled([sageAllowCompile], kjSageMissing);
+      const kjSageMessage = aioFormat("warning.optionalDependencyMissing", {
+        backend: "SageAttention",
+        pack: optionalDependencyPack("kjSage"),
+      });
+      aioMarkMissingDependencyControl(sageAttention, kjSageMissing, kjSageMessage);
       if (kjSageMissing && sageAttention.value !== "disabled") {
         sageAttention.value = "disabled";
         sageAllowCompile.checked = false;
@@ -361,7 +383,6 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
 
       const kjCompileMissing = !optionalDependencyAvailable("kjTorchCompile");
       setControlsDisabled([
-        torchCompileEnabled,
         torchCompileBackend,
         torchCompileFullgraph,
         torchCompileMode,
@@ -371,6 +392,11 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
         torchCompileDebug,
         torchCompileDisableVram,
       ], kjCompileMissing);
+      const kjCompileMessage = aioFormat("warning.optionalDependencyMissing", {
+        backend: "Torch Compile",
+        pack: optionalDependencyPack("kjTorchCompile"),
+      });
+      aioMarkMissingDependencyControl(torchCompileEnabled, kjCompileMissing, kjCompileMessage);
       if (kjCompileMissing && torchCompileEnabled.checked) {
         torchCompileEnabled.checked = false;
       }
@@ -386,8 +412,29 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
       refreshSageDetails();
       refreshTorchDetails();
     };
-    sageAttention.addEventListener("change", refreshSageDetails);
-    torchCompileEnabled.addEventListener("change", refreshTorchDetails);
+    const guardToggle = (control, dependencyKey, backend) => {
+      if (control.checked && !optionalDependencyAvailable(dependencyKey)) {
+        notifyMissingDependency(backend, [dependencyKey]);
+        control.checked = false;
+      }
+      refreshAdvancedDependencyLocks();
+    };
+    daveEnabled.addEventListener("change", () => guardToggle(daveEnabled, "dave", "Anima DAVE"));
+    safePagEnabled.addEventListener("change", () => guardToggle(safePagEnabled, "safePag", "Anima Safe PAG"));
+    fp16Accum.addEventListener("change", () => guardToggle(fp16Accum, "kjFp16", "KJNodes FP16 accum"));
+    sageAttention.addEventListener("change", () => {
+      if (sageAttention.value !== "disabled" && !optionalDependencyAvailable("kjSage")) {
+        notifyMissingDependency("SageAttention", ["kjSage"]);
+        sageAttention.value = "disabled";
+        sageAllowCompile.checked = false;
+      }
+      refreshAdvancedDependencyLocks();
+    });
+    torchCompileEnabled.addEventListener("change", () => guardToggle(
+      torchCompileEnabled,
+      "kjTorchCompile",
+      "Torch Compile",
+    ));
     refreshSageDetails();
     refreshTorchDetails();
     refreshAdvancedDependencyLocks();
@@ -410,12 +457,12 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
         1,
         10,
       );
-      next.model_patches.dave.enabled = daveEnabled.checked && !daveEnabled.disabled;
+      next.model_patches.dave.enabled = daveEnabled.checked && optionalDependencyAvailable("dave");
       next.model_patches.dave.mask = daveMask.value || "dave_alpha.npz";
       next.model_patches.dave.strength = Number(daveStrength.value || 0.30);
       next.model_patches.dave.tau = Number(daveTau.value || 0.10);
       next.model_patches.safe_pag ||= {};
-      next.model_patches.safe_pag.enabled = safePagEnabled.checked && !safePagEnabled.disabled;
+      next.model_patches.safe_pag.enabled = safePagEnabled.checked && optionalDependencyAvailable("safePag");
       next.model_patches.safe_pag.scale = clampGeneratorNumber(safePagScale.value, 4.0, 0, 100);
       next.model_patches.safe_pag.block_indices = safePagBlocks.value || "18";
       next.model_patches.safe_pag.perturbation_strength = clampGeneratorNumber(
@@ -429,10 +476,14 @@ export function aioCreateAdvancedSettingsDialog(dependencies) {
       next.model_patches.safe_pag.end_percent = clampGeneratorNumber(safePagEnd.value, 0.7, 0, 1);
       next.model_patches.safe_pag.rescale = clampGeneratorNumber(safePagRescale.value, 0.2, 0, 1);
       next.model_patches.safe_pag.rescale_mode = safePagRescaleMode.value || "full";
-      next.model_patches.kj.fp16_accumulation = fp16Accum.checked && !fp16Accum.disabled;
-      next.model_patches.kj.sage_attention = sageAttention.disabled ? "disabled" : (sageAttention.value || "disabled");
-      next.model_patches.kj.sage_allow_compile = sageAllowCompile.checked && !sageAttention.disabled;
-      next.model_patches.kj.torch_compile.enabled = torchCompileEnabled.checked && !torchCompileEnabled.disabled;
+      next.model_patches.kj.fp16_accumulation = fp16Accum.checked && optionalDependencyAvailable("kjFp16");
+      next.model_patches.kj.sage_attention = optionalDependencyAvailable("kjSage")
+        ? (sageAttention.value || "disabled")
+        : "disabled";
+      next.model_patches.kj.sage_allow_compile = sageAllowCompile.checked
+        && optionalDependencyAvailable("kjSage");
+      next.model_patches.kj.torch_compile.enabled = torchCompileEnabled.checked
+        && optionalDependencyAvailable("kjTorchCompile");
       next.model_patches.kj.torch_compile.backend = torchCompileBackend.value || "inductor";
       next.model_patches.kj.torch_compile.fullgraph = torchCompileFullgraph.checked;
       next.model_patches.kj.torch_compile.mode = torchCompileMode.value || "max-autotune-no-cudagraphs";

--- a/web/js/aio/dependency_controls.js
+++ b/web/js/aio/dependency_controls.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+const dependencyControlState = new WeakMap();
+
+/**
+ * Keep a dependency-gated primary control interactive so an explicit user
+ * attempt can be explained, while visually marking it as unavailable.
+ * Dependent detail controls should still use their native disabled state.
+ *
+ * @param {any} control
+ * @param {boolean} missing
+ * @param {string} message
+ */
+export function aioMarkMissingDependencyControl(control, missing, message = "") {
+  if (!control) {
+    return;
+  }
+  const row = control.parentElement || null;
+  if (!dependencyControlState.has(control)) {
+    dependencyControlState.set(control, {
+      controlTitle: control.title || "",
+      rowTitle: row?.title || "",
+    });
+  }
+  const original = dependencyControlState.get(control);
+  control.disabled = false;
+  if (typeof control.setAttribute === "function") {
+    control.setAttribute("aria-disabled", missing ? "true" : "false");
+  }
+  row?.classList?.toggle("easyuse-anima-aio-unsupported", missing);
+  control.title = missing ? message : original.controlTitle;
+  if (row) {
+    row.title = missing ? message : original.rowTitle;
+  }
+}

--- a/web/js/aio/detailer_settings_dialog.js
+++ b/web/js/aio/detailer_settings_dialog.js
@@ -49,6 +49,8 @@
  * @typedef {object} AioDetailerDialogDependencyAdapter
  * @property {(key: string) => boolean} available
  * @property {(key: string) => string} pack
+ * @property {(control: any, missing: boolean, message?: string) => void} markMissingControl
+ * @property {(backend: string, keys: string[]) => boolean} notifyMissing
  * @property {(options?: Record<string, any>) => Promise<any>} load
  */
 
@@ -121,6 +123,8 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
   const {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyMissingDependency,
     load: loadGeneratorOptionalDependencies,
   } = dependencyAdapter;
 
@@ -436,18 +440,30 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
         missingPacks.push(optionalDependencyPack("impactMaskToSegs"));
       }
       const missing = missingPacks.length > 0;
-      enabled.disabled = missing;
-      if (missing && enabled.checked) {
-        enabled.checked = false;
-      }
-      dependencyWarning.hidden = !missing;
-      dependencyWarning.textContent = missing
+      const message = missing
         ? aioFormat("warning.optionalDependencyMissing", {
             backend: "Detailer",
             pack: [...new Set(missingPacks)].join(", "),
           })
         : "";
+      aioMarkMissingDependencyControl(enabled, missing, message);
+      if (missing && enabled.checked) {
+        enabled.checked = false;
+      }
+      dependencyWarning.hidden = !missing;
+      dependencyWarning.textContent = message;
     };
+    enabled.addEventListener("change", () => {
+      if (enabled.checked) {
+        const missingKeys = ["impactDetailer", "impactMaskToSegs"]
+          .filter((key) => !optionalDependencyAvailable(key));
+        if (missingKeys.length) {
+          notifyMissingDependency("Detailer", missingKeys);
+          enabled.checked = false;
+        }
+      }
+      refreshDetailerDependencyLocks();
+    });
     refreshDetailerDependencyLocks();
     loadGeneratorOptionalDependencies().then(() => {
       if (closed || backdrop.isConnected === false) {
@@ -477,7 +493,9 @@ export function aioCreateDetailerSettingsDialog(dependencies) {
     });
     apply.addEventListener("click", () => {
       const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
-      const detailerEnabled = enabled.checked && !enabled.disabled;
+      const detailerEnabled = enabled.checked
+        && optionalDependencyAvailable("impactDetailer")
+        && optionalDependencyAvailable("impactMaskToSegs");
       const nextDetailer = {
         ...next.detailer,
         enabled: detailerEnabled,

--- a/web/js/aio/sampler_settings_dialog.js
+++ b/web/js/aio/sampler_settings_dialog.js
@@ -54,6 +54,8 @@
  * @property {(key: string) => Record<string, any>} nodeInputMap
  * @property {(key: string, inputName: string) => string} nodeInputTooltip
  * @property {(key: string, inputName: string) => boolean} nodeInputSupported
+ * @property {(control: any, missing: boolean, message?: string) => void} markMissingControl
+ * @property {(backend: string, keys: string[]) => boolean} notifyMissing
  * @property {(options?: Record<string, any>) => Promise<any>} load
  */
 
@@ -187,6 +189,8 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
     nodeInputMap,
     nodeInputTooltip,
     nodeInputSupported,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyMissingDependency,
     load: loadGeneratorOptionalDependencies,
   } = dependencyAdapter;
 
@@ -275,7 +279,7 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
     const settings = mergeVisibleGeneratorSettings(node, parseSettings(widget, DEFAULT_GENERATION_SETTINGS));
     const { backdrop, body, actions } = createDialog(
       "Sampler Details",
-      "Choose one of three sampler paths. Missing optional node packs are locked before queue execution."
+      "Choose one of three sampler paths. Selecting an unavailable path shows its required node pack."
     );
 
     const makeSection = (title, className = "easyuse-anima-aio-section full") => {
@@ -421,8 +425,12 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
         const dependencyKey = AIO_BACKEND_DEPENDENCIES[option.value];
         const pack = optionalDependencyPack(dependencyKey);
         const missing = !!dependencyKey && !optionalDependencyAvailable(dependencyKey);
-        option.disabled = missing;
+        option.disabled = false;
         option.textContent = missing ? `${option.value} (${pack} missing)` : option.value;
+        option.classList?.toggle("easyuse-anima-aio-missing-option", missing);
+        option.title = missing
+          ? aioFormat("warning.optionalDependencyMissing", { backend: option.value, pack })
+          : "";
         if (missing && option.selected) {
           messages.push(aioFormat("warning.optionalDependencyMissing", {
             backend: option.value,
@@ -432,8 +440,12 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
         }
       }
       const spectrumPatchMissing = !optionalDependencyAvailable("spectrumPatch");
-      spectrumPatchEnabled.disabled = spectrumPatchMissing;
-      correctionsEnabled.disabled = spectrumPatchMissing;
+      const spectrumPatchMessage = aioFormat("warning.optionalDependencyMissing", {
+        backend: "Spectrum Patch",
+        pack: optionalDependencyPack("spectrumPatch"),
+      });
+      aioMarkMissingDependencyControl(spectrumPatchEnabled, spectrumPatchMissing, spectrumPatchMessage);
+      aioMarkMissingDependencyControl(correctionsEnabled, spectrumPatchMissing, spectrumPatchMessage);
       const spectrumInputDependency = backend.value === "comfy_ksampler" ? "spectrumPatch" : "spectrumAdvanced";
       const correctionInputDependency = backend.value === "comfy_ksampler" ? "spectrumCorrections" : "spectrumAdvanced";
       const spectrumControls = [
@@ -473,7 +485,23 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
       dependencyWarning.textContent = messages.join(" ");
       refreshBackendDetails();
     };
-    backend.addEventListener("change", refreshDependencyLocks);
+    backend.addEventListener("change", () => {
+      const dependencyKey = AIO_BACKEND_DEPENDENCIES[backend.value];
+      if (dependencyKey && !optionalDependencyAvailable(dependencyKey)) {
+        notifyMissingDependency(backend.value, [dependencyKey]);
+        backend.value = "comfy_ksampler";
+      }
+      refreshDependencyLocks();
+    });
+    const guardSpectrumToggle = (control) => {
+      if (control.checked && !optionalDependencyAvailable("spectrumPatch")) {
+        notifyMissingDependency("Spectrum Patch", ["spectrumPatch"]);
+        control.checked = false;
+      }
+      refreshDependencyLocks();
+    };
+    spectrumPatchEnabled.addEventListener("change", () => guardSpectrumToggle(spectrumPatchEnabled));
+    correctionsEnabled.addEventListener("change", () => guardSpectrumToggle(correctionsEnabled));
     refreshBackendDetails();
     refreshDependencyLocks();
     loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
@@ -488,7 +516,12 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
     apply.addEventListener("click", () => {
       const next = mergeDefaults(DEFAULT_GENERATION_SETTINGS, settings);
       delete next.sampler.dave;
-      next.sampler.backend = backend.value || "comfy_ksampler";
+      const selectedBackend = backend.value || "comfy_ksampler";
+      const selectedBackendDependency = AIO_BACKEND_DEPENDENCIES[selectedBackend];
+      next.sampler.backend = selectedBackendDependency
+        && !optionalDependencyAvailable(selectedBackendDependency)
+        ? "comfy_ksampler"
+        : selectedBackend;
       next.sampler.seed = normalizeSeedValue(seed.value, GENERATOR_SPECIAL_SEED_RANDOM);
       next.sampler.seed_after_generate = normalizeSeedControl(seedControl.value);
       next.sampler.steps = Math.trunc(clampGeneratorNumber(steps.value, DEFAULT_GENERATION_SETTINGS.sampler.steps, 1, 75));
@@ -498,7 +531,9 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
       next.sampler.scheduler = scheduler.value || DEFAULT_GENERATION_SETTINGS.sampler.scheduler;
       next.sampler.spectrum.enabled = (
         next.sampler.backend === "spectrum_mod_guidance_advanced"
-        || (next.sampler.backend === "comfy_ksampler" && spectrumPatchEnabled.checked && !spectrumPatchEnabled.disabled)
+        || (next.sampler.backend === "comfy_ksampler"
+          && spectrumPatchEnabled.checked
+          && optionalDependencyAvailable("spectrumPatch"))
       );
       next.sampler.spectrum.window_size = Number(windowSize.value || 2);
       next.sampler.spectrum.flex_window = Number(flexWindow.value || 0.25);
@@ -513,7 +548,8 @@ export function aioCreateSamplerSettingsDialog(dependencies) {
       next.sampler.spd.adaptive_smc_alpha = Number(spdSmc.value || 0);
       next.sampler.spectrum_extra = spectrumExtra.values();
       next.sampler.spd_extra = spdExtra.values();
-      next.sampler.dit_corrections.enabled = correctionsEnabled.checked && !correctionsEnabled.disabled;
+      next.sampler.dit_corrections.enabled = correctionsEnabled.checked
+        && optionalDependencyAvailable("spectrumPatch");
       next.sampler.dit_corrections.dcw_mode = dcwMode.value || "off";
       next.sampler.dit_corrections.dcw_lambda = Number(dcwLambda.value || 0.01);
       next.sampler.dit_corrections.dcw_band_mask = dcwBand.value || "LL";

--- a/web/js/aio/save_settings_dialog.js
+++ b/web/js/aio/save_settings_dialog.js
@@ -41,6 +41,8 @@
  * @typedef {object} AioSaveDialogDependencyAdapter
  * @property {(key: string) => boolean} available
  * @property {(key: string) => string} pack
+ * @property {(control: any, missing: boolean, message?: string) => void} markMissingControl
+ * @property {(backend: string, keys: string[]) => boolean} notifyMissing
  * @property {(options?: Record<string, any>) => Promise<any>} load
  */
 
@@ -103,6 +105,8 @@ export function aioCreateSaveSettingsDialog(dependencies) {
   const {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyMissingDependency,
     load: loadGeneratorOptionalDependencies,
   } = dependencyAdapter;
 
@@ -303,7 +307,7 @@ export function aioCreateSaveSettingsDialog(dependencies) {
     );
     const { backdrop, body, actions } = createDialog(
       "Save Options",
-      "Image Saver requires ComfyUI-Image-Saver. Missing node packs are reported during queue execution."
+      "Image Saver requires ComfyUI-Image-Saver. Selecting an unavailable backend shows its required node pack."
     );
     body.classList.add("easyuse-anima-aio-save-body");
     const main = document.createElement("section");
@@ -323,10 +327,17 @@ export function aioCreateSaveSettingsDialog(dependencies) {
       const imageSaverMissing = !optionalDependencyAvailable("imageSaver");
       for (const option of Array.from(backend.options)) {
         if (option.value === "image_saver") {
-          option.disabled = imageSaverMissing;
+          option.disabled = false;
           option.textContent = imageSaverMissing
             ? `image_saver (${optionalDependencyPack("imageSaver")} missing)`
             : "image_saver";
+          option.classList?.toggle("easyuse-anima-aio-missing-option", imageSaverMissing);
+          option.title = imageSaverMissing
+            ? aioFormat("warning.optionalDependencyMissing", {
+                backend: "image_saver",
+                pack: optionalDependencyPack("imageSaver"),
+              })
+            : "";
         }
       }
       if (imageSaverMissing && backend.value === "image_saver") {
@@ -340,6 +351,11 @@ export function aioCreateSaveSettingsDialog(dependencies) {
         dependencyWarning.hidden = true;
         dependencyWarning.textContent = "";
       }
+      aioMarkMissingDependencyControl(
+        backend,
+        imageSaverMissing && backend.value === "image_saver",
+        dependencyWarning.textContent,
+      );
     };
 
     const files = document.createElement("section");
@@ -370,6 +386,13 @@ export function aioCreateSaveSettingsDialog(dependencies) {
     const easyRemix = field(metadata, "Easy remix", checkbox(imageSaver.easy_remix));
     const custom = field(metadata, "Custom metadata", textareaInput(imageSaver.custom));
     body.append(main, files, metadata);
+    backend.addEventListener("change", () => {
+      if (backend.value === "image_saver" && !optionalDependencyAvailable("imageSaver")) {
+        notifyMissingDependency("image_saver", ["imageSaver"]);
+        backend.value = "comfy_save_image";
+      }
+      refreshSaveDependencyLocks();
+    });
     refreshSaveDependencyLocks();
     loadGeneratorOptionalDependencies().then(refreshSaveDependencyLocks);
 

--- a/web/js/aio/stage_settings_dialogs.js
+++ b/web/js/aio/stage_settings_dialogs.js
@@ -43,6 +43,9 @@
  * @property {(key: string) => boolean} available
  * @property {(key: string) => string} pack
  * @property {(backend: string) => string[]} upscaleBackendMissingPacks
+ * @property {(backend: string) => string[]} upscaleBackendMissingKeys
+ * @property {(control: any, missing: boolean, message?: string) => void} markMissingControl
+ * @property {(backend: string, keys: string[]) => boolean} notifyMissing
  * @property {(options?: Record<string, any>) => Promise<any>} load
  */
 
@@ -111,6 +114,9 @@ export function aioCreateStageSettingsDialogs(dependencies) {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
     upscaleBackendMissingPacks,
+    upscaleBackendMissingKeys,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyMissingDependency,
     load: loadGeneratorOptionalDependencies,
   } = dependencyAdapter;
 
@@ -155,21 +161,31 @@ export function aioCreateStageSettingsDialogs(dependencies) {
     section.append(dependencyWarning);
     const refreshDependencyLocks = () => {
       const spectrumPatchMissing = !optionalDependencyAvailable("spectrumPatch");
-      spectrumEnabled.disabled = spectrumPatchMissing;
-      correctionsEnabled.disabled = spectrumPatchMissing;
+      const message = aioFormat("warning.optionalDependencyMissing", {
+        backend: title,
+        pack: optionalDependencyPack("spectrumPatch"),
+      });
+      aioMarkMissingDependencyControl(spectrumEnabled, spectrumPatchMissing, message);
+      aioMarkMissingDependencyControl(correctionsEnabled, spectrumPatchMissing, message);
       if (spectrumPatchMissing) {
         spectrumEnabled.checked = false;
         correctionsEnabled.checked = false;
         dependencyWarning.hidden = false;
-        dependencyWarning.textContent = aioFormat("warning.optionalDependencyMissing", {
-          backend: title,
-          pack: optionalDependencyPack("spectrumPatch"),
-        });
+        dependencyWarning.textContent = message;
       } else {
         dependencyWarning.hidden = true;
         dependencyWarning.textContent = "";
       }
     };
+    const guardSpectrumToggle = (control) => {
+      if (control.checked && !optionalDependencyAvailable("spectrumPatch")) {
+        notifyMissingDependency(title, ["spectrumPatch"]);
+        control.checked = false;
+      }
+      refreshDependencyLocks();
+    };
+    spectrumEnabled.addEventListener("change", () => guardSpectrumToggle(spectrumEnabled));
+    correctionsEnabled.addEventListener("change", () => guardSpectrumToggle(correctionsEnabled));
     refreshDependencyLocks();
     loadGeneratorOptionalDependencies().then(refreshDependencyLocks);
 
@@ -186,7 +202,7 @@ export function aioCreateStageSettingsDialogs(dependencies) {
       values() {
         return {
           spectrum: {
-            enabled: spectrumEnabled.checked && !spectrumEnabled.disabled,
+            enabled: spectrumEnabled.checked && optionalDependencyAvailable("spectrumPatch"),
             window_size: Number(windowSize.value || defaults.spectrum.window_size || 2),
             flex_window: Number(flexWindow.value || defaults.spectrum.flex_window || 0.25),
             warmup_steps: Number(warmupSteps.value || defaults.spectrum.warmup_steps || 6),
@@ -200,7 +216,7 @@ export function aioCreateStageSettingsDialogs(dependencies) {
             compat_policy: compatPolicy.value || "conservative",
           },
           dit_corrections: {
-            enabled: correctionsEnabled.checked && !correctionsEnabled.disabled,
+            enabled: correctionsEnabled.checked && optionalDependencyAvailable("spectrumPatch"),
             dcw_mode: dcwMode.value || "off",
             dcw_lambda: Number(dcwLambda.value || defaults.dit_corrections.dcw_lambda || 0.01),
             dcw_band_mask: dcwBand.value || "LL",
@@ -469,10 +485,17 @@ export function aioCreateStageSettingsDialogs(dependencies) {
       const messages = [];
       for (const option of Array.from(backend.options)) {
         const missingPacks = upscaleBackendMissingPacks(option.value);
-        option.disabled = missingPacks.length > 0;
+        option.disabled = false;
         option.textContent = missingPacks.length
           ? `${option.value} (${missingPacks.join(", ")} missing)`
           : option.value;
+        option.classList?.toggle("easyuse-anima-aio-missing-option", missingPacks.length > 0);
+        option.title = missingPacks.length
+          ? aioFormat("warning.optionalDependencyMissing", {
+              backend: option.value,
+              pack: missingPacks.join(", "),
+            })
+          : "";
         if (option.selected && missingPacks.length) {
           messages.push(aioFormat("warning.optionalDependencyMissing", {
             backend: option.value,
@@ -485,7 +508,20 @@ export function aioCreateStageSettingsDialogs(dependencies) {
       dependencyWarning.textContent = messages.join(" ");
       updateVisibility();
     };
-    backend.addEventListener("change", refreshDependencyLocks);
+    backend.addEventListener("change", () => {
+      const missingKeys = upscaleBackendMissingKeys(backend.value);
+      if (missingKeys.length) {
+        const attemptedBackend = backend.value;
+        notifyMissingDependency(attemptedBackend, missingKeys);
+        const fallback = Array.from(backend.options)
+          .find((option) => upscaleBackendMissingPacks(option.value).length === 0);
+        if (fallback) {
+          backend.value = fallback.value;
+        }
+        enabled.checked = false;
+      }
+      refreshDependencyLocks();
+    });
     autoTile.addEventListener("change", updateVisibility);
     inheritSampler.addEventListener("change", updateVisibility);
     body.append(main, usduSection, usduSampler, optimization.section, resshiftSection);

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -29,6 +29,7 @@ import { aioCreateDetailerSettingsDialog } from "./aio/detailer_settings_dialog.
 import { aioCreateSamplerSettingsDialog } from "./aio/sampler_settings_dialog.js";
 import { aioCreateSaveSettingsDialog } from "./aio/save_settings_dialog.js";
 import { aioCreateAdvancedSettingsDialog } from "./aio/advanced_settings_dialog.js";
+import { aioMarkMissingDependencyControl } from "./aio/dependency_controls.js";
 import { aioCreateNativePreviewRuntime } from "./aio/native_preview_runtime.js";
 import {
   aioCreateExtensionRuntime,
@@ -48,6 +49,7 @@ import {
   aioOptionalDependencyStatus,
   aioQueryOptionalDependencies,
   aioUpscaleBackendMissingPacks,
+  aioUpscaleBackendDependencyKeys,
 } from "./aio/dependencies.js";
 import {
   aioAppendPreviewFeed,
@@ -1019,11 +1021,8 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileDebug": "Enables debug compile keys in KJNodes for troubleshooting compile cache behavior.",
     "tip.torchCompileVram": "Disables ComfyUI dynamic VRAM handling around compiled model execution when enabled.",
     "tip.samplerBackend": "Selects the actual first-pass execution path. Model patches selected in Advanced Options are applied before this backend runs. SPD/SPEED is Euler-only, so its sampler is normalized to euler.",
-    "warning.optionalDependencyMissing": "{backend} is locked because {pack} is not installed.",
-    "info.optionalDependency.title": "EasyUseAnima AiO dependency check",
-    "info.optionalDependency.complete": "Available: {available}/{total}.",
-    "info.optionalDependency.missing": "Missing: {items}. Related features will be disabled or changed before queueing.",
-    "info.optionalDependency.error": "Query failed: {items}. Settings were kept unchanged and will be checked again before queueing.",
+    "warning.optionalDependencyMissing": "{backend} requires {pack}, which is not installed.",
+    "info.optionalDependency.title": "EasyUseAnima AiO dependency required",
     "tip.modMode": "Controls whether Mod Guidance follows prompt_data, is forced on, or is disabled.",
     "tip.modProfile": "Preset layer profile for Anima Mod Guidance. Off disables Mod Guidance even when prompt_data asks for it.",
     "tip.modAdapter": "Adapter name passed to Spectrum Mod Guidance. Auto-download default uses the node pack default adapter.",
@@ -1130,11 +1129,8 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileDebug": "컴파일 캐시 문제를 추적하기 위한 KJNodes debug compile keys를 켭니다.",
     "tip.torchCompileVram": "켜면 compiled model 실행 중 ComfyUI dynamic VRAM 처리를 끕니다.",
     "tip.samplerBackend": "실제 1차 샘플링 경로를 선택합니다. Advanced Options에서 선택한 모델 패치는 이 백엔드 실행 전에 적용됩니다. SPD/SPEED는 Euler 전용이라 내부 sampler는 euler로 정규화됩니다.",
-    "warning.optionalDependencyMissing": "{pack}이 설치되지 않아 {backend} 옵션을 잠갔습니다.",
-    "info.optionalDependency.title": "EasyUseAnima AiO 의존성 조회",
-    "info.optionalDependency.complete": "사용 가능: {available}/{total}.",
-    "info.optionalDependency.missing": "미설치: {items}. 관련 기능은 큐 실행 전에 비활성화되거나 대체됩니다.",
-    "info.optionalDependency.error": "조회 실패: {items}. 설정을 변경하지 않았으며 다음 큐 실행 전에 다시 조회합니다.",
+    "warning.optionalDependencyMissing": "{backend} 기능을 사용하려면 설치되지 않은 {pack}이 필요합니다.",
+    "info.optionalDependency.title": "EasyUseAnima AiO 의존성 필요",
     "tip.modMode": "Mod Guidance를 prompt_data에 따르게 할지, 강제로 켤지, 끌지 정합니다.",
     "tip.modProfile": "Anima Mod Guidance 레이어 프리셋입니다. off는 prompt_data가 켜져 있어도 Mod Guidance를 비활성화합니다.",
     "tip.modAdapter": "Spectrum Mod Guidance에 전달할 adapter입니다. auto-download default는 노드팩 기본 adapter를 사용합니다.",
@@ -1241,11 +1237,8 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileDebug": "compile cache の確認用に KJNodes debug compile keys を有効化します。",
     "tip.torchCompileVram": "有効時、compiled model 実行中の ComfyUI dynamic VRAM 処理を無効化します。",
     "tip.samplerBackend": "一回目の実行経路を選択します。Advanced Options で選んだ model patch は、この backend 実行前に適用されます。SPD/SPEED は Euler 専用のため、sampler は内部で euler に正規化されます。",
-    "warning.optionalDependencyMissing": "{pack} が未インストールのため {backend} をロックしました。",
-    "info.optionalDependency.title": "EasyUseAnima AiO 依存関係チェック",
-    "info.optionalDependency.complete": "利用可能: {available}/{total}。",
-    "info.optionalDependency.missing": "未インストール: {items}。関連機能はキュー実行前に無効化または変更されます。",
-    "info.optionalDependency.error": "照会失敗: {items}。設定は変更せず、次回のキュー実行前に再確認します。",
+    "warning.optionalDependencyMissing": "{backend} を使用するには、未インストールの {pack} が必要です。",
+    "info.optionalDependency.title": "EasyUseAnima AiO 依存関係が必要です",
     "tip.modMode": "Mod Guidance を prompt_data に従わせるか、強制有効または無効にするかを選択します。",
     "tip.modProfile": "Anima Mod Guidance の layer profile です。off は prompt_data が有効でも Mod Guidance を無効化します。",
     "tip.modAdapter": "Spectrum Mod Guidance に渡す adapter です。auto-download default は node pack の既定 adapter を使います。",
@@ -1342,11 +1335,8 @@ const AIO_TOOLTIP_TEXT = {
     "tip.torchCompileDebug": "启用 KJNodes debug compile keys，用于排查 compile cache 行为。",
     "tip.torchCompileVram": "启用后，在 compiled model 执行期间关闭 ComfyUI dynamic VRAM 处理。",
     "tip.samplerBackend": "选择第一次采样的实际执行路径。Advanced Options 中选择的 model patch 会在此 backend 执行前应用。SPD/SPEED 仅支持 Euler，因此内部 sampler 会规范化为 euler。",
-    "warning.optionalDependencyMissing": "{pack} 未安装，因此已锁定 {backend} 选项。",
-    "info.optionalDependency.title": "EasyUseAnima AiO 依赖项检查",
-    "info.optionalDependency.complete": "可用: {available}/{total}。",
-    "info.optionalDependency.missing": "未安装: {items}。相关功能将在加入队列前被禁用或替换。",
-    "info.optionalDependency.error": "查询失败: {items}。设置未被修改，并将在下次加入队列前重新检查。",
+    "warning.optionalDependencyMissing": "使用 {backend} 需要尚未安装的 {pack}。",
+    "info.optionalDependency.title": "EasyUseAnima AiO 需要依赖项",
     "tip.modMode": "选择 Mod Guidance 跟随 prompt_data、强制开启或关闭。",
     "tip.modProfile": "Anima Mod Guidance layer profile。off 会禁用 Mod Guidance，即使 prompt_data 要求启用。",
     "tip.modAdapter": "传给 Spectrum Mod Guidance 的 adapter。auto-download default 使用节点包默认 adapter。",
@@ -1855,7 +1845,6 @@ const generatorOptionalDependencyState = {
   status: {},
   nodeInfo: {},
   errors: {},
-  reportedSignature: "",
 };
 
 async function fetchGeneratorSamplerOptions() {
@@ -1903,57 +1892,28 @@ async function fetchGeneratorOptionalDependencies() {
   generatorOptionalDependencyState.errors = next.errors;
 }
 
-function optionalDependencyResultLabel(key) {
-  const spec = AIO_OPTIONAL_DEPENDENCY_SPECS[key];
-  return spec ? `${spec.nodeId} (${spec.pack})` : key;
-}
-
-function reportGeneratorOptionalDependencyStatus() {
-  const rows = Object.entries(AIO_OPTIONAL_DEPENDENCY_SPECS).map(([key, spec]) => ({
-    key,
-    node: spec.nodeId,
-    pack: spec.pack,
-    status: generatorOptionalDependencyState.status[key] || "error",
-    error: generatorOptionalDependencyState.errors[key] || "",
-  }));
-  const available = rows.filter((row) => row.status === "available");
-  const missing = rows.filter((row) => row.status === "missing");
-  const failed = rows.filter((row) => row.status === "error");
-  console.info("[EasyUseAnima] AiO optional dependency query result", rows);
-
-  const details = [aioFormat("info.optionalDependency.complete", {
-    available: available.length,
-    total: rows.length,
-  })];
-  if (missing.length) {
-    details.push(aioFormat("info.optionalDependency.missing", {
-      items: missing.map((row) => optionalDependencyResultLabel(row.key)).join(", "),
-    }));
+function notifyGeneratorMissingDependencies(backend, dependencyKeys) {
+  const missingKeys = [...new Set(Array.isArray(dependencyKeys) ? dependencyKeys : [dependencyKeys])]
+    .filter((key) => optionalDependencyStatus(key) === "missing");
+  if (!missingKeys.length) {
+    return false;
   }
-  if (failed.length) {
-    details.push(aioFormat("info.optionalDependency.error", {
-      items: failed.map((row) => optionalDependencyResultLabel(row.key)).join(", "),
-    }));
-  }
-
-  const signature = rows.map((row) => `${row.key}:${row.status}:${row.error}`).join("|");
-  if (signature === generatorOptionalDependencyState.reportedSignature) {
-    return;
-  }
-  generatorOptionalDependencyState.reportedSignature = signature;
-  const summary = aioText("info.optionalDependency.title");
-  const detail = details.join(" ");
+  const detail = aioFormat("warning.optionalDependencyMissing", {
+    backend,
+    pack: [...new Set(missingKeys.map((key) => optionalDependencyPack(key)))].join(", "),
+  });
   const toast = app?.extensionManager?.toast;
   if (typeof toast?.add === "function") {
     toast.add({
-      severity: failed.length ? "warn" : "info",
-      summary,
+      severity: "warn",
+      summary: aioText("info.optionalDependency.title"),
       detail,
-      life: failed.length || missing.length ? 10000 : 5000,
+      life: 10000,
     });
   } else if (typeof app?.ui?.dialog?.show === "function") {
-    app.ui.dialog.show(`${summary}\n${detail}`);
+    app.ui.dialog.show(`${aioText("info.optionalDependency.title")}\n${detail}`);
   }
+  return true;
 }
 
 function loadGeneratorOptionalDependencies({ retryErrors = false } = {}) {
@@ -1975,7 +1935,6 @@ function loadGeneratorOptionalDependencies({ retryErrors = false } = {}) {
       })
       .then(() => {
         generatorOptionalDependencyState.loaded = true;
-        reportGeneratorOptionalDependencyStatus();
         return generatorOptionalDependencyState;
       })
       .finally(() => {
@@ -2351,6 +2310,9 @@ function ensureStyle() {
     }
     .easyuse-anima-aio-field.easyuse-anima-aio-unsupported {
       opacity: 0.48;
+    }
+    .easyuse-anima-aio-field option.easyuse-anima-aio-missing-option {
+      color: #7f898f;
     }
     .easyuse-anima-aio-field input,
     .easyuse-anima-aio-field select,
@@ -3799,6 +3761,10 @@ const {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
     upscaleBackendMissingPacks,
+    upscaleBackendMissingKeys: (backend) => aioUpscaleBackendDependencyKeys(backend)
+      .filter((key) => optionalDependencyStatus(key) === "missing"),
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyGeneratorMissingDependencies,
     load: loadGeneratorOptionalDependencies,
   },
 });
@@ -3846,6 +3812,8 @@ const openDetailerSettings = aioCreateDetailerSettingsDialog({
   dependencyAdapter: {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyGeneratorMissingDependencies,
     load: loadGeneratorOptionalDependencies,
   },
 });
@@ -3897,6 +3865,8 @@ const openSamplerSettings = aioCreateSamplerSettingsDialog({
     nodeInputMap,
     nodeInputTooltip,
     nodeInputSupported,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyGeneratorMissingDependencies,
     load: loadGeneratorOptionalDependencies,
   },
 });
@@ -3935,6 +3905,8 @@ const openSaveSettings = aioCreateSaveSettingsDialog({
   dependencyAdapter: {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyGeneratorMissingDependencies,
     load: loadGeneratorOptionalDependencies,
   },
 });
@@ -3969,6 +3941,8 @@ const openAdvancedSettings = aioCreateAdvancedSettingsDialog({
   dependencyAdapter: {
     available: optionalDependencyAvailable,
     pack: optionalDependencyPack,
+    markMissingControl: aioMarkMissingDependencyControl,
+    notifyMissing: notifyGeneratorMissingDependencies,
     load: loadGeneratorOptionalDependencies,
   },
 });


### PR DESCRIPTION
## 변경 요약

- AiO 사용 여부와 무관하게 의존성 조회 결과를 띄우던 전역 팝업을 제거했습니다.
- AiO 설정에서 설치되지 않은 기능을 사용자가 직접 선택할 때만 해당 기능과 필요한 노드팩을 안내합니다.
- 저장 워크플로우 로드, 설정창 열기, 의존성 조회 완료, 큐 전 안전 정리는 알림 없이 처리합니다.
- 누락 옵션은 회색 표시와 툴팁을 유지하면서 선택 시 안전한 값으로 되돌립니다.

## 원인

전역 `beforeQueue()` 훅이 매 큐 실행마다 선택적 의존성을 조회했고, 조회 완료 경로가 AiO 노드 사용 여부 및 사용자 선택 여부와 관계없이 toast/dialog를 호출했습니다.

## 주요 파일

- `web/js/easyuse_anima_aio.js`
- `web/js/aio/dependency_controls.js`
- `web/js/aio/*_settings_dialog.js`
- 관련 Frontend smoke 및 Python 구조 계약 테스트

## 검증

- `powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile quick`
  - 통과
- `powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <worktree> -Profile full`
  - Python unittest 732개 통과
  - Frontend 113개 JavaScript/TypeScript 검사 통과
- `git diff --check`
  - 통과

## 테스트 표면

- ComfyUI Codex test environment: 저장소 공식 full 정적/모듈/계약 테스트
- Live ComfyUI browser smoke: 미실행

## 남은 위험

- 네이티브 select의 누락 option 색상 표현은 브라우저/OS 테마에 따라 차이가 있을 수 있습니다. 선택 거부와 기능별 알림 동작은 DOM smoke로 검증했습니다.

Fixes #240