### PR TITLE
test(backend): enforce completed-package import boundaries (G-03a)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -36,7 +36,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
-| G - quality ratchet | G-01 and G-02a complete | G-02b strict allowlist, G-03 imports, G-04 public API, G-05 size, G-06 test ownership |
+| G - quality ratchet | G-01, G-02a/G-02b, and G-03a complete | Extend G-03 enrollment, then continue with G-04 through G-06 |
 | H - shim retirement | Not started | Requires canonical release evidence and ADR-002 gates |
 
 ### Measured Phase B progress
@@ -284,9 +284,9 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 3 | G-02b strict-clean pure/service allowlist | COMPLETE on `dev` | Contract/gate | #188 | PR #254 / `76237a60` |
 | 4 | C168-04 pure version-dispatch/migration registry | COMPLETE on `dev` | Contract | #168 | PR #255 / `29aa200e` |
 | 5 | C168-05 cross-surface setting omission gate | COMPLETE | Contract/gate | #168 | PR #256 merged |
-| 6 | G-03a completed-package import boundary fail gate | READY/PARALLEL | Contract/gate | #188 | G-02b merged |
-| 7 | C168-06 normalizer ownership move | IN REVIEW | Move | #168/#184 | PR #257 / C168 contracts and omission gate complete |
-| 8 | B-08a through B-08e AiO support-helper extraction | BLOCKED by #168 exit | Move | #184 | C168-03 through C168-06 complete |
+| 6 | G-03a completed-package import boundary fail gate | COMPLETE on `dev` | Contract/gate | #188 | PR #258 / six reviewed zero-violation prefixes enrolled |
+| 7 | C168-06 normalizer ownership move | COMPLETE on `dev` | Move | #168/#184 | PR #257 / `3ca5500` |
+| 8 | B-08a through B-08e AiO support-helper extraction | READY/SEQUENTIAL | Move | #184 | #168 closed; C168-03 through C168-06 complete |
 | 9 | B-09a/B-09b AiO node and legacy orchestration move | BLOCKED by B-08 | Move | #184 | AiO helpers canonical |
 | 10 | B-10 compatibility/private-alias audit | BLOCKED by B-09 | Contract/cleanup, split PRs | #184/#188 | All node implementations canonical |
 | 11 | B-11 registration/bootstrap/root shim | BLOCKED by B-10 | Move | #184 | Alias surface frozen |
@@ -432,6 +432,26 @@ relax or block the package-migration rules above.
   effects.
 - Existing root loader compatibility may remain baseline debt until B-11/D-14;
   the gate must not be weakened to accommodate new canonical violations.
+- The first blocking ledger contains exactly six reviewed prefixes:
+  `common`, `image`, `infrastructure/comfy`, `lora`, `naia`, and `profiles`.
+  Group id, owner issue, prefix, role, ordering, uniqueness, and the exact group
+  set are validated so deleting or broadening an entry cannot silently weaken
+  the gate. New Python files beneath an enrolled prefix are covered
+  automatically.
+- The checker consumes `analyze_python_backend.py` output without importing
+  production modules. It rejects enrolled canonical imports of repository-root
+  modules, references to `easyuse_anima/nodes/`,
+  `easyuse_anima/api/routes/`, exact `bootstrap.py` or `registration.py`,
+  runtime cyclic SCC membership, compatibility fallback imports, and narrowly
+  identified import-time registration or mapping-mutation calls.
+- The cycle view covers the analyzer's shipped Python inventory. Exact absolute
+  imports that resolve to an inventoried local module complete the graph before
+  the analyzer's own runtime-edge filter and SCC helper run, so the existing
+  `TYPE_CHECKING` exclusion policy remains authoritative.
+- Genuine external and optional dependencies with no repository-local target
+  remain allowed. Unenrolled legacy package debt stays report-only until its
+  own reviewed completion checkpoint. The official quick/full quality path
+  invokes this checker exactly once per project check.
 
 ## 8. AiO mechanical extraction plan
 

--- a/docs/architecture/python-backend.md
+++ b/docs/architecture/python-backend.md
@@ -411,6 +411,42 @@ boundary, or public compatibility surface. New strict groups require their own
 reviewed owner and focused evidence. Import direction, public API, size, and
 test-ownership gates remain G-03 through G-06.
 
