### PR TITLE
chore: Ruff G-01 report-only 품질 검사 추가

### DIFF
--- a/docs/architecture/python-backend.md
+++ b/docs/architecture/python-backend.md
@@ -351,6 +351,20 @@ G-series minimums are:
 - G-06: align unit, integration, contract, and packaging tests with canonical
   feature ownership while retaining the repository's `unittest` runner.
 
+### G-01 implementation contract
+
+G-01 pins Ruff `0.15.22` as maintenance tooling and runs it through
+`tools/check_python_quality.ps1` from both project-check profiles. The initial
+production report covers `F`, `E4`, `E7`, `E9`, `I`, and safe `UP` rules for
+Python 3.10 while excluding test and maintenance-tool sources.
+
+Lint findings remain visible but non-blocking through Ruff's `--exit-zero`
+mode. A missing `uvx`, an invalid Ruff configuration, or another execution
+failure still fails the project check. The runner never applies `--fix` or
+formatting and disables Ruff's repository cache. This report-only step does
+not establish a new-violation ratchet, complete G-02 or later phases, or close
+Issue #188.
+
 ## Overall Definition of Done
 
 The Python backend refactor is complete only when all of the following hold.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,10 @@ Repository = "https://github.com/n0va39/ComfyUI-EasyUseAnima"
 [tool.comfy]
 PublisherId = "n0va39"
 DisplayName = "ComfyUI EasyUse Anima"
