### PR TITLE
refactor(aio): move Spectrum model variants (B-08b2)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | State at the snapshot | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | In progress through B-08b1 | Continue B-08b2, then B-08c through B-09 AiO extraction, compatibility audit, registration/bootstrap, final root shim |
+| B - `nodes.py` extraction | In progress through B-08b2 | Continue B-08c through B-09 AiO extraction, compatibility audit, registration/bootstrap, final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,11 +42,11 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- At the snapshot commit, root `nodes.py` is 5,762 lines.
-- The mechanical extraction has therefore removed 6,901 lines, approximately
-  54.5% of the baseline, while preserving the root compatibility surface.
-- B-01 through B-08a are integrated. The latest completed slice is the AiO
-  resource helper Move in PR #259.
+- At the B-08b2 snapshot, root `nodes.py` is 3,985 lines.
+- The mechanical extraction has therefore removed 8,678 lines, approximately
+  68.5% of the baseline, while preserving the root compatibility surface.
+- B-01 through B-08b2 are integrated. The latest completed slice is the AiO
+  Spectrum model-variant and ephemeral-cleanup Move in PR #261.
 - Root `nodes.py` still owns substantial AiO implementation.
 - Root `__init__.py` still imports `api.py` for route-registration side effects,
   initializes the wildcard directory during package import, and owns mapping
@@ -286,7 +286,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 5 | C168-05 cross-surface setting omission gate | COMPLETE | Contract/gate | #168 | PR #256 merged |
 | 6 | G-03a completed-package import boundary fail gate | COMPLETE on `dev` | Contract/gate | #188 | PR #258 / six reviewed zero-violation prefixes enrolled |
 | 7 | C168-06 normalizer ownership move | COMPLETE on `dev` | Move | #168/#184 | PR #257 / `3ca5500` |
-| 8 | B-08a through B-08e AiO support-helper extraction | B-08a/B-08b1 COMPLETE; B-08b2 READY/SEQUENTIAL | Move | #184 | B-08a PR #259; B-08b1 PR #260; later slices remain sequential |
+| 8 | B-08a through B-08e AiO support-helper extraction | B-08a/B-08b1/B-08b2 COMPLETE; B-08c READY/SEQUENTIAL | Move | #184 | B-08a PR #259; B-08b1 PR #260; B-08b2 PR #261; later slices remain sequential |
 | 9 | B-09a/B-09b AiO node and legacy orchestration move | BLOCKED by B-08 | Move | #184 | AiO helpers canonical |
 | 10 | B-10 compatibility/private-alias audit | BLOCKED by B-09 | Contract/cleanup, split PRs | #184/#188 | All node implementations canonical |
 | 11 | B-11 registration/bootstrap/root shim | BLOCKED by B-10 | Move | #184 | Alias surface frozen |
@@ -481,8 +481,12 @@ keeps the root names as direct identity aliases with a call-time runtime seam.
 B-08b1 is complete on `dev` in PR #260. This first B-08b mechanical slice moves shared
 CLIP encoding to `easyuse_anima.infrastructure.comfy.invocation`, moves LoRA and
 base-model patch preparation to `easyuse_anima.aio.model_preparation`, and moves
-USDU conditioning preparation to `easyuse_anima.aio.conditioning`. Spectrum
-model variants and ephemeral cleanup remain a later B-08b slice.
+USDU conditioning preparation to `easyuse_anima.aio.conditioning`.
+
+B-08b2 is complete on `dev` in PR #261. This second B-08b mechanical slice moves
+Spectrum correction/forecast model variants and ephemeral model cleanup to
+`easyuse_anima.aio.model_preparation`, preserving direct root identities,
+call-time sub-helper replacement, optional dependency timing, and cleanup order.
 
 Rules for every B-08 PR:
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -126,6 +126,13 @@ EasyUseAnimaWildcard
   `easyuse_anima.infrastructure.comfy.invocation` behind the existing root
   injection wrapper. These are internal transition surfaces through the B-10
   compatibility audit and are not added to public package `__all__`.
+- B-08b2 internal AiO model-variant transition: Spectrum correction/forecast
+  model patching and ephemeral model cleanup move to
+  `easyuse_anima.aio.model_preparation`. Their four root private names remain
+  direct identity aliases so the current sampler/stage/generator callers and
+  focused monkeypatch seams preserve call-time behavior. These are internal
+  transition surfaces through the B-10 compatibility audit and are not added
+  to public package `__all__`.
 - Removal gate: 0.5.2 node/workflow fixture, mapping identity, direct import,
   Registry archive closure, consumer evidence, separate breaking-change issue,
   and release note. With no external-consumer evidence, retain these exports.

--- a/easyuse_anima/aio/model_preparation.py
+++ b/easyuse_anima/aio/model_preparation.py
@@ -1,4 +1,4 @@
-"""AiO LoRA application and base-model patch preparation helpers."""
+"""AiO LoRA application, model patching, and variant lifecycle helpers."""
 
 from __future__ import annotations
 
@@ -279,6 +279,179 @@ def _apply_aio_safe_pag_patch(model, safe_pag_settings: dict[str, Any]):
     if not values:
         raise RuntimeError("[EasyUseAnima] AnimaSafePAG returned no MODEL.")
     return values[0]
+
+
+def _cleanup_aio_ephemeral_model(model, base_model=None) -> None:
+    if model is None or model is base_model:
+        return
+    detach = getattr(model, "detach", None)
+    if callable(detach):
+        try:
+            detach(unpatch_all=False)
+            return
+        except Exception as exc:
+            _runtime_helper("logger").debug(
+                "[EasyUseAnima] failed to detach ephemeral AiO model clone: %s", exc
+            )
+    try:
+        import comfy.model_management as model_management  # type: ignore
+
+        unload = getattr(model_management, "unload_model_and_clones", None)
+        if callable(unload):
+            unload(model, unload_additional_models=True)
+            return
+    except Exception as exc:
+        _runtime_helper("logger").debug(
+            "[EasyUseAnima] failed to unload ephemeral AiO model clone: %s", exc
+        )
+
+
+def _apply_aio_spectrum_correction_patch_for_comfy_sampler(
+    model,
+    clip,
+    positive,
+    sampler_settings: dict[str, Any],
+):
+    corrections = sampler_settings.get("dit_corrections", {})
+    if not isinstance(corrections, dict) or not _runtime_helper("_as_bool")(
+        corrections.get("enabled"), False
+    ):
+        return model
+    patch_cls = _runtime_helper("_require_custom_node_class")(
+        "DiTCFGFSGPatch",
+        "ComfyUI-Spectrum-KSampler",
+        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
+    )
+    use_smc = _runtime_helper("_as_bool")(corrections.get("smc_cfg"), False)
+    use_cfgpp = _runtime_helper("_as_bool")(corrections.get("cfgpp"), False)
+    use_fsg = _runtime_helper("_as_bool")(corrections.get("fsg"), False)
+    values = _runtime_helper("_node_output_tuple")(
+        patch_cls().patch(
+            model,
+            True,
+            str(corrections.get("dcw_mode") or "off"),
+            _runtime_helper("_as_float")(corrections.get("dcw_lambda"), 0.01),
+            str(corrections.get("dcw_band_mask") or "LL"),
+            str(corrections.get("dcw_calibrator") or "(auto-download default)"),
+            use_smc,
+            _runtime_helper("_as_float")(corrections.get("adaptive_smc_alpha"), 0.0)
+            if use_smc
+            else 0.0,
+            _runtime_helper("_as_float")(corrections.get("smc_cfg_lambda"), 6.0)
+            if use_smc
+            else 0.0,
+            use_cfgpp,
+            _runtime_helper("_as_float")(corrections.get("cfgpp_lambda"), 0.0)
+            if use_cfgpp
+            else 0.0,
+            use_fsg,
+            _runtime_helper("_as_float")(corrections.get("fsg_band_lo"), 0.59),
+            _runtime_helper("_as_float")(corrections.get("fsg_band_hi"), 0.75),
+            _runtime_helper("_as_int")(corrections.get("fsg_k"), 3),
+            _runtime_helper("_as_float")(corrections.get("fsg_d_sigma"), 0.1),
+            _runtime_helper("_as_float")(corrections.get("fsg_gamma"), 0.0),
+            _runtime_helper("_as_bool")(
+                corrections.get("replace_existing_cfg"), False
+            ),
+            steps=_runtime_helper("_as_int")(sampler_settings.get("steps"), 28),
+            cfg=_runtime_helper("_as_float")(sampler_settings.get("cfg"), 5.0),
+            sampler_name=str(
+                sampler_settings.get("sampler_name") or "euler_ancestral"
+            ),
+            scheduler=str(sampler_settings.get("scheduler") or "normal"),
+            denoise=_runtime_helper("_as_float")(
+                sampler_settings.get("denoise"), 1.0
+            ),
+            clip=clip,
+            positive=positive,
+        )
+    )
+    if not values:
+        raise RuntimeError("[EasyUseAnima] DiTCFGFSGPatch returned no MODEL.")
+    return values[0]
+
+
+def _apply_aio_spectrum_forecast_patch_for_comfy_sampler(
+    model,
+    sampler_settings: dict[str, Any],
+):
+    spectrum = sampler_settings.get("spectrum", {})
+    if not isinstance(spectrum, dict) or not _runtime_helper("_as_bool")(
+        spectrum.get("enabled"), False
+    ):
+        return model
+    node_id, patch_cls = _runtime_helper("_require_any_custom_node_class")(
+        ("DiTSpectrumPatchAdvanced", "DiTSpectrumPatch"),
+        "ComfyUI-Spectrum-KSampler",
+        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
+    )
+    patcher = patch_cls()
+    patch = getattr(patcher, "patch", None)
+    if patch is None:
+        raise RuntimeError(f"[EasyUseAnima] {node_id} does not expose patch().")
+    patch_kwargs = {
+        "model": model,
+        "steps": _runtime_helper("_as_int")(sampler_settings.get("steps"), 28),
+        "window_size": _runtime_helper("_as_float")(
+            spectrum.get("window_size"), 2.0
+        ),
+        "flex_window": _runtime_helper("_as_float")(
+            spectrum.get("flex_window"), 0.25
+        ),
+        "warmup_steps": _runtime_helper("_as_int")(
+            spectrum.get("warmup_steps"), 6
+        ),
+        "tail_actual_steps": _runtime_helper("_as_int")(
+            spectrum.get("tail_actual_steps"), 3
+        ),
+        "blend_w": _runtime_helper("_as_float")(spectrum.get("blend_w"), 0.3),
+        "cheby_degree": _runtime_helper("_as_int")(
+            spectrum.get("cheby_degree"), 3
+        ),
+        "ridge_lambda": _runtime_helper("_as_float")(
+            spectrum.get("ridge_lambda"), 0.1
+        ),
+        "history_size": _runtime_helper("_as_int")(
+            spectrum.get("history_size"), 100
+        ),
+        "enabled": True,
+        "one_sampler_only": _runtime_helper("_as_bool")(
+            spectrum.get("one_sampler_only"), False
+        ),
+        "verbose": _runtime_helper("_as_bool")(spectrum.get("verbose"), False),
+        "compat_policy": str(spectrum.get("compat_policy") or "conservative"),
+    }
+    values = _runtime_helper("_node_output_tuple")(
+        _runtime_helper("_call_with_supported_kwargs")(
+            patch,
+            (),
+            patch_kwargs,
+            f"{node_id}.patch()",
+        )
+    )
+    if not values:
+        raise RuntimeError(f"[EasyUseAnima] {node_id} returned no MODEL.")
+    return values[0]
+
+
+def _apply_aio_spectrum_model_patches_for_comfy_sampler(
+    model,
+    clip,
+    positive,
+    sampler_settings: dict[str, Any],
+):
+    patched = _runtime_helper(
+        "_apply_aio_spectrum_correction_patch_for_comfy_sampler"
+    )(
+        model,
+        clip,
+        positive,
+        sampler_settings,
+    )
+    return _runtime_helper("_apply_aio_spectrum_forecast_patch_for_comfy_sampler")(
+        patched,
+        sampler_settings,
+    )
 
 
 __all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -30,7 +30,11 @@ try:
         _apply_aio_lora_stack as _apply_aio_lora_stack,
         _apply_aio_model_patches as _apply_aio_model_patches,
         _apply_aio_safe_pag_patch as _apply_aio_safe_pag_patch,
