### PR TITLE
test(aio): add C168-05 cross-surface omission gate

### DIFF
--- a/docs/architecture/aio-settings-contract.md
+++ b/docs/architecture/aio-settings-contract.md
@@ -185,5 +185,19 @@ frontend coercion/unknown-field 정책과 manifest 내부 coercion/item 정의 �
 root/nested unknown field, custom Detailer order/target, Spectrum/SPD extension object, legacy 비복원 및 mutable
 reference 격리를 검증한다.
 
+`tests/fixtures/aio_generation_settings_surface_coverage.v1.json`은 manifest의 canonical field와 `$ref` site를
+기준으로 Python default/typed owner, JavaScript default owner, sanitization owner, UI owner/exposure, 유지 문서 heading을
+명시하는 golden coverage ledger다. entry 전체 또는 surface 하나가 빠지거나 owner module/document heading이
+사라지면 gate는 `/<contract-path>: missing surface <surface>`로 실패한다. Python 쪽은 각 normalized default
+leaf를 하나씩 제거했을 때 typed conversion이 반드시 거부하는지도 검증하므로, unknown extension 보존이 새 known
+field의 typed 누락을 숨길 수 없다. manifest shape와 default의 불일치는 `manifest_default` 또는
+`manifest_shape` surface로 별도 보고한다. empty Civitai fetcher item은 대표 row를 합성해 같은 ownership을
+확인한다.
+
+frontend smoke는 manifest와 JavaScript default의 leaf set을 비교하고, default를 compact serialization한 결과가
+동일한 leaf set을 보존하는지 별도로 확인한다. 따라서 default 추가와 sanitization 경로 추가는 독립된 surface로
+보고된다. coverage ledger는 runtime에서 import하지 않으며 dynamic capability choice, dialog 동작, optional
+dependency policy를 변경하지 않는다.
+
 manifest는 runtime package에 포함되어야 하므로 tracked 상태, `.comfyignore` 비제외, `git archive HEAD` 포함도
 dedicated schema test에서 검증한다. 문서와 테스트는 Registry archive에서 제외되어도 된다.

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -282,8 +282,8 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 1 | B-07f SAM3 mechanical vertical slice | COMPLETE on `dev` | Move | #184 | PR #251 / `015b8197` |
 | 2 | C168-03 typed AiO config boundary | COMPLETE on `dev` | Contract | #168 | PR #252 / `7f686bed` |
 | 3 | G-02b strict-clean pure/service allowlist | COMPLETE on `dev` | Contract/gate | #188 | PR #254 / `76237a60` |
-| 4 | C168-04 pure version-dispatch/migration registry | IN PROGRESS | Contract | #168 | Typed config boundary |
-| 5 | C168-05 cross-surface setting omission gate | READY after C168-04 | Contract/gate | #168 | Typed config and manifest ownership decision |
+| 4 | C168-04 pure version-dispatch/migration registry | COMPLETE on `dev` | Contract | #168 | PR #255 / `29aa200e` |
+| 5 | C168-05 cross-surface setting omission gate | IN PROGRESS | Contract/gate | #168 | PR #256 / C168-04 merged |
 | 6 | G-03a completed-package import boundary fail gate | READY/PARALLEL | Contract/gate | #188 | G-02b merged |
 | 7 | C168-06 normalizer ownership move | BLOCKED by C168-05 | Move | #168/#184 | C168 contracts and omission gate complete |
 | 8 | B-08a through B-08e AiO support-helper extraction | BLOCKED by #168 exit | Move | #184 | C168-03 through C168-06 complete |
@@ -387,6 +387,10 @@ relax or block the package-migration rules above.
 - Dynamic capability-derived choices remain outside static schema ownership.
 - The gate must report the exact missing field/surface and run offline in the
   official project check.
+- The golden coverage ledger owns explicit Python typed, JavaScript default and
+  sanitization, UI owner/exposure, and maintained-documentation records for
+  every canonical field and reference site. It is validation-only and is not a
+  runtime manifest/code-generation dependency.
 - #168 exits only after C168-03 through C168-06 and the issue's remaining
   completion boxes pass.
 

