### PR TITLE
chore: #188 G-02a Pyright baseline ratchet

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -14,6 +14,7 @@ SECURITY.md
 MAINTAINING.md
 RELEASE.md
 jsconfig.json
+pyrightconfig.json
 .gitignore
 .gitattributes
 .gitmodules

--- a/docs/architecture/python-backend.md
+++ b/docs/architecture/python-backend.md
@@ -365,6 +365,35 @@ formatting and disables Ruff's repository cache. This report-only step does
 not establish a new-violation ratchet, complete G-02 or later phases, or close
 Issue #188.
 
+### G-02a implementation contract
+
+G-02a pins Pyright `1.1.411` as npm-based maintenance tooling and applies
+`basic` checking to the complete canonical `easyuse_anima` package for Python
+3.10. The reviewed settings live in `pyrightconfig.json`; the baseline checker
+rejects any setting or value change so an ignore path or weaker mode cannot
+silently lower the diagnostic count. `reportMissingModuleSource` is disabled
+because availability of source alongside installed stubs is an environment
+property, while missing imports and all ordinary basic diagnostics remain
+visible.
+
+`tests/fixtures/pyright_baseline.json` records the current diagnostic debt by
+repository-relative path, rule, severity, and count. The official quick/full
+runner permits a diagnostic group to shrink, but fails when an existing group
+grows or a new path/rule/severity group appears. Pyright exit code 1 is accepted
+only as a successfully generated diagnostic report; fatal, configuration, and
+CLI failures remain blocking. Production files, broad ignore paths, and inline
+suppression comments are not changed to establish the baseline.
+
+The project runner uses cache-preferred resolution by default. Passing
+`-OfflineMaintenanceTools` to `tools/check_project.ps1` (or `-Offline` to the
+quality runner) disables network access for both pinned Ruff and Pyright after
+their packages have been cached. This provides the Phase G offline
+reproducibility check without adding either tool as a runtime dependency.
+
+This slice does not introduce strict allowlists. G-02b will add reviewed pure
+model/service paths only after they are independently strict-clean. Import
+direction, public API, size, and test-ownership gates remain G-03 through G-06.
+
 ## Overall Definition of Done
 
 The Python backend refactor is complete only when all of the following hold.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": [
+    "easyuse_anima"
+  ],
+  "pythonPlatform": "All",
+  "pythonVersion": "3.10",
+  "reportMissingModuleSource": "none",
+  "typeCheckingMode": "basic"
+}

--- a/tests/fixtures/pyright_baseline.json
+++ b/tests/fixtures/pyright_baseline.json
@@ -1,0 +1,84 @@
+{
+  "schema": "easyuse_anima_pyright_diagnostic_baseline",
+  "version": 1,
+  "tool": {
+    "name": "pyright",
+    "version": "1.1.411"
+  },
+  "config": {
+    "include": [
+      "easyuse_anima"
+    ],
+    "python_platform": "All",
+    "python_version": "3.10",
+    "report_missing_module_source": "none",
+    "type_checking_mode": "basic"
+  },
+  "totals": {
+    "error": 60,
+    "information": 0,
+    "warning": 0
+  },
+  "diagnostics": [
+    {
+      "count": 1,
+      "path": "easyuse_anima/nodes/naia_nodes.py",
+      "rule": "reportArgumentType",
+      "severity": "error"
+    },
+    {
+      "count": 4,
+      "path": "easyuse_anima/nodes/prompt_data_nodes.py",
+      "rule": "reportUndefinedVariable",
+      "severity": "error"
+    },
+    {
+      "count": 5,
+      "path": "easyuse_anima/nodes/regional_nodes.py",
+      "rule": "reportGeneralTypeIssues",
+      "severity": "error"
+    },
+    {
+      "count": 4,
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "rule": "reportOptionalMemberAccess",
+      "severity": "error"
+    },
+    {
+      "count": 1,
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "rule": "reportOptionalOperand",
+      "severity": "error"
+    },
+    {
+      "count": 37,
+      "path": "easyuse_anima/prompt/artist_mix.py",
+      "rule": "reportUndefinedVariable",
+      "severity": "error"
+    },
+    {
+      "count": 2,
+      "path": "easyuse_anima/prompt/regional.py",
+      "rule": "reportArgumentType",
+      "severity": "error"
+    },
+    {
+      "count": 3,
+      "path": "easyuse_anima/prompt/regional.py",
+      "rule": "reportOptionalIterable",
+      "severity": "error"
+    },
+    {
+      "count": 2,
+      "path": "easyuse_anima/prompt/regional.py",
+      "rule": "reportOptionalMemberAccess",
+      "severity": "error"
+    },
+    {
+      "count": 1,
+      "path": "easyuse_anima/prompt/regional.py",
+      "rule": "reportReturnType",
+      "severity": "error"
+    }
+  ]
+}

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -43603,7 +43603,7 @@
       }
     ],
     "ignore_file": ".comfyignore",