+        _apply_aio_spectrum_correction_patch_for_comfy_sampler as _apply_aio_spectrum_correction_patch_for_comfy_sampler,
+        _apply_aio_spectrum_forecast_patch_for_comfy_sampler as _apply_aio_spectrum_forecast_patch_for_comfy_sampler,
+        _apply_aio_spectrum_model_patches_for_comfy_sampler as _apply_aio_spectrum_model_patches_for_comfy_sampler,
         _bind_aio_model_preparation_runtime as _bind_aio_model_preparation_runtime,
+        _cleanup_aio_ephemeral_model as _cleanup_aio_ephemeral_model,
         _normalize_aio_lora_stack as _normalize_aio_lora_stack,
         _patch_model_sampling_aura_flow as _patch_model_sampling_aura_flow,
     )
@@ -481,7 +485,11 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _apply_aio_lora_stack as _apply_aio_lora_stack,
         _apply_aio_model_patches as _apply_aio_model_patches,
         _apply_aio_safe_pag_patch as _apply_aio_safe_pag_patch,
+        _apply_aio_spectrum_correction_patch_for_comfy_sampler as _apply_aio_spectrum_correction_patch_for_comfy_sampler,
+        _apply_aio_spectrum_forecast_patch_for_comfy_sampler as _apply_aio_spectrum_forecast_patch_for_comfy_sampler,
+        _apply_aio_spectrum_model_patches_for_comfy_sampler as _apply_aio_spectrum_model_patches_for_comfy_sampler,
         _bind_aio_model_preparation_runtime as _bind_aio_model_preparation_runtime,
+        _cleanup_aio_ephemeral_model as _cleanup_aio_ephemeral_model,
         _normalize_aio_lora_stack as _normalize_aio_lora_stack,
         _patch_model_sampling_aura_flow as _patch_model_sampling_aura_flow,
     )
@@ -2027,141 +2035,6 @@ def _aio_prompt_with_lora_metadata(prompt: str, applied_loras) -> str:
     base = str(prompt or "").strip()
     suffix = " ".join(tags)
     return f"{base} {suffix}".strip() if base else suffix