--- a/tests/fixtures/aio_generation_settings_surface_coverage.v1.json
+++ b/tests/fixtures/aio_generation_settings_surface_coverage.v1.json
@@ -1,0 +1,600 @@
+{
+  "schema": "easyuse_anima_aio_generation_settings_surface_coverage",
+  "version": 1,
+  "manifest": "easyuse_anima/aio/schemas/generation_settings.v1.json",
+  "required_surfaces": [
+    "python_default",
+    "python_typed",
+    "frontend_default",
+    "frontend_sanitization",
+    "ui",
+    "documentation"
+  ],
+  "owners": {
+    "python_default": {
+      "root-default": {
+        "module": "nodes.py"
+      },
+      "schema-definition": {
+        "module": "easyuse_anima/aio/schemas/generation_settings.v1.json"
+      }
+    },
+    "python_typed": {
+      "generation-settings": {
+        "module": "easyuse_anima/aio/generation_settings.py"
+      },
+      "generation-sampling": {
+        "module": "easyuse_anima/aio/generation_sampling.py"
+      },
+      "generation-features": {
+        "module": "easyuse_anima/aio/generation_features.py"
+      },
+      "generation-detailer": {
+        "module": "easyuse_anima/aio/generation_detailer.py"
+      },
+      "generation-output": {
+        "module": "easyuse_anima/aio/generation_output.py"
+      },
+      "generation-values": {
+        "module": "easyuse_anima/aio/generation_values.py"
+      }
+    },
+    "frontend_default": {
+      "settings-core": {
+        "module": "web/js/aio/settings.js"
+      }
+    },
+    "frontend_sanitization": {
+      "default-merge": {
+        "module": "web/js/aio/settings.js"
+      },
+      "preview-normalizer": {
+        "module": "web/js/aio/settings.js"
+      },
+      "extension-preserve": {
+        "module": "web/js/aio/settings.js"
+      },
+      "optional-dependency-sanitizer": {
+        "module": "web/js/easyuse_anima_aio.js"
+      },
+      "optional-dependency-aware-merge": {
+        "module": "web/js/easyuse_anima_aio.js"
+      }
+    },
+    "ui": {
+      "hidden-contract": {
+        "module": "web/js/aio/settings.js",
+        "exposure": "hidden"
+      },
+      "hidden-extension": {
+        "module": "web/js/aio/settings.js",
+        "exposure": "hidden"
+      },
+      "generator-panel": {
+        "module": "web/js/aio/generator_panel_runtime.js",
+        "exposure": "editable"
+      },
+      "sampler-dialog": {
+        "module": "web/js/aio/sampler_settings_dialog.js",
+        "exposure": "editable"
+      },
+      "advanced-dialog": {
+        "module": "web/js/aio/advanced_settings_dialog.js",
+        "exposure": "editable"
+      },
+      "stage-dialogs": {
+        "module": "web/js/aio/stage_settings_dialogs.js",
+        "exposure": "editable"
+      },
+      "postprocess-dialog": {
+        "module": "web/js/aio/postprocess_settings_dialog.js",
+        "exposure": "editable"
+      },
+      "detailer-dialog": {
+        "module": "web/js/aio/detailer_settings_dialog.js",
+        "exposure": "editable"
+      },
+      "save-dialog": {
+        "module": "web/js/aio/save_settings_dialog.js",
+        "exposure": "editable"
+      },
+      "preview-dialog": {
+        "module": "web/js/aio/preview_settings_dialog.js",
+        "exposure": "editable"
+      },
+      "reusable-optimization-editor": {
+        "modules": [
+          "web/js/aio/sampler_settings_dialog.js",
+          "web/js/aio/stage_settings_dialogs.js",
+          "web/js/aio/detailer_settings_dialog.js"
+        ],
+        "exposure": "editable"
+      }
+    },
+    "documentation": {
+      "architecture-ownership": {
+        "path": "docs/architecture/aio-settings-contract.md",
+        "heading": "## 소유권"
+      },
+      "architecture-static-fields": {
+        "path": "docs/architecture/aio-settings-contract.md",
+        "heading": "## 정적 field 정책"
+      },
+      "architecture-unknown-fields": {
+        "path": "docs/architecture/aio-settings-contract.md",
+        "heading": "## Unknown-field 정책과 현재 drift"
+      }
+    }
+  },
+  "groups": [
+    {
+      "coverage": {
+        "python_default": "schema-definition",
+        "python_typed": "generation-output",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "save-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/definitions/civitai_hash_fetcher/enabled",
+        "/definitions/civitai_hash_fetcher/model_name",
+        "/definitions/civitai_hash_fetcher/username",
+        "/definitions/civitai_hash_fetcher/version"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-detailer",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "detailer-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/definitions/detailer_target/alignment",
+        "/definitions/detailer_target/bbox_fill",
+        "/definitions/detailer_target/cfg",
+        "/definitions/detailer_target/combined",
+        "/definitions/detailer_target/contour_fill",
+        "/definitions/detailer_target/crop_factor",
+        "/definitions/detailer_target/cycle",
+        "/definitions/detailer_target/denoise",
+        "/definitions/detailer_target/detect_count",
+        "/definitions/detailer_target/detect_prompt",
+        "/definitions/detailer_target/dit_corrections",
+        "/definitions/detailer_target/drop_size",
+        "/definitions/detailer_target/enabled",
+        "/definitions/detailer_target/feather",
+        "/definitions/detailer_target/force_inpaint",
+        "/definitions/detailer_target/guide_size",
+        "/definitions/detailer_target/guide_size_for",
+        "/definitions/detailer_target/individual_masks",
+        "/definitions/detailer_target/inherit_sampler_settings",
+        "/definitions/detailer_target/inpaint_model",
+        "/definitions/detailer_target/label",
+        "/definitions/detailer_target/max_size",
+        "/definitions/detailer_target/noise_mask",
+        "/definitions/detailer_target/noise_mask_feather",
+        "/definitions/detailer_target/refine_iterations",
+        "/definitions/detailer_target/sampler_name",
+        "/definitions/detailer_target/scheduler",
+        "/definitions/detailer_target/spectrum",
+        "/definitions/detailer_target/steps",
+        "/definitions/detailer_target/threshold",
+        "/definitions/detailer_target/tiled_decode",
+        "/definitions/detailer_target/tiled_encode",
+        "/definitions/detailer_target/wildcard",
+        "/shape/detailer/order",
+        "/shape/detailer/sam3/checkpoint",
+        "/shape/detailer/sam3/context"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "schema-definition",
+        "python_typed": "generation-detailer",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "detailer-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/definitions/detailer_target_name"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-sampling",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "optional-dependency-aware-merge",
+        "ui": "reusable-optimization-editor",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/definitions/dit_corrections/adaptive_smc_alpha",
+        "/definitions/dit_corrections/cfgpp",
+        "/definitions/dit_corrections/cfgpp_lambda",
+        "/definitions/dit_corrections/dcw_band_mask",
+        "/definitions/dit_corrections/dcw_calibrator",
+        "/definitions/dit_corrections/dcw_lambda",
+        "/definitions/dit_corrections/dcw_mode",
+        "/definitions/dit_corrections/enabled",
+        "/definitions/dit_corrections/fsg",
+        "/definitions/dit_corrections/fsg_band_hi",
+        "/definitions/dit_corrections/fsg_band_lo",
+        "/definitions/dit_corrections/fsg_d_sigma",
+        "/definitions/dit_corrections/fsg_gamma",
+        "/definitions/dit_corrections/fsg_k",
+        "/definitions/dit_corrections/replace_existing_cfg",
+        "/definitions/dit_corrections/smc_cfg",
+        "/definitions/dit_corrections/smc_cfg_lambda",
+        "/definitions/spectrum/blend_w",
+        "/definitions/spectrum/cheby_degree",
+        "/definitions/spectrum/compat_policy",
+        "/definitions/spectrum/enabled",
+        "/definitions/spectrum/flex_window",
+        "/definitions/spectrum/history_size",
+        "/definitions/spectrum/one_sampler_only",
+        "/definitions/spectrum/ridge_lambda",
+        "/definitions/spectrum/tail_actual_steps",
+        "/definitions/spectrum/verbose",
+        "/definitions/spectrum/warmup_steps",
+        "/definitions/spectrum/window_size"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "schema-definition",
+        "python_typed": "generation-values",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "extension-preserve",
+        "ui": "hidden-extension",
+        "documentation": "architecture-unknown-fields"
+      },
+      "paths": [
+        "/definitions/json_value"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-features",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "advanced-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/artist_mix/cluster_count",
+        "/shape/artist_mix/dominant_isolation",
+        "/shape/artist_mix/dominant_threshold",
+        "/shape/artist_mix/exact_top_k",
+        "/shape/artist_mix/mode",
+        "/shape/artist_mix/rms_scale_cap",
+        "/shape/artist_mix/start_percent",
+        "/shape/artist_mix/strength_scale",
+        "/shape/artist_mix/style_gain",
+        "/shape/model_patches/aura_flow/shift",
+        "/shape/model_patches/dave/mask",
+        "/shape/model_patches/dave/strength",
+        "/shape/model_patches/dave/tau",
+        "/shape/model_patches/kj/sage_allow_compile",
+        "/shape/model_patches/kj/torch_compile/backend",
+        "/shape/model_patches/kj/torch_compile/compile_transformer_blocks_only",
+        "/shape/model_patches/kj/torch_compile/debug_compile_keys",
+        "/shape/model_patches/kj/torch_compile/disable_dynamic_vram",
+        "/shape/model_patches/kj/torch_compile/dynamic",
+        "/shape/model_patches/kj/torch_compile/dynamo_cache_size_limit",
+        "/shape/model_patches/kj/torch_compile/fullgraph",
+        "/shape/model_patches/kj/torch_compile/mode",
+        "/shape/model_patches/safe_pag/block_indices",
+        "/shape/model_patches/safe_pag/end_percent",
+        "/shape/model_patches/safe_pag/head_indices",
+        "/shape/model_patches/safe_pag/perturbation_strength",
+        "/shape/model_patches/safe_pag/rescale",
+        "/shape/model_patches/safe_pag/rescale_mode",
+        "/shape/model_patches/safe_pag/scale",
+        "/shape/model_patches/safe_pag/start_percent"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-detailer",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "optional-dependency-sanitizer",
+        "ui": "detailer-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/detailer/enabled",
+        "/shape/detailer/eye",
+        "/shape/detailer/face"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-features",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "stage-dialogs",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/highres/cfg",
+        "/shape/highres/denoise",
+        "/shape/highres/enabled",
+        "/shape/highres/inherit_sampler_settings",
+        "/shape/highres/max_long_edge",
+        "/shape/highres/multiple",
+        "/shape/highres/sampler_name",
+        "/shape/highres/scale_by",
+        "/shape/highres/scheduler",
+        "/shape/highres/steps",
+        "/shape/highres/upscale_method",
+        "/shape/upscale/backend",
+        "/shape/upscale/cfg",
+        "/shape/upscale/denoise",
+        "/shape/upscale/inherit_sampler_settings",
+        "/shape/upscale/resshift/chop",
+        "/shape/upscale/resshift/dtype",
+        "/shape/upscale/resshift/overlap",
+        "/shape/upscale/resshift/scale",
+        "/shape/upscale/resshift/student_name",
+        "/shape/upscale/resshift/tile_batch",
+        "/shape/upscale/sampler_name",
+        "/shape/upscale/scale_by",
+        "/shape/upscale/scheduler",
+        "/shape/upscale/steps",
+        "/shape/upscale/usdu/auto_tile_max",
+        "/shape/upscale/usdu/auto_tile_min",
+        "/shape/upscale/usdu/auto_tile_size",
+        "/shape/upscale/usdu/auto_tile_target",
+        "/shape/upscale/usdu/batch_size",
+        "/shape/upscale/usdu/force_uniform_tiles",
+        "/shape/upscale/usdu/mask_blur",
+        "/shape/upscale/usdu/mode_type",
+        "/shape/upscale/usdu/prompt_mode",
+        "/shape/upscale/usdu/seam_fix_denoise",
+        "/shape/upscale/usdu/seam_fix_mask_blur",
+        "/shape/upscale/usdu/seam_fix_mode",
+        "/shape/upscale/usdu/seam_fix_padding",
+        "/shape/upscale/usdu/seam_fix_width",
+        "/shape/upscale/usdu/tile_height",
+        "/shape/upscale/usdu/tile_padding",
+        "/shape/upscale/usdu/tile_width",
+        "/shape/upscale/usdu/tiled_decode",
+        "/shape/upscale/usdu/upscale_model_name"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-features",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "optional-dependency-sanitizer",
+        "ui": "stage-dialogs",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/highres/dit_corrections",
+        "/shape/highres/spectrum",
+        "/shape/upscale/dit_corrections",
+        "/shape/upscale/enabled",
+        "/shape/upscale/spectrum"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-features",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "sampler-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/mod_guidance/advanced/adapter",
+        "/shape/mod_guidance/advanced/mod_end_layer",
+        "/shape/mod_guidance/advanced/mod_final_w",
+        "/shape/mod_guidance/advanced/mod_start_layer",
+        "/shape/mod_guidance/advanced/mod_taper",
+        "/shape/mod_guidance/advanced/mod_taper_scale",
+        "/shape/mod_guidance/advanced/mod_w",
+        "/shape/mod_guidance/advanced/quality_neg",
+        "/shape/mod_guidance/advanced/quality_tags",
+        "/shape/mod_guidance/mode",
+        "/shape/mod_guidance/profile"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-settings",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "generator-panel",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/mode"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-features",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "optional-dependency-sanitizer",
+        "ui": "advanced-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/model_patches/dave/enabled",
+        "/shape/model_patches/kj/fp16_accumulation",
+        "/shape/model_patches/kj/sage_attention",
+        "/shape/model_patches/kj/torch_compile/enabled",
+        "/shape/model_patches/safe_pag/enabled"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-features",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "postprocess-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/postprocess/enabled",
+        "/shape/postprocess/fit/max_long_edge",
+        "/shape/postprocess/fit/max_megapixels",
+        "/shape/postprocess/fit/method",
+        "/shape/postprocess/fit/mode"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-output",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "preview-normalizer",
+        "ui": "preview-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/preview/compare_previous",
+        "/shape/preview/feed_count",
+        "/shape/preview/image_feed",
+        "/shape/preview/intermediate_images"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-sampling",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "optional-dependency-sanitizer",
+        "ui": "sampler-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/sampler/backend",
+        "/shape/sampler/dit_corrections",
+        "/shape/sampler/spectrum"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-sampling",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "generator-panel",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/sampler/cfg",
+        "/shape/sampler/denoise",
+        "/shape/sampler/sampler_name",
+        "/shape/sampler/scheduler",
+        "/shape/sampler/seed",
+        "/shape/sampler/seed_after_generate",
+        "/shape/sampler/steps"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-sampling",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "sampler-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/sampler/spd/adaptive_smc_alpha",
+        "/shape/sampler/spd/scale",
+        "/shape/sampler/spd/sigma",
+        "/shape/sampler/spd/split_mode"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-sampling",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "extension-preserve",
+        "ui": "hidden-extension",
+        "documentation": "architecture-unknown-fields"
+      },
+      "paths": [
+        "/shape/sampler/spd_extra",
+        "/shape/sampler/spectrum_extra"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-output",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "optional-dependency-sanitizer",
+        "ui": "save-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/save/backend"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-output",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "save-dialog",
+        "documentation": "architecture-static-fields"
+      },
+      "paths": [
+        "/shape/save/enabled",
+        "/shape/save/image_saver/additional_hash_bundles",
+        "/shape/save/image_saver/additional_hashes",
+        "/shape/save/image_saver/civitai_hash_fetchers",
+        "/shape/save/image_saver/clip_skip",
+        "/shape/save/image_saver/counter",
+        "/shape/save/image_saver/custom",
+        "/shape/save/image_saver/download_civitai_data",
+        "/shape/save/image_saver/easy_remix",
+        "/shape/save/image_saver/embed_workflow",
+        "/shape/save/image_saver/extension",
+        "/shape/save/image_saver/filename",
+        "/shape/save/image_saver/lossless_webp",
+        "/shape/save/image_saver/optimize_png",
+        "/shape/save/image_saver/path",
+        "/shape/save/image_saver/quality_jpeg_or_webp",
+        "/shape/save/image_saver/save_prompt_metadata",
+        "/shape/save/image_saver/save_workflow_as_json",
+        "/shape/save/image_saver/time_format"
+      ]
+    },
+    {
+      "coverage": {
+        "python_default": "root-default",
+        "python_typed": "generation-settings",
+        "frontend_default": "settings-core",
+        "frontend_sanitization": "default-merge",
+        "ui": "hidden-contract",
+        "documentation": "architecture-ownership"
+      },
+      "paths": [
+        "/shape/schema",
+        "/shape/version"
+      ]
+    }
+  ]
+}