+
+[tool.ruff]
+target-version = "py310"
+extend-exclude = [".github", "tests", "tools"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I", "UP"]

--- a/tests/test_python_quality_contract.py
+++ b/tests/test_python_quality_contract.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import tomllib
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PythonQualityContractTests(unittest.TestCase):
+    def test_ruff_version_and_initial_rules_are_pinned(self):
+        pyproject = tomllib.loads(
+            (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        )
+
+        ruff = pyproject["tool"]["ruff"]
+        self.assertEqual(ruff["target-version"], "py310")
+        self.assertEqual(
+            set(ruff["extend-exclude"]),
+            {".github", "tests", "tools"},
+        )
+        self.assertEqual(
+            ruff["lint"]["select"],
+            ["E4", "E7", "E9", "F", "I", "UP"],
+        )
+
+    def test_dedicated_runner_reports_findings_without_enabling_fixes(self):
+        source = (
+            ROOT / "tools" / "check_python_quality.ps1"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('[string]$RuffVersion = "0.15.22"', source)
+        self.assertIn('"ruff@$RuffVersion"', source)
+        self.assertIn('"--exit-zero"', source)
+        self.assertIn('"--no-cache"', source)
+        self.assertIn('"--output-format"', source)
+        self.assertNotIn('"--fix"', source)
+        self.assertNotIn('"format"', source)
+
+    def test_dedicated_runner_keeps_execution_failures_blocking(self):
+        source = (
+            ROOT / "tools" / "check_python_quality.ps1"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("$ruffExitCode = $LASTEXITCODE", source)
+        self.assertIn("if ($ruffExitCode -ne 0)", source)
+        self.assertIn("Ruff report execution failed", source)
+
+    def test_project_runner_calls_g01_before_profile_specific_full_tests(self):
+        source = (
+            ROOT / "tools" / "check_project.ps1"
+        ).read_text(encoding="utf-8")
+
+        quality_call = (
+            '& (Join-Path $PSScriptRoot "check_python_quality.ps1") '
+            "-RuffVersion $RuffVersion"
+        )
+        self.assertIn('[string]$RuffVersion = "0.15.22"', source)
+        self.assertIn(quality_call, source)
+        self.assertLess(
+            source.index(quality_call),
+            source.index('if ($Profile -eq "full")'),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_project.ps1
+++ b/tools/check_project.ps1
@@ -3,7 +3,8 @@ param(
     [ValidateSet("quick", "full")]
     [string]$Profile = "quick",
     [string]$Python = "python",
-    [string]$TypeScriptVersion = "6.0.3"
+    [string]$TypeScriptVersion = "6.0.3",
+    [string]$RuffVersion = "0.15.22"
 )
 
 Set-StrictMode -Version Latest
@@ -29,6 +30,9 @@ try {
     if ($LASTEXITCODE -ne 0) {
         throw "Python compile failed with exit code $LASTEXITCODE."
     }
+
+    Write-Host "`n== Python quality report =="
+    & (Join-Path $PSScriptRoot "check_python_quality.ps1") -RuffVersion $RuffVersion
 
     if ($Profile -eq "full") {
         Write-Host "`n== Python unittest =="

--- a/tools/check_python_quality.ps1
+++ b/tools/check_python_quality.ps1
@@ -1,0 +1,43 @@
+[CmdletBinding()]
+param(
+    [string]$RuffVersion = "0.15.22",
+    [string]$Uv = "uvx"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$originalLocation = (Get-Location).Path
+$uvCommand = if (Test-Path -LiteralPath $Uv) {
+    (Resolve-Path -LiteralPath $Uv -ErrorAction Stop).ProviderPath
+} else {
+    (Get-Command $Uv -ErrorAction Stop).Source
+}
+
+try {
+    Set-Location -LiteralPath $repoRoot
+
+    Write-Host "== Python quality report (G-01, report-only) =="
+    Write-Host "Ruff: $RuffVersion"
+
+    $ruffArgs = @(
+        "ruff@$RuffVersion"
+        "check"
+        "--exit-zero"
+        "--no-cache"
+        "--output-format"
+        "concise"
+        "."
+    )
+    & $uvCommand @ruffArgs
+    $ruffExitCode = $LASTEXITCODE
+    if ($ruffExitCode -ne 0) {
+        throw "Ruff report execution failed with exit code $ruffExitCode."
+    }
+
+    Write-Host "Ruff report completed. Findings are non-blocking during G-01; execution and configuration failures remain blocking."
+}
+finally {
+    Set-Location -LiteralPath $originalLocation
+}


### PR DESCRIPTION
## 변경 요약

- #188 G-01 범위로 Ruff `0.15.22`와 초기 규칙 `F`, `E4`, `E7`, `E9`, `I`, `UP`를 고정했습니다.
- production Python의 기존 위반은 그대로 출력하되 `--exit-zero`로 quick/full gate를 차단하지 않는 전용 report-only 검사를 추가했습니다.
- `uvx` 누락, Ruff 설정 오류, 실행 실패는 계속 project check를 실패시키도록 분리했습니다.
- Ruff autofix, formatting, Pyright, 신규 위반 ratchet, production 코드 수정은 포함하지 않았습니다.

## 주요 파일

- `pyproject.toml`: Ruff Python 3.10 및 초기 lint 규칙
- `tools/check_python_quality.ps1`: Ruff 0.15.22 report-only 실행 경계
- `tools/check_project.ps1`: quick/full 공통 G-01 보고 단계 연결
- `tests/test_python_quality_contract.py`: 버전·규칙·비차단/실패 계약 회귀 테스트
- `docs/architecture/python-backend.md`: G-01 현재 계약과 후속 범위 기록

## 검증

- `python -m unittest discover -s tests -p test_python_quality_contract.py` — 4건 통과
- `python -m unittest discover -s tests -p test_validation_contract.py` — 4건 통과
- missing `uvx` PowerShell smoke — 예상된 실행 실패가 차단 상태로 유지됨
- `powershell -ExecutionPolicy Bypass -File tools\check_python_quality.ps1` — 기존 100건 보고, 종료 성공
- `powershell -ExecutionPolicy Bypass -File tools\check_project.ps1 -Profile quick -Python <Codex test Python>` — compile, Ruff report, frontend 114 JavaScript 파일, TypeScript 6.0.3, diff 검사 통과
- exact rebased PR HEAD `7b00d04`에서 공식 full — Ruff 기존 100건 report-only, Python 738 passed, frontend 114 JavaScript 파일, TypeScript 6.0.3
- `git diff --check` — 통과

## 검증 표면과 남은 위험

- production/runtime 파일을 변경하지 않아 ComfyUI live/API/browser smoke는 실행하지 않았습니다.
- 첫 실행 시 `uvx`가 고정 Ruff 버전을 받아야 할 수 있으며, `uvx` 또는 실행 환경이 없으면 의도적으로 project check가 실패합니다.
- G-01은 관측 단계이므로 새 Ruff 위반을 아직 차단하지 않습니다. ratchet과 Pyright는 후속 G-02 이상 범위입니다.
- #188의 전체 완료 조건은 남아 있으므로 이 PR이 병합되어도 이슈를 닫지 않습니다.

Closes no issue; tracks #188.