-
-
-def _cleanup_aio_ephemeral_model(model, base_model=None) -> None:
-    if model is None or model is base_model:
-        return
-    detach = getattr(model, "detach", None)
-    if callable(detach):
-        try:
-            detach(unpatch_all=False)
-            return
-        except Exception as exc:
-            logger.debug("[EasyUseAnima] failed to detach ephemeral AiO model clone: %s", exc)
-    try:
-        import comfy.model_management as model_management  # type: ignore
-
-        unload = getattr(model_management, "unload_model_and_clones", None)
-        if callable(unload):
-            unload(model, unload_additional_models=True)
-            return
-    except Exception as exc:
-        logger.debug("[EasyUseAnima] failed to unload ephemeral AiO model clone: %s", exc)
-
-
-def _apply_aio_spectrum_correction_patch_for_comfy_sampler(
-    model,
-    clip,
-    positive,
-    sampler_settings: dict[str, Any],
-):
-    corrections = sampler_settings.get("dit_corrections", {})
-    if not isinstance(corrections, dict) or not _as_bool(corrections.get("enabled"), False):
-        return model
-    patch_cls = _require_custom_node_class(
-        "DiTCFGFSGPatch",
-        "ComfyUI-Spectrum-KSampler",
-        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
-    )
-    use_smc = _as_bool(corrections.get("smc_cfg"), False)
-    use_cfgpp = _as_bool(corrections.get("cfgpp"), False)
-    use_fsg = _as_bool(corrections.get("fsg"), False)
-    values = _node_output_tuple(
-        patch_cls().patch(
-            model,
-            True,
-            str(corrections.get("dcw_mode") or "off"),
-            _as_float(corrections.get("dcw_lambda"), 0.01),
-            str(corrections.get("dcw_band_mask") or "LL"),
-            str(corrections.get("dcw_calibrator") or "(auto-download default)"),
-            use_smc,
-            _as_float(corrections.get("adaptive_smc_alpha"), 0.0) if use_smc else 0.0,
-            _as_float(corrections.get("smc_cfg_lambda"), 6.0) if use_smc else 0.0,
-            use_cfgpp,
-            _as_float(corrections.get("cfgpp_lambda"), 0.0) if use_cfgpp else 0.0,
-            use_fsg,
-            _as_float(corrections.get("fsg_band_lo"), 0.59),
-            _as_float(corrections.get("fsg_band_hi"), 0.75),
-            _as_int(corrections.get("fsg_k"), 3),
-            _as_float(corrections.get("fsg_d_sigma"), 0.1),
-            _as_float(corrections.get("fsg_gamma"), 0.0),
-            _as_bool(corrections.get("replace_existing_cfg"), False),
-            steps=_as_int(sampler_settings.get("steps"), 28),
-            cfg=_as_float(sampler_settings.get("cfg"), 5.0),
-            sampler_name=str(sampler_settings.get("sampler_name") or "euler_ancestral"),
-            scheduler=str(sampler_settings.get("scheduler") or "normal"),
-            denoise=_as_float(sampler_settings.get("denoise"), 1.0),
-            clip=clip,
-            positive=positive,
-        )
-    )
-    if not values:
-        raise RuntimeError("[EasyUseAnima] DiTCFGFSGPatch returned no MODEL.")
-    return values[0]
-
-
-def _apply_aio_spectrum_forecast_patch_for_comfy_sampler(
-    model,
-    sampler_settings: dict[str, Any],
-):
-    spectrum = sampler_settings.get("spectrum", {})
-    if not isinstance(spectrum, dict) or not _as_bool(spectrum.get("enabled"), False):
-        return model
-    node_id, patch_cls = _require_any_custom_node_class(
-        ("DiTSpectrumPatchAdvanced", "DiTSpectrumPatch"),
-        "ComfyUI-Spectrum-KSampler",
-        "Repository: https://github.com/blepping/ComfyUI-Spectrum-KSampler",
-    )
-    patcher = patch_cls()
-    patch = getattr(patcher, "patch", None)
-    if patch is None:
-        raise RuntimeError(f"[EasyUseAnima] {node_id} does not expose patch().")
-    patch_kwargs = {
-        "model": model,
-        "steps": _as_int(sampler_settings.get("steps"), 28),
-        "window_size": _as_float(spectrum.get("window_size"), 2.0),
-        "flex_window": _as_float(spectrum.get("flex_window"), 0.25),
-        "warmup_steps": _as_int(spectrum.get("warmup_steps"), 6),
-        "tail_actual_steps": _as_int(spectrum.get("tail_actual_steps"), 3),
-        "blend_w": _as_float(spectrum.get("blend_w"), 0.3),
-        "cheby_degree": _as_int(spectrum.get("cheby_degree"), 3),
-        "ridge_lambda": _as_float(spectrum.get("ridge_lambda"), 0.1),
-        "history_size": _as_int(spectrum.get("history_size"), 100),
-        "enabled": True,
-        "one_sampler_only": _as_bool(spectrum.get("one_sampler_only"), False),
-        "verbose": _as_bool(spectrum.get("verbose"), False),
-        "compat_policy": str(spectrum.get("compat_policy") or "conservative"),
-    }
-    values = _node_output_tuple(
-        _call_with_supported_kwargs(
-            patch,
-            (),
-            patch_kwargs,
-            f"{node_id}.patch()",
-        )
-    )
-    if not values:
-        raise RuntimeError(f"[EasyUseAnima] {node_id} returned no MODEL.")
-    return values[0]
-
-
-def _apply_aio_spectrum_model_patches_for_comfy_sampler(
-    model,
-    clip,
-    positive,
-    sampler_settings: dict[str, Any],
-):
-    patched = _apply_aio_spectrum_correction_patch_for_comfy_sampler(
-        model,
-        clip,
-        positive,
-        sampler_settings,
-    )
-    return _apply_aio_spectrum_forecast_patch_for_comfy_sampler(
-        patched,
-        sampler_settings,
-    )
 
 
 def _sample_latent_with_spectrum_mod_guidance_advanced(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6089,6 +6089,31 @@
         "source": "easyuse_anima/aio/model_preparation.py"
       },
       {
+        "alias": "model_management",
+        "bound_name": "model_management",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 296
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "comfy.model_management",
+        "kind": "static_import",
+        "line": 297,
+        "name": null,
+        "optional": true,
+        "requested": "comfy.model_management",
+        "role": "optional_dependency",
+        "scope": "_cleanup_aio_ephemeral_model",
+        "source": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
         "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
@@ -13440,6 +13465,99 @@
         "target": "easyuse_anima/aio/model_preparation.py"
       },
       {
+        "alias": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.model_preparation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.model_preparation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.model_preparation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
         "alias": "_bind_aio_model_preparation_runtime",
         "bound_name": "_bind_aio_model_preparation_runtime",
         "branch_context": [
@@ -13463,6 +13581,37 @@
         "kind": "static_from",
         "line": 27,
         "name": "_bind_aio_model_preparation_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.model_preparation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": "_cleanup_aio_ephemeral_model",
+        "bound_name": "_cleanup_aio_ephemeral_model",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_cleanup_aio_ephemeral_model",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
+        "kind": "static_from",
+        "line": 27,
+        "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
         "role": "compatibility_primary",
@@ -13554,7 +13703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13585,7 +13734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13616,7 +13765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13647,7 +13796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13678,7 +13827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13709,7 +13858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13740,7 +13889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13771,7 +13920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13802,7 +13951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13833,7 +13982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13864,7 +14013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -13895,7 +14044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 50,
+        "line": 54,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -13926,7 +14075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 50,
+        "line": 54,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -13957,7 +14106,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 50,
+        "line": 54,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -13988,7 +14137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 55,
+        "line": 59,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -14019,7 +14168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 55,
+        "line": 59,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -14050,7 +14199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 55,
+        "line": 59,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -14081,7 +14230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 55,
+        "line": 59,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -14112,7 +14261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 55,
+        "line": 59,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -14143,7 +14292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 62,
+        "line": 66,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -14174,7 +14323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 62,
+        "line": 66,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -14205,7 +14354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 62,
+        "line": 66,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -14236,7 +14385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 62,
+        "line": 66,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -14267,7 +14416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14298,7 +14447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14329,7 +14478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14360,7 +14509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14391,7 +14540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14422,7 +14571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14453,7 +14602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14484,7 +14633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14515,7 +14664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14546,7 +14695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14577,7 +14726,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14608,7 +14757,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 68,
+        "line": 72,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -14639,7 +14788,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14670,7 +14819,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14701,7 +14850,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14732,7 +14881,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14763,7 +14912,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14794,7 +14943,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14825,7 +14974,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14856,7 +15005,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14887,7 +15036,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14918,7 +15067,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14949,7 +15098,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -14980,7 +15129,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -15011,7 +15160,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -15042,7 +15191,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -15073,7 +15222,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -15104,7 +15253,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 82,
+        "line": 86,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -15135,7 +15284,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15166,7 +15315,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "ADVANCED_FIELD_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15197,7 +15346,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "ADVANCED_FIELD_PANES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15228,7 +15377,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "ADVANCED_FIELD_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15259,7 +15408,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "EXTEND_PROMPT_SLOT_SPECS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15290,7 +15439,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15321,7 +15470,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15352,7 +15501,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15383,7 +15532,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15414,7 +15563,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15445,7 +15594,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15476,7 +15625,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15507,7 +15656,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15538,7 +15687,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15569,7 +15718,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15600,7 +15749,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15631,7 +15780,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_fields_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15662,7 +15811,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15693,7 +15842,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_pane_parts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15724,7 +15873,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_prompt_data_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15755,7 +15904,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15786,7 +15935,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15817,7 +15966,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15848,7 +15997,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15879,7 +16028,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15910,7 +16059,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15941,7 +16090,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -15972,7 +16121,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -16003,7 +16152,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -16034,7 +16183,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -16065,7 +16214,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -16096,7 +16245,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -16127,7 +16276,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -16158,7 +16307,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -16189,7 +16338,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "REGIONAL_CONFIG_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16220,7 +16369,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16251,7 +16400,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16282,7 +16431,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "REGIONAL_FIELD_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16313,7 +16462,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16344,7 +16493,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "REGIONAL_PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16375,7 +16524,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "REGIONAL_PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16406,7 +16555,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16437,7 +16586,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16468,7 +16617,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16499,7 +16648,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16530,7 +16679,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16561,7 +16710,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_normalize_mask_geometry",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16592,7 +16741,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16623,7 +16772,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16654,7 +16803,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16685,7 +16834,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_normalize_regional_mask",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16716,7 +16865,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16747,7 +16896,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16778,7 +16927,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_default_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16809,7 +16958,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16840,7 +16989,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16871,7 +17020,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16902,7 +17051,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16933,7 +17082,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16964,7 +17113,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 136,
+        "line": 140,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -16995,7 +17144,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17026,7 +17175,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17057,7 +17206,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17088,7 +17237,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17119,7 +17268,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17150,7 +17299,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17181,7 +17330,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17212,7 +17361,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17243,7 +17392,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17274,7 +17423,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17305,7 +17454,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17336,7 +17485,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17367,7 +17516,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17398,7 +17547,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 164,
+        "line": 168,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -17429,7 +17578,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17460,7 +17609,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17491,7 +17640,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17522,7 +17671,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17553,7 +17702,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17584,7 +17733,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17615,7 +17764,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17646,7 +17795,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17677,7 +17826,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17708,7 +17857,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17739,7 +17888,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17770,7 +17919,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17801,7 +17950,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17832,7 +17981,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17863,7 +18012,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17894,7 +18043,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17925,7 +18074,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17956,7 +18105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -17987,7 +18136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18018,7 +18167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18049,7 +18198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18080,7 +18229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18111,7 +18260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18142,7 +18291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18173,7 +18322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18204,7 +18353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18235,7 +18384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18266,7 +18415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18297,7 +18446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18328,7 +18477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18359,7 +18508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18390,7 +18539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18421,7 +18570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18452,7 +18601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_group_token",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18483,7 +18632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18514,7 +18663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18545,7 +18694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18576,7 +18725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18607,7 +18756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18638,7 +18787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18669,7 +18818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18700,7 +18849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18731,7 +18880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18762,7 +18911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18793,7 +18942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18824,7 +18973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18855,7 +19004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18886,7 +19035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18917,7 +19066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18948,7 +19097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -18979,7 +19128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19010,7 +19159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19041,7 +19190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19072,7 +19221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19103,7 +19252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19134,7 +19283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19165,7 +19314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19196,7 +19345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19227,7 +19376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19258,7 +19407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19289,7 +19438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19320,7 +19469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19351,7 +19500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19382,7 +19531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19413,7 +19562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19444,7 +19593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19475,7 +19624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19506,7 +19655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19537,7 +19686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19568,7 +19717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19599,7 +19748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19630,7 +19779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19661,7 +19810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19692,7 +19841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19723,7 +19872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19754,7 +19903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19785,7 +19934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19816,7 +19965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 180,
+        "line": 184,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19847,7 +19996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 260,
+        "line": 264,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19878,7 +20027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 260,
+        "line": 264,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19909,7 +20058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 260,
+        "line": 264,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19940,7 +20089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 260,
+        "line": 264,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -19971,7 +20120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 266,
+        "line": 270,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20002,7 +20151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 266,
+        "line": 270,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20033,7 +20182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 266,
+        "line": 270,
         "name": "EasyUseAnimaPromptStudioExtend",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20064,7 +20213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 266,
+        "line": 270,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20095,7 +20244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 272,
+        "line": 276,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20126,7 +20275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 272,
+        "line": 276,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20157,7 +20306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 272,
+        "line": 276,
         "name": "_align_up",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20188,7 +20337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 272,
+        "line": 276,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20219,7 +20368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 272,
+        "line": 276,
         "name": "_alignment_value",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -20250,7 +20399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 279,
+        "line": 283,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": ".easyuse_anima.image.detailer",
@@ -20281,7 +20430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20312,7 +20461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20343,7 +20492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20374,7 +20523,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20405,7 +20554,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20436,7 +20585,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20467,7 +20616,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20498,7 +20647,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20529,7 +20678,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20560,7 +20709,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20591,7 +20740,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 282,
+        "line": 286,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -20622,7 +20771,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 295,
+        "line": 299,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20653,7 +20802,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 295,
+        "line": 299,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20684,7 +20833,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 295,
+        "line": 299,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20715,7 +20864,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 295,
+        "line": 299,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20746,7 +20895,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 295,
+        "line": 299,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20777,7 +20926,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 295,
+        "line": 299,
         "name": "_scale_by_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -20808,7 +20957,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20839,7 +20988,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20870,7 +21019,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20901,7 +21050,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20932,7 +21081,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20963,7 +21112,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_impact_core_module",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -20994,7 +21143,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21025,7 +21174,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21056,7 +21205,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 303,
+        "line": 307,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21087,7 +21236,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 314,
+        "line": 318,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21118,7 +21267,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 314,
+        "line": 318,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21149,7 +21298,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 314,
+        "line": 318,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21180,7 +21329,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 314,
+        "line": 318,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21211,7 +21360,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 320,
+        "line": 324,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21242,7 +21391,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 320,
+        "line": 324,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21273,7 +21422,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 320,
+        "line": 324,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21304,7 +21453,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 320,
+        "line": 324,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21335,7 +21484,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 320,
+        "line": 324,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21366,7 +21515,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 320,
+        "line": 324,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21397,7 +21546,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 328,
+        "line": 332,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21428,7 +21577,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 328,
+        "line": 332,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21459,7 +21608,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21490,7 +21639,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -21521,7 +21670,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21552,7 +21701,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21583,7 +21732,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -21614,7 +21763,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 341,
+        "line": 345,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21645,7 +21794,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 341,
+        "line": 345,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21676,7 +21825,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 341,
+        "line": 345,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21707,7 +21856,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 341,
+        "line": 345,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21738,7 +21887,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 341,
+        "line": 345,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -21769,7 +21918,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 348,
+        "line": 352,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21800,7 +21949,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 348,
+        "line": 352,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21831,7 +21980,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 348,
+        "line": 352,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -21862,7 +22011,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21893,7 +22042,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21924,7 +22073,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21955,7 +22104,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -21986,7 +22135,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22017,7 +22166,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22048,7 +22197,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22079,7 +22228,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "NAI_1MP",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22110,7 +22259,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22141,7 +22290,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22172,7 +22321,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22203,7 +22352,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_clean_prompt",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22234,7 +22383,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22265,7 +22414,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22296,7 +22445,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22327,7 +22476,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22358,7 +22507,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22389,7 +22538,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22420,7 +22569,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22451,7 +22600,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22482,7 +22631,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22513,7 +22662,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22544,7 +22693,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22575,7 +22724,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22606,7 +22755,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22637,7 +22786,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22668,7 +22817,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22699,7 +22848,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22730,7 +22879,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22761,7 +22910,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22792,7 +22941,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22823,7 +22972,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22854,7 +23003,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22885,7 +23034,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22916,7 +23065,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22947,7 +23096,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22978,7 +23127,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 371,
+        "line": 375,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23009,7 +23158,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23040,7 +23189,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 394,
+        "line": 398,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23071,7 +23220,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 398,
+        "line": 402,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23102,7 +23251,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 398,
+        "line": 402,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23133,7 +23282,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 398,
+        "line": 402,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23164,7 +23313,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23195,7 +23344,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23226,7 +23375,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23257,7 +23406,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23288,7 +23437,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23319,7 +23468,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23350,7 +23499,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23381,7 +23530,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23412,7 +23561,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23443,7 +23592,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23474,7 +23623,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23505,7 +23654,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23536,7 +23685,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23567,7 +23716,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23598,7 +23747,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23629,7 +23778,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23660,7 +23809,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23691,7 +23840,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23722,7 +23871,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23753,7 +23902,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23784,7 +23933,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23815,7 +23964,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23846,7 +23995,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 420,
+        "line": 424,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23877,7 +24026,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 430,
+        "line": 434,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23908,7 +24057,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 430,
+        "line": 434,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23939,7 +24088,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 434,
+        "line": 438,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23970,7 +24119,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 434,
+        "line": 438,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24001,7 +24150,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 435,
+        "line": 439,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24032,7 +24181,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 436,
+        "line": 440,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24063,7 +24212,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 436,
+        "line": 440,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24094,7 +24243,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 436,
+        "line": 440,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24125,7 +24274,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 441,
+        "line": 445,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24156,7 +24305,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 441,
+        "line": 445,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24187,7 +24336,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24218,7 +24367,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24249,7 +24398,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24280,7 +24429,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24311,7 +24460,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24342,7 +24491,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24373,7 +24522,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24404,7 +24553,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24435,7 +24584,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24466,7 +24615,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24497,7 +24646,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24528,7 +24677,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24559,7 +24708,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24590,7 +24739,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24621,7 +24770,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24652,7 +24801,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24683,7 +24832,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24714,7 +24863,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24745,7 +24894,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 442,
+        "line": 446,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24764,7 +24913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -24779,7 +24928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 464,
+        "line": 468,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24798,7 +24947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -24813,7 +24962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 464,
+        "line": 468,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24832,7 +24981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -24847,7 +24996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 464,
+        "line": 468,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24866,7 +25015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -24881,7 +25030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 469,
+        "line": 473,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -24900,7 +25049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -24915,7 +25064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24934,7 +25083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -24949,7 +25098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -24968,7 +25117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -24983,7 +25132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25002,7 +25151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25017,7 +25166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25036,7 +25185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25051,7 +25200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25070,7 +25219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25085,7 +25234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25104,7 +25253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25119,7 +25268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25138,7 +25287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25153,7 +25302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25172,7 +25321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25187,8 +25336,110 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_apply_aio_safe_pag_patch",
+        "optional": false,
+        "requested": "easyuse_anima.aio.model_preparation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 482,
+        "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "optional": false,
+        "requested": "easyuse_anima.aio.model_preparation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 482,
+        "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "optional": false,
+        "requested": "easyuse_anima.aio.model_preparation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 482,
+        "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
         "role": "compatibility_fallback",
@@ -25206,7 +25457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25221,8 +25472,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_bind_aio_model_preparation_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.model_preparation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "alias": "_cleanup_aio_ephemeral_model",
+        "bound_name": "_cleanup_aio_ephemeral_model",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_cleanup_aio_ephemeral_model",
+          "target": "easyuse_anima/aio/model_preparation.py",
+          "try_line": 12
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
+        "kind": "static_from",
+        "line": 482,
+        "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
         "role": "compatibility_fallback",
@@ -25240,7 +25525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25255,7 +25540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25274,7 +25559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25289,7 +25574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25308,7 +25593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25323,7 +25608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25342,7 +25627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25357,7 +25642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25376,7 +25661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25391,7 +25676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25410,7 +25695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25425,7 +25710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25444,7 +25729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25459,7 +25744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25478,7 +25763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25493,7 +25778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25512,7 +25797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25527,7 +25812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25546,7 +25831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25561,7 +25846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25580,7 +25865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25595,7 +25880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25614,7 +25899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25629,7 +25914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25648,7 +25933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25663,7 +25948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -25682,7 +25967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25697,7 +25982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 501,
+        "line": 509,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25716,7 +26001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25731,7 +26016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 501,
+        "line": 509,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25750,7 +26035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25765,7 +26050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 501,
+        "line": 509,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -25784,7 +26069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25799,7 +26084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25818,7 +26103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25833,7 +26118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25852,7 +26137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25867,7 +26152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25886,7 +26171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25901,7 +26186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25920,7 +26205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25935,7 +26220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -25954,7 +26239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -25969,7 +26254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -25988,7 +26273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26003,7 +26288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26022,7 +26307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26037,7 +26322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26056,7 +26341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26071,7 +26356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -26090,7 +26375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26105,7 +26390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26124,7 +26409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26139,7 +26424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26158,7 +26443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26173,7 +26458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26192,7 +26477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26207,7 +26492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26226,7 +26511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26241,7 +26526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26260,7 +26545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26275,7 +26560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26294,7 +26579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26309,7 +26594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26328,7 +26613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26343,7 +26628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26362,7 +26647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26377,7 +26662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26396,7 +26681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26411,7 +26696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26430,7 +26715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26445,7 +26730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26464,7 +26749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26479,7 +26764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -26498,7 +26783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26513,7 +26798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26532,7 +26817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26547,7 +26832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26566,7 +26851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26581,7 +26866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26600,7 +26885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26615,7 +26900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26634,7 +26919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26649,7 +26934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26668,7 +26953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26683,7 +26968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26702,7 +26987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26717,7 +27002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26736,7 +27021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26751,7 +27036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26770,7 +27055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26785,7 +27070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26804,7 +27089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26819,7 +27104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26838,7 +27123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26853,7 +27138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26872,7 +27157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26887,7 +27172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26906,7 +27191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26921,7 +27206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26940,7 +27225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26955,7 +27240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -26974,7 +27259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -26989,7 +27274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27008,7 +27293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27023,7 +27308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -27042,7 +27327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27057,7 +27342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27076,7 +27361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27091,7 +27376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "ADVANCED_FIELD_LABELS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27110,7 +27395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27125,7 +27410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "ADVANCED_FIELD_PANES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27144,7 +27429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27159,7 +27444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "ADVANCED_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27178,7 +27463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27193,7 +27478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "EXTEND_PROMPT_SLOT_SPECS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27212,7 +27497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27227,7 +27512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27246,7 +27531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27261,7 +27546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27280,7 +27565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27295,7 +27580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27314,7 +27599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27329,7 +27614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27348,7 +27633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27363,7 +27648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27382,7 +27667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27397,7 +27682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27416,7 +27701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27431,7 +27716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27450,7 +27735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27465,7 +27750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27484,7 +27769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27499,7 +27784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27518,7 +27803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27533,7 +27818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27552,7 +27837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27567,7 +27852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27586,7 +27871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27601,7 +27886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_fields_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27620,7 +27905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27635,7 +27920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27654,7 +27939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27669,7 +27954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_pane_parts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27688,7 +27973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27703,7 +27988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_prompt_data_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27722,7 +28007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27737,7 +28022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27756,7 +28041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27771,7 +28056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27790,7 +28075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27805,7 +28090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27824,7 +28109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27839,7 +28124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27858,7 +28143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27873,7 +28158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27892,7 +28177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27907,7 +28192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27926,7 +28211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27941,7 +28226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27960,7 +28245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -27975,7 +28260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -27994,7 +28279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28009,7 +28294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28028,7 +28313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28043,7 +28328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28062,7 +28347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28077,7 +28362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28096,7 +28381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28111,7 +28396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28130,7 +28415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28145,7 +28430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28164,7 +28449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28179,7 +28464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28198,7 +28483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28213,7 +28498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "REGIONAL_CONFIG_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28232,7 +28517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28247,7 +28532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28266,7 +28551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28281,7 +28566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28300,7 +28585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28315,7 +28600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "REGIONAL_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28334,7 +28619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28349,7 +28634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28368,7 +28653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28383,7 +28668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "REGIONAL_PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28402,7 +28687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28417,7 +28702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "REGIONAL_PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28436,7 +28721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28451,7 +28736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28470,7 +28755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28485,7 +28770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28504,7 +28789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28519,7 +28804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28538,7 +28823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28553,7 +28838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28572,7 +28857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28587,7 +28872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28606,7 +28891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28621,7 +28906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_normalize_mask_geometry",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28640,7 +28925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28655,7 +28940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28674,7 +28959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28689,7 +28974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28708,7 +28993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28723,7 +29008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28742,7 +29027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28757,7 +29042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_normalize_regional_mask",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28776,7 +29061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28791,7 +29076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28810,7 +29095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28825,7 +29110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28844,7 +29129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28859,7 +29144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_default_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28878,7 +29163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28893,7 +29178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28912,7 +29197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28927,7 +29212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28946,7 +29231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28961,7 +29246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -28980,7 +29265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -28995,7 +29280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29014,7 +29299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29029,7 +29314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29048,7 +29333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29063,7 +29348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29082,7 +29367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29097,7 +29382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29116,7 +29401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29131,7 +29416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29150,7 +29435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29165,7 +29450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29184,7 +29469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29199,7 +29484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29218,7 +29503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29233,7 +29518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29252,7 +29537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29267,7 +29552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29286,7 +29571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29301,7 +29586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29320,7 +29605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29335,7 +29620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29354,7 +29639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29369,7 +29654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29388,7 +29673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29403,7 +29688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29422,7 +29707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29437,7 +29722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29456,7 +29741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29471,7 +29756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29490,7 +29775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29505,7 +29790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29524,7 +29809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29539,7 +29824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29558,7 +29843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29573,7 +29858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29592,7 +29877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29607,7 +29892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29626,7 +29911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29641,7 +29926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29660,7 +29945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29675,7 +29960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29694,7 +29979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29709,7 +29994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29728,7 +30013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29743,7 +30028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29762,7 +30047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29777,7 +30062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29796,7 +30081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29811,7 +30096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29830,7 +30115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29845,7 +30130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29864,7 +30149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29879,7 +30164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29898,7 +30183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29913,7 +30198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29932,7 +30217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29947,7 +30232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -29966,7 +30251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -29981,7 +30266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30000,7 +30285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30015,7 +30300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30034,7 +30319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30049,7 +30334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30068,7 +30353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30083,7 +30368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30102,7 +30387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30117,7 +30402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30136,7 +30421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30151,7 +30436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30170,7 +30455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30185,7 +30470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30204,7 +30489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30219,7 +30504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30238,7 +30523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30253,7 +30538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30272,7 +30557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30287,7 +30572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30306,7 +30591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30321,7 +30606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30340,7 +30625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30355,7 +30640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30374,7 +30659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30389,7 +30674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30408,7 +30693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30423,7 +30708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30442,7 +30727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30457,7 +30742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30476,7 +30761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30491,7 +30776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30510,7 +30795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30525,7 +30810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30544,7 +30829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30559,7 +30844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30578,7 +30863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30593,7 +30878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30612,7 +30897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30627,7 +30912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30646,7 +30931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30661,7 +30946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30680,7 +30965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30695,7 +30980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_group_token",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30714,7 +30999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30729,7 +31014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30748,7 +31033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30763,7 +31048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30782,7 +31067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30797,7 +31082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30816,7 +31101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30831,7 +31116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30850,7 +31135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30865,7 +31150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30884,7 +31169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30899,7 +31184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30918,7 +31203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30933,7 +31218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30952,7 +31237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -30967,7 +31252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30986,7 +31271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31001,7 +31286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31020,7 +31305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31035,7 +31320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31054,7 +31339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31069,7 +31354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31088,7 +31373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31103,7 +31388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31122,7 +31407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31137,7 +31422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31156,7 +31441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31171,7 +31456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31190,7 +31475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31205,7 +31490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31224,7 +31509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31239,7 +31524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31258,7 +31543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31273,7 +31558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31292,7 +31577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31307,7 +31592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31326,7 +31611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31341,7 +31626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31360,7 +31645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31375,7 +31660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31394,7 +31679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31409,7 +31694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31428,7 +31713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31443,7 +31728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31462,7 +31747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31477,7 +31762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31496,7 +31781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31511,7 +31796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31530,7 +31815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31545,7 +31830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31564,7 +31849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31579,7 +31864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31598,7 +31883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31613,7 +31898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31632,7 +31917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31647,7 +31932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31666,7 +31951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31681,7 +31966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31700,7 +31985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31715,7 +32000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31734,7 +32019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31749,7 +32034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31768,7 +32053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31783,7 +32068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31802,7 +32087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31817,7 +32102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31836,7 +32121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31851,7 +32136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31870,7 +32155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31885,7 +32170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31904,7 +32189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31919,7 +32204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31938,7 +32223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31953,7 +32238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31972,7 +32257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -31987,7 +32272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32006,7 +32291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32021,7 +32306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32040,7 +32325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32055,7 +32340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32074,7 +32359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32089,7 +32374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32108,7 +32393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32123,7 +32408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32142,7 +32427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32157,7 +32442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32176,7 +32461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32191,7 +32476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32210,7 +32495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32225,7 +32510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32244,7 +32529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32259,7 +32544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32278,7 +32563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32293,7 +32578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32312,7 +32597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32327,7 +32612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32346,7 +32631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32361,7 +32646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32380,7 +32665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32395,7 +32680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32414,7 +32699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32429,7 +32714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "name": "EasyUseAnimaPromptStudioExtend",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32448,7 +32733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32463,7 +32748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32482,7 +32767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32497,7 +32782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32516,7 +32801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32531,7 +32816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32550,7 +32835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32565,7 +32850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32584,7 +32869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32599,7 +32884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32618,7 +32903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32633,7 +32918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32652,7 +32937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32667,7 +32952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 730,
+        "line": 738,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -32686,7 +32971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32701,7 +32986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32720,7 +33005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32735,7 +33020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32754,7 +33039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32769,7 +33054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32788,7 +33073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32803,7 +33088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32822,7 +33107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32837,7 +33122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32856,7 +33141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32871,7 +33156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32890,7 +33175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32905,7 +33190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32924,7 +33209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32939,7 +33224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32958,7 +33243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -32973,7 +33258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32992,7 +33277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33007,7 +33292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -33026,7 +33311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33041,7 +33326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -33060,7 +33345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33075,7 +33360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33094,7 +33379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33109,7 +33394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33128,7 +33413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33143,7 +33428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33162,7 +33447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33177,7 +33462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33196,7 +33481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33211,7 +33496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33230,7 +33515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33245,7 +33530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33264,7 +33549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33279,7 +33564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33298,7 +33583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33313,7 +33598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33332,7 +33617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33347,7 +33632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33366,7 +33651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33381,7 +33666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33400,7 +33685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33415,7 +33700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33434,7 +33719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33449,7 +33734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_impact_core_module",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33468,7 +33753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33483,7 +33768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33502,7 +33787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33517,7 +33802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33536,7 +33821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33551,7 +33836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33570,7 +33855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33585,7 +33870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33604,7 +33889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33619,7 +33904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33638,7 +33923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33653,7 +33938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33672,7 +33957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33687,7 +33972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33706,7 +33991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33721,7 +34006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33740,7 +34025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33755,7 +34040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33774,7 +34059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33789,7 +34074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33808,7 +34093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33823,7 +34108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33842,7 +34127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33857,7 +34142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33876,7 +34161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33891,7 +34176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33910,7 +34195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33925,7 +34210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 779,
+        "line": 787,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33944,7 +34229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33959,7 +34244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 779,
+        "line": 787,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33978,7 +34263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -33993,7 +34278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 783,
+        "line": 791,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -34012,7 +34297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34027,7 +34312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 783,
+        "line": 791,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -34046,7 +34331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34061,7 +34346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 787,
+        "line": 795,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -34080,7 +34365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34095,7 +34380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 787,
+        "line": 795,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -34114,7 +34399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34129,7 +34414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 787,
+        "line": 795,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -34148,7 +34433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34163,7 +34448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34182,7 +34467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34197,7 +34482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34216,7 +34501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34231,7 +34516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34250,7 +34535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34265,7 +34550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34284,7 +34569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34299,7 +34584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -34318,7 +34603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34333,7 +34618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 799,
+        "line": 807,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -34352,7 +34637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34367,7 +34652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 799,
+        "line": 807,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -34386,7 +34671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34401,7 +34686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 799,
+        "line": 807,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -34420,7 +34705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34435,7 +34720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34454,7 +34739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34469,7 +34754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34488,7 +34773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34503,7 +34788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34522,7 +34807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34537,7 +34822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34556,7 +34841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34571,7 +34856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34590,7 +34875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34605,7 +34890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34624,7 +34909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34639,7 +34924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34658,7 +34943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34673,7 +34958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34692,7 +34977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34707,7 +34992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34726,7 +35011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34741,7 +35026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34760,7 +35045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34775,7 +35060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34794,7 +35079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34809,7 +35094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34828,7 +35113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34843,7 +35128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34862,7 +35147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34877,7 +35162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34896,7 +35181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34911,7 +35196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34930,7 +35215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34945,7 +35230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -34964,7 +35249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -34979,7 +35264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34998,7 +35283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35013,7 +35298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35032,7 +35317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35047,7 +35332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35066,7 +35351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35081,7 +35366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35100,7 +35385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35115,7 +35400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35134,7 +35419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35149,7 +35434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35168,7 +35453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35183,7 +35468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35202,7 +35487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35217,7 +35502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35236,7 +35521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35251,7 +35536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35270,7 +35555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35285,7 +35570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35304,7 +35589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35319,7 +35604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35338,7 +35623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35353,7 +35638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35372,7 +35657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35387,7 +35672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35406,7 +35691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35421,7 +35706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35440,7 +35725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35455,7 +35740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35474,7 +35759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35489,7 +35774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35508,7 +35793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35523,7 +35808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35542,7 +35827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35557,7 +35842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35576,7 +35861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35591,7 +35876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35610,7 +35895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35625,7 +35910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35644,7 +35929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35659,7 +35944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -35678,7 +35963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35693,7 +35978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 845,
+        "line": 853,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -35712,7 +35997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35727,7 +36012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 845,
+        "line": 853,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -35746,7 +36031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35761,7 +36046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 849,
+        "line": 857,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -35780,7 +36065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35795,7 +36080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 849,
+        "line": 857,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -35814,7 +36099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35829,7 +36114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 849,
+        "line": 857,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -35848,7 +36133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35863,7 +36148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35882,7 +36167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35897,7 +36182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35916,7 +36201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35931,7 +36216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35950,7 +36235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35965,7 +36250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -35984,7 +36269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -35999,7 +36284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36018,7 +36303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36033,7 +36318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36052,7 +36337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36067,7 +36352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36086,7 +36371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36101,7 +36386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36120,7 +36405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36135,7 +36420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36154,7 +36439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36169,7 +36454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36188,7 +36473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36203,7 +36488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36222,7 +36507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36237,7 +36522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36256,7 +36541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36271,7 +36556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36290,7 +36575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36305,7 +36590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36324,7 +36609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36339,7 +36624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -36358,7 +36643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36373,7 +36658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36392,7 +36677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36407,7 +36692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36426,7 +36711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36441,7 +36726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36460,7 +36745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36475,7 +36760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36494,7 +36779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36509,7 +36794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36528,7 +36813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36543,7 +36828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36562,7 +36847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36577,7 +36862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36596,7 +36881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36611,7 +36896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -36630,7 +36915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36645,7 +36930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 881,
+        "line": 889,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -36664,7 +36949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36679,7 +36964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 881,
+        "line": 889,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -36698,7 +36983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36713,7 +36998,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 885,
+        "line": 893,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -36732,7 +37017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36747,7 +37032,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 885,
+        "line": 893,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -36766,7 +37051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36781,7 +37066,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -36800,7 +37085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36815,7 +37100,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 887,
+        "line": 895,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -36834,7 +37119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36849,7 +37134,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 887,
+        "line": 895,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -36868,7 +37153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36883,7 +37168,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 887,
+        "line": 895,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -36902,7 +37187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36917,7 +37202,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -36936,7 +37221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36951,7 +37236,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -36970,7 +37255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -36985,7 +37270,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37004,7 +37289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37019,7 +37304,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37038,7 +37323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37053,7 +37338,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37072,7 +37357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37087,7 +37372,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37106,7 +37391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37121,7 +37406,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37140,7 +37425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37155,7 +37440,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37174,7 +37459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37189,7 +37474,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37208,7 +37493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37223,7 +37508,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37242,7 +37527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37257,7 +37542,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37276,7 +37561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37291,7 +37576,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37310,7 +37595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37325,7 +37610,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37344,7 +37629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37359,7 +37644,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37378,7 +37663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37393,7 +37678,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37412,7 +37697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37427,7 +37712,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37446,7 +37731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37461,7 +37746,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37480,7 +37765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37495,7 +37780,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37514,7 +37799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37529,7 +37814,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37548,7 +37833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37563,7 +37848,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37582,7 +37867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -37597,7 +37882,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37615,7 +37900,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1761
+            "line": 1769
           }
         ],
         "classification": "external",