+### G-03a implementation contract
+
+G-03a adds a blocking import-boundary checker for six completed canonical
+prefixes: `common`, `image`, `infrastructure/comfy`, `lora`, `naia`, and
+`profiles`. Its checked-in ledger records exact group ids, owner issues,
+prefixes, and roles. The checker also owns the reviewed exact group set, so a
+missing, duplicated, reordered, empty, renamed, or reassigned ledger entry
+fails rather than reducing coverage. Every new Python file below an enrolled
+prefix is included automatically.
+
+The checker consumes the deterministic AST report from
+`tools/analyze_python_backend.py`; it does not import production modules. For
+enrolled sources it rejects repository-local targets outside
+`easyuse_anima`, references to `easyuse_anima/nodes/`,
+`easyuse_anima/api/routes/`, exact canonical `bootstrap.py` or
+`registration.py`, runtime cyclic SCC membership, compatibility fallback
+imports, and narrowly classified import-time route/registration or explicit
+mapping-mutation calls. External and optional dependencies without a local
+target remain valid. Infrastructure use by feature packages is not newly
+restricted in this slice because that direction does not yet have a separate
+reviewed contract.
+
+Cycle enforcement uses the analyzer's shipped Python inventory as its node
+scope. The checker completes that graph only when an absolute import exactly
+matches an inventoried local module, then delegates runtime-edge filtering and
+SCC calculation to the analyzer's existing helpers. This keeps
+`TYPE_CHECKING` exclusion identical to the report policy while preventing an
+absolute canonical edge from bypassing the cycle gate.
+
+`tools/check_python_quality.ps1` runs the checker once in the shared quality
+path used by both quick and full project profiles. Existing unenrolled debt in
+root loaders, Prompt, and node adapters remains visible in the analyzer report
+but does not block this first package gate. Enrolling another prefix requires a
+separate reviewed zero-violation checkpoint and an intentional update to both
+the ledger and checker-owned expected set.
+
 ## Overall Definition of Done
 
 The Python backend refactor is complete only when all of the following hold.

--- a/tests/fixtures/python_import_boundary_contract.v1.json
+++ b/tests/fixtures/python_import_boundary_contract.v1.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "groups": [
+    {
+      "group": "common",
+      "owner_issue": 184,
+      "prefix": "easyuse_anima/common/",
+      "role": "common"
+    },
+    {
+      "group": "image",
+      "owner_issue": 184,
+      "prefix": "easyuse_anima/image/",
+      "role": "feature"
+    },
+    {
+      "group": "infrastructure-comfy",
+      "owner_issue": 184,
+      "prefix": "easyuse_anima/infrastructure/comfy/",
+      "role": "infrastructure"
+    },
+    {
+      "group": "lora",
+      "owner_issue": 184,
+      "prefix": "easyuse_anima/lora/",
+      "role": "feature"
+    },
+    {
+      "group": "naia",
+      "owner_issue": 184,
+      "prefix": "easyuse_anima/naia/",
+      "role": "feature"
+    },
+    {
+      "group": "profiles",
+      "owner_issue": 163,
+      "prefix": "easyuse_anima/profiles/",
+      "role": "feature"
+    }
+  ]
+}

--- a/tests/test_python_import_boundaries.py
+++ b/tests/test_python_import_boundaries.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import ast
+import copy
 import importlib.util
+import json
 import unittest
 from pathlib import Path
 
@@ -9,6 +11,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ANALYZER_PATH = ROOT / "tools" / "analyze_nodes_module.py"
 INTERNAL_PACKAGE = ROOT / "easyuse_anima"
+CHECKER_PATH = ROOT / "tools" / "check_python_import_boundaries.py"
+CONTRACT_PATH = (
+    ROOT / "tests" / "fixtures" / "python_import_boundary_contract.v1.json"
+)
 
 
 def load_analyzer():
@@ -20,10 +26,31 @@ def load_analyzer():
     return module
 
 