-    "ignore_file_normalized_git_blob_sha1": "eb21e90ae0cf04f8a0763090ec8ca3301fd8cffa",
+    "ignore_file_normalized_git_blob_sha1": "e447b6d3726fe4e06da1bef09ed7b035dbd14aa8",
     "missing_internal_imports": [],
     "optional_imports": [
       {

--- a/tests/test_pyright_baseline.py
+++ b/tests/test_pyright_baseline.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER_PATH = ROOT / "tools" / "check_pyright_baseline.py"
+BASELINE_PATH = ROOT / "tests" / "fixtures" / "pyright_baseline.json"
+CONFIG_PATH = ROOT / "pyrightconfig.json"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_pyright_baseline_checker",
+        CHECKER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load checker: {CHECKER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def _baseline() -> dict:
+    return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+def _config() -> dict:
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def _report_from_baseline(baseline: dict, *, version: str | None = None) -> dict:
+    diagnostics = []
+    for entry in baseline["diagnostics"]:
+        for _ in range(entry["count"]):
+            diagnostics.append(
+                {
+                    "file": str(ROOT / entry["path"]),
+                    "severity": entry["severity"],
+                    "rule": entry["rule"],
+                    "message": "baseline diagnostic",
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 1},
+                    },
+                }
+            )
+    return {
+        "version": version or baseline["tool"]["version"],
+        "generalDiagnostics": diagnostics,
+        "summary": {
+            "filesAnalyzed": 41,
+            "errorCount": sum(
+                item["severity"] == "error" for item in diagnostics
+            ),
+            "warningCount": sum(
+                item["severity"] == "warning" for item in diagnostics
+            ),
+            "informationCount": sum(
+                item["severity"] == "information" for item in diagnostics
+            ),
+            "timeInSec": 0.1,
+        },
+    }
+
+
+class PyrightBaselineTests(unittest.TestCase):
+    def test_checked_in_fixture_is_internally_consistent(self):
+        baseline = _baseline()
+        report = _report_from_baseline(baseline)
+
+        summary, failures = checker.compare_report(report, baseline, _config(), ROOT)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(summary["totals"], baseline["totals"])
+        self.assertEqual(sum(baseline["totals"].values()), 60)
+
+    def test_decreased_diagnostic_group_passes_without_rewriting_baseline(self):
+        baseline = _baseline()
+        report = _report_from_baseline(baseline)
+        report["generalDiagnostics"].pop()
+        report["summary"]["errorCount"] -= 1
+
+        _summary, failures = checker.compare_report(report, baseline, _config(), ROOT)
+
+        self.assertEqual(failures, [])
+
+    def test_increased_existing_group_and_new_group_fail(self):
+        baseline = _baseline()
+        report = _report_from_baseline(baseline)
+        report["generalDiagnostics"].extend(
+            [
+                dict(report["generalDiagnostics"][0]),
+                {
+                    "file": str(ROOT / "easyuse_anima" / "new_module.py"),
+                    "severity": "error",
+                    "rule": "reportAssignmentType",
+                    "message": "new diagnostic",
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 1},
+                    },
+                },
+            ]
+        )
+        report["summary"]["errorCount"] += 2
+
+        _summary, failures = checker.compare_report(report, baseline, _config(), ROOT)
+
+        self.assertTrue(any("allowed 1, got 2" in failure for failure in failures))
+        self.assertTrue(any("new_module.py" in failure for failure in failures))
+        self.assertTrue(any("total error diagnostics" in failure for failure in failures))
+
+    def test_version_change_fails_even_when_diagnostics_match(self):
+        baseline = _baseline()
+        report = _report_from_baseline(baseline, version="9.9.9")
+
+        _summary, failures = checker.compare_report(report, baseline, _config(), ROOT)
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("Pyright version changed", failures[0])
+
+    def test_summary_must_match_diagnostic_severities(self):
+        baseline = _baseline()
+        report = _report_from_baseline(baseline)
+        report["summary"]["errorCount"] -= 1
+
+        with self.assertRaisesRegex(ValueError, "summary totals do not match"):
+            checker.summarize_report(report, ROOT)
+
+    def test_baseline_rejects_path_escape_and_zero_count(self):
+        baseline = _baseline()
+        report = _report_from_baseline(baseline)
+        baseline["diagnostics"][0]["path"] = "../outside.py"
+
+        with self.assertRaisesRegex(ValueError, "canonical repository-relative POSIX"):
+            checker.compare_report(report, baseline, _config(), ROOT)
+
+        baseline = _baseline()
+        baseline["diagnostics"][0]["count"] = 0
+        with self.assertRaisesRegex(ValueError, "count must be positive"):
+            checker.compare_report(report, baseline, _config(), ROOT)
+
+    def test_weakened_or_unreviewed_config_fails(self):
+        baseline = _baseline()
+        report = _report_from_baseline(baseline)
+        config = _config()
+        config["typeCheckingMode"] = "off"
+        config["ignore"] = ["easyuse_anima"]
+
+        _summary, failures = checker.compare_report(report, baseline, config, ROOT)
+
+        self.assertTrue(any("config fields changed" in failure for failure in failures))
+        self.assertTrue(any("typeCheckingMode changed" in failure for failure in failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_quality_contract.py
+++ b/tests/test_python_quality_contract.py
@@ -1,9 +1,11 @@
-from pathlib import Path
-import tomllib
+import json
 import unittest
+from pathlib import Path
 
+import tomllib
 
 ROOT = Path(__file__).resolve().parents[1]
+PYRIGHT_BASELINE_PATH = ROOT / "tests" / "fixtures" / "pyright_baseline.json"
 
 
 class PythonQualityContractTests(unittest.TestCase):
@@ -21,6 +23,33 @@ class PythonQualityContractTests(unittest.TestCase):
         self.assertEqual(
             ruff["lint"]["select"],
             ["E4", "E7", "E9", "F", "I", "UP"],
+        )
+
+    def test_pyright_basic_canonical_package_contract_is_pinned(self):
+        pyright = json.loads(
+            (ROOT / "pyrightconfig.json").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(pyright["include"], ["easyuse_anima"])
+        self.assertEqual(pyright["pythonVersion"], "3.10")
+        self.assertEqual(pyright["pythonPlatform"], "All")
+        self.assertEqual(pyright["typeCheckingMode"], "basic")
+        self.assertEqual(pyright["reportMissingModuleSource"], "none")
+        self.assertNotIn("exclude", pyright)
+        self.assertNotIn("ignore", pyright)
+        self.assertNotIn("reportMissingImports", pyright)
+
+        baseline = json.loads(PYRIGHT_BASELINE_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(baseline["tool"], {"name": "pyright", "version": "1.1.411"})
+        self.assertEqual(
+            baseline["config"],
+            {
+                "include": pyright["include"],
+                "python_platform": pyright["pythonPlatform"],
+                "python_version": pyright["pythonVersion"],
+                "report_missing_module_source": pyright["reportMissingModuleSource"],
+                "type_checking_mode": pyright["typeCheckingMode"],
+            },
         )
 
     def test_dedicated_runner_reports_findings_without_enabling_fixes(self):
@@ -45,17 +74,35 @@ class PythonQualityContractTests(unittest.TestCase):
         self.assertIn("if ($ruffExitCode -ne 0)", source)
         self.assertIn("Ruff report execution failed", source)
 
+    def test_dedicated_runner_pins_pyright_and_ratchets_json_report(self):
+        source = (
+            ROOT / "tools" / "check_python_quality.ps1"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('[string]$PyrightVersion = "1.1.411"', source)
+        self.assertIn('"pyright@$PyrightVersion"', source)
+        self.assertIn('"--prefer-offline"', source)
+        self.assertIn('if ($Offline) { "--offline" }', source)
+        self.assertIn('"--outputjson"', source)
+        self.assertIn('"pyrightconfig.json"', source)
+        self.assertIn('"check_pyright_baseline.py"', source)
+        self.assertIn("if ($pyrightExitCode -notin @(0, 1))", source)
+        self.assertIn("Pyright execution failed", source)
+        self.assertIn("Pyright baseline ratchet failed", source)
+
     def test_project_runner_calls_g01_before_profile_specific_full_tests(self):
         source = (
             ROOT / "tools" / "check_project.ps1"
         ).read_text(encoding="utf-8")
 
-        quality_call = (
-            '& (Join-Path $PSScriptRoot "check_python_quality.ps1") '
-            "-RuffVersion $RuffVersion"
-        )
+        quality_call = '& (Join-Path $PSScriptRoot "check_python_quality.ps1")'
         self.assertIn('[string]$RuffVersion = "0.15.22"', source)
+        self.assertIn('[string]$PyrightVersion = "1.1.411"', source)
         self.assertIn(quality_call, source)
+        self.assertIn("-RuffVersion $RuffVersion", source)
+        self.assertIn("-PyrightVersion $PyrightVersion", source)
+        self.assertIn("-Python $pythonCommand", source)
+        self.assertIn("-Offline:$OfflineMaintenanceTools", source)
         self.assertLess(
             source.index(quality_call),
             source.index('if ($Profile -eq "full")'),

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -210,6 +210,7 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "MAINTAINING.md",
             "RELEASE.md",
             "jsconfig.json",
+            "pyrightconfig.json",
             ".gitignore",
             ".gitattributes",
             ".gitmodules",

--- a/tools/check_project.ps1
+++ b/tools/check_project.ps1
@@ -4,7 +4,9 @@ param(
     [string]$Profile = "quick",
     [string]$Python = "python",
     [string]$TypeScriptVersion = "6.0.3",
-    [string]$RuffVersion = "0.15.22"
+    [string]$RuffVersion = "0.15.22",
+    [string]$PyrightVersion = "1.1.411",
+    [switch]$OfflineMaintenanceTools
 )
 
 Set-StrictMode -Version Latest
@@ -32,7 +34,11 @@ try {
     }
 
     Write-Host "`n== Python quality report =="
-    & (Join-Path $PSScriptRoot "check_python_quality.ps1") -RuffVersion $RuffVersion
+    & (Join-Path $PSScriptRoot "check_python_quality.ps1") `
+        -RuffVersion $RuffVersion `
+        -PyrightVersion $PyrightVersion `
+        -Python $pythonCommand `
+        -Offline:$OfflineMaintenanceTools
 
     if ($Profile -eq "full") {
         Write-Host "`n== Python unittest =="

--- a/tools/check_pyright_baseline.py
+++ b/tools/check_pyright_baseline.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASELINE = ROOT / "tests" / "fixtures" / "pyright_baseline.json"
+DEFAULT_CONFIG = ROOT / "pyrightconfig.json"
+BASELINE_SCHEMA = "easyuse_anima_pyright_diagnostic_baseline"
+BASELINE_VERSION = 1
+SEVERITIES = ("error", "warning", "information")
+CONFIG_FIELDS = {
+    "include": "include",
+    "python_platform": "pythonPlatform",
+    "python_version": "pythonVersion",
+    "report_missing_module_source": "reportMissingModuleSource",
+    "type_checking_mode": "typeCheckingMode",
+}
+
+
+def _require_mapping(value, label: str) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object.")
+    return value
+
+
+def _require_non_negative_int(value, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer.")
+    return value
+
+
+def _require_non_empty_string(value, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string.")
+    return value
+
+
+def _normalize_baseline_config(value) -> dict:
+    config = _require_mapping(value, "Pyright baseline config")
+    expected_fields = set(CONFIG_FIELDS)
+    if set(config) != expected_fields:
+        raise ValueError(
+            "Pyright baseline config fields changed: "
+            f"expected {sorted(expected_fields)}, got {sorted(config)}"
+        )
+
+    include = config["include"]
+    if (
+        not isinstance(include, list)
+        or not include
+        or any(not isinstance(item, str) or not item for item in include)
+    ):
+        raise ValueError("Pyright baseline config.include must be a non-empty string array.")
+
+    normalized = {"include": include}
+    for field in expected_fields - {"include"}:
+        normalized[field] = _require_non_empty_string(
+            config[field],
+            f"Pyright baseline config.{field}",
+        )
+    return normalized
+
+
+def _compare_config(pyright_config: dict, expected_config: dict) -> list[str]:
+    config = _require_mapping(pyright_config, "Pyright config")
+    expected_pyright_fields = set(CONFIG_FIELDS.values())
+    failures: list[str] = []
+
+    if set(config) != expected_pyright_fields:
+        failures.append(
+            "Pyright config fields changed: "
+            f"expected {sorted(expected_pyright_fields)}, got {sorted(config)}"
+        )
+
+    for baseline_field, pyright_field in CONFIG_FIELDS.items():
+        expected_value = expected_config[baseline_field]
+        actual_value = config.get(pyright_field)
+        if actual_value != expected_value:
+            failures.append(
+                f"Pyright config {pyright_field} changed: "
+                f"expected {expected_value!r}, got {actual_value!r}"
+            )
+    return failures
+
+
+def _relative_diagnostic_path(value, repo_root: Path) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("Pyright diagnostic file must be a non-empty string.")
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root / path
+    try:
+        relative = path.resolve().relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"Pyright diagnostic is outside the repository: {value}") from exc
+    return relative.as_posix()
+
+
+def summarize_report(report: dict, repo_root: Path = ROOT) -> dict:
+    report = _require_mapping(report, "Pyright report")
+    version = report.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("Pyright report version must be a non-empty string.")
+
+    diagnostics = report.get("generalDiagnostics")
+    if not isinstance(diagnostics, list):
+        raise ValueError("Pyright generalDiagnostics must be a JSON array.")
+
+    counts: Counter[tuple[str, str, str]] = Counter()
+    severity_counts: Counter[str] = Counter()
+    for index, diagnostic in enumerate(diagnostics):
+        diagnostic = _require_mapping(diagnostic, f"generalDiagnostics[{index}]")
+        severity = diagnostic.get("severity")
+        if severity not in SEVERITIES:
+            raise ValueError(
+                f"generalDiagnostics[{index}].severity is unsupported: {severity!r}"
+            )
+        rule = diagnostic.get("rule") or "<none>"
+        if not isinstance(rule, str):
+            raise ValueError(f"generalDiagnostics[{index}].rule must be a string.")
+        path = _relative_diagnostic_path(diagnostic.get("file"), repo_root)
+        counts[(path, rule, severity)] += 1
+        severity_counts[severity] += 1
+
+    report_summary = _require_mapping(report.get("summary"), "Pyright summary")
+    files_analyzed = _require_non_negative_int(
+        report_summary.get("filesAnalyzed"),
+        "Pyright summary.filesAnalyzed",
+    )
+    totals = {
+        severity: _require_non_negative_int(
+            report_summary.get(f"{severity}Count"),
+            f"Pyright summary.{severity}Count",
+        )
+        for severity in SEVERITIES
+    }
+    observed_totals = {severity: severity_counts[severity] for severity in SEVERITIES}
+    if totals != observed_totals:
+        raise ValueError(
+            "Pyright summary totals do not match generalDiagnostics: "
+            f"summary={totals}, diagnostics={observed_totals}"
+        )
+
+    return {
+        "version": version,
+        "files_analyzed": files_analyzed,
+        "totals": totals,
+        "diagnostics": [
+            {
+                "path": path,
+                "rule": rule,
+                "severity": severity,
+                "count": count,
+            }
+            for (path, rule, severity), count in sorted(counts.items())
+        ],
+    }
+
+
+def _baseline_counts(baseline: dict) -> tuple[dict, Counter[tuple[str, str, str]]]:
+    baseline = _require_mapping(baseline, "Pyright baseline")
+    if baseline.get("schema") != BASELINE_SCHEMA:
+        raise ValueError(f"Unsupported Pyright baseline schema: {baseline.get('schema')!r}")
+    if baseline.get("version") != BASELINE_VERSION:
+        raise ValueError(f"Unsupported Pyright baseline version: {baseline.get('version')!r}")
+
+    tool = _require_mapping(baseline.get("tool"), "Pyright baseline tool")
+    if tool.get("name") != "pyright":
+        raise ValueError(f"Unsupported baseline tool: {tool.get('name')!r}")
+    if not isinstance(tool.get("version"), str) or not tool["version"]:
+        raise ValueError("Pyright baseline tool.version must be a non-empty string.")
+
+    totals = _require_mapping(baseline.get("totals"), "Pyright baseline totals")
+    normalized_totals = {
+        severity: _require_non_negative_int(
+            totals.get(severity),
+            f"Pyright baseline totals.{severity}",
+        )
+        for severity in SEVERITIES
+    }
+
+    entries = baseline.get("diagnostics")
+    if not isinstance(entries, list):
+        raise ValueError("Pyright baseline diagnostics must be a JSON array.")
+    counts: Counter[tuple[str, str, str]] = Counter()
+    for index, entry in enumerate(entries):
+        entry = _require_mapping(entry, f"baseline diagnostics[{index}]")
+        path = entry.get("path")
+        rule = entry.get("rule")
+        severity = entry.get("severity")
+        baseline_path = Path(path) if isinstance(path, str) else None
+        if (
+            baseline_path is None
+            or not path
+            or baseline_path.is_absolute()
+            or ".." in baseline_path.parts
+            or baseline_path.as_posix() != path
+        ):
+            raise ValueError(
+                f"baseline diagnostics[{index}].path must be canonical repository-relative POSIX."
+            )
+        if not isinstance(rule, str) or not rule:
+            raise ValueError(f"baseline diagnostics[{index}].rule must be non-empty.")
+        if severity not in SEVERITIES:
+            raise ValueError(
+                f"baseline diagnostics[{index}].severity is unsupported: {severity!r}"
+            )
+        count = _require_non_negative_int(
+            entry.get("count"),
+            f"baseline diagnostics[{index}].count",
+        )
+        if count == 0:
+            raise ValueError(f"baseline diagnostics[{index}].count must be positive.")
+        key = (path, rule, severity)
+        if key in counts:
+            raise ValueError(f"Duplicate Pyright baseline diagnostic group: {key}")
+        counts[key] = count
+
+    counted_totals = {
+        severity: sum(
+            count for (*_, entry_severity), count in counts.items()
+            if entry_severity == severity
+        )
+        for severity in SEVERITIES
+    }
+    if normalized_totals != counted_totals:
+        raise ValueError(
+            "Pyright baseline totals do not match diagnostic groups: "
+            f"totals={normalized_totals}, diagnostics={counted_totals}"
+        )
+    return {
+        "tool": tool,
+        "config": _normalize_baseline_config(baseline.get("config")),
+        "totals": normalized_totals,
+    }, counts
+
+
+def compare_report(
+    report: dict,
+    baseline: dict,
+    pyright_config: dict,
+    repo_root: Path = ROOT,
+) -> tuple[dict, list[str]]:
+    summary = summarize_report(report, repo_root)
+    metadata, expected_counts = _baseline_counts(baseline)
+    failures = _compare_config(pyright_config, metadata["config"])
+
+    if summary["version"] != metadata["tool"]["version"]:
+        failures.append(
+            "Pyright version changed: "
+            f"expected {metadata['tool']['version']}, got {summary['version']}"
+        )
+
+    current_counts = {
+        (entry["path"], entry["rule"], entry["severity"]): entry["count"]
+        for entry in summary["diagnostics"]
+    }
+    for key, current_count in sorted(current_counts.items()):
+        allowed_count = expected_counts.get(key, 0)
+        if current_count > allowed_count:
+            path, rule, severity = key
+            failures.append(
+                f"{path} {rule} {severity}: allowed {allowed_count}, got {current_count}"
+            )
+
+    for severity in SEVERITIES:
+        current_total = summary["totals"][severity]
+        allowed_total = metadata["totals"][severity]
+        if current_total > allowed_total:
+            failures.append(
+                f"total {severity} diagnostics: allowed {allowed_total}, got {current_total}"
+            )
+
+    return summary, failures
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare a Pyright JSON report with the reviewed diagnostic baseline."
+    )
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--repo-root", type=Path, default=ROOT)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        report = json.load(sys.stdin)
+        baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+        pyright_config = json.loads(args.config.read_text(encoding="utf-8"))
+        summary, failures = compare_report(
+            report,
+            baseline,
+            pyright_config,
+            args.repo_root,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"Pyright baseline input error: {exc}", file=sys.stderr)
+        return 2
+
+    if failures:
+        print("Pyright baseline ratchet failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    totals = summary["totals"]
+    print(
+        "Pyright baseline ratchet passed: "
+        f"{summary['files_analyzed']} files, "
+        f"{totals['error']} errors, {totals['warning']} warnings, "
+        f"{totals['information']} information diagnostics."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_python_quality.ps1
+++ b/tools/check_python_quality.ps1
@@ -1,7 +1,11 @@
 [CmdletBinding()]
 param(
     [string]$RuffVersion = "0.15.22",
-    [string]$Uv = "uvx"
+    [string]$PyrightVersion = "1.1.411",
+    [string]$Python = "python",
+    [string]$Uv = "uvx",
+    [string]$Npm = "npm",
+    [switch]$Offline
 )
 
 Set-StrictMode -Version Latest
@@ -14,6 +18,16 @@ $uvCommand = if (Test-Path -LiteralPath $Uv) {
 } else {
     (Get-Command $Uv -ErrorAction Stop).Source
 }
+$npmCommand = if (Test-Path -LiteralPath $Npm) {
+    (Resolve-Path -LiteralPath $Npm -ErrorAction Stop).ProviderPath
+} else {
+    (Get-Command $Npm -ErrorAction Stop).Source
+}
+$pythonCommand = if (Test-Path -LiteralPath $Python) {
+    (Resolve-Path -LiteralPath $Python -ErrorAction Stop).ProviderPath
+} else {
+    (Get-Command $Python -ErrorAction Stop).Source
+}
 
 try {
     Set-Location -LiteralPath $repoRoot
@@ -21,7 +35,11 @@ try {
     Write-Host "== Python quality report (G-01, report-only) =="
     Write-Host "Ruff: $RuffVersion"
 
-    $ruffArgs = @(
+    $ruffArgs = @()
+    if ($Offline) {
+        $ruffArgs += "--offline"
+    }
+    $ruffArgs += @(
         "ruff@$RuffVersion"
         "check"
         "--exit-zero"
@@ -37,6 +55,38 @@ try {
     }
 
     Write-Host "Ruff report completed. Findings are non-blocking during G-01; execution and configuration failures remain blocking."
+
+    Write-Host "`n== Pyright baseline ratchet (G-02a) =="
+    Write-Host "Pyright: $PyrightVersion"
+
+    $pyrightCacheArg = if ($Offline) { "--offline" } else { "--prefer-offline" }
+    $pyrightArgs = @(
+        "exec"
+        "--yes"
+        $pyrightCacheArg
+        "--package"
+        "pyright@$PyrightVersion"
+        "--"
+        "pyright"
+        "--outputjson"
+        "--project"
+        "pyrightconfig.json"
+    )
+    $pyrightOutput = @(& $npmCommand @pyrightArgs)
+    $pyrightExitCode = $LASTEXITCODE
+    if ($pyrightExitCode -notin @(0, 1)) {
+        throw "Pyright execution failed with exit code $pyrightExitCode."
+    }
+    if ($pyrightOutput.Count -eq 0) {
+        throw "Pyright produced no JSON report."
+    }
+
+    $pyrightOutput |
+        & $pythonCommand (Join-Path $PSScriptRoot "check_pyright_baseline.py")
+    $baselineExitCode = $LASTEXITCODE
+    if ($baselineExitCode -ne 0) {
+        throw "Pyright baseline ratchet failed with exit code $baselineExitCode."
+    }
 }
 finally {
     Set-Location -LiteralPath $originalLocation


### PR DESCRIPTION
## 변경 요약

- Pyright `1.1.411`의 `basic` 검사를 canonical `easyuse_anima` 패키지에 고정했습니다.
- 현재 진단 60건을 경로·규칙·심각도별 기준선으로 기록하고, 감소는 허용하되 기존 그룹 증가와 새 그룹은 차단합니다.
- `pyrightconfig.json`의 승인 설정을 기준선과 exact 비교해 검사 범위나 모드 완화로 우회할 수 없게 했습니다.
- Ruff/Pyright 캐시가 준비된 환경에서 네트워크를 차단하는 `-OfflineMaintenanceTools` / `-Offline` 검증 경로를 추가했습니다.
- 유지보수 전용 Pyright 설정은 Registry archive에서 제외하고 관련 scanner/analyzer 계약 기준선을 갱신했습니다.

## 주요 파일

- `pyrightconfig.json`
- `tools/check_pyright_baseline.py`
- `tools/check_python_quality.ps1`
- `tools/check_project.ps1`
- `tests/fixtures/pyright_baseline.json`
- `tests/test_pyright_baseline.py`
- `tests/test_python_quality_contract.py`
- `docs/architecture/python-backend.md`

## 검증

- `python -m unittest tests.test_pyright_baseline tests.test_python_quality_contract tests.test_validation_contract tests.test_python_backend_analyzer tests.test_registry_scanner_safety`: 43 tests passed
- `uvx --offline ruff@0.15.22 check tools/check_pyright_baseline.py tests/test_pyright_baseline.py tests/test_python_quality_contract.py`: passed
- `tools/check_python_quality.ps1 -Offline`: Ruff 기존 100건 report-only, Pyright 38 files / 60 errors 기준선 통과
- `tools/check_project.ps1 -Profile quick -OfflineMaintenanceTools`: Python compile, quality ratchet, frontend 114 JavaScript files / TypeScript 6.0.3, diff check 통과
- 공식 `full` runner: Python unittest 747 tests, frontend 114 JavaScript files / TypeScript 6.0.3, compile·quality·diff check 통과
- 독립 읽기 전용 재리뷰: 최종 finding 없음

## 테스트 표면

- ComfyUI Codex test environment: repository contract and frontend smoke
- Live ComfyUI smoke: 미실행 (production/runtime 파일 변경 없음)

## 남은 위험과 후속

- 캐시가 없는 최초 실행은 고정된 Ruff/Pyright 패키지를 내려받기 위한 네트워크가 필요합니다. 이후 offline 검증이 가능합니다.
- 이번 PR은 G-02a baseline ratchet이며 strict allowlist 확대는 별도 G-02b로 남깁니다.
- import boundary, public API, size/complexity, test ownership은 G-03~G-06 범위이므로 #188은 계속 열어둡니다.

Closes no issue. Related to #188.