@@ -37623,37 +37908,12 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1762,
+        "line": 1770,
         "name": null,
         "optional": true,
         "requested": "nodes",
         "role": "optional_dependency",
         "scope": "_comfy_max_resolution",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1798
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1799,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_find_comfy_node_class",
         "source": "nodes.py"
       },
       {
@@ -37678,6 +37938,31 @@
         "optional": true,
         "requested": "nodes",
         "role": "optional_dependency",
+        "scope": "_find_comfy_node_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1814
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1815,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
         "scope": "_find_comfy_node_mapping_class",
         "source": "nodes.py"
       },
@@ -37690,7 +37975,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2002
+            "line": 2010
           }
         ],
         "classification": "external",
@@ -37698,37 +37983,12 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2003,
+        "line": 2011,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
         "role": "optional_dependency",
         "scope": "_aio_lora_metadata_name",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "model_management",
-        "bound_name": "model_management",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 2042
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "comfy.model_management",
-        "kind": "static_import",
-        "line": 2043,
-        "name": null,
-        "optional": true,
-        "requested": "comfy.model_management",
-        "role": "optional_dependency",
-        "scope": "_cleanup_aio_ephemeral_model",
         "source": "nodes.py"
       },
       {
@@ -37740,7 +38000,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3119
+            "line": 2992
           }
         ],
         "classification": "external",