+def load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_import_boundary_checker",
+        CHECKER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load checker: {CHECKER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 analyzer = load_analyzer()
+checker = load_checker()
 
 
-class PythonImportBoundaryTests(unittest.TestCase):
+def analyzed(sources: dict[str, str]):
+    return checker.analyzer.analyze_source_set(sources)
+
+
+def synthetic_root(*module_imports: str) -> str:
+    return "\n".join(module_imports) + "\n"
+
+
+class PythonImportBoundarySeedTests(unittest.TestCase):
     def test_future_internal_package_never_imports_root_nodes(self):
         violations = analyzer.scan_internal_package(INTERNAL_PACKAGE)
 
@@ -190,6 +217,179 @@ class PythonImportBoundaryTests(unittest.TestCase):
                     "inner-layer-imports-outer-layer",
                     {violation["rule"] for violation in violations},
                 )
+
+
+class CompletedPackageImportBoundaryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.contract_document = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+        cls.groups = checker.validate_contract(cls.contract_document)
+
+    def test_synthetic_report_rejects_all_five_boundary_rules(self):
+        report = analyzed(
+            {
+                "__init__.py": synthetic_root(
+                    "from .easyuse_anima.common import root_ref",
+                    "from .easyuse_anima.image import backref",
+                    "from .easyuse_anima.lora import cycle_a",
+                    "from .easyuse_anima.naia import fallback",
+                    "from .easyuse_anima.profiles import registration",
+                ),
+                "nodes.py": "VALUE = 1\n",
+                "easyuse_anima/__init__.py": "",
+                "easyuse_anima/common/__init__.py": "",
+                "easyuse_anima/common/root_ref.py": "import nodes\n",
+                "easyuse_anima/image/__init__.py": "",
+                "easyuse_anima/image/backref.py": (
+                    "from ..nodes import image_nodes\n"
+                ),
+                "easyuse_anima/nodes/__init__.py": "",
+                "easyuse_anima/nodes/image_nodes.py": "VALUE = 1\n",
+                "easyuse_anima/lora/__init__.py": "",
+                "easyuse_anima/lora/cycle_a.py": (
+                    "import easyuse_anima.lora.cycle_b\n"
+                ),
+                "easyuse_anima/lora/cycle_b.py": "from . import cycle_a\n",
+                "easyuse_anima/naia/__init__.py": "",
+                "easyuse_anima/naia/dep.py": "VALUE = 1\n",
+                "easyuse_anima/naia/fallback.py": (
+                    "try:\n"
+                    "    from .dep import VALUE\n"
+                    "except ImportError:\n"
+                    "    from easyuse_anima.naia.dep import VALUE\n"
+                ),
+                "easyuse_anima/profiles/__init__.py": "",
+                "easyuse_anima/profiles/registration.py": (
+                    "NODE_CLASS_MAPPINGS = {}\n"
+                    "NODE_CLASS_MAPPINGS.update({})\n"
+                    "REGISTRY = {}\n"
+                    "REGISTRY.update({})\n"
+                    "MAPPINGS = {}\n"
+                    "MAPPINGS.update({})\n"
+                ),
+            }
+        )
+
+        root_edge = next(
+            edge
+            for edge in report["imports"]["edges"]
+            if edge["source"] == "easyuse_anima/common/root_ref.py"
+        )
+        self.assertEqual(root_edge["classification"], "external")
+        self.assertNotIn("target", root_edge)
+
+        violations = checker.check_report(report, self.groups)
+        self.assertEqual(
+            {violation["rule"] for violation in violations},
+            {
+                "canonical-imports-root",
+                "compatibility-fallback",
+                "cyclic-runtime-scc",
+                "registration-side-effect",
+                "role-back-reference",
+            },
+        )
+        self.assertTrue(
+            all(violation["source"] and violation["target"] for violation in violations)
+        )
+        registration_targets = {
+            violation["target"]
+            for violation in violations
+            if violation["rule"] == "registration-side-effect"
+        }
+        self.assertTrue(
+            {
+                "MAPPINGS.update",
+                "NODE_CLASS_MAPPINGS.update",
+                "REGISTRY.update",
+            }.issubset(registration_targets)
+        )
+
+    def test_external_target_none_and_optional_external_imports_are_allowed(self):
+        report = analyzed(
+            {
+                "__init__.py": "from .easyuse_anima.image import optional\n",
+                "easyuse_anima/__init__.py": "",
+                "easyuse_anima/image/__init__.py": "",
+                "easyuse_anima/image/optional.py": (
+                    "import json\n"
+                    "try:\n"
+                    "    import optional_runtime\n"
+                    "except ImportError:\n"
+                    "    optional_runtime = None\n"
+                ),
+            }
+        )
+
+        external_edges = [
+            edge
+            for edge in report["imports"]["edges"]
+            if edge["source"] == "easyuse_anima/image/optional.py"
+        ]
+        self.assertTrue(external_edges)
+        self.assertTrue(all("target" not in edge for edge in external_edges))
+        self.assertEqual(checker.check_report(report, self.groups), [])
+
+    def test_contract_rejects_missing_duplicate_unsorted_empty_and_changed_groups(self):
+        mutations = []
+
+        missing = copy.deepcopy(self.contract_document)
+        missing["groups"].pop()
+        mutations.append(missing)
+
+        duplicate = copy.deepcopy(self.contract_document)
+        duplicate["groups"].insert(1, copy.deepcopy(duplicate["groups"][0]))
+        mutations.append(duplicate)
+
+        unsorted = copy.deepcopy(self.contract_document)
+        unsorted["groups"].reverse()
+        mutations.append(unsorted)
+
+        empty_prefix = copy.deepcopy(self.contract_document)
+        empty_prefix["groups"][0]["prefix"] = ""
+        mutations.append(empty_prefix)
+
+        changed_owner = copy.deepcopy(self.contract_document)
+        changed_owner["groups"][0]["owner_issue"] = 188
+        mutations.append(changed_owner)
+
+        changed_role = copy.deepcopy(self.contract_document)
+        changed_role["groups"][1]["role"] = "common"
+        mutations.append(changed_role)
+
+        renamed_group = copy.deepcopy(self.contract_document)
+        renamed_group["groups"][0]["group"] = "common-renamed"
+        mutations.append(renamed_group)
+
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                with self.assertRaises(checker.ContractError):
+                    checker.validate_contract(mutation)
+
+    def test_current_repository_has_zero_enrolled_violations(self):
+        self.assertEqual(checker.check_repository(ROOT, CONTRACT_PATH), [])
+
+    def test_unenrolled_legacy_debt_does_not_block_the_gate(self):
+        report = analyzed(
+            {
+                "__init__.py": "from .easyuse_anima.prompt import debt\n",
+                "nodes.py": "VALUE = 1\n",
+                "easyuse_anima/__init__.py": "",
+                "easyuse_anima/prompt/__init__.py": "",
+                "easyuse_anima/prompt/debt.py": "import nodes\n",
+            }
+        )
+
+        self.assertEqual(checker.check_report(report, self.groups), [])
+
+    def test_quality_runner_invokes_the_checker_once_for_quick_and_full(self):
+        source = (ROOT / "tools" / "check_python_quality.ps1").read_text(
+            encoding="utf-8"
+        )
+        invocation = '(Join-Path $PSScriptRoot "check_python_import_boundaries.py")'
+
+        self.assertEqual(source.count(invocation), 1)
+        self.assertIn("Python import boundary gate failed", source)
 
 
 if __name__ == "__main__":

