### PR TITLE
fix: AiO 중첩 팝업 계층 보정

### DIFF
--- a/tests/frontend_aio_dialog_primitives_smoke.mjs
+++ b/tests/frontend_aio_dialog_primitives_smoke.mjs
@@ -229,10 +229,23 @@ assert(!firstDialog.backdrop.removed, "Pointerdown inside a dialog must keep the
 firstDialog.backdrop.dispatch("pointerdown");
 assert(firstDialog.backdrop.removed, "Pointerdown on the backdrop must close the dialog");
 
-const secondDialog = primitives.createDialog("Second", "Dialog");
+let secondDialogCloseCount = 0;
+const secondDialog = primitives.createDialog("Second", "Dialog", () => {
+  secondDialogCloseCount += 1;
+});
 assert(ensureStyleCalls === 2, "Every dialog open must ensure the AiO stylesheet");
+assert(
+  secondDialog.dialog === secondDialog.backdrop.children[0]
+    && typeof secondDialog.close === "function",
+  "Dialog creation must expose the dialog element and an imperative close contract",
+);
 const secondClose = secondDialog.backdrop.children[0].children[0].children[1];
 secondClose.dispatch("click");
 assert(secondDialog.backdrop.removed, "The dialog close button must remove its backdrop");
+secondDialog.close();
+assert(
+  secondDialogCloseCount === 1,
+  "Dialog close callbacks and removals must be idempotent",
+);
 
 console.log("AiO dialog primitives smoke passed.");

--- a/tests/frontend_aio_profile_dialogs_smoke.mjs
+++ b/tests/frontend_aio_profile_dialogs_smoke.mjs
@@ -6,94 +6,192 @@ function dataModule(relativePath) {
   return `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
 }
 
-const module = await import(dataModule("../web/js/aio/profile_dialogs.js"));
+class FakeClassList {
+  constructor(owner) {
+    this.owner = owner;
+  }
+
+  add(...tokens) {
+    const classes = new Set(String(this.owner.className || "").split(/\s+/).filter(Boolean));
+    for (const token of tokens) {
+      classes.add(token);
+    }
+    this.owner.className = [...classes].join(" ");
+  }
+
+  contains(token) {
+    return String(this.owner.className || "").split(/\s+/).includes(token);
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName).toUpperCase();
+    this.type = "";
+    this.className = "";
+    this.textContent = "";
+    this.value = "";
+    this.children = [];
+    this.parentElement = null;
+    this.listeners = new Map();
+    this.attributes = new Map();
+    this.isConnected = true;
+    this.focused = false;
+    this.selected = false;
+    this.classList = new FakeClassList(this);
+  }
+
+  append(...children) {
+    for (const child of children) {
+      child.parentElement = this;
+      this.children.push(child);
+    }
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type, properties = {}) {
+    let prevented = false;
+    const event = {
+      target: this,
+      preventDefault() {
+        prevented = true;
+      },
+      ...properties,
+    };
+    for (const listener of this.listeners.get(type) || []) {
+      listener(event);
+    }
+    return { prevented };
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  focus() {
+    this.focused = true;
+  }
+
+  select() {
+    this.selected = true;
+  }
+
+  remove() {
+    this.isConnected = false;
+    if (this.parentElement) {
+      this.parentElement.children = this.parentElement.children.filter((child) => child !== this);
+      this.parentElement = null;
+    }
+  }
+}
+
+const [profileModule, primitiveModule] = await Promise.all([
+  import(dataModule("../web/js/aio/profile_dialogs.js")),
+  import(dataModule("../web/js/aio/dialog_primitives.js")),
+]);
 assert.deepEqual(
-  Object.keys(module),
+  Object.keys(profileModule),
   ["aioCreateProfileDialogs"],
   "profile dialogs must expose only their factory contract",
 );
 
-const calls = { prompt: [], confirm: [], toast: [] };
-const promptResults = ["Spectrum SPD", null, 42];
-const confirmResults = [true, false, null];
-let managerReads = 0;
-const extensionManager = {
-  dialog: {
-    async prompt(options) {
-      calls.prompt.push(options);
-      return promptResults.shift();
-    },
-    async confirm(options) {
-      calls.confirm.push(options);
-      return confirmResults.shift();
-    },
-  },
-  toast: {
-    add(options) {
-      calls.toast.push(options);
-    },
+const body = new FakeElement("body");
+const fakeDocument = {
+  body,
+  createElement(tagName) {
+    return new FakeElement(tagName);
   },
 };
-const dialogs = module.aioCreateProfileDialogs({
-  getExtensionManager() {
-    managerReads += 1;
-    return extensionManager;
-  },
-  text(key) {
-    return `text:${key}`;
-  },
+const text = (key) => `text:${key}`;
+const primitives = primitiveModule.aioCreateDialogPrimitives({
+  document: fakeDocument,
+  ensureStyle() {},
+  staticText: (value) => String(value),
+  text,
+  resolveFieldPresentation: (label) => ({ displayLabel: label, tooltipText: "" }),
+  applyTooltip() {},
+  applyTooltipText() {},
 });
-
+const dialogs = profileModule.aioCreateProfileDialogs({
+  document: fakeDocument,
+  createDialog: primitives.createDialog,
+  text,
+});
 assert.deepEqual(Object.keys(dialogs), ["prompt", "alert", "confirm"]);
 assert.equal(Object.isFrozen(dialogs), true);
-assert.equal(managerReads, 0, "factory creation must not read host services eagerly");
 
-assert.equal(await dialogs.prompt("Save profile", "Current"), "Spectrum SPD");
-assert.deepEqual(calls.prompt.at(-1), {
-  title: "text:dialog.profile.title",
-  message: "Save profile",
-  defaultValue: "Current",
-  placeholder: "",
-});
-assert.equal(await dialogs.prompt("Cancel"), null);
-assert.equal(await dialogs.prompt("Invalid host result"), null);
+const parent = primitives.createDialog("Parent", "Settings");
+assert.equal(body.children.length, 1);
 
-assert.equal(await dialogs.confirm("Overwrite?", "overwrite"), true);
-assert.equal(await dialogs.confirm("Delete?", "delete"), false);
-assert.equal(await dialogs.confirm("Dismissed"), false);
-assert.deepEqual(calls.confirm, [
-  {
-    title: "text:dialog.profile.title",
-    message: "Overwrite?",
-    type: "overwrite",
-  },
-  {
-    title: "text:dialog.profile.title",
-    message: "Delete?",
-    type: "delete",
-  },
-  {
-    title: "text:dialog.profile.title",
-    message: "Dismissed",
-    type: "default",
-  },
-]);
+const promptResult = dialogs.prompt("Save profile", "Current");
+assert.equal(body.children.length, 2, "nested prompts must be appended after the parent AiO modal");
+const promptBackdrop = body.children.at(-1);
+const promptDialog = promptBackdrop.children[0];
+const promptInput = promptDialog.children[1].children[0];
+const promptActions = promptDialog.children[2];
+assert.equal(promptDialog.classList.contains("easyuse-anima-aio-dialog-compact"), true);
+assert.equal(promptInput.value, "Current");
+assert.equal(promptInput.getAttribute("aria-label"), "Save profile");
+assert.equal(promptInput.focused, true);
+assert.equal(promptInput.selected, true);
+promptInput.value = "Spectrum SPD";
+promptActions.children[1].dispatch("click");
+assert.equal(await promptResult, "Spectrum SPD");
+assert.deepEqual(body.children, [parent.backdrop], "accepting a prompt must keep the parent modal open");
 
-await dialogs.alert("Profile operation failed", "error");
-assert.deepEqual(calls.toast, [{
-  severity: "error",
-  summary: "text:dialog.profile.title",
-  detail: "Profile operation failed",
-  life: 5000,
-}]);
+const enterResult = dialogs.prompt("Rename profile", "Old");
+const enterDialog = body.children.at(-1).children[0];
+const enterInput = enterDialog.children[1].children[0];
+enterInput.value = "New";
+const enterEvent = enterInput.dispatch("keydown", { key: "Enter" });
+assert.equal(enterEvent.prevented, true);
+assert.equal(await enterResult, "New");
 
-const missingDialogs = module.aioCreateProfileDialogs({
-  getExtensionManager: () => ({}),
-  text: (key) => key,
-});
-await assert.rejects(
-  missingDialogs.prompt("Unavailable"),
-  /ComfyUI dialog service is unavailable/,
-);
+const escapeResult = dialogs.prompt("Cancel profile");
+const escapeInput = body.children.at(-1).children[0].children[1].children[0];
+const escapeEvent = escapeInput.dispatch("keydown", { key: "Escape" });
+assert.equal(escapeEvent.prevented, true);
+assert.equal(await escapeResult, null);
 
-console.log("AiO profile host dialogs smoke passed.");
+const dismissedPrompt = dialogs.prompt("Dismiss profile");
+const dismissPromptBackdrop = body.children.at(-1);
+dismissPromptBackdrop.dispatch("pointerdown", { target: dismissPromptBackdrop });
+assert.equal(await dismissedPrompt, null, "backdrop dismissal must settle prompts as cancelled");
+
+const confirmed = dialogs.confirm("Overwrite?", "overwrite");
+const confirmDialog = body.children.at(-1).children[0];
+confirmDialog.children[2].children[1].dispatch("click");
+assert.equal(await confirmed, true);
+
+const cancelled = dialogs.confirm("Delete?", "delete");
+const cancelDialog = body.children.at(-1).children[0];
+cancelDialog.children[2].children[0].dispatch("click");
+assert.equal(await cancelled, false);
+
+const dismissedConfirm = dialogs.confirm("Dismiss?");
+const dismissConfirmDialog = body.children.at(-1).children[0];
+dismissConfirmDialog.children[0].children[1].dispatch("click");
+assert.equal(await dismissedConfirm, false, "close buttons must settle confirmations as cancelled");
+
+const alertResult = dialogs.alert("Install the required pack", "warn", "Dependency required");
+const alertDialog = body.children.at(-1).children[0];
+assert.equal(alertDialog.children[0].children[0].children[0].textContent, "Dependency required");
+assert.equal(alertDialog.children[0].children[0].children[1].textContent, "Install the required pack");
+assert.equal(alertDialog.classList.contains("easyuse-anima-aio-dialog-alert-warn"), true);
+alertDialog.children[2].children[0].dispatch("click");
+await alertResult;
+
+assert.deepEqual(body.children, [parent.backdrop]);
+parent.close();
+assert.equal(body.children.length, 0);
+
+console.log("AiO nested profile dialogs smoke passed.");

--- a/tests/test_aio_frontend.py
+++ b/tests/test_aio_frontend.py
@@ -776,9 +776,11 @@ class AIOFrontendSourceTests(unittest.TestCase):
         self.assertNotIn("toast.add", load_body)
         self.assertNotIn("app.ui.dialog.show", load_body)
         self.assertIn('optionalDependencyStatus(key) === "missing"', notify_body)
-        self.assertIn('severity: "warn"', notify_body)
-        self.assertIn("toast.add", notify_body)
-        self.assertIn("app.ui.dialog.show", notify_body)
+        self.assertIn("void generatorProfileDialogs.alert(", notify_body)
+        self.assertIn('"warn"', notify_body)
+        self.assertIn('aioText("info.optionalDependency.title")', notify_body)
+        self.assertNotIn("toast.add", notify_body)
+        self.assertNotIn("app.ui.dialog.show", notify_body)
         self.assertNotIn("reportGeneratorOptionalDependencyStatus", source)
 
     def test_optional_dependency_query_retries_errors_before_queueing(self):

--- a/tests/test_frontend_modules.py
+++ b/tests/test_frontend_modules.py
@@ -320,7 +320,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             entry_source,
         )
         self.assertIn(
-            "getExtensionManager: () => app.extensionManager,",
+            "document,\n  createDialog,\n  text: aioText,",
             entry_source,
         )
         self.assertIn(
@@ -437,7 +437,7 @@ class FrontendModuleStructureTests(unittest.TestCase):
             frontend_check_source,
         )
 
-    def test_aio_profile_dialogs_use_host_services(self):
+    def test_aio_profile_dialogs_use_nested_aio_dialogs(self):
         source = AIO_PROFILE_DIALOGS_JS.read_text(encoding="utf-8")
         frontend_check_source = FRONTEND_CHECK_SCRIPT.read_text(encoding="utf-8")
 
@@ -447,11 +447,13 @@ class FrontendModuleStructureTests(unittest.TestCase):
             ["aioCreateProfileDialogs"],
         )
         self.assertNotRegex(source, r"window\.(?:prompt|confirm|alert)\(")
-        self.assertIn("extensionManager?.dialog", source)
-        self.assertIn("extensionManager?.toast", source)
-        self.assertIn("dialog.prompt({", source)
-        self.assertIn("dialog.confirm({", source)
-        self.assertIn("toast.add({", source)
+        self.assertNotIn("extensionManager", source)
+        self.assertIn("const { document, createDialog, text } = dependencies", source)
+        self.assertIn('input.type = "text"', source)
+        self.assertIn('event.key === "Enter"', source)
+        self.assertIn('event.key === "Escape"', source)
+        self.assertIn("modal.close()", source)
+        self.assertIn("title = text(\"dialog.profile.title\")", source)
         self.assertTrue(AIO_PROFILE_DIALOGS_SMOKE.is_file())
         self.assertIn(
             r'node "tests\frontend_aio_profile_dialogs_smoke.mjs"',

--- a/tools/check_frontend.ps1
+++ b/tools/check_frontend.ps1
@@ -51,7 +51,7 @@ try {
 
     & node "tests\frontend_aio_profile_dialogs_smoke.mjs"
     if ($LASTEXITCODE -ne 0) {
-        throw "Frontend AiO profile host dialogs smoke failed with exit code $LASTEXITCODE."
+        throw "Frontend AiO nested profile dialogs smoke failed with exit code $LASTEXITCODE."
     }
 
     & node "tests\frontend_aio_profile_settings_runtime_smoke.mjs"

--- a/web/js/aio/dialog_primitives.js
+++ b/web/js/aio/dialog_primitives.js
@@ -87,8 +87,9 @@ export function aioCreateDialogPrimitives(dependencies) {
   /**
    * @param {any} title
    * @param {any} subtitle
+   * @param {() => void} [onClose]
    */
-  function createDialog(title, subtitle) {
+  function createDialog(title, subtitle, onClose) {
     ensureStyle();
     const backdrop = document.createElement("div");
     backdrop.className = "easyuse-anima-aio-backdrop";
@@ -111,14 +112,23 @@ export function aioCreateDialogPrimitives(dependencies) {
     actions.className = "easyuse-anima-aio-actions";
     dialog.append(header, body, actions);
     backdrop.append(dialog);
-    close.addEventListener("click", () => backdrop.remove());
+    let closed = false;
+    function closeDialog() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      backdrop.remove();
+      onClose?.();
+    }
+    close.addEventListener("click", closeDialog);
     backdrop.addEventListener("pointerdown", (event) => {
       if (event.target === backdrop) {
-        backdrop.remove();
+        closeDialog();
       }
     });
     document.body.append(backdrop);
-    return { backdrop, body, actions };
+    return { backdrop, dialog, body, actions, close: closeDialog };
   }
 
   return Object.freeze({

--- a/web/js/aio/profile_dialogs.js
+++ b/web/js/aio/profile_dialogs.js
@@ -2,28 +2,27 @@
 
 /**
  * @typedef {object} AioProfileDialogDependencies
- * @property {() => any} getExtensionManager
+ * @property {any} document
+ * @property {(title: any, subtitle: any, onClose?: () => void) => {dialog: any, body: any, actions: any, close: () => void}} createDialog
  * @property {(key: string) => string} text
  */
 
 /**
- * Adapt ComfyUI's extension dialog and toast services for AiO profile CRUD.
- * Browser-native prompt/confirm/alert APIs are unavailable in some ComfyUI
- * Desktop webviews, while this host service is shared by Desktop and browser.
+ * Build Promise-based prompt, confirm, and alert dialogs in AiO's own modal
+ * layer. Keeping nested dialogs in the same layer prevents host dialogs and
+ * toasts from being obscured by the AiO settings backdrop.
  *
  * @param {AioProfileDialogDependencies} dependencies
  */
 export function aioCreateProfileDialogs(dependencies) {
-  const { getExtensionManager, text } = dependencies;
+  const { document, createDialog, text } = dependencies;
 
-  function services() {
-    const extensionManager = getExtensionManager();
-    const dialog = extensionManager?.dialog;
-    const toast = extensionManager?.toast;
-    if (typeof dialog?.prompt !== "function" || typeof dialog?.confirm !== "function") {
-      throw new Error("ComfyUI dialog service is unavailable");
-    }
-    return { dialog, toast };
+  function actionButton(label, className = "") {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = className;
+    button.textContent = label;
+    return button;
   }
 
   /**
@@ -31,14 +30,44 @@ export function aioCreateProfileDialogs(dependencies) {
    * @param {string} [defaultValue]
    * @returns {Promise<string | null>}
    */
-  async function prompt(message, defaultValue = "") {
-    const result = await services().dialog.prompt({
-      title: text("dialog.profile.title"),
-      message,
-      defaultValue,
-      placeholder: "",
+  function prompt(message, defaultValue = "") {
+    return new Promise((resolve) => {
+      let settled = false;
+      let modal;
+      const finish = (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        modal.close();
+        resolve(value);
+      };
+      modal = createDialog(text("dialog.profile.title"), message, () => finish(null));
+      modal.dialog.classList.add("easyuse-anima-aio-dialog-compact");
+
+      const input = document.createElement("input");
+      input.type = "text";
+      input.className = "easyuse-anima-aio-dialog-text-input";
+      input.value = String(defaultValue ?? "");
+      input.setAttribute("aria-label", String(message));
+      const cancel = actionButton(text("button.cancel"));
+      const apply = actionButton(text("button.apply"), "primary");
+      cancel.addEventListener("click", () => finish(null));
+      apply.addEventListener("click", () => finish(input.value));
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          finish(input.value);
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          finish(null);
+        }
+      });
+      modal.body.append(input);
+      modal.actions.append(cancel, apply);
+      input.focus();
+      input.select();
     });
-    return typeof result === "string" ? result : null;
   }
 
   /**
@@ -46,30 +75,56 @@ export function aioCreateProfileDialogs(dependencies) {
    * @param {"default" | "overwrite" | "delete" | "info"} [type]
    * @returns {Promise<boolean>}
    */
-  async function confirm(message, type = "default") {
-    const result = await services().dialog.confirm({
-      title: text("dialog.profile.title"),
-      message,
-      type,
+  function confirm(message, type = "default") {
+    void type;
+    return new Promise((resolve) => {
+      let settled = false;
+      let modal;
+      const finish = (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        modal.close();
+        resolve(value);
+      };
+      modal = createDialog(text("dialog.profile.title"), message, () => finish(false));
+      modal.dialog.classList.add("easyuse-anima-aio-dialog-compact");
+      const cancel = actionButton(text("button.cancel"));
+      const apply = actionButton(text("button.apply"), "primary");
+      cancel.addEventListener("click", () => finish(false));
+      apply.addEventListener("click", () => finish(true));
+      modal.actions.append(cancel, apply);
     });
-    return result === true;
   }
 
   /**
    * @param {string} message
    * @param {"info" | "success" | "warn" | "error"} [severity]
+   * @param {string} [title]
    * @returns {Promise<void>}
    */
-  async function alert(message, severity = "warn") {
-    const { toast } = services();
-    if (typeof toast?.add !== "function") {
-      throw new Error("ComfyUI toast service is unavailable");
-    }
-    toast.add({
-      severity,
-      summary: text("dialog.profile.title"),
-      detail: message,
-      life: 5000,
+  function alert(message, severity = "warn", title = text("dialog.profile.title")) {
+    return new Promise((resolve) => {
+      let settled = false;
+      let modal;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        modal.close();
+        resolve();
+      };
+      modal = createDialog(title, message, finish);
+      modal.dialog.classList.add(
+        "easyuse-anima-aio-dialog-compact",
+        "easyuse-anima-aio-dialog-alert",
+        `easyuse-anima-aio-dialog-alert-${severity}`,
+      );
+      const close = actionButton(text("button.close"), "primary");
+      close.addEventListener("click", finish);
+      modal.actions.append(close);
     });
   }
 

--- a/web/js/easyuse_anima_aio.js
+++ b/web/js/easyuse_anima_aio.js
@@ -1903,17 +1903,11 @@ function notifyGeneratorMissingDependencies(backend, dependencyKeys) {
     backend,
     pack: [...new Set(missingKeys.map((key) => optionalDependencyPack(key)))].join(", "),
   });
-  const toast = app?.extensionManager?.toast;
-  if (typeof toast?.add === "function") {
-    toast.add({
-      severity: "warn",
-      summary: aioText("info.optionalDependency.title"),
-      detail,
-      life: 10000,
-    });
-  } else if (typeof app?.ui?.dialog?.show === "function") {
-    app.ui.dialog.show(`${aioText("info.optionalDependency.title")}\n${detail}`);
-  }
+  void generatorProfileDialogs.alert(
+    detail,
+    "warn",
+    aioText("info.optionalDependency.title"),
+  );
   return true;
 }
 
@@ -2129,6 +2123,29 @@ function ensureStyle() {
       box-shadow: 0 18px 56px rgba(0, 0, 0, 0.45);
       border-radius: 8px;
       font: 13px "Segoe UI", sans-serif;
+    }
+    .easyuse-anima-aio-dialog.easyuse-anima-aio-dialog-compact {
+      width: min(480px, calc(100vw - 48px));
+      height: auto;
+      max-height: min(360px, calc(100vh - 48px));
+    }
+    .easyuse-anima-aio-dialog-compact .easyuse-anima-aio-body {
+      grid-template-columns: minmax(0, 1fr);
+      flex: 0 1 auto;
+    }
+    .easyuse-anima-aio-dialog-text-input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 9px 10px;
+      color: #f3f0e8;
+      background: #0f1419;
+      border: 1px solid #4b5661;
+      border-radius: 5px;
+      font: inherit;
+    }
+    .easyuse-anima-aio-dialog-text-input:focus {
+      border-color: #7ea0c4;
+      outline: 1px solid #7ea0c4;
     }
     .easyuse-anima-aio-dialog header {
       display: flex;
@@ -3625,7 +3642,8 @@ const generatorProfileApi = createAioProfileApiClient({
 });
 
 const generatorProfileDialogs = aioCreateProfileDialogs({
-  getExtensionManager: () => app.extensionManager,
+  document,
+  createDialog,
   text: aioText,
 });
 


### PR DESCRIPTION
## 변경 요약

- AiO 생성 프로필의 입력·확인·알림을 AiO 자체 중첩 모달로 전환했습니다.
- 누락 의존성을 선택했을 때만 같은 중첩 모달로 안내하도록 변경했습니다.
- X 버튼과 배경 클릭도 Promise를 한 번만 종료하도록 공용 대화상자 닫기 계약을 보강했습니다.

## 원인

AiO 설정 창은 높은 z-index의 자체 backdrop을 사용하지만 프로필 저장과 의존성 안내는 ComfyUI 호스트 dialog/toast를 사용했습니다. 이 서로 다른 계층 때문에 호스트 팝업이 AiO 창 뒤에 가려졌습니다.

## 주요 파일

- `web/js/aio/dialog_primitives.js`: 단발성 close 콜백과 명시적 close 계약
- `web/js/aio/profile_dialogs.js`: Promise 기반 AiO 중첩 prompt/confirm/alert
- `web/js/easyuse_anima_aio.js`: 프로필 및 누락 의존성 경로 통합, compact modal 스타일
- 관련 frontend smoke와 Python 소스 계약 테스트

## 검증

- `tools/check_project.ps1 -Profile quick`: 통과
- 공식 full runner: Python unittest 733개 통과
- frontend: JavaScript 114개 스모크 및 TypeScript 6.0.3 검사 통과
- ComfyUI v0.27.0 Codex test instance, Node 2.0 UI:
  - 부모 프로필 관리자 위에 저장 prompt가 표시됨
  - 실제 테스트 프로필 저장·목록 반영·삭제 성공
  - 누락된 ResShift 선택 시 부모 업스케일 설정 위에 의존성 안내 표시
  - 안내를 닫은 뒤 부모 설정 창 유지 확인

## 영향 및 위험

- 프로필 CRUD와 누락 의존성 안내만 변경하며 워크플로우 데이터 형식과 백엔드 API는 변경하지 않습니다.
- 사용자 실사용 인스턴스 브라우저 확인은 요청에 따라 수행하지 않고 파일 반영 후 수동 확인으로 남깁니다.

Follow-up to #238 and #240.