### PR TITLE
fix: ComfyUI Desktop AiO 프로필 대화상자 지원

### DIFF
--- a/tests/frontend_aio_profile_dialogs_smoke.mjs
+++ b/tests/frontend_aio_profile_dialogs_smoke.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function dataModule(relativePath) {
+  const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+}
+
+const module = await import(dataModule("../web/js/aio/profile_dialogs.js"));
+assert.deepEqual(
+  Object.keys(module),
+  ["aioCreateProfileDialogs"],
+  "profile dialogs must expose only their factory contract",
+);
+
+const calls = { prompt: [], confirm: [], toast: [] };
+const promptResults = ["Spectrum SPD", null, 42];
+const confirmResults = [true, false, null];
+let managerReads = 0;
+const extensionManager = {
+  dialog: {
+    async prompt(options) {
+      calls.prompt.push(options);
+      return promptResults.shift();
+    },
+    async confirm(options) {
+      calls.confirm.push(options);
+      return confirmResults.shift();
+    },
+  },
+  toast: {
+    add(options) {
+      calls.toast.push(options);
+    },
+  },
+};
+const dialogs = module.aioCreateProfileDialogs({
+  getExtensionManager() {
+    managerReads += 1;
+    return extensionManager;
+  },
+  text(key) {
+    return `text:${key}`;
+  },
+});
+
+assert.deepEqual(Object.keys(dialogs), ["prompt", "alert", "confirm"]);
+assert.equal(Object.isFrozen(dialogs), true);
+assert.equal(managerReads, 0, "factory creation must not read host services eagerly");
+
+assert.equal(await dialogs.prompt("Save profile", "Current"), "Spectrum SPD");
+assert.deepEqual(calls.prompt.at(-1), {
+  title: "text:dialog.profile.title",
+  message: "Save profile",
+  defaultValue: "Current",
+  placeholder: "",
+});
+assert.equal(await dialogs.prompt("Cancel"), null);
+assert.equal(await dialogs.prompt("Invalid host result"), null);
+
+assert.equal(await dialogs.confirm("Overwrite?", "overwrite"), true);
+assert.equal(await dialogs.confirm("Delete?", "delete"), false);
+assert.equal(await dialogs.confirm("Dismissed"), false);
+assert.deepEqual(calls.confirm, [
+  {
+    title: "text:dialog.profile.title",
+    message: "Overwrite?",
+    type: "overwrite",
+  },
+  {
+    title: "text:dialog.profile.title",
+    message: "Delete?",
+    type: "delete",
+  },
+  {
+    title: "text:dialog.profile.title",
+    message: "Dismissed",
+    type: "default",
+  },
+]);
+
+await dialogs.alert("Profile operation failed", "error");
+assert.deepEqual(calls.toast, [{
+  severity: "error",
+  summary: "text:dialog.profile.title",
+  detail: "Profile operation failed",
+  life: 5000,
+}]);
+
+const missingDialogs = module.aioCreateProfileDialogs({
+  getExtensionManager: () => ({}),
+  text: (key) => key,
+});
+await assert.rejects(
+  missingDialogs.prompt("Unavailable"),
+  /ComfyUI dialog service is unavailable/,
+);
+
+console.log("AiO profile host dialogs smoke passed.");