@@ -37748,7 +38008,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3120,
+        "line": 2993,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -37765,7 +38025,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3181
+            "line": 3054
           }
         ],
         "classification": "external",
@@ -37773,7 +38033,7 @@
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 3182,
+        "line": 3055,
         "name": "PromptServer",
         "optional": true,
         "requested": "server",
@@ -37790,7 +38050,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
@@ -37798,7 +38058,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3209,
+        "line": 3082,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -37815,7 +38075,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
@@ -37823,7 +38083,7 @@
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 3210,
+        "line": 3083,
         "name": null,
         "optional": true,
         "requested": "numpy",
@@ -37840,7 +38100,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
@@ -37848,7 +38108,7 @@
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 3211,
+        "line": 3084,
         "name": "Image",
         "optional": true,
         "requested": "PIL",
@@ -40648,13 +40908,13 @@
       },
       {
         "is_package": false,
-        "loc": 284,
+        "loc": 457,
         "module": "easyuse_anima.aio.model_preparation",
-        "normalized_git_blob_sha1": "feeb99c5f7fcdfba3eddb0d4001feb6d668d9934",
+        "normalized_git_blob_sha1": "9488410f6ea0722496760c6e42aa63eed91e92a2",
         "path": "easyuse_anima/aio/model_preparation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 9,
+          "function_count": 13,
           "global_count": 3
         }
       },
@@ -41164,13 +41424,13 @@
       },
       {
         "is_package": false,
-        "loc": 4112,
+        "loc": 3985,
         "module": "nodes",
-        "normalized_git_blob_sha1": "a0935a57fc324743d81ab0ecb97907dc25e01b75",
+        "normalized_git_blob_sha1": "442e1a864ccfcc73c515cb15bd5e821511442f64",
         "path": "nodes.py",
         "top_level": {
           "class_count": 4,
-          "function_count": 75,
+          "function_count": 71,
           "global_count": 40
         }
       },