--- a/tests/frontend_aio_settings_core_smoke.mjs
+++ b/tests/frontend_aio_settings_core_smoke.mjs
@@ -15,6 +15,69 @@ function assertJsonEqual(actual, expected, message) {
   assert(JSON.stringify(actual) === JSON.stringify(expected), message);
 }
 
+function collectLeafPaths(value, path = [], output = []) {
+  if (value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0) {
+    for (const [name, child] of Object.entries(value)) {
+      collectLeafPaths(child, [...path, name], output);
+    }
+    return output;
+  }
+  output.push(`/${path.join("/")}`);
+  return output;
+}
+
+function collectContractPaths(contract, path, output = []) {
+  if (Object.prototype.hasOwnProperty.call(contract, "$ref")) {
+    output.push(`/${path.join("/")}`);
+    return output;
+  }
+  const fields = contract?.fields;
+  if (fields && typeof fields === "object" && !Array.isArray(fields) && Object.keys(fields).length > 0) {
+    for (const [name, child] of Object.entries(fields)) {
+      collectContractPaths(child, [...path, name], output);
+    }
+    return output;
+  }
+  output.push(`/${path.join("/")}`);
+  return output;
+}
+
+function manifestContractPaths(manifest) {
+  const paths = collectContractPaths(manifest.shape, ["shape"]);
+  for (const [name, definition] of Object.entries(manifest.definitions)) {
+    collectContractPaths(definition, ["definitions", name], paths);
+  }
+  return paths.sort();
+}
+
+function assertSurfacePaths(expectedPaths, actualPaths, surface) {
+  const expected = new Set(expectedPaths);
+  const actual = new Set(actualPaths);
+  const failures = [
+    ...[...expected].filter((path) => !actual.has(path)).sort()
+      .map((path) => `${path}: missing surface ${surface}`),
+    ...[...actual].filter((path) => !expected.has(path)).sort()
+      .map((path) => `${path}: stale surface ${surface}`),
+  ];
+  assert(failures.length === 0, failures.join("\n"));
+}
+
+function coverageEntries(coverage) {
+  const entries = {};
+  assert(Array.isArray(coverage.groups) && coverage.groups.length > 0, "Surface coverage groups are missing");
+  for (const [index, group] of coverage.groups.entries()) {
+    assert(
+      group && typeof group.coverage === "object" && Array.isArray(group.paths) && group.paths.length > 0,
+      `Surface coverage group ${index} is invalid`,
+    );
+    for (const path of group.paths) {
+      assert(!Object.prototype.hasOwnProperty.call(entries, path), `${path}: duplicate surface coverage entry`);
+      entries[path] = group.coverage;
+    }
+  }
+  return entries;
+}
+
 function collectCoercionReferences(value, output = new Set()) {
   if (Array.isArray(value)) {
     for (const child of value) {
@@ -37,6 +100,10 @@ function collectCoercionReferences(value, output = new Set()) {
 const settingsModule = await import(dataModule("../web/js/aio/settings.js"));
 const generationManifest = JSON.parse(readFileSync(
   new URL("../easyuse_anima/aio/schemas/generation_settings.v1.json", import.meta.url),
+  "utf8",
+));
+const generationSurfaceCoverage = JSON.parse(readFileSync(
+  new URL("./fixtures/aio_generation_settings_surface_coverage.v1.json", import.meta.url),
   "utf8",
 ));
 const aioRuntimeSource = readFileSync(
@@ -92,6 +159,50 @@ assertJsonEqual(
   AIO_DEFAULT_GENERATION_SETTINGS,
   generationManifest.default,
   "AiO manifest defaults must deep-equal the frontend generation defaults",
+);
+assertSurfacePaths(
+  collectLeafPaths(generationManifest.default, ["shape"]),
+  collectLeafPaths(AIO_DEFAULT_GENERATION_SETTINGS, ["shape"]),
+  "frontend_default",
+);
+const requiredSettingSurfaces = [
+  "python_default",
+  "python_typed",
+  "frontend_default",
+  "frontend_sanitization",
+  "ui",
+  "documentation",
+];
+assertJsonEqual(
+  generationSurfaceCoverage.required_surfaces,
+  requiredSettingSurfaces,
+  "AiO surface coverage must retain every required maintenance surface",
+);
+const surfaceCoverageEntries = coverageEntries(generationSurfaceCoverage);
+assertSurfacePaths(
+  manifestContractPaths(generationManifest),
+  Object.keys(surfaceCoverageEntries),
+  "ui_metadata",
+);
+for (const [path, record] of Object.entries(surfaceCoverageEntries)) {
+  for (const surface of requiredSettingSurfaces) {
+    assert(
+      typeof record[surface] === "string" && record[surface].length > 0,
+      `${path}: missing surface ${surface}`,
+    );
+    assert(
+      Object.prototype.hasOwnProperty.call(generationSurfaceCoverage.owners[surface], record[surface]),
+      `${path}: unknown owner ${String(record[surface])} for surface ${surface}`,
+    );
+  }
+}
+const sanitizedGenerationDefaults = JSON.parse(
+  aioSettingsToCompactJson(AIO_DEFAULT_GENERATION_SETTINGS),
+);
+assertSurfacePaths(
+  collectLeafPaths(generationManifest.default, ["shape"]),
+  collectLeafPaths(sanitizedGenerationDefaults, ["shape"]),
+  "frontend_sanitization",
 );
 const coercionReferences = collectCoercionReferences({
   shape: generationManifest.shape,

--- a/tests/test_aio_schema_contract.py
+++ b/tests/test_aio_schema_contract.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 import nodes
+from easyuse_anima.aio.generation_settings import (
+    _aio_generation_config_from_dict,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,10 +22,25 @@ MANIFEST_PATH = ROOT / "easyuse_anima" / "aio" / "schemas" / "generation_setting
 MANIFEST_REPOSITORY_PATH = MANIFEST_PATH.relative_to(ROOT).as_posix()
 FRONTEND_SETTINGS_PATH = ROOT / "web" / "js" / "aio" / "settings.js"
 AIO_WORKFLOW_0_5_2_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "aio_generation_settings_0_5_2.json"
+SURFACE_COVERAGE_PATH = (
+    ROOT / "tests" / "fixtures" / "aio_generation_settings_surface_coverage.v1.json"
+)
+REQUIRED_SETTING_SURFACES = (
+    "python_default",
+    "python_typed",
+    "frontend_default",
+    "frontend_sanitization",
+    "ui",
+    "documentation",
+)
 
 
 def _manifest() -> dict:
     return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _surface_coverage() -> dict:
+    return json.loads(SURFACE_COVERAGE_PATH.read_text(encoding="utf-8"))
 
 
 def _resolve_contract(manifest: dict, contract: dict) -> dict:
@@ -90,6 +108,212 @@ def _default_leaves(value, path: tuple[str, ...] = ()):
             yield from _default_leaves(child, (*path, name))
         return
     yield path, value
+
+
+def _contract_surface_paths(contract: dict, path: tuple[str, ...]):
+    if "$ref" in contract:
+        yield "/" + "/".join(path)
+        return
+    fields = contract.get("fields")
+    if isinstance(fields, dict) and fields:
+        for name, child in fields.items():
+            yield from _contract_surface_paths(child, (*path, name))
+        return
+    yield "/" + "/".join(path)
+
+
+def _all_contract_surface_paths(manifest: dict) -> tuple[str, ...]:
+    paths = list(_contract_surface_paths(manifest["shape"], ("shape",)))
+    for name, definition in manifest["definitions"].items():
+        paths.extend(
+            _contract_surface_paths(definition, ("definitions", name))
+        )
+    return tuple(sorted(paths))
+
+
+def _manifest_shape_default_failures(manifest: dict) -> list[str]:
+    contract_paths = {
+        "/shape/" + "/".join(path)
+        for path, _contract in _leaf_contracts(manifest, manifest["shape"])
+    }
+    default_paths = {
+        "/shape/" + "/".join(path)
+        for path, _value in _default_leaves(manifest["default"])
+    }
+    return [
+        *(
+            f"{path}: missing surface manifest_default"
+            for path in sorted(contract_paths - default_paths)
+        ),
+        *(
+            f"{path}: missing surface manifest_shape"
+            for path in sorted(default_paths - contract_paths)
+        ),
+    ]
+
+
+def _coverage_entries(coverage: dict) -> tuple[dict[str, dict], list[str]]:
+    groups = coverage.get("groups")
+    if not isinstance(groups, list) or not groups:
+        return {}, ["surface coverage: groups must be a non-empty array"]
+
+    entries: dict[str, dict] = {}
+    failures: list[str] = []
+    for index, group in enumerate(groups):
+        if not isinstance(group, dict) or set(group) != {"coverage", "paths"}:
+            failures.append(
+                f"surface coverage: groups[{index}] must contain coverage and paths"
+            )
+            continue
+        record = group["coverage"]
+        paths = group["paths"]
+        if not isinstance(record, dict):
+            failures.append(f"surface coverage: groups[{index}].coverage must be an object")
+            continue
+        if (
+            not isinstance(paths, list)
+            or not paths
+            or any(not isinstance(path, str) or not path.startswith("/") for path in paths)
+        ):
+            failures.append(
+                f"surface coverage: groups[{index}].paths must be canonical paths"
+            )
+            continue
+        if paths != sorted(paths) or len(paths) != len(set(paths)):
+            failures.append(
+                f"surface coverage: groups[{index}].paths must be sorted and unique"
+            )
+        for path in paths:
+            if path in entries:
+                failures.append(f"{path}: duplicate surface coverage entry")
+            else:
+                entries[path] = record
+    return entries, failures
+
+
+def _surface_coverage_failures(manifest: dict, coverage: dict) -> list[str]:
+    expected_paths = set(_all_contract_surface_paths(manifest))
+    entries, failures = _coverage_entries(coverage)
+    required = tuple(coverage.get("required_surfaces", ()))
+    if required != REQUIRED_SETTING_SURFACES:
+        failures.append(
+            "surface coverage: required_surfaces changed: "
+            f"expected {list(REQUIRED_SETTING_SURFACES)!r}, got {list(required)!r}"
+        )
+
+    entry_paths = set(entries)
+    for path in sorted(expected_paths - entry_paths):
+        for surface in REQUIRED_SETTING_SURFACES:
+            failures.append(f"{path}: missing surface {surface}")
+    for path in sorted(entry_paths - expected_paths):
+        failures.append(f"{path}: stale surface coverage entry")
+
+    owners = coverage.get("owners")
+    if not isinstance(owners, dict):
+        failures.append("surface coverage: owners must be an object")
+        owners = {}
+    owner_registries: dict[str, dict] = {}
+    for surface in REQUIRED_SETTING_SURFACES:
+        surface_owners = owners.get(surface)
+        if not isinstance(surface_owners, dict) or not surface_owners:
+            failures.append(f"surface coverage: missing owner registry {surface}")
+            surface_owners = {}
+        owner_registries[surface] = surface_owners
+
+    for path in sorted(expected_paths & entry_paths):
+        record = entries[path]
+        if not isinstance(record, dict):
+            failures.append(f"{path}: surface record must be an object")
+            continue
+        missing = [name for name in REQUIRED_SETTING_SURFACES if name not in record]
+        extra = sorted(set(record) - set(REQUIRED_SETTING_SURFACES))
+        for name in missing:
+            failures.append(f"{path}: missing surface {name}")
+        for name in extra:
+            failures.append(f"{path}: unsupported surface {name}")
+        for surface in REQUIRED_SETTING_SURFACES:
+            owner = record.get(surface)
+            if not isinstance(owner, str) or not owner:
+                failures.append(f"{path}: invalid owner for surface {surface}")
+            elif owner not in owner_registries[surface]:
+                failures.append(
+                    f"{path}: unknown owner {owner!r} for surface {surface}"
+                )
+
+    return failures
+
+
+def _surface_owner_failures(coverage: dict) -> list[str]:
+    failures: list[str] = []
+    for surface, owners in coverage["owners"].items():
+        for owner, metadata in owners.items():
+            if not isinstance(metadata, dict):
+                failures.append(f"{surface}/{owner}: owner metadata must be an object")
+                continue
+            if isinstance(metadata.get("module"), str):
+                repository_paths = [metadata["module"]]
+            elif (
+                isinstance(metadata.get("modules"), list)
+                and metadata["modules"]
+                and all(isinstance(path, str) and path for path in metadata["modules"])
+            ):
+                repository_paths = metadata["modules"]
+            elif isinstance(metadata.get("path"), str):
+                repository_paths = [metadata["path"]]
+            else:
+                failures.append(f"{surface}/{owner}: owner path is missing")
+                continue
+            if surface == "ui" and metadata.get("exposure") not in {
+                "editable",
+                "hidden",
+                "visible-readonly",
+            }:
+                failures.append(f"{surface}/{owner}: UI exposure must be explicit")
+            if surface == "documentation" and not isinstance(
+                metadata.get("heading"), str
+            ):
+                failures.append(
+                    f"{surface}/{owner}: documentation heading must be explicit"
+                )
+            owner_paths: list[Path] = []
+            for repository_path in repository_paths:
+                owner_path = ROOT / repository_path
+                owner_paths.append(owner_path)
+                if not owner_path.is_file():
+                    failures.append(
+                        f"{surface}/{owner}: owner path does not exist: {repository_path}"
+                    )
+                    continue
+                try:
+                    tracked = _git("ls-files", "--error-unmatch", "--", repository_path)
+                except subprocess.CalledProcessError:
+                    failures.append(
+                        f"{surface}/{owner}: owner path is not tracked: {repository_path}"
+                    )
+                else:
+                    if tracked.stdout.strip() != repository_path:
+                        failures.append(
+                            f"{surface}/{owner}: owner path is not tracked: {repository_path}"
+                        )
+            heading = metadata.get("heading")
+            if heading is not None:
+                text = (
+                    owner_paths[0].read_text(encoding="utf-8")
+                    if owner_paths[0].is_file()
+                    else ""
+                )
+                if not isinstance(heading, str) or heading not in text.splitlines():
+                    failures.append(
+                        f"{surface}/{owner}: documentation heading is missing: {heading!r}"
+                    )
+    return failures
+
+
+def _delete_path(value: dict, path: tuple[str, ...]) -> None:
+    current = value
+    for name in path[:-1]:
+        current = current[name]
+    del current[path[-1]]
 
 
 def _get_path(value: dict, path: tuple[str, ...]):
@@ -223,9 +447,127 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
     def test_manifest_default_matches_python_runtime_default(self):
         manifest = _manifest()
 
+        manifest_paths = dict(_default_leaves(manifest["default"]))
+        python_paths = dict(_default_leaves(nodes.AIO_GENERATION_DEFAULT_SETTINGS))
+        failures = [
+            *(
+                f"/shape/{'/'.join(path)}: missing surface python_default"
+                for path in sorted(set(manifest_paths) - set(python_paths))
+            ),
+            *(
+                f"/shape/{'/'.join(path)}: stale surface python_default"
+                for path in sorted(set(python_paths) - set(manifest_paths))
+            ),
+        ]
+        if failures:
+            self.fail("\n".join(failures))
+
         self.assertEqual(manifest["settings"]["schema"], nodes.AIO_GENERATION_SETTINGS_SCHEMA)
         self.assertEqual(manifest["settings"]["version"], nodes.AIO_GENERATION_SETTINGS_VERSION)
         self.assertEqual(manifest["default"], nodes.AIO_GENERATION_DEFAULT_SETTINGS)
+
+    def test_every_manifest_default_leaf_is_owned_by_typed_config(self):
+        manifest = _manifest()
+        missing: list[str] = []
+
+        for path, _value in _default_leaves(manifest["default"]):
+            source = copy.deepcopy(nodes.AIO_GENERATION_DEFAULT_SETTINGS)
+            _delete_path(source, path)
+            try:
+                _aio_generation_config_from_dict(source)
+            except (TypeError, ValueError):
+                continue
+            missing.append(f"/shape/{'/'.join(path)}: missing surface python_typed")
+
+        fetcher_fields = tuple(
+            manifest["definitions"]["civitai_hash_fetcher"]["fields"]
+        )
+        fetcher = {
+            "enabled": True,
+            "username": "owner",
+            "model_name": "model",
+            "version": "v1",
+        }
+        for field in fetcher_fields:
+            source = copy.deepcopy(nodes.AIO_GENERATION_DEFAULT_SETTINGS)
+            source["save"]["image_saver"]["civitai_hash_fetchers"] = [
+                {name: value for name, value in fetcher.items() if name != field}
+            ]
+            try:
+                _aio_generation_config_from_dict(source)
+            except (TypeError, ValueError):
+                continue
+            missing.append(
+                f"/definitions/civitai_hash_fetcher/{field}: "
+                "missing surface python_typed"
+            )
+
+        if missing:
+            self.fail("\n".join(missing))
+
+    def test_surface_coverage_registry_matches_every_manifest_contract_path(self):
+        manifest = _manifest()
+        coverage = _surface_coverage()
+
+        self.assertEqual(
+            coverage["schema"],
+            "easyuse_anima_aio_generation_settings_surface_coverage",
+        )
+        self.assertEqual(coverage["version"], 1)
+        self.assertEqual(coverage["manifest"], MANIFEST_REPOSITORY_PATH)
+        self.assertEqual(
+            [group["paths"][0] for group in coverage["groups"]],
+            sorted(group["paths"][0] for group in coverage["groups"]),
+            "Surface coverage groups must remain deterministically sorted",
+        )
+        failures = _surface_coverage_failures(manifest, coverage)
+        if failures:
+            self.fail("\n".join(failures))
+
+    def test_surface_coverage_reports_exact_missing_path_and_surface(self):
+        manifest = _manifest()
+        coverage = _surface_coverage()
+        path = coverage["groups"][0]["paths"][0]
+        del coverage["groups"][0]["coverage"]["ui"]
+
+        failures = _surface_coverage_failures(manifest, coverage)
+
+        self.assertIn(f"{path}: missing surface ui", failures)
+        self.assertNotIn(f"{path}: missing surface python_typed", failures)
+
+        manifest["shape"]["fields"]["omission_probe"] = {"type": "string"}
+        failures = _surface_coverage_failures(manifest, _surface_coverage())
+        for surface in REQUIRED_SETTING_SURFACES:
+            self.assertIn(
+                f"/shape/omission_probe: missing surface {surface}",
+                failures,
+            )
+        self.assertIn(
+            "/shape/omission_probe: missing surface manifest_default",
+            _manifest_shape_default_failures(manifest),
+        )
+
+        owner_coverage = _surface_coverage()
+        ui_owner = next(iter(owner_coverage["owners"]["ui"]))
+        documentation_owner = next(iter(owner_coverage["owners"]["documentation"]))
+        del owner_coverage["owners"]["ui"][ui_owner]["exposure"]
+        del owner_coverage["owners"]["documentation"][documentation_owner]["heading"]
+        owner_failures = _surface_owner_failures(owner_coverage)
+        self.assertIn(
+            f"ui/{ui_owner}: UI exposure must be explicit",
+            owner_failures,
+        )
+        self.assertIn(
+            f"documentation/{documentation_owner}: documentation heading must be explicit",
+            owner_failures,
+        )
+
+    def test_surface_coverage_owners_are_tracked_and_documented(self):
+        coverage = _surface_coverage()
+        failures = _surface_owner_failures(coverage)
+
+        if failures:
+            self.fail("\n".join(failures))
 
     def test_0_5_2_saved_aio_workflow_normalizes_generation_settings_identically(self):
         fixture = json.loads(AIO_WORKFLOW_0_5_2_FIXTURE_PATH.read_text(encoding="utf-8"))
@@ -260,6 +602,9 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
         contracts = dict(_leaf_contracts(manifest, manifest["shape"]))
         defaults = dict(_default_leaves(manifest["default"]))
 
+        failures = _manifest_shape_default_failures(manifest)
+        if failures:
+            self.fail("\n".join(failures))
         self.assertEqual(set(contracts), set(defaults))
         for path, value in defaults.items():
             contract = contracts[path]


### PR DESCRIPTION
## 변경 요약

- #168 C168-05의 cross-surface setting omission gate Contract를 추가합니다.
- 새 manifest setting이 Python default/typed config, JavaScript default/sanitization, UI metadata, 유지 문서 중 어느 표면에서 빠졌는지 exact path와 surface로 실패하게 합니다.
- runtime normalization, UI 동작, schema version, 저장 데이터는 변경하지 않습니다.

## Task manifest

- Task: C168-05 cross-surface setting omission gate
- Type: Contract/gate
- Base: `dev@29aa200eba4568a4dc83a3ef62b702451ca872ef`
- Owner: #168
- Prerequisite: C168-03 typed config / C168-04 pure migration registry merged

## 변경 전 symbol / caller / alias / global-state inventory

### Symbols and current checks

- canonical manifest: `easyuse_anima/aio/schemas/generation_settings.v1.json`
- Python default: `nodes.AIO_GENERATION_DEFAULT_SETTINGS`
- Python typed boundary: `AIOGenerationConfig`와 section-specific frozen dataclass의 `from_value()`/`to_dict()`
- JavaScript default: `AIO_DEFAULT_GENERATION_SETTINGS`
- JavaScript merge/sanitization: `aioMergeDefaults()`, `aioParseSettingsValue()`, `aioSettingsToCompactJson()`, preview/legacy normalizers
- current Python golden test는 manifest default/shape/runtime normalization을 검증하고, frontend smoke는 manifest와 JS default의 deep equality를 검증함
- 현재 누락: typed known-field ownership, sanitized output path, explicit UI owner metadata, maintained field ledger를 하나의 exact-path omission gate로 묶는 계약이 없음

### Callers and compatibility seams

- production runtime callers는 `EasyUseAnimaAIOGenerator.IS_CHANGED()`와 `generate()`에서 root normalizer를 사용함
- browser callers는 settings core의 parse/merge/compact helpers와 각 dialog module을 사용함
- 이번 gate는 production caller에 새 호출을 연결하지 않고 offline validation에서만 실행됨
- dynamic sampler/scheduler/max-resolution capability choices는 static field ownership 대상이 아님

### Alias / public surface

- public node ID/input/output/widget/serialization 변경 없음
- root private facade/alias, canonical `__all__`, class identity 변경 없음
- manifest schema/version/default 값과 기존 field path 변경 없음

### Global state / lifecycle

- mutable root/JavaScript default의 현재 identity와 clone/merge 동작 유지
- 새 coverage metadata는 static read-only validation data이며 import-time registration, I/O side effect, cache, lock, executor, persistence 없음
- workflow/profile read/write와 live Comfy lifecycle 변경 없음

## Allowed-file boundary

- `generation_settings.v1.json`을 기준으로 하는 golden surface coverage fixture
- existing Python schema Contract test와 frontend settings smoke의 exact-path assertions
- coverage ledger와 관련 architecture/roadmap 상태 문서
- production Python/JavaScript와 official runner는 변경하지 않음

## 금지 범위

- `_normalize_aio_generation_settings()` 또는 typed config Move(C168-06)
- strict migration dispatcher runtime 연결, schema v2, 새 setting/default/enum/min/max 추가
- JavaScript sanitize/UI behavior 변경 또는 dialog 재구성
- profile/workflow write-on-read, 자동 migration, stage/cache/seed 변경
- dynamic capability choice를 static manifest가 소유하도록 변경

## 구현 결과

- manifest leaf path를 canonical set으로 사용
- Python default와 typed known-field ownership을 각각 독립적으로 검증
- JavaScript default와 compact sanitized output의 leaf path를 각각 검증
- 각 manifest leaf에 explicit UI owner/sanitizer metadata를 요구하고 허용된 tracked module만 사용
- 유지 문서 ledger가 metadata와 exact equality인지 확인
- 누락은 `/<path>: <surface>` 형태로 deterministic하게 보고
- checker는 filesystem/network/runtime dependency 없이 official project check에서 실행

## 주요 변경 파일

- `tests/fixtures/aio_generation_settings_surface_coverage.v1.json`
- `tests/test_aio_schema_contract.py`
- `tests/frontend_aio_settings_core_smoke.mjs`
- `docs/architecture/aio-settings-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

## 검증 결과

- schema Contract focused unittest: 18 tests passed
- frontend AiO settings core smoke: passed
- frontend smoke `node --check`: passed
- targeted Python compile 및 `git diff --check`: passed
- independent diff review: 최초 shape/default 및 UI/docs owner 필수 metadata 허점을 보강한 뒤 최종 blocking finding 없음
- official full at `b15e52e`: Python 787 tests passed, frontend 114 JavaScript files passed, TypeScript 6.0.3, compile/Pyright baseline/diff checks passed
- Ruff repository report-only baseline: 기존 105 findings, blocking failure 없음
- live ComfyUI smoke: Contract-only 변경이므로 미실행

## 남은 위험 / 미확인

- coverage ledger는 explicit maintenance ownership을 강제하지만 production UI/runtime에서 import하지 않음
- duplicate path, unknown owner, stale entry helper 분기는 구현상 차단되며 별도 negative mutation self-test는 비차단 보강점으로 남음
- runtime normalizer ownership Move는 C168-06에서 별도 수행

## 롤백 경계

- coverage checker/metadata/ledger와 관련 tests/docs/runner 연결만 되돌리면 됨
- runtime code와 persisted data에는 영향 없음

## 현재 상태

- Ready for `dev`
- 구현, focused 검증, 독립 리뷰, exact-head full 완료