--- a/tests/frontend_aio_profile_settings_runtime_smoke.mjs
+++ b/tests/frontend_aio_profile_settings_runtime_smoke.mjs
@@ -103,6 +103,8 @@ function createFixture() {
   const alerts = [];
   const promptCalls = [];
   const confirmCalls = [];
+  const confirmTypes = [];
+  const alertCalls = [];
   const resolveCalls = [];
   const prompts = [];
   const confirms = [];
@@ -311,21 +313,23 @@ function createFixture() {
   };
 
   const dialogsAdapter = {
-    prompt(message, defaultValue = "") {
+    async prompt(message, defaultValue = "") {
       dependencyCalls += 1;
       trace.push("prompt");
       promptCalls.push({ message, defaultValue });
       return prompts.shift();
     },
-    alert(message) {
+    async alert(message, severity = "warn") {
       dependencyCalls += 1;
       trace.push("alert");
       alerts.push(message);
+      alertCalls.push({ message, severity });
     },
-    confirm(message) {
+    async confirm(message, type = "default") {
       dependencyCalls += 1;
       trace.push("confirm");
       confirmCalls.push(message);
+      confirmTypes.push(type);
       return confirms.shift();
     },
   };
@@ -353,6 +357,8 @@ function createFixture() {
     confirms,
     promptCalls,
     confirmCalls,
+    confirmTypes,
+    alertCalls,
     resolveCalls,
     trace,
     defaultSettings,
@@ -548,12 +554,27 @@ dialog = fixture.dialogs.at(-1);
 buttons = dialogButtons(dialog);
 buttons.select.value = "user:Portrait";
 fixture.apiQueues.loadProfile.push({
-  profile: { name: "Portrait Canonical", settings: { sampler: { steps: 44 }, user: true } },
+  profile: {
+    name: "Portrait Canonical",
+    settings: {
+      sampler: {
+        backend: "spectrum_spd_speed",
+        steps: 44,
+        spd: { scale: 0.7, sigma_max: 1.2 },
+      },
+      user: true,
+    },
+  },
 });
 await buttons.apply.dispatch("click");
 assert.deepEqual(fixture.apiCalls.loadProfile.at(-1), ["Portrait"]);
 assert.equal(node.__easyuseAnimaGeneratorProfileValue, "user:Portrait Canonical");
 assert.equal(node.settings.user, true);
+assert.deepEqual(node.settings.sampler, {
+  backend: "spectrum_spd_speed",
+  steps: 44,
+  spd: { scale: 0.7, sigma_max: 1.2 },
+});
 assert.equal(dialog.backdrop.isConnected, false);
 
 node.__easyuseAnimaGeneratorProfileValue = "user:Portrait";
@@ -568,12 +589,20 @@ assert.equal(dialog.backdrop.isConnected, true, "failed apply must keep the dial
 assert.equal(fixture.dialogs.length, dialogsBeforeLoadError);
 assert.match(fixture.alerts.at(-1), /profile\.requestFailed/);
 assert.match(fixture.alerts.at(-1), /Profile settings are missing/);
+assert.equal(fixture.alertCalls.at(-1).severity, "error");
 assert.equal(buttons.save.disabled, false);
 assert.equal(buttons.cancel.disabled, false);
 assert.equal(buttons.apply.disabled, false);
 
 const saveNode = {
-  settings: { sampler: { steps: 55 }, save_snapshot: true },
+  settings: {
+    sampler: {
+      backend: "spectrum_spd_speed",
+      steps: 55,
+      spd: { scale: 0.8, sigma_max: 1.4 },
+    },
+    save_snapshot: true,
+  },
   __easyuseAnimaGeneratorProfileValue: "user:Portrait",
   __easyuseAnimaGeneratorProfileFingerprint: "old-fingerprint",
 };
@@ -596,13 +625,21 @@ assert.match(fixture.confirmCalls.at(-1), /Landscape/);
 assert.deepEqual(fixture.apiCalls.saveProfile.at(-1), [
   "Landscape",
   true,
-  { sampler: { steps: 55 }, save_snapshot: true },
+  {
+    sampler: {
+      backend: "spectrum_spd_speed",
+      steps: 55,
+      spd: { scale: 0.8, sigma_max: 1.4 },
+    },
+    save_snapshot: true,
+  },
   { name: "Landscape" },
 ]);
 assert.equal(saveNode.__easyuseAnimaGeneratorProfileValue, "user:Landscape");
 assert.match(saveNode.__easyuseAnimaGeneratorProfileFingerprint, /^fingerprint:/);
 assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeSave + 1);
 assert.equal(fixture.trace.includes("refresh-panels"), true);
+assert.equal(fixture.confirmTypes.at(-1), "overwrite");
 assert.equal(dialog.backdrop.isConnected, false);
 assert.equal(fixture.dialogs.length, dialogsBeforeSave + 1, "successful save must reopen");
 const reopenedAfterSave = fixture.dialogs.at(-1);
@@ -632,6 +669,7 @@ fixture.prompts.push("   ");
 const dialogsBeforeBlankName = fixture.dialogs.length;
 await buttons.save.dispatch("click");
 assert.equal(fixture.alerts.at(-1), "text:profile.nameRequired");
+assert.equal(fixture.alertCalls.at(-1).severity, "warn");
 assert.equal(dialog.backdrop.isConnected, false);
 assert.equal(fixture.dialogs.length, dialogsBeforeBlankName + 1);
 
@@ -692,6 +730,7 @@ const deleteCallsBeforeDecline = fixture.apiCalls.deleteProfile.length;
 const dialogsBeforeDeleteDecline = fixture.dialogs.length;
 await buttons.delete.dispatch("click");
 assert.equal(fixture.apiCalls.deleteProfile.length, deleteCallsBeforeDecline);
+assert.equal(fixture.confirmTypes.at(-1), "delete");
 assert.equal(dialog.backdrop.isConnected, false);
 assert.equal(fixture.dialogs.length, dialogsBeforeDeleteDecline + 1);
 
@@ -784,7 +823,14 @@ await buttons.save.dispatch("click");
 assert.deepEqual(fixture.apiCalls.saveProfile.at(-1), [
   "Refresh Failure",
   false,
-  { sampler: { steps: 55 }, save_snapshot: true },
+  {
+    sampler: {
+      backend: "spectrum_spd_speed",
+      steps: 55,
+      spd: { scale: 0.8, sigma_max: 1.4 },
+    },
+    save_snapshot: true,
+  },
   null,
 ]);
 assert.equal(fixture.apiCalls.listProfiles.length, listCallsBeforeRefreshError + 1);

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -45,6 +45,8 @@ AIO_PROFILE_API_CLIENT_JS = AIO_MODULES / "profile_api_client.js"
 AIO_PROFILE_API_CLIENT_SMOKE = (
     ROOT / "tests" / "frontend_aio_profile_api_client_smoke.mjs"
 )
+AIO_PROFILE_DIALOGS_JS = AIO_MODULES / "profile_dialogs.js"
+AIO_PROFILE_DIALOGS_SMOKE = ROOT / "tests" / "frontend_aio_profile_dialogs_smoke.mjs"
 AIO_PROFILE_SETTINGS_RUNTIME_JS = AIO_MODULES / "profile_settings_runtime.js"
 AIO_PROFILE_SETTINGS_RUNTIME_SMOKE = (
     ROOT / "tests" / "frontend_aio_profile_settings_runtime_smoke.mjs"
@@ -309,6 +311,19 @@ class FrontendModuleStructureTests(unittest.TestCase):
             entry_source,
         )
         self.assertIn(
+            'import { aioCreateProfileDialogs } from "./aio/profile_dialogs.js";',
+            entry_source,
+        )
+        self.assertNotRegex(entry_source, r"window\.(?:prompt|confirm|alert)\(")
+        self.assertIn(
+            "const generatorProfileDialogs = aioCreateProfileDialogs({",
+            entry_source,
+        )
+        self.assertIn(
+            "getExtensionManager: () => app.extensionManager,",
+            entry_source,
+        )
+        self.assertIn(
             "const generatorProfileRuntime = aioCreateProfileSettingsRuntime({",
             entry_source,
         )
@@ -335,11 +350,6 @@ class FrontendModuleStructureTests(unittest.TestCase):
                 )
 
         nested_dependencies = {
-            "dialogs": [
-                "prompt: (message, defaultValue) => window.prompt(message, defaultValue),",
-                "alert: (message) => window.alert(message),",
-                "confirm: (message) => window.confirm(message),",
-            ],
             "profileCore": [
                 "customValue: GENERATOR_PROFILE_CUSTOM_VALUE,",
                 "builtinIds: aioBuiltinProfileIds,",
@@ -375,6 +385,8 @@ class FrontendModuleStructureTests(unittest.TestCase):
                     [line.strip() for line in group_match.group("body").splitlines()],
                     expected_lines,
                 )
+
+        self.assertRegex(runtime_dependencies, r"(?m)^  dialogs: generatorProfileDialogs,$")
 
         self.assertIn(
             "loadProfiles: loadGeneratorUserProfiles,",
@@ -422,6 +434,27 @@ class FrontendModuleStructureTests(unittest.TestCase):
         self.assertTrue(AIO_PROFILE_SETTINGS_RUNTIME_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_profile_settings_runtime_smoke.mjs"',
+            frontend_check_source,
+        )
+
+    def test_aio_profile_dialogs_use_host_services(self):
+        source = AIO_PROFILE_DIALOGS_JS.read_text(encoding="utf-8")
+        frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertEqual(source.splitlines()[0], "// @ts-check")
+        self.assertEqual(
+            re.findall(r"export function ([A-Za-z0-9_]+)\(", source),
+            ["aioCreateProfileDialogs"],
+        )
+        self.assertNotRegex(source, r"window\.(?:prompt|confirm|alert)\(")
+        self.assertIn("extensionManager?.dialog", source)
+        self.assertIn("extensionManager?.toast", source)
+        self.assertIn("dialog.prompt({", source)
+        self.assertIn("dialog.confirm({", source)
+        self.assertIn("toast.add({", source)
+        self.assertTrue(AIO_PROFILE_DIALOGS_SMOKE.is_file())
+        self.assertIn(
+            r'node "tests\frontend_aio_profile_dialogs_smoke.mjs"',
             frontend_check_source,
         )
 

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -49,6 +49,11 @@ try {
         throw "Frontend AiO profile API client smoke failed with exit code $LASTEXITCODE."
     }
 
+    & node "tests\frontend_aio_profile_dialogs_smoke.mjs"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Frontend AiO profile host dialogs smoke failed with exit code $LASTEXITCODE."
+    }
+
     & node "tests\frontend_aio_profile_settings_runtime_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
         throw "Frontend AiO profile settings runtime smoke failed with exit code $LASTEXITCODE."

--- a/web/js/aio/profile_dialogs.js
+++ b/web/js/aio/profile_dialogs.js
@@ -1,0 +1,77 @@
+// @ts-check
+
+/**
+ * @typedef {object} AioProfileDialogDependencies
+ * @property {() => any} getExtensionManager
+ * @property {(key: string) => string} text
+ */
+
+/**
+ * Adapt ComfyUI's extension dialog and toast services for AiO profile CRUD.
+ * Browser-native prompt/confirm/alert APIs are unavailable in some ComfyUI
+ * Desktop webviews, while this host service is shared by Desktop and browser.
+ *
+ * @param {AioProfileDialogDependencies} dependencies
+ */
+export function aioCreateProfileDialogs(dependencies) {
+  const { getExtensionManager, text } = dependencies;
+
+  function services() {
+    const extensionManager = getExtensionManager();
+    const dialog = extensionManager?.dialog;
+    const toast = extensionManager?.toast;
+    if (typeof dialog?.prompt !== "function" || typeof dialog?.confirm !== "function") {
+      throw new Error("ComfyUI dialog service is unavailable");
+    }
+    return { dialog, toast };
+  }
+
+  /**
+   * @param {string} message
+   * @param {string} [defaultValue]
+   * @returns {Promise<string | null>}
+   */
+  async function prompt(message, defaultValue = "") {
+    const result = await services().dialog.prompt({
+      title: text("dialog.profile.title"),
+      message,
+      defaultValue,
+      placeholder: "",
+    });
+    return typeof result === "string" ? result : null;
+  }
+
+  /**
+   * @param {string} message
+   * @param {"default" | "overwrite" | "delete" | "info"} [type]
+   * @returns {Promise<boolean>}
+   */
+  async function confirm(message, type = "default") {
+    const result = await services().dialog.confirm({
+      title: text("dialog.profile.title"),
+      message,
+      type,
+    });
+    return result === true;
+  }
+
+  /**
+   * @param {string} message
+   * @param {"info" | "success" | "warn" | "error"} [severity]
+   * @returns {Promise<void>}
+   */
+  async function alert(message, severity = "warn") {
+    const { toast } = services();
+    if (typeof toast?.add !== "function") {
+      throw new Error("ComfyUI toast service is unavailable");
+    }
+    toast.add({
+      severity,
+      summary: text("dialog.profile.title"),
+      detail: message,
+      life: 5000,
+    });
+  }
+
+  return Object.freeze({ prompt, alert, confirm });
+}

--- a/web/js/aio/profile_settings_runtime.js
+++ b/web/js/aio/profile_settings_runtime.js
@@ -42,9 +42,9 @@ const PROFILE_EXISTS_CODE = "profile_exists";
 
 /**
  * @typedef {object} AioProfileDialogs
- * @property {(message: string, defaultValue?: string) => string | null} prompt
- * @property {(message: string) => void} alert
- * @property {(message: string) => boolean} confirm
+ * @property {(message: string, defaultValue?: string) => Promise<string | null>} prompt
+ * @property {(message: string, severity?: "info" | "success" | "warn" | "error") => Promise<void>} alert
+ * @property {(message: string, type?: "default" | "overwrite" | "delete" | "info") => Promise<boolean>} confirm
  */
 
 /**
@@ -205,18 +205,21 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
 
   async function saveUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
     const selectedName = userName(selectedValue);
-    const requestedName = dialogs.prompt(text("profile.savePrompt"), selectedName || "");
+    const requestedName = await dialogs.prompt(text("profile.savePrompt"), selectedName || "");
     if (requestedName == null) {
       return;
     }
     const name = requestedName.trim();
     if (!name) {
-      dialogs.alert(text("profile.nameRequired"));
+      await dialogs.alert(text("profile.nameRequired"));
       return;
     }
     const existing = userProfileByName(name);
     const overwrite = !!existing;
-    if (overwrite && !dialogs.confirm(format("profile.overwriteConfirm", { name: existing.name }))) {
+    if (overwrite && !(await dialogs.confirm(
+      format("profile.overwriteConfirm", { name: existing.name }),
+      "overwrite",
+    ))) {
       return;
     }
     const settings = getSettings(node);
@@ -232,7 +235,10 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
         }
         const target = await loadConflictProfile(name);
         const targetName = String(target?.name || name);
-        if (!dialogs.confirm(format("profile.overwriteConfirm", { name: targetName }))) {
+        if (!(await dialogs.confirm(
+          format("profile.overwriteConfirm", { name: targetName }),
+          "overwrite",
+        ))) {
           return;
         }
         data = await profileApi.saveProfile(name, true, settings, target);
@@ -251,18 +257,21 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
       return;
     }
     const currentName = userName(syncValue(node));
-    const requestedName = dialogs.prompt(text("profile.renamePrompt"), oldName);
+    const requestedName = await dialogs.prompt(text("profile.renamePrompt"), oldName);
     if (requestedName == null) {
       return;
     }
     const newName = requestedName.trim();
     if (!newName) {
-      dialogs.alert(text("profile.nameRequired"));
+      await dialogs.alert(text("profile.nameRequired"));
       return;
     }
     const existing = userProfileByName(newName);
     const overwrite = !!existing && existing.name.toLowerCase() !== oldName.toLowerCase();
-    if (overwrite && !dialogs.confirm(format("profile.overwriteConfirm", { name: existing.name }))) {
+    if (overwrite && !(await dialogs.confirm(
+      format("profile.overwriteConfirm", { name: existing.name }),
+      "overwrite",
+    ))) {
       return;
     }
     const current = userProfileByName(oldName);
@@ -278,7 +287,10 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
         }
         const target = await loadConflictProfile(newName);
         const targetName = String(target?.name || newName);
-        if (!dialogs.confirm(format("profile.overwriteConfirm", { name: targetName }))) {
+        if (!(await dialogs.confirm(
+          format("profile.overwriteConfirm", { name: targetName }),
+          "overwrite",
+        ))) {
           return;
         }
         data = await profileApi.renameProfile(oldName, newName, true, current, target);
@@ -294,7 +306,7 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
 
   async function deleteUserProfile(node, selectedValue = node.__easyuseAnimaGeneratorProfileValue) {
     const name = userName(selectedValue);
-    if (!name || !dialogs.confirm(format("profile.deleteConfirm", { name }))) {
+    if (!name || !(await dialogs.confirm(format("profile.deleteConfirm", { name }), "delete"))) {
       return;
     }
     const currentName = userName(syncValue(node));
@@ -427,9 +439,9 @@ export function aioCreateProfileSettingsRuntime(dependencies) {
           open(node);
         }
       } catch (error) {
-        dialogs.alert(format("profile.requestFailed", {
+        await dialogs.alert(format("profile.requestFailed", {
           message: errorMessage(error),
-        }));
+        }), "error");
       } finally {
         busy = false;
         if (backdrop.isConnected) {

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -18,6 +18,7 @@ import { aioCreateInputSettingsDialog } from "./aio/input_settings_dialog.js";
 import { aioCreatePostprocessSettingsDialog } from "./aio/postprocess_settings_dialog.js";
 import { aioCreatePreviewSettingsDialog } from "./aio/preview_settings_dialog.js";
 import { createAioProfileApiClient } from "./aio/profile_api_client.js";
+import { aioCreateProfileDialogs } from "./aio/profile_dialogs.js";
 import { aioCreateProfileSettingsRuntime } from "./aio/profile_settings_runtime.js";
 import { aioCreateGeneratorPanelRuntime } from "./aio/generator_panel_runtime.js";
 import {
@@ -3623,17 +3624,18 @@ const generatorProfileApi = createAioProfileApiClient({
   encodeURIComponent,
 });
 
+const generatorProfileDialogs = aioCreateProfileDialogs({
+  getExtensionManager: () => app.extensionManager,
+  text: aioText,
+});
+
 const generatorProfileRuntime = aioCreateProfileSettingsRuntime({
   document,
   createDialog,
   field,
   text: aioText,
   format: aioFormat,
-  dialogs: {
-    prompt: (message, defaultValue) => window.prompt(message, defaultValue),
-    alert: (message) => window.alert(message),
-    confirm: (message) => window.confirm(message),
-  },
+  dialogs: generatorProfileDialogs,
   profileApi: generatorProfileApi,
   profileCore: {
     customValue: GENERATOR_PROFILE_CUSTOM_VALUE,


### PR DESCRIPTION
## 변경 요약

- AiO 사용자 프로필 저장·이름 변경에서 브라우저 네이티브 `window.prompt/confirm/alert` 직접 호출을 제거했습니다.
- ComfyUI 공식 `app.extensionManager.dialog` 및 `toast` 서비스를 비동기 어댑터로 연결했습니다.
- 덮어쓰기와 삭제 확인을 호스트 대화상자의 전용 타입으로 구분했습니다.
- Spectrum SPD/SPEED 샘플러 설정이 사용자 프로필 저장·불러오기에서 그대로 왕복하는 회귀 검증을 추가했습니다.

## 원인

ComfyUI Desktop 웹뷰는 브라우저 네이티브 `prompt()`를 지원하지 않는데, AiO 프로필 런타임이 이를 직접 호출해 저장이 시작되기 전에 `prompt() is not supported` 오류가 발생했습니다.

## 주요 파일

- `web/js/aio/profile_dialogs.js`
- `web/js/aio/profile_settings_runtime.js`
- `web/js/easyuse_anima_aio.js`
- `tests/frontend_aio_profile_dialogs_smoke.mjs`
- `tests/frontend_aio_profile_settings_runtime_smoke.mjs`

## 검증

- `node tests/frontend_aio_profile_dialogs_smoke.mjs` — 통과
- `node tests/frontend_aio_profile_settings_runtime_smoke.mjs` — 통과
- `python -m unittest discover -s tests -p test_frontend_modules.py` — 50건 통과
- `tools/check_project.ps1 -Profile quick` — 통과
- 공식 full: `tools/check_custom_node.ps1 -Project <이 작업 워크트리> -Profile full`
  - Python unittest 733건 통과
  - 프런트엔드 JavaScript 114개 구문/스모크 및 TypeScript 6.0.3 검사 통과

## 테스트 표면과 남은 위험

- ComfyUI Codex test instance: 정적/모듈/비동기 계약 스모크
- Spectrum SPD/SPEED 프로필 설정 저장·불러오기 왕복: 회귀 테스트 통과
- ComfyUI Desktop 실제 UI 수동 클릭 및 Legacy/Node 2.0 브라우저 스모크: 미실행
- 호스트 대화상자 서비스는 렌더링 모드와 무관한 ComfyUI 공식 extension manager 표면을 사용합니다.

Refs #238

라벨 후보: `type: fix`, `area: frontend`, `status: ready`