@@ -42520,7 +42780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42529,7 +42789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 464,
+        "line": 468,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42543,7 +42803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42552,7 +42812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 464,
+        "line": 468,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42566,7 +42826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42575,7 +42835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 464,
+        "line": 468,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42589,7 +42849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42598,7 +42858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 469,
+        "line": 473,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42612,7 +42872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42621,7 +42881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42635,7 +42895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42644,7 +42904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42658,7 +42918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42667,7 +42927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42681,7 +42941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42690,7 +42950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 472,
+        "line": 476,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42704,7 +42964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42713,7 +42973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42727,7 +42987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42736,7 +42996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42750,7 +43010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42759,7 +43019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42773,7 +43033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42782,7 +43042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42796,7 +43056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42805,7 +43065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42819,7 +43079,76 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 482,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 482,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
+        "kind": "static_from",
+        "line": 482,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42828,7 +43157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42842,7 +43171,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
+            "kind": "try",
+            "line": 12
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
+        "kind": "static_from",
+        "line": 482,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42851,7 +43203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42865,7 +43217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42874,7 +43226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 478,
+        "line": 482,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42888,7 +43240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42897,7 +43249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42911,7 +43263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42920,7 +43272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42934,7 +43286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42943,7 +43295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42957,7 +43309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42966,7 +43318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42980,7 +43332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -42989,7 +43341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43003,7 +43355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43012,7 +43364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43026,7 +43378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43035,7 +43387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43049,7 +43401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43058,7 +43410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43072,7 +43424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43081,7 +43433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43095,7 +43447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43104,7 +43456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43118,7 +43470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43127,7 +43479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 488,
+        "line": 496,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43141,7 +43493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43150,7 +43502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 501,
+        "line": 509,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43164,7 +43516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43173,7 +43525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 501,
+        "line": 509,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43187,7 +43539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43196,7 +43548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 501,
+        "line": 509,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43210,7 +43562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43219,7 +43571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43233,7 +43585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43242,7 +43594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43256,7 +43608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43265,7 +43617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43279,7 +43631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43288,7 +43640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43302,7 +43654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43311,7 +43663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 506,
+        "line": 514,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43325,7 +43677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43334,7 +43686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43348,7 +43700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43357,7 +43709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43371,7 +43723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43380,7 +43732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43394,7 +43746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43403,7 +43755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 513,
+        "line": 521,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43417,7 +43769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43426,7 +43778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43440,7 +43792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43449,7 +43801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43463,7 +43815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43472,7 +43824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43486,7 +43838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43495,7 +43847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43509,7 +43861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43518,7 +43870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43532,7 +43884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43541,7 +43893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43555,7 +43907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43564,7 +43916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43578,7 +43930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43587,7 +43939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43601,7 +43953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43610,7 +43962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43624,7 +43976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43633,7 +43985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43647,7 +43999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43656,7 +44008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43670,7 +44022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43679,7 +44031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 519,
+        "line": 527,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43693,7 +44045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43702,7 +44054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43716,7 +44068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43725,7 +44077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43739,7 +44091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43748,7 +44100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43762,7 +44114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43771,7 +44123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43785,7 +44137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43794,7 +44146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43808,7 +44160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43817,7 +44169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43831,7 +44183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43840,7 +44192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43854,7 +44206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43863,7 +44215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43877,7 +44229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43886,7 +44238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43900,7 +44252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43909,7 +44261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43923,7 +44275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43932,7 +44284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43946,7 +44298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43955,7 +44307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43969,7 +44321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -43978,7 +44330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43992,7 +44344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44001,7 +44353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44015,7 +44367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44024,7 +44376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44038,7 +44390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44047,7 +44399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 533,
+        "line": 541,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44061,7 +44413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44070,7 +44422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44084,7 +44436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44093,7 +44445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44107,7 +44459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44116,7 +44468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44130,7 +44482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44139,7 +44491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44153,7 +44505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44162,7 +44514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44176,7 +44528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44185,7 +44537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44199,7 +44551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44208,7 +44560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44222,7 +44574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44231,7 +44583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44245,7 +44597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44254,7 +44606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44268,7 +44620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44277,7 +44629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44291,7 +44643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44300,7 +44652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44314,7 +44666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44323,7 +44675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44337,7 +44689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44346,7 +44698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44360,7 +44712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44369,7 +44721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44383,7 +44735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44392,7 +44744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44406,7 +44758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44415,7 +44767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44429,7 +44781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44438,7 +44790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44452,7 +44804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44461,7 +44813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44475,7 +44827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44484,7 +44836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44498,7 +44850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44507,7 +44859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44521,7 +44873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44530,7 +44882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44544,7 +44896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44553,7 +44905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44567,7 +44919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44576,7 +44928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44590,7 +44942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44599,7 +44951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44613,7 +44965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44622,7 +44974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44636,7 +44988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44645,7 +44997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44659,7 +45011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44668,7 +45020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44682,7 +45034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44691,7 +45043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44705,7 +45057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44714,7 +45066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44728,7 +45080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44737,7 +45089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44751,7 +45103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44760,7 +45112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44774,7 +45126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44783,7 +45135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44797,7 +45149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44806,7 +45158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44820,7 +45172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44829,7 +45181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 551,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44843,7 +45195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44852,7 +45204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44866,7 +45218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44875,7 +45227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44889,7 +45241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44898,7 +45250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44912,7 +45264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44921,7 +45273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44935,7 +45287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44944,7 +45296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44958,7 +45310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44967,7 +45319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44981,7 +45333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -44990,7 +45342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45004,7 +45356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45013,7 +45365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45027,7 +45379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45036,7 +45388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45050,7 +45402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45059,7 +45411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45073,7 +45425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45082,7 +45434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45096,7 +45448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45105,7 +45457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45119,7 +45471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45128,7 +45480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45142,7 +45494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45151,7 +45503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45165,7 +45517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45174,7 +45526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45188,7 +45540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45197,7 +45549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45211,7 +45563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45220,7 +45572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45234,7 +45586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45243,7 +45595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45257,7 +45609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45266,7 +45618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45280,7 +45632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45289,7 +45641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45303,7 +45655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45312,7 +45664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45326,7 +45678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45335,7 +45687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45349,7 +45701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45358,7 +45710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45372,7 +45724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45381,7 +45733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45395,7 +45747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45404,7 +45756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45418,7 +45770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45427,7 +45779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 587,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45441,7 +45793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45450,7 +45802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45464,7 +45816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45473,7 +45825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45487,7 +45839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45496,7 +45848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45510,7 +45862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45519,7 +45871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45533,7 +45885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45542,7 +45894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45556,7 +45908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45565,7 +45917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45579,7 +45931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45588,7 +45940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45602,7 +45954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45611,7 +45963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45625,7 +45977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45634,7 +45986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45648,7 +46000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45657,7 +46009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45671,7 +46023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45680,7 +46032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45694,7 +46046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45703,7 +46055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45717,7 +46069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45726,7 +46078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45740,7 +46092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45749,7 +46101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 615,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45763,7 +46115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45772,7 +46124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45786,7 +46138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45795,7 +46147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45809,7 +46161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45818,7 +46170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45832,7 +46184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45841,7 +46193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45855,7 +46207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45864,7 +46216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45878,7 +46230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45887,7 +46239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45901,7 +46253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45910,7 +46262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45924,7 +46276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45933,7 +46285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45947,7 +46299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45956,7 +46308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45970,7 +46322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -45979,7 +46331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45993,7 +46345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46002,7 +46354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46016,7 +46368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46025,7 +46377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46039,7 +46391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46048,7 +46400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46062,7 +46414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46071,7 +46423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46085,7 +46437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46094,7 +46446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46108,7 +46460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46117,7 +46469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46131,7 +46483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46140,7 +46492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46154,7 +46506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46163,7 +46515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46177,7 +46529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46186,7 +46538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46200,7 +46552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46209,7 +46561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46223,7 +46575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46232,7 +46584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46246,7 +46598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46255,7 +46607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46269,7 +46621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46278,7 +46630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46292,7 +46644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46301,7 +46653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46315,7 +46667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46324,7 +46676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46338,7 +46690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46347,7 +46699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46361,7 +46713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46370,7 +46722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46384,7 +46736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46393,7 +46745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46407,7 +46759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46416,7 +46768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46430,7 +46782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46439,7 +46791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46453,7 +46805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46462,7 +46814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46476,7 +46828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46485,7 +46837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46499,7 +46851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46508,7 +46860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46522,7 +46874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46531,7 +46883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46545,7 +46897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46554,7 +46906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46568,7 +46920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46577,7 +46929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46591,7 +46943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46600,7 +46952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46614,7 +46966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46623,7 +46975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46637,7 +46989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46646,7 +46998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46660,7 +47012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46669,7 +47021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46683,7 +47035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46692,7 +47044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46706,7 +47058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46715,7 +47067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46729,7 +47081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46738,7 +47090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46752,7 +47104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46761,7 +47113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46775,7 +47127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46784,7 +47136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46798,7 +47150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46807,7 +47159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46821,7 +47173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46830,7 +47182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46844,7 +47196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46853,7 +47205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46867,7 +47219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46876,7 +47228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46890,7 +47242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46899,7 +47251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46913,7 +47265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46922,7 +47274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46936,7 +47288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46945,7 +47297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46959,7 +47311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46968,7 +47320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46982,7 +47334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -46991,7 +47343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47005,7 +47357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47014,7 +47366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47028,7 +47380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47037,7 +47389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47051,7 +47403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47060,7 +47412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47074,7 +47426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47083,7 +47435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47097,7 +47449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47106,7 +47458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47120,7 +47472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47129,7 +47481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47143,7 +47495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47152,7 +47504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47166,7 +47518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47175,7 +47527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47189,7 +47541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47198,7 +47550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47212,7 +47564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47221,7 +47573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47235,7 +47587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47244,7 +47596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47258,7 +47610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47267,7 +47619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47281,7 +47633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47290,7 +47642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47304,7 +47656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47313,7 +47665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47327,7 +47679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47336,7 +47688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47350,7 +47702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47359,7 +47711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47373,7 +47725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47382,7 +47734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47396,7 +47748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47405,7 +47757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47419,7 +47771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47428,7 +47780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47442,7 +47794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47451,7 +47803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47465,7 +47817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47474,7 +47826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47488,7 +47840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47497,7 +47849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47511,7 +47863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47520,7 +47872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47534,7 +47886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47543,7 +47895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 631,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47557,7 +47909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47566,7 +47918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47580,7 +47932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47589,7 +47941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47603,7 +47955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47612,7 +47964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47626,7 +47978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47635,7 +47987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 711,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47649,7 +48001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47658,7 +48010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47672,7 +48024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47681,7 +48033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47695,7 +48047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47704,7 +48056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47718,7 +48070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47727,7 +48079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 717,
+        "line": 725,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47741,7 +48093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47750,7 +48102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47764,7 +48116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47773,7 +48125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47787,7 +48139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47796,7 +48148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47810,7 +48162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47819,7 +48171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47833,7 +48185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47842,7 +48194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 723,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47856,7 +48208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47865,7 +48217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 730,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47879,7 +48231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47888,7 +48240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47902,7 +48254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47911,7 +48263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47925,7 +48277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47934,7 +48286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47948,7 +48300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47957,7 +48309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47971,7 +48323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -47980,7 +48332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47994,7 +48346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48003,7 +48355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48017,7 +48369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48026,7 +48378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48040,7 +48392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48049,7 +48401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48063,7 +48415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48072,7 +48424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48086,7 +48438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48095,7 +48447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48109,7 +48461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48118,7 +48470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 733,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48132,7 +48484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48141,7 +48493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48155,7 +48507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48164,7 +48516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48178,7 +48530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48187,7 +48539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48201,7 +48553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48210,7 +48562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48224,7 +48576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48233,7 +48585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48247,7 +48599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48256,7 +48608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 746,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48270,7 +48622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48279,7 +48631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48293,7 +48645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48302,7 +48654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48316,7 +48668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48325,7 +48677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48339,7 +48691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48348,7 +48700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48362,7 +48714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48371,7 +48723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48385,7 +48737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48394,7 +48746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48408,7 +48760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48417,7 +48769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48431,7 +48783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48440,7 +48792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48454,7 +48806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48463,7 +48815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 754,
+        "line": 762,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48477,7 +48829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48486,7 +48838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48500,7 +48852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48509,7 +48861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48523,7 +48875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48532,7 +48884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48546,7 +48898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48555,7 +48907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 765,
+        "line": 773,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48569,7 +48921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48578,7 +48930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48592,7 +48944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48601,7 +48953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48615,7 +48967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48624,7 +48976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48638,7 +48990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48647,7 +48999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48661,7 +49013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48670,7 +49022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48684,7 +49036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48693,7 +49045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 771,
+        "line": 779,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48707,7 +49059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48716,7 +49068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 779,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48730,7 +49082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48739,7 +49091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 779,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48753,7 +49105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48762,7 +49114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 783,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48776,7 +49128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48785,7 +49137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 783,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48799,7 +49151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48808,7 +49160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 787,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48822,7 +49174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48831,7 +49183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 787,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48845,7 +49197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48854,7 +49206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 787,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48868,7 +49220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48877,7 +49229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48891,7 +49243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48900,7 +49252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48914,7 +49266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48923,7 +49275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48937,7 +49289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48946,7 +49298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48960,7 +49312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48969,7 +49321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 792,
+        "line": 800,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48983,7 +49335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -48992,7 +49344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 799,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49006,7 +49358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49015,7 +49367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 799,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49029,7 +49381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49038,7 +49390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 799,
+        "line": 807,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49052,7 +49404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49061,7 +49413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49075,7 +49427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49084,7 +49436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49098,7 +49450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49107,7 +49459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49121,7 +49473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49130,7 +49482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49144,7 +49496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49153,7 +49505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49167,7 +49519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49176,7 +49528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49190,7 +49542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49199,7 +49551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49213,7 +49565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49222,7 +49574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49236,7 +49588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49245,7 +49597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49259,7 +49611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49268,7 +49620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49282,7 +49634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49291,7 +49643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49305,7 +49657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49314,7 +49666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49328,7 +49680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49337,7 +49689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49351,7 +49703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49360,7 +49712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49374,7 +49726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49383,7 +49735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49397,7 +49749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49406,7 +49758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 804,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49420,7 +49772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49429,7 +49781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49443,7 +49795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49452,7 +49804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49466,7 +49818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49475,7 +49827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49489,7 +49841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49498,7 +49850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49512,7 +49864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49521,7 +49873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49535,7 +49887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49544,7 +49896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49558,7 +49910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49567,7 +49919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49581,7 +49933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49590,7 +49942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49604,7 +49956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49613,7 +49965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49627,7 +49979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49636,7 +49988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49650,7 +50002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49659,7 +50011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49673,7 +50025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49682,7 +50034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49696,7 +50048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49705,7 +50057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49719,7 +50071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49728,7 +50080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49742,7 +50094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49751,7 +50103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49765,7 +50117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49774,7 +50126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49788,7 +50140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49797,7 +50149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49811,7 +50163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49820,7 +50172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49834,7 +50186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49843,7 +50195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49857,7 +50209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49866,7 +50218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49880,7 +50232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49889,7 +50241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49903,7 +50255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49912,7 +50264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 845,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49926,7 +50278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49935,7 +50287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 845,
+        "line": 853,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49949,7 +50301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49958,7 +50310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 849,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49972,7 +50324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -49981,7 +50333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 849,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49995,7 +50347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50004,7 +50356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 849,
+        "line": 857,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50018,7 +50370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50027,7 +50379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50041,7 +50393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50050,7 +50402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50064,7 +50416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50073,7 +50425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50087,7 +50439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50096,7 +50448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50110,7 +50462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50119,7 +50471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50133,7 +50485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50142,7 +50494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50156,7 +50508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50165,7 +50517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50179,7 +50531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50188,7 +50540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50202,7 +50554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50211,7 +50563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50225,7 +50577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50234,7 +50586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50248,7 +50600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50257,7 +50609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50271,7 +50623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50280,7 +50632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50294,7 +50646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50303,7 +50655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50317,7 +50669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50326,7 +50678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50340,7 +50692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50349,7 +50701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 854,
+        "line": 862,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50363,7 +50715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50372,7 +50724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50386,7 +50738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50395,7 +50747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50409,7 +50761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50418,7 +50770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50432,7 +50784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50441,7 +50793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50455,7 +50807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50464,7 +50816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50478,7 +50830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50487,7 +50839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50501,7 +50853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50510,7 +50862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50524,7 +50876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50533,7 +50885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 871,
+        "line": 879,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50547,7 +50899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50556,7 +50908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 881,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50570,7 +50922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50579,7 +50931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 881,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50593,7 +50945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50602,7 +50954,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 885,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50616,7 +50968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50625,7 +50977,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 885,
+        "line": 893,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50639,7 +50991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50648,7 +51000,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 886,
+        "line": 894,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50662,7 +51014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50671,7 +51023,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 887,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50685,7 +51037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50694,7 +51046,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 887,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50708,7 +51060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50717,7 +51069,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 887,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50731,7 +51083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50740,7 +51092,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50754,7 +51106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50763,7 +51115,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50777,7 +51129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50786,7 +51138,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50800,7 +51152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50809,7 +51161,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50823,7 +51175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50832,7 +51184,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50846,7 +51198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50855,7 +51207,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50869,7 +51221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50878,7 +51230,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50892,7 +51244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50901,7 +51253,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50915,7 +51267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50924,7 +51276,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50938,7 +51290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50947,7 +51299,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50961,7 +51313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50970,7 +51322,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50984,7 +51336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -50993,7 +51345,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51007,7 +51359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51016,7 +51368,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51030,7 +51382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51039,7 +51391,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51053,7 +51405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51062,7 +51414,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51076,7 +51428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51085,7 +51437,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51099,7 +51451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51108,7 +51460,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51122,7 +51474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51131,7 +51483,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51145,7 +51497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51154,7 +51506,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51168,7 +51520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51177,7 +51529,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51191,7 +51543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 463,
+            "handler_line": 467,
             "kind": "try",
             "line": 12
           }