--- a/tools/check_python_import_boundaries.py
+++ b/tools/check_python_import_boundaries.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Fail on reviewed import-boundary regressions in completed packages.
+
+The checker consumes the deterministic report produced by
+``analyze_python_backend.py``.  It does not import production modules, execute
+repository code, access the network, or write repository state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+ANALYZER_PATH = Path(__file__).with_name("analyze_python_backend.py")
+DEFAULT_CONTRACT_PATH = (
+    REPOSITORY_ROOT
+    / "tests"
+    / "fixtures"
+    / "python_import_boundary_contract.v1.json"
+)
+CONTRACT_SCHEMA_VERSION = 1
+EXPECTED_GROUPS = (
+    ("common", 184, "easyuse_anima/common/", "common"),
+    ("image", 184, "easyuse_anima/image/", "feature"),
+    (
+        "infrastructure-comfy",
+        184,
+        "easyuse_anima/infrastructure/comfy/",
+        "infrastructure",
+    ),
+    ("lora", 184, "easyuse_anima/lora/", "feature"),
+    ("naia", 184, "easyuse_anima/naia/", "feature"),
+    ("profiles", 163, "easyuse_anima/profiles/", "feature"),
+)
+ALLOWED_ROLES = frozenset({"common", "feature", "infrastructure"})
+BACK_REFERENCE_PREFIXES_BY_ROLE = {
+    role: (
+        "easyuse_anima/api/routes/",
+        "easyuse_anima/nodes/",
+    )
+    for role in ALLOWED_ROLES
+}
+BACK_REFERENCE_EXACT = frozenset(
+    {
+        "easyuse_anima/bootstrap.py",
+        "easyuse_anima/registration.py",
+    }
+)
+REGISTRATION_SIDE_EFFECT_KINDS = frozenset(
+    {"route_registration", "route_registry_creation"}
+)
+MAPPING_MUTATION_METHODS = frozenset(
+    {"clear", "pop", "popitem", "setdefault", "update"}
+)
+
+
+class ContractError(ValueError):
+    """The checked-in boundary ledger is invalid or weaker than expected."""
+
+
+def _load_analyzer():
+    spec = importlib.util.spec_from_file_location(
+        "easyuse_anima_python_backend_analyzer",
+        ANALYZER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load analyzer: {ANALYZER_PATH.name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+analyzer = _load_analyzer()
+
+
+def validate_contract(document: object) -> tuple[dict[str, object], ...]:
+    """Validate the ledger and return its immutable ordered group records."""
+
+    if not isinstance(document, dict):
+        raise ContractError("contract must be a JSON object")
+    if set(document) != {"schema_version", "groups"}:
+        raise ContractError("contract keys must be exactly: groups, schema_version")
+    if type(document["schema_version"]) is not int:
+        raise ContractError("schema_version must be an integer")
+    if document["schema_version"] != CONTRACT_SCHEMA_VERSION:
+        raise ContractError(
+            f"schema_version must be {CONTRACT_SCHEMA_VERSION}"
+        )
+
+    raw_groups = document["groups"]
+    if not isinstance(raw_groups, list) or not raw_groups:
+        raise ContractError("groups must be a non-empty array")
+
+    groups: list[dict[str, object]] = []
+    expected_keys = {"group", "owner_issue", "prefix", "role"}
+    for index, raw_group in enumerate(raw_groups):
+        if not isinstance(raw_group, dict):
+            raise ContractError(f"groups[{index}] must be an object")
+        if set(raw_group) != expected_keys:
+            raise ContractError(
+                f"groups[{index}] keys must be exactly: "
+                "group, owner_issue, prefix, role"
+            )
+        group = raw_group["group"]
+        owner_issue = raw_group["owner_issue"]
+        prefix = raw_group["prefix"]
+        role = raw_group["role"]
+        if not isinstance(group, str) or not group.strip():
+            raise ContractError(f"groups[{index}].group must be non-empty")
+        if type(owner_issue) is not int or owner_issue <= 0:
+            raise ContractError(
+                f"groups[{index}].owner_issue must be a positive integer"
+            )
+        if (
+            not isinstance(prefix, str)
+            or not prefix.startswith("easyuse_anima/")
+            or not prefix.endswith("/")
+        ):
+            raise ContractError(
+                f"groups[{index}].prefix must be a canonical package prefix"
+            )
+        if role not in ALLOWED_ROLES:
+            raise ContractError(
+                f"groups[{index}].role must be one of: "
+                f"{', '.join(sorted(ALLOWED_ROLES))}"
+            )
+        groups.append(
+            {
+                "group": group,
+                "owner_issue": owner_issue,
+                "prefix": prefix,
+                "role": role,
+            }
+        )
+
+    group_ids = [str(group["group"]) for group in groups]
+    prefixes = [str(group["prefix"]) for group in groups]
+    if group_ids != sorted(group_ids):
+        raise ContractError("groups must be sorted by group id")
+    if len(group_ids) != len(set(group_ids)):
+        raise ContractError("group ids must be unique")
+    if len(prefixes) != len(set(prefixes)):
+        raise ContractError("group prefixes must be unique")
+
+    actual = tuple(
+        (
+            str(group["group"]),
+            int(group["owner_issue"]),
+            str(group["prefix"]),
+            str(group["role"]),
+        )
+        for group in groups
+    )
+    if actual != EXPECTED_GROUPS:
+        raise ContractError(
+            "groups must exactly match the reviewed completed-package set"
+        )
+    return tuple(groups)
+
+
+def load_contract(path: Path = DEFAULT_CONTRACT_PATH) -> tuple[dict[str, object], ...]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ContractError(f"could not read contract {path}: {exc}") from exc
+    return validate_contract(document)
+
+
+def _source_group(
+    path: str,
+    groups: Sequence[Mapping[str, object]],
+) -> Mapping[str, object] | None:
+    return next(
+        (
+            group
+            for group in groups
+            if path.startswith(str(group["prefix"]))
+        ),
+        None,
+    )
+
+
+def _module_path_index(report: Mapping[str, object]) -> dict[str, str]:
+    inventory = report["inventory"]
+    return {
+        str(module["module"]): str(module["path"])
+        for module in inventory["modules"]
+    }
+
+
+def _local_target(
+    edge: Mapping[str, object],
+    module_paths: Mapping[str, str],
+) -> str | None:
+    target = edge.get("target")
+    if isinstance(target, str):
+        return target
+
+    requested = edge.get("requested")
+    if not isinstance(requested, str) or not requested or requested.startswith("."):
+        return None
+    options = []
+    imported_name = edge.get("name")
+    if isinstance(imported_name, str) and imported_name != "*":
+        options.append(f"{requested}.{imported_name}")
+    options.append(requested)
+    return next(
+        (module_paths[option] for option in options if option in module_paths),
+        None,
+    )
+
+
+def _local_sccs(
+    report: Mapping[str, object],
+    module_paths: Mapping[str, str],
+) -> list[dict[str, object]]:
+    """Complete the analyzer runtime graph with exact absolute local targets."""
+
+    shipped_paths = sorted(set(module_paths.values()))
+    shipped_set = set(shipped_paths)
+    imports = report["imports"]
+    graph_edges = sorted(
+        {
+            (str(edge["source"]), target)
+            for edge in imports["edges"]
+            if analyzer._is_runtime_relevant_edge(edge)
+            for target in [_local_target(edge, module_paths)]
+            if target is not None
+            and str(edge["source"]) in shipped_set
+            and target in shipped_set
+        }
+    )
+    return analyzer._strongly_connected_components(
+        shipped_paths,
+        [
+            {"from": source, "to": target}
+            for source, target in graph_edges
+        ],
+    )
+
+
+def _is_role_back_reference(role: str, target: str) -> bool:
+    return target in BACK_REFERENCE_EXACT or target.startswith(
+        BACK_REFERENCE_PREFIXES_BY_ROLE[role]
+    )
+
+
+def _is_registration_side_effect(candidate: Mapping[str, object]) -> bool:
+    if candidate.get("kind") in REGISTRATION_SIDE_EFFECT_KINDS:
+        return True
+    callee = str(candidate.get("callee", ""))
+    tail = callee.rsplit(".", 1)[-1].lower()
+    if tail == "register" or tail.startswith("register_") or tail.endswith("_register"):
+        return True
+    owner, separator, method = callee.rpartition(".")
+    owner_tail = owner.rsplit(".", 1)[-1]
+    return bool(
+        separator
+        and method.lower() in MAPPING_MUTATION_METHODS
+        and owner_tail.isupper()
+        and (
+            owner_tail in {"MAPPINGS", "REGISTRY"}
+            or owner_tail.endswith(("_MAPPINGS", "_REGISTRY"))
+        )
+    )
+
+
+def _violation(
+    *,
+    source: str,
+    line: int,
+    rule: str,
+    target: str,
+    group: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "source": source,
+        "line": line,
+        "rule": rule,
+        "target": target,
+        "group": group["group"],
+        "owner_issue": group["owner_issue"],
+    }
+
+
+def check_report(
+    report: Mapping[str, object],
+    groups: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Return deterministic completed-package boundary violations."""
+
+    violations: list[dict[str, object]] = []
+    module_paths = _module_path_index(report)
+    imports = report["imports"]
+    for edge in imports["edges"]:
+        source = str(edge["source"])
+        group = _source_group(source, groups)
+        if group is None:
+            continue
+        target = _local_target(edge, module_paths)
+        if target is not None and not target.startswith("easyuse_anima/"):
+            violations.append(
+                _violation(
+                    source=source,
+                    line=int(edge["line"]),
+                    rule="canonical-imports-root",
+                    target=target,
+                    group=group,
+                )
+            )
+        if target is not None and _is_role_back_reference(
+            str(group["role"]),
+            target,
+        ):
+            violations.append(
+                _violation(
+                    source=source,
+                    line=int(edge["line"]),
+                    rule="role-back-reference",
+                    target=target,
+                    group=group,
+                )
+            )
+        if edge.get("role") == "compatibility_fallback":
+            violations.append(
+                _violation(
+                    source=source,
+                    line=int(edge["line"]),
+                    rule="compatibility-fallback",
+                    target=target or str(edge.get("imported", "<unknown>")),
+                    group=group,
+                )
+            )
+
+    for component in _local_sccs(report, module_paths):
+        if not component.get("cyclic"):
+            continue
+        members = [str(member) for member in component["modules"]]
+        cycle_target = " -> ".join((*members, members[0]))
+        for source in members:
+            group = _source_group(source, groups)
+            if group is not None:
+                violations.append(
+                    _violation(
+                        source=source,
+                        line=0,
+                        rule="cyclic-runtime-scc",
+                        target=cycle_target,
+                        group=group,
+                    )
+                )
+
+    side_effects = report["side_effects"]
+    for candidate in side_effects["candidates"]:
+        source = str(candidate["module"])
+        group = _source_group(source, groups)
+        if group is None or not _is_registration_side_effect(candidate):
+            continue
+        violations.append(
+            _violation(
+                source=source,
+                line=int(candidate["line"]),
+                rule="registration-side-effect",
+                target=str(candidate["callee"]),
+                group=group,
+            )
+        )
+
+    violations.sort(
+        key=lambda item: (
+            str(item["source"]),
+            int(item["line"]),
+            str(item["rule"]),
+            str(item["target"]),
+        )
+    )
+    return violations
+
+
+def check_repository(
+    root: Path = REPOSITORY_ROOT,
+    contract_path: Path = DEFAULT_CONTRACT_PATH,
+) -> list[dict[str, object]]:
+    groups = load_contract(contract_path)
+    report = analyzer.analyze_repository(root)
+    return check_report(report, groups)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPOSITORY_ROOT)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT_PATH)
+    args = parser.parse_args(argv)
+
+    try:
+        groups = load_contract(args.contract)
+        report = analyzer.analyze_repository(args.root)
+        violations = check_report(report, groups)
+    except (ContractError, OSError, SyntaxError, ValueError, KeyError, TypeError) as exc:
+        print(f"python-import-boundary: checker-error: {exc}", file=sys.stderr)
+        return 2
+
+    if violations:
+        for violation in violations:
+            line = violation["line"] or "scc"
+            print(
+                f"{violation['source']}:{line}: rule={violation['rule']} "
+                f"target={violation['target']} group={violation['group']} "
+                f"owner=#{violation['owner_issue']}",
+                file=sys.stderr,
+            )
+        print(
+            f"Python import boundary gate failed: {len(violations)} violation(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "Python import boundary gate passed: "
+        f"{len(groups)} completed package groups, 0 violations."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_python_quality.ps1
+++ b/tools/check_python_quality.ps1
@@ -87,6 +87,13 @@ try {
     if ($baselineExitCode -ne 0) {
         throw "Pyright baseline ratchet failed with exit code $baselineExitCode."
     }
+
+    Write-Host "`n== Python import boundary gate (G-03a) =="
+    & $pythonCommand (Join-Path $PSScriptRoot "check_python_import_boundaries.py")
+    $importBoundaryExitCode = $LASTEXITCODE
+    if ($importBoundaryExitCode -ne 0) {
+        throw "Python import boundary gate failed with exit code $importBoundaryExitCode."
+    }
 }
 finally {
     Set-Location -LiteralPath $originalLocation


### PR DESCRIPTION
## 작업 단위

- Task: G-03a — Completed-package import boundary fail gate
- Owner: #188
- 분류: **Contract/gate**
- Base: `dev` / `3ca550067f8d54ac2405e8972f76a209165a9637`
- 상태: Ready

## 작업 전 인벤토리

### 현재 analyzer와 caller

- `tools/analyze_python_backend.py`는 shipped module, local/internal/fallback import edge, runtime SCC, import-time call과 Registry closure를 이미 결정적으로 생성합니다.
- `tests/test_python_import_boundaries.py`는 전체 package의 root `nodes` import와 이름 기반 inner→outer 역참조 일부만 blocking합니다.
- `tools/check_python_quality.ps1`는 공식 quick/full에서 Ruff report-only와 Pyright baseline ratchet을 실행하며, G-03a checker의 단일 호출 지점입니다.
- package skeleton/scanner와 `python_backend_baseline.json`은 package 존재·closure·전체 inventory를 소유하며 이번 gate의 정책 ledger를 소유하지 않습니다.

### 현재 관측 상태

- shipped Python module 68개, global cyclic SCC 0개입니다.
- 기존 canonical→root local edge는 4개 source에서 40개이며 그중 compatibility fallback은 20개입니다.
- 기존 debt는 `easyuse_anima/nodes/prompt_nodes.py`, `nodes/wildcard_nodes.py`, `prompt/correction.py`, `prompt/fields.py`에 있으므로 G-03a 첫 blocking ledger에 포함하지 않습니다.
- 완료되어 현재 위반이 0인 package prefix 6개만 등록합니다.
  - `easyuse_anima/common/` — owner #184, role common
  - `easyuse_anima/image/` — owner #184, role feature
  - `easyuse_anima/infrastructure/comfy/` — owner #184, role infrastructure
  - `easyuse_anima/lora/` — owner #184, role feature
  - `easyuse_anima/naia/` — owner #184, role feature
  - `easyuse_anima/profiles/` — owner #163, role feature
- mutable runtime/global state는 추가하지 않습니다. checker는 AST report와 checked-in ledger만 읽습니다.

## 차단 규칙

1. 등록 prefix source의 local target이 `easyuse_anima/` 밖이면 canonical→root 위반입니다. target이 없는 외부/optional dependency는 제외합니다.
2. feature/common/infrastructure source에서 `easyuse_anima/nodes/`, `easyuse_anima/api/routes/`, exact `bootstrap.py`/`registration.py`로 가는 back reference를 차단합니다.
3. runtime cyclic SCC가 등록 source를 포함하면 차단합니다. `TYPE_CHECKING` edge는 기존 analyzer 정책을 유지합니다.
4. 등록 source의 `compatibility_fallback` import를 차단합니다. optional external ImportError fallback은 허용합니다.
5. 등록 source의 route registration/registry creation과 명시적 register/mapping mutation import-time side effect만 차단합니다.
6. ledger group id/owner/prefix/role, 정렬, 중복, 부재와 exact 등록 그룹 집합을 검증해 gate 약화를 차단합니다. 새 `.py`는 prefix에 자동 포함됩니다.

## 변경 경계

### 허용

- 신규 `tools/check_python_import_boundaries.py`
- `tools/check_python_quality.ps1`
- 신규 `tests/fixtures/python_import_boundary_contract.v1.json`
- `tests/test_python_import_boundaries.py`
- `docs/architecture/python-backend.md`
- `docs/architecture/python-backend-execution-roadmap.md`

### 금지

- production `easyuse_anima/**` 또는 root runtime 코드 변경
- 기존 prompt/nodes debt 정리 또는 전체 canonical package 일괄 차단
- `tools/analyze_python_backend.py` report schema 변경
- `tests/fixtures/python_backend_baseline.json` 재생성
- package/Registry 동작 또는 public surface 변경
- Ruff/Pyright 정책 변경과 광범위 formatting

## 검증 결과

- final head: `18f4e4dd34b6250ad96878b675d226e652de3021`
- focused import-boundary unittest: 15/15 통과
- checker CLI: 6개 완료 package group, 위반 0건
- targeted Ruff 및 `git diff --check`: 통과
- 독립 diff review: P0-P2 차단점 없음
- official full (exact final head, 1회): Python unittest 795개 통과, frontend JavaScript 114개와 TypeScript 6.0.3 통과, compile/Pyright baseline/import-boundary/package·Registry closure/diff check 통과
- 전체 Ruff 106건은 기존 G-01 report-only baseline이며 실행·구성 실패는 없습니다.
- production·package surface 불변이므로 별도 live smoke는 실행하지 않았습니다.

## 롤백 경계

- 신규 checker/ledger, quality runner 한 줄, 두 architecture 문서와 focused tests만 되돌리면 이전 report-only 상태로 복귀합니다.

## 잔여 위험

- checker가 같은 저장소의 analyzer private helper 두 개를 재사용합니다. 현재 analyzer 계약과 회귀 테스트 안에서는 비차단이며, helper 변경 시 official quality path가 즉시 실패합니다.

Closes no issue; #188의 G-03a 완료 기록만 추가합니다.