@@ -51200,7 +51552,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52618,6 +52970,25 @@
         "line": 7,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 296
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.model_management",
+        "kind": "static_import",
+        "line": 297,
+        "optional": true,
+        "role": "optional_dependency",
         "source": "easyuse_anima/aio/model_preparation.py"
       },
       {
@@ -54465,33 +54836,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1761
+            "line": 1769
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1762,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1798
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1799,
+        "line": 1770,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54522,14 +54874,33 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2002
+            "line": 1814
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1815,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2010
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2003,
+        "line": 2011,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54541,33 +54912,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2042
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "comfy.model_management",
-        "kind": "static_import",
-        "line": 2043,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 3119
+            "line": 2992
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3120,
+        "line": 2993,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54579,14 +54931,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3181
+            "line": 3054
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 3182,
+        "line": 3055,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54598,14 +54950,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3209,
+        "line": 3082,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54617,14 +54969,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 3210,
+        "line": 3083,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54636,14 +54988,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 3211,
+        "line": 3084,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55287,6 +55639,25 @@
         "branch_context": [
           {
             "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 296
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "comfy.model_management",
+        "kind": "static_import",
+        "line": 297,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/aio/model_preparation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
             "kind": "if",
             "line": 135,
             "type_checking": false
@@ -55885,33 +56256,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1761
+            "line": 1769
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1762,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1798
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1799,
+        "line": 1770,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55942,14 +56294,33 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2002
+            "line": 1814
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1815,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 2010
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 2003,
+        "line": 2011,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55961,33 +56332,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 2042
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "comfy.model_management",
-        "kind": "static_import",
-        "line": 2043,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 3119
+            "line": 2992
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3120,
+        "line": 2993,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55999,14 +56351,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3181
+            "line": 3054
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "server:PromptServer",
         "kind": "static_from",
-        "line": 3182,
+        "line": 3055,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -56018,14 +56370,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 3209,
+        "line": 3082,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -56037,14 +56389,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "numpy",
         "kind": "static_import",
-        "line": 3210,
+        "line": 3083,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -56056,14 +56408,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 3208
+            "line": 3081
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "PIL:Image",
         "kind": "static_from",
-        "line": 3211,
+        "line": 3084,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -57653,7 +58005,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 915,
+        "line": 923,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57662,7 +58014,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1431,
+        "line": 1439,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57671,7 +58023,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1597,
+        "line": 1605,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57680,7 +58032,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3494,
+        "line": 3367,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57689,7 +58041,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3497,
+        "line": 3370,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57698,7 +58050,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3500,
+        "line": 3373,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57707,7 +58059,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3503,
+        "line": 3376,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57716,7 +58068,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3506,
+        "line": 3379,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57725,7 +58077,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3509,
+        "line": 3382,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57734,7 +58086,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3512,
+        "line": 3385,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57743,7 +58095,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3515,
+        "line": 3388,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57752,7 +58104,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3518,
+        "line": 3391,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57761,7 +58113,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3522,
+        "line": 3395,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57770,7 +58122,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3525,
+        "line": 3398,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57779,7 +58131,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3529,
+        "line": 3402,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57788,7 +58140,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3533,
+        "line": 3406,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57797,7 +58149,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3536,
+        "line": 3409,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57806,7 +58158,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3539,
+        "line": 3412,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57815,7 +58167,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3542,
+        "line": 3415,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57824,7 +58176,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3545,
+        "line": 3418,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57833,7 +58185,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3548,
+        "line": 3421,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57842,7 +58194,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3555,
+        "line": 3428,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57851,7 +58203,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3561,
+        "line": 3434,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57860,7 +58212,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3566,
+        "line": 3439,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -57869,7 +58221,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 3570,
+        "line": 3443,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -58341,43 +58693,43 @@
       },
       {
         "kind": "dict",
-        "line": 985,
+        "line": 993,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 974,
+        "line": 982,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 3091,
+        "line": 2964,
         "module": "nodes.py",
         "name": "AIO_PREVIEW_STAGE_LABELS"
       },
       {
         "kind": "set",
-        "line": 969,
+        "line": 977,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1596,
+        "line": 1604,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },
       {
         "kind": "dict",
-        "line": 3104,
+        "line": 2977,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
       {
         "kind": "list",
-        "line": 3105,
+        "line": 2978,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },
@@ -58570,7 +58922,7 @@
           "mutable_container"
         ],
         "initializer": "Dict",
-        "line": 3104,
+        "line": 2977,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE"
       },
@@ -58580,7 +58932,7 @@
           "mutable_container"
         ],
         "initializer": "List",
-        "line": 3105,
+        "line": 2978,
         "module": "nodes.py",
         "name": "_AIO_FIRST_PASS_CACHE_ORDER"
       },

--- a/tests/test_aio_model_preparation.py
+++ b/tests/test_aio_model_preparation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import types
 import unittest
 from unittest.mock import Mock, patch
 
@@ -17,6 +19,10 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
             "_apply_aio_lora_stack",
             "_apply_aio_anima_dave_patch",
             "_apply_aio_safe_pag_patch",
+            "_cleanup_aio_ephemeral_model",
+            "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+            "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+            "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         ):
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(model_preparation, name))
@@ -178,6 +184,124 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
                 True,
             ),
         )
+
+    def test_ephemeral_cleanup_preserves_identity_detach_and_unload_fallback(self):
+        class DetachableModel:
+            def __init__(self, *, fail: bool = False):
+                self.fail = fail
+                self.calls: list[bool] = []
+
+            def detach(self, *, unpatch_all: bool):
+                self.calls.append(unpatch_all)
+                if self.fail:
+                    raise RuntimeError("detach failed")
+
+        base_model = object()
+        detachable = DetachableModel()
+        failing = DetachableModel(fail=True)
+        unload = Mock()
+        comfy = types.ModuleType("comfy")
+        comfy.__path__ = []
+        model_management = types.ModuleType("comfy.model_management")
+        model_management.unload_model_and_clones = unload
+        comfy.model_management = model_management
+
+        with (
+            patch.dict(
+                sys.modules,
+                {"comfy": comfy, "comfy.model_management": model_management},
+            ),
+            patch.object(nodes.logger, "debug") as debug,
+        ):
+            model_preparation._cleanup_aio_ephemeral_model(None, base_model)
+            model_preparation._cleanup_aio_ephemeral_model(base_model, base_model)
+            model_preparation._cleanup_aio_ephemeral_model(detachable, base_model)
+            model_preparation._cleanup_aio_ephemeral_model(failing, base_model)
+
+        self.assertEqual(detachable.calls, [False])
+        self.assertEqual(failing.calls, [False])
+        unload.assert_called_once_with(failing, unload_additional_models=True)
+        debug.assert_called_once()
+        self.assertIn("failed to detach ephemeral AiO model clone", debug.call_args.args[0])
+
+    def test_ephemeral_cleanup_swallows_unload_failure_after_debug_logging(self):
+        model = object()
+        unload = Mock(side_effect=RuntimeError("unload failed"))
+        comfy = types.ModuleType("comfy")
+        comfy.__path__ = []
+        model_management = types.ModuleType("comfy.model_management")
+        model_management.unload_model_and_clones = unload
+        comfy.model_management = model_management
+        with (
+            patch.dict(
+                sys.modules,
+                {"comfy": comfy, "comfy.model_management": model_management},
+            ),
+            patch.object(nodes.logger, "debug") as debug,
+        ):
+            model_preparation._cleanup_aio_ephemeral_model(model)
+
+        debug.assert_called_once()
+        self.assertIn("failed to unload ephemeral AiO model clone", debug.call_args.args[0])
+
+    def test_spectrum_aggregate_re_resolves_root_subcalls_in_order(self):
+        trace: list[tuple[str, object]] = []
+        replacement_forecast = Mock(
+            side_effect=lambda model, _settings: trace.append(("forecast", model))
+            or "forecast"
+        )
+
+        def apply_correction(model, _clip, _positive, _settings):
+            trace.append(("correction", model))
+            nodes._apply_aio_spectrum_forecast_patch_for_comfy_sampler = (
+                replacement_forecast
+            )
+            return "corrected"
+
+        stale_forecast = Mock(return_value="stale")
+        with (
+            patch.object(
+                nodes,
+                "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+                side_effect=apply_correction,
+            ),
+            patch.object(
+                nodes,
+                "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+                stale_forecast,
+            ),
+        ):
+            result = (
+                model_preparation._apply_aio_spectrum_model_patches_for_comfy_sampler(
+                    "base", "clip", "positive", {}
+                )
+            )
+
+        self.assertEqual(result, "forecast")
+        self.assertEqual(trace, [("correction", "base"), ("forecast", "corrected")])
+        stale_forecast.assert_not_called()
+
+    def test_disabled_spectrum_variants_preserve_model_identity(self):
+        model = object()
+        with (
+            patch.object(nodes, "_require_custom_node_class") as require_correction,
+            patch.object(nodes, "_require_any_custom_node_class") as require_forecast,
+        ):
+            self.assertIs(
+                model_preparation._apply_aio_spectrum_correction_patch_for_comfy_sampler(
+                    model, "clip", "positive", {"dit_corrections": []}
+                ),
+                model,
+            )
+            self.assertIs(
+                model_preparation._apply_aio_spectrum_forecast_patch_for_comfy_sampler(
+                    model, {"spectrum": {"enabled": False}}
+                ),
+                model,
+            )
+
+        require_correction.assert_not_called()
+        require_forecast.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "a0935a57fc324743d81ab0ecb97907dc25e01b75")
-        # Issue #184 B-08b1 preserves the root AiO facade while moving model and
-        # USDU conditioning helpers behind direct aliases and runtime bindings.
-        self.assertEqual(report["top_level"]["function_count"], 75)
+        self.assertEqual(report["git_blob_sha1"], "442e1a864ccfcc73c515cb15bd5e821511442f64")
+        # Issue #184 B-08b2 preserves the root AiO facade while moving Spectrum
+        # model variants and ephemeral cleanup behind direct aliases.
+        self.assertEqual(report["top_level"]["function_count"], 71)
         self.assertEqual(report["top_level"]["class_count"], 4)
-        self.assertEqual(report["line_count"], 4_112)
+        self.assertEqual(report["line_count"], 3_985)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaPromptStudioAdvanced", class_names)


### PR DESCRIPTION
## 작업 단위

- Task: B-08b2 — AiO Spectrum model variants / ephemeral cleanup Move
- Owner: #184
- 분류: **Move**
- Base: `dev` / `60678e36cffc1f566423aae51a7075bb0bcfdcfd`
- 상태: Ready
- Exact head: `db0e62e591aa6d0dc97a290adec94cf87b14d94c`

## 작업 전 symbol / caller / alias / global-state inventory

### ephemeral model cleanup

- `_cleanup_aio_ephemeral_model` (`nodes.py:2032`)
  - callers: highres, USDU upscale, detailer target, 최종 generator cleanup
  - dependencies: model `detach(unpatch_all=False)`, lazy `comfy.model_management.unload_model_and_clones`, root `logger.debug`
  - identity contract: `None` 또는 `base_model`과 동일한 객체면 아무 작업도 하지 않습니다.
  - fallback contract: detach가 성공하면 즉시 종료하고, 없거나 실패한 경우에만 Comfy unload를 시도합니다. cleanup 오류는 debug log 후 삼킵니다.

### Spectrum correction / forecast model variants

- `_apply_aio_spectrum_correction_patch_for_comfy_sampler` (`nodes.py:2053`)
  - only direct caller: aggregate helper
  - dependencies: `_require_custom_node_class`, `_node_output_tuple`, `_as_bool`, `_as_float`, `_as_int`
  - provider/node: `DiTCFGFSGPatch` / ComfyUI-Spectrum-KSampler
- `_apply_aio_spectrum_forecast_patch_for_comfy_sampler` (`nodes.py:2104`)
  - only direct caller: aggregate helper
  - dependencies: `_require_any_custom_node_class`, `_call_with_supported_kwargs`, `_node_output_tuple`, coercion helpers
  - provider/node fallback order: `DiTSpectrumPatchAdvanced` → `DiTSpectrumPatch`
- `_apply_aio_spectrum_model_patches_for_comfy_sampler` (`nodes.py:2149`)
  - callers: base sampler, highres, USDU upscale, detailer target
  - order: correction 결과를 forecast 입력으로 직렬 전달

### canonical owner / compatibility seam

- 기존 `easyuse_anima/aio/model_preparation.py`가 네 helper를 추가로 소유합니다. 기존 284 LOC에서 예상 약 418 LOC로 유지되어 신규 module 분리 없이 B-08b의 model preparation/variant lifecycle 책임에 응집됩니다.
- root의 네 private 이름은 direct identity alias로 유지해 기존 stage/generator caller와 `patch.object(nodes, ...)` seam을 보존합니다.
- canonical module은 root `nodes.py`를 import하지 않고 B-08b1의 좁은 call-time runtime resolver를 재사용합니다.
- aggregate helper는 correction/forecast root 이름을 실제 호출 직전에 각각 다시 조회합니다.
- cleanup의 logger와 Comfy/custom-node adapter/coercion helper도 필요한 시점에 root resolver로 조회하며 optional provider lookup 시점을 앞당기지 않습니다.

### mutable/global state

- 신규 global state는 추가하지 않고 기존 model-preparation runtime resolver slot을 재사용합니다.
- MODEL clone, provider instance, cache, registry 또는 cleanup queue를 저장하는 신규 global state는 추가하지 않습니다.
- cleanup 호출 위치, `try/finally`, identity de-duplication과 lifecycle 순서는 root caller에 그대로 둡니다.

## 동작·호환 계약

- correction disabled/non-dict, forecast disabled/non-dict일 때 원본 model identity를 반환합니다.
- correction → forecast 순서와 모든 node ID, 기본값, 인자/keyword 모양, legacy signature filtering, 오류문을 보존합니다.
- optional Spectrum provider와 `comfy.model_management`는 기존과 같은 실행 경로에서만 lazy 조회합니다.
- detach 성공 우선, unload fallback, cleanup 예외 억제 및 debug logging을 보존합니다.
- public node/workflow, sampler dispatch, seed, stage order, cache, save/metadata 동작은 바꾸지 않습니다.

## allowed-file boundary

### production

- `nodes.py`
- `easyuse_anima/aio/model_preparation.py`

### tests / analyzer / docs (필요한 항목만)

- `tests/test_aio_model_preparation.py`
- `tests/test_aio_nodes.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_backend_analyzer.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 범위

- B-08c sampler backend dispatch, latent/VAE invocation 이동
- B-08d preview/save/output metadata 이동 또는 변경
- B-08e first-pass cache key/clone/eviction 이동 또는 정책 변경
- B-09 generator/stage orchestration, Mod Guidance closures 또는 public node 이동
- Spectrum/cleanup 설정, 기본값, provider requirement, 모델 identity, cleanup 호출 위치·순서 변경
- 신규 retry/cleanup queue, eager dependency import, lifecycle policy 추가
- generation schema/default/migration 또는 #169 behavior 변경

## 검증 결과

- focused unittest: 109 passed
  - model-preparation direct identity, Spectrum correction→forecast order/call-time lookup, cleanup detach/unload fallback
  - 기존 AiO Spectrum/stage/generator lifecycle와 analyzer/package/scanner 계약
- targeted compile: 3개 파일 통과
- targeted Pyright 1.1.411: 0 diagnostics
- targeted Ruff 0.15.22: 통과
- G-03a import boundary: 6 completed package groups, 0 violations
- 독립 final diff review: P0-P2 없음
- exact-head official full:
  - Python unittest: 817 passed
  - frontend: 114 JavaScript files, TypeScript 6.0.3 통과
  - Pyright baseline ratchet, G-03a, analyzer/package/Registry, `git diff --check`: 통과
  - Ruff: 기존 G-01 report-only 105건, blocking 아님
- 실제 optional Spectrum provider 성공 경로와 live ComfyUI smoke는 미실행이며 fake-node parity로 이동 동등성을 검증했습니다.

## 롤백 경계

- 기존 model-preparation module의 네 helper 추가, root imports와 네 원본 helper 이동, 대응 fixtures/tests/docs만 되돌리면 기존 root 구현으로 복귀합니다.

구현, focused 검증, 독립 diff review와 exact-head full gate를 완료했습니다.

Closes no issue; #184 B-08b2 완료 기록만 추가합니다.
