### PR TITLE
refactor(aio): move input adapter node (B-09a)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-22
 - Snapshot branch: `dev`
-- Snapshot commit: `9827dab527d1346ce8fc8aad28e6cd903fde36a9`
+- Snapshot commit: `d2594118607b3d1c2decaa37b96b57c51fe2c1f4`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | State at the snapshot | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | In progress through B-08e | Continue B-09 AiO extraction, compatibility audit, registration/bootstrap, final root shim |
+| B - `nodes.py` extraction | In progress through B-09a | Continue B-09b AiO extraction, compatibility audit, registration/bootstrap, final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,11 +42,11 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- At the B-08e snapshot, root `nodes.py` is 3,222 lines.
-- The mechanical extraction has therefore removed 9,441 lines, approximately
-  74.6% of the baseline, while preserving the root compatibility surface.
-- B-01 through B-08e are integrated. The latest completed slice is the current
-  AiO first-pass cache Move in PR #265.
+- At the B-09a snapshot, root `nodes.py` is 3,122 lines.
+- The mechanical extraction has therefore removed 9,541 lines, approximately
+  75.3% of the baseline, while preserving the root compatibility surface.
+- B-01 through B-08e are integrated. The latest completed implementation slice
+  is the AiO input-adapter Move in PR #268.
 - Root `nodes.py` still owns substantial AiO implementation.
 - Root `__init__.py` still imports `api.py` for route-registration side effects,
   initializes the wildcard directory during package import, and owns mapping
@@ -287,15 +287,16 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 6 | G-03a completed-package import boundary fail gate | COMPLETE on `dev` | Contract/gate | #188 | PR #258 / six reviewed zero-violation prefixes enrolled |
 | 7 | C168-06 normalizer ownership move | COMPLETE on `dev` | Move | #168/#184 | PR #257 / `3ca5500` |
 | 8 | B-08a through B-08e AiO support-helper extraction | COMPLETE on `dev` | Move | #184 | B-08a PR #259; B-08b1 PR #260; B-08b2 PR #261; B-08c PR #262; B-08d1 PR #263; B-08d2 PR #264; B-08e PR #265 |
-| 9 | B-09a/B-09b AiO node and legacy orchestration move | READY/SEQUENTIAL | Move | #184 | AiO helpers canonical through B-08e |
-| 10 | B-10 compatibility/private-alias audit | BLOCKED by B-09 | Contract/cleanup, split PRs | #184/#188 | All node implementations canonical |
-| 11 | B-11 registration/bootstrap/root shim | BLOCKED by B-10 | Move | #184 | Alias surface frozen |
-| 12 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
-| 13 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 14 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
-| 15 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
-| 16 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
-| 17 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
+| 9 | B-09a AiO input adapter move | COMPLETE in PR #268 | Move | #184 | AiO helpers canonical through B-08e |
+| 10 | B-09b AiO generator and legacy orchestration move | READY | Move | #184 | B-09a implementation complete |
+| 11 | B-10 compatibility/private-alias audit | BLOCKED by B-09b | Contract/cleanup, split PRs | #184/#188 | All node implementations canonical |
+| 12 | B-11 registration/bootstrap/root shim | BLOCKED by B-10 | Move | #184 | Alias surface frozen |
+| 13 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
+| 14 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
+| 15 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
+| 16 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
+| 17 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
+| 18 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
 Issue #199, authenticated diagnostics/settings access, is an independent security
 track. It may proceed when its threat model and owner are ready, but it does not
@@ -531,6 +532,14 @@ Move the public class to `easyuse_anima/nodes/aio_nodes.py` after #168 owns the
 config boundary. Preserve class identity, input order/defaults, hidden inputs,
 outputs, workflow serialization, and existing runtime lookup behavior. The
 adapter must delegate typed normalization instead of re-owning schema logic.
+
+B-09a is complete in PR #268. The canonical public adapter now lives in
+`easyuse_anima.nodes.aio_nodes`; root package and direct-import modes bind the
+same class object. Its ComfyUI contract keeps the local import-time socket
+literal while resolving resource candidates, normalizers, schema/version
+constants, change-key helpers, and copy helpers from the root compatibility
+runtime at call time. Input order/defaults, serialized context shape, copy
+boundaries, and helper evaluation order remain unchanged.
 
 ### B-09b — `EasyUseAnimaAIOGenerator` and legacy orchestration move
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -163,6 +163,13 @@ EasyUseAnimaWildcard
   surfaces through the B-10 compatibility audit and are not added to public
   package `__all__`. The shared root `_aio_lora_stack_signature` is not part of
   this move; the canonical cache key resolves it at call time.
+- B-09a public AiO input-adapter transition: `EasyUseAnimaInput` moves to
+  `easyuse_anima.nodes.aio_nodes` and remains a direct root alias, so direct
+  imports and the package `NODE_CLASS_MAPPINGS` entry retain class identity.
+  The canonical module publicly exports only `EasyUseAnimaInput` through
+  `__all__`; its narrow call-time runtime seam preserves root monkeypatches for
+  resource candidates, normalization, stable change keys, schema/version
+  values, and prompt-data copying. The adapter does not import `nodes.py`.
 - Removal gate: 0.5.2 node/workflow fixture, mapping identity, direct import,
   Registry archive closure, consumer evidence, separate breaking-change issue,
   and release note. With no external-consumer evidence, retain these exports.

--- a/easyuse_anima/nodes/aio_nodes.py
+++ b/easyuse_anima/nodes/aio_nodes.py
@@ -1,0 +1,156 @@
+"""ComfyUI adapters for the AiO input context."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+_RuntimeResolver: TypeAlias = Callable[[str], Any]
+_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+
+
+def _bind_aio_node_runtime(*, resolve_helper: _RuntimeResolver) -> None:
+    """Bind root compatibility helpers without importing the root module."""
+
+    global _RUNTIME_RESOLVER
+    _RUNTIME_RESOLVER = resolve_helper
+
+
+def _runtime_helper(name: str) -> Any:
+    resolver = _RUNTIME_RESOLVER
+    if resolver is None:
+        raise RuntimeError(
+            f"[EasyUseAnima] AiO node runtime helper is not bound: {name}"
+        )
+    return resolver(name)
+
+
+class EasyUseAnimaInput:
+    """Bundle prompt data and resource loader settings for the AiO generator."""
+
+    DESCRIPTION = (
+        "Receives EASYUSE_ANIMA_PROMPT_DATA and selected ANIMA resource names, then returns "
+        "one dedicated easy use anima input context. The context stores only serializable "
+        "prompt/resource data; the AiO Generator loads MODEL, CLIP, and VAE at execution "
+        "time so model patches and Torch compile do not live inside a custom dict socket."
+    )
+    OUTPUT_TOOLTIPS = (
+        "Dedicated context containing prompt data, resource metadata, and versioned loader settings.",
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        unet_names = _runtime_helper("_comfy_diffusion_model_names")()
+        vae_names = _runtime_helper("_comfy_vae_names")()
+        clip_names = _runtime_helper("_comfy_text_encoder_names")()
+        clip_types = _runtime_helper("_comfy_clip_loader_types")()
+        return {
+            "required": {
+                _runtime_helper("PROMPT_DATA_TYPE"): (_runtime_helper("PROMPT_DATA_TYPE"), {
+                    "forceInput": True,
+                    "tooltip": "Structured prompt data from Anima Prompt Studio Advanced v2.",
+                }),
+                "unet_name": (unet_names, {
+                    "default": _runtime_helper("_preferred_name_default")(
+                        unet_names,
+                        _runtime_helper("ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES"),
+                    ),
+                    "tooltip": "ANIMA diffusion model loaded with ComfyUI UNETLoader.",
+                }),
+                "vae_name": (vae_names, {
+                    "default": _runtime_helper("_preferred_name_default")(
+                        vae_names,
+                        _runtime_helper("ANIMA_DEFAULT_VAE_CANDIDATES"),
+                    ),
+                    "tooltip": "VAE loaded with ComfyUI VAELoader.",
+                }),
+                "clip_name": (clip_names, {
+                    "default": _runtime_helper("_preferred_name_default")(
+                        clip_names,
+                        _runtime_helper("ANIMA_DEFAULT_CLIP_CANDIDATES"),
+                    ),
+                    "tooltip": "Text encoder loaded with ComfyUI CLIPLoader.",
+                }),
+                "clip_type": (clip_types, {
+                    "default": _runtime_helper("_preferred_clip_type_default")(clip_types),
+                    "tooltip": "ComfyUI CLIPLoader type. Core ANIMA uses qwen_image.",
+                }),
+                "input_settings": ("STRING", {
+                    "multiline": True,
+                    "default": _runtime_helper("_aio_input_settings_json")(),
+                    "hidden": True,
+                    "tooltip": "Hidden versioned JSON storage for future resource settings. Kept serialized for workflow compatibility.",
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("EASY_USE_ANIMA_INPUT",)
+    RETURN_NAMES = ("easy use anima input",)
+    FUNCTION = "build"
+    CATEGORY = "EasyUse Anima/AiO"
+
+    @classmethod
+    def IS_CHANGED(
+        cls,
+        EASYUSE_ANIMA_PROMPT_DATA: str | dict | None = None,
+        unet_name: str = "",
+        vae_name: str = "",
+        clip_name: str = "",
+        clip_type: str = "",
+        input_settings: str | dict | None = None,
+        **kwargs,
+    ):
+        return _runtime_helper("_stable_change_key")({
+            "mode": "easy_use_anima_input",
+            "prompt_data": _runtime_helper("_prompt_data_json_safe")(
+                _runtime_helper("_normalize_prompt_data")(
+                    EASYUSE_ANIMA_PROMPT_DATA
+                )
+            ),
+            "unet_name": str(unet_name or ""),
+            "vae_name": str(vae_name or ""),
+            "clip_name": str(clip_name or ""),
+            "clip_type": str(clip_type or ""),
+            "input_settings": _runtime_helper("_normalize_aio_input_settings")(
+                input_settings
+            ),
+        })
+
+    def build(
+        self,
+        EASYUSE_ANIMA_PROMPT_DATA: str | dict,
+        unet_name: str,
+        vae_name: str,
+        clip_name: str,
+        clip_type: str = "qwen_image",
+        input_settings: str | dict | None = None,
+    ):
+        settings = _runtime_helper("_normalize_aio_input_settings")(input_settings)
+        prompt_data = _runtime_helper("_copy_prompt_data_for_update")(
+            EASYUSE_ANIMA_PROMPT_DATA
+        )
+        resources = settings.get("resources", {})
+        resource_info = {
+            "loader_mode": "split",
+            "unet_name": str(unet_name),
+            "vae_name": str(vae_name),
+            "clip_name": str(clip_name),
+            "clip_type": str(clip_type or "qwen_image"),
+            "unet_weight_dtype": str(resources.get("unet_weight_dtype") or "default"),
+            "clip_device": str(resources.get("clip_device") or "default"),
+        }
+        prompt_data["easy_use_anima_input"] = {
+            "schema": _runtime_helper("EASY_USE_ANIMA_INPUT_SCHEMA"),
+            "version": _runtime_helper("EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"),
+            "resource_info": dict(resource_info),
+        }
+        return ({
+            "schema": _runtime_helper("EASY_USE_ANIMA_INPUT_SCHEMA"),
+            "version": _runtime_helper("EASY_USE_ANIMA_INPUT_SETTINGS_VERSION"),
+            "prompt_data": prompt_data,
+            "resource_info": resource_info,
+            "input_settings": settings,
+        },)
+
+
+__all__ = ("EasyUseAnimaInput",)

--- a/nodes.py
+++ b/nodes.py
@@ -319,6 +319,10 @@ try:
         EasyUseAnimaPromptStudioExtend as EasyUseAnimaPromptStudioExtend,
         _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
     )
+    from .easyuse_anima.nodes.aio_nodes import (
+        EasyUseAnimaInput as EasyUseAnimaInput,
+        _bind_aio_node_runtime as _bind_aio_node_runtime,
+    )
     from .easyuse_anima.image.geometry import (
         _align_down as _align_down,
         _align_nearest as _align_nearest,
@@ -820,6 +824,10 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaPromptStudioAdvancedV2 as EasyUseAnimaPromptStudioAdvancedV2,
         EasyUseAnimaPromptStudioExtend as EasyUseAnimaPromptStudioExtend,
         _bind_prompt_advanced_node_runtime as _bind_prompt_advanced_node_runtime,
+    )
+    from easyuse_anima.nodes.aio_nodes import (
+        EasyUseAnimaInput as EasyUseAnimaInput,
+        _bind_aio_node_runtime as _bind_aio_node_runtime,
     )
     from easyuse_anima.image.geometry import (
         _align_down as _align_down,
@@ -2636,6 +2644,9 @@ _bind_prompt_advanced_node_runtime(
     resolve_helper=lambda name: globals()[name],
     flexible_optional_input_type=_FlexibleOptionalInputType,
 )
+_bind_aio_node_runtime(
+    resolve_helper=lambda name: globals()[name],
+)
 _bind_conditioning_runtime(
     resolve_helper=lambda name: globals()[name],
     resolve_logger=lambda: logger,
@@ -2706,117 +2717,6 @@ def _require_easy_use_anima_input(value) -> dict[str, Any]:
             + ", ".join(missing)
         )
     return value
-
-
-class EasyUseAnimaInput:
-    """Bundle prompt data and resource loader settings for the AiO generator."""
-
-    DESCRIPTION = (
-        "Receives EASYUSE_ANIMA_PROMPT_DATA and selected ANIMA resource names, then returns "
-        "one dedicated easy use anima input context. The context stores only serializable "
-        "prompt/resource data; the AiO Generator loads MODEL, CLIP, and VAE at execution "
-        "time so model patches and Torch compile do not live inside a custom dict socket."
-    )
-    OUTPUT_TOOLTIPS = (
-        "Dedicated context containing prompt data, resource metadata, and versioned loader settings.",
-    )
-
-    @classmethod
-    def INPUT_TYPES(cls):
-        unet_names = _comfy_diffusion_model_names()
-        vae_names = _comfy_vae_names()
-        clip_names = _comfy_text_encoder_names()
-        clip_types = _comfy_clip_loader_types()
-        return {
-            "required": {
-                PROMPT_DATA_TYPE: (PROMPT_DATA_TYPE, {
-                    "forceInput": True,
-                    "tooltip": "Structured prompt data from Anima Prompt Studio Advanced v2.",
-                }),
-                "unet_name": (unet_names, {
-                    "default": _preferred_name_default(unet_names, ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES),
-                    "tooltip": "ANIMA diffusion model loaded with ComfyUI UNETLoader.",
-                }),
-                "vae_name": (vae_names, {
-                    "default": _preferred_name_default(vae_names, ANIMA_DEFAULT_VAE_CANDIDATES),
-                    "tooltip": "VAE loaded with ComfyUI VAELoader.",
-                }),
-                "clip_name": (clip_names, {
-                    "default": _preferred_name_default(clip_names, ANIMA_DEFAULT_CLIP_CANDIDATES),
-                    "tooltip": "Text encoder loaded with ComfyUI CLIPLoader.",
-                }),
-                "clip_type": (clip_types, {
-                    "default": _preferred_clip_type_default(clip_types),
-                    "tooltip": "ComfyUI CLIPLoader type. Core ANIMA uses qwen_image.",
-                }),
-                "input_settings": ("STRING", {
-                    "multiline": True,
-                    "default": _aio_input_settings_json(),
-                    "hidden": True,
-                    "tooltip": "Hidden versioned JSON storage for future resource settings. Kept serialized for workflow compatibility.",
-                }),
-            },
-        }
-
-    RETURN_TYPES = (EASY_USE_ANIMA_INPUT_TYPE,)
-    RETURN_NAMES = ("easy use anima input",)
-    FUNCTION = "build"
-    CATEGORY = "EasyUse Anima/AiO"
-
-    @classmethod
-    def IS_CHANGED(
-        cls,
-        EASYUSE_ANIMA_PROMPT_DATA: str | dict | None = None,
-        unet_name: str = "",
-        vae_name: str = "",
-        clip_name: str = "",
-        clip_type: str = "",
-        input_settings: str | dict | None = None,
-        **kwargs,
-    ):
-        return _stable_change_key({
-            "mode": "easy_use_anima_input",
-            "prompt_data": _prompt_data_json_safe(_normalize_prompt_data(EASYUSE_ANIMA_PROMPT_DATA)),
-            "unet_name": str(unet_name or ""),
-            "vae_name": str(vae_name or ""),
-            "clip_name": str(clip_name or ""),
-            "clip_type": str(clip_type or ""),
-            "input_settings": _normalize_aio_input_settings(input_settings),
-        })
-
-    def build(
-        self,
-        EASYUSE_ANIMA_PROMPT_DATA: str | dict,
-        unet_name: str,
-        vae_name: str,
-        clip_name: str,
-        clip_type: str = "qwen_image",
-        input_settings: str | dict | None = None,
-    ):
-        settings = _normalize_aio_input_settings(input_settings)
-        prompt_data = _copy_prompt_data_for_update(EASYUSE_ANIMA_PROMPT_DATA)
-        resources = settings.get("resources", {})
-        resource_info = {
-            "loader_mode": "split",
-            "unet_name": str(unet_name),
-            "vae_name": str(vae_name),
-            "clip_name": str(clip_name),
-            "clip_type": str(clip_type or "qwen_image"),
-            "unet_weight_dtype": str(resources.get("unet_weight_dtype") or "default"),
-            "clip_device": str(resources.get("clip_device") or "default"),
-        }
-        prompt_data["easy_use_anima_input"] = {
-            "schema": EASY_USE_ANIMA_INPUT_SCHEMA,
-            "version": EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
-            "resource_info": dict(resource_info),
-        }
-        return ({
-            "schema": EASY_USE_ANIMA_INPUT_SCHEMA,
-            "version": EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
-            "prompt_data": prompt_data,
-            "resource_info": resource_info,
-            "input_settings": settings,
-        },)
 
 
 class EasyUseAnimaAIOGenerator:

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8233,6 +8233,74 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/nodes/image_nodes.py"
       },
       {
@@ -21905,6 +21973,68 @@
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
       },
       {
+        "alias": "EasyUseAnimaInput",
+        "bound_name": "EasyUseAnimaInput",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaInput",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
+        "kind": "static_from",
+        "line": 322,
+        "name": "EasyUseAnimaInput",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_bind_aio_node_runtime",
+        "bound_name": "_bind_aio_node_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_node_runtime",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
+        "kind": "static_from",
+        "line": 322,
+        "name": "_bind_aio_node_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
         "alias": "_align_down",
         "bound_name": "_align_down",
         "branch_context": [
@@ -21926,7 +22056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 322,
+        "line": 326,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21957,7 +22087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 322,
+        "line": 326,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21988,7 +22118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 322,
+        "line": 326,
         "name": "_align_up",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22019,7 +22149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 322,
+        "line": 326,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22050,7 +22180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 322,
+        "line": 326,
         "name": "_alignment_value",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22081,7 +22211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 329,
+        "line": 333,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": ".easyuse_anima.image.detailer",
@@ -22112,7 +22242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22143,7 +22273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22174,7 +22304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22205,7 +22335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22236,7 +22366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22267,7 +22397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22298,7 +22428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22329,7 +22459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22360,7 +22490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22391,7 +22521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22422,7 +22552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 332,
+        "line": 336,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22453,7 +22583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 345,
+        "line": 349,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22484,7 +22614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 345,
+        "line": 349,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22515,7 +22645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 345,
+        "line": 349,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22546,7 +22676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 345,
+        "line": 349,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22577,7 +22707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 345,
+        "line": 349,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22608,7 +22738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 345,
+        "line": 349,
         "name": "_scale_by_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22639,7 +22769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22670,7 +22800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22701,7 +22831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22732,7 +22862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22763,7 +22893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22794,7 +22924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_impact_core_module",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22825,7 +22955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22856,7 +22986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22887,7 +23017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 353,
+        "line": 357,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22918,7 +23048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 364,
+        "line": 368,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22949,7 +23079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 364,
+        "line": 368,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22980,7 +23110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 364,
+        "line": 368,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23011,7 +23141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 364,
+        "line": 368,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23042,7 +23172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 374,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23073,7 +23203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 370,
+        "line": 374,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23104,7 +23234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 374,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23135,7 +23265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 374,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23166,7 +23296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 374,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23197,7 +23327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 370,
+        "line": 374,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23228,7 +23358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 378,
+        "line": 382,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23259,7 +23389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 378,
+        "line": 382,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23290,7 +23420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 382,
+        "line": 386,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -23321,7 +23451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 382,
+        "line": 386,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -23352,7 +23482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 386,
+        "line": 390,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23383,7 +23513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 386,
+        "line": 390,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23414,7 +23544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 386,
+        "line": 390,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23445,7 +23575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 391,
+        "line": 395,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23476,7 +23606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 391,
+        "line": 395,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23507,7 +23637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 391,
+        "line": 395,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23538,7 +23668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 391,
+        "line": 395,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23569,7 +23699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 391,
+        "line": 395,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23600,7 +23730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 398,
+        "line": 402,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23631,7 +23761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 398,
+        "line": 402,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23662,7 +23792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 398,
+        "line": 402,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23693,7 +23823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23724,7 +23854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23755,7 +23885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23786,7 +23916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23817,7 +23947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23848,7 +23978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23879,7 +24009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23910,7 +24040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "NAI_1MP",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23941,7 +24071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23972,7 +24102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24003,7 +24133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24034,7 +24164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_clean_prompt",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24065,7 +24195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24096,7 +24226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24127,7 +24257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24158,7 +24288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 403,
+        "line": 407,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24189,7 +24319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24220,7 +24350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24251,7 +24381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24282,7 +24412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24313,7 +24443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24344,7 +24474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24375,7 +24505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24406,7 +24536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24437,7 +24567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24468,7 +24598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24499,7 +24629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24530,7 +24660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24561,7 +24691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24592,7 +24722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24623,7 +24753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24654,7 +24784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24685,7 +24815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24716,7 +24846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24747,7 +24877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24778,7 +24908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24809,7 +24939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 421,
+        "line": 425,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24840,7 +24970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 444,
+        "line": 448,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -24871,7 +25001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 444,
+        "line": 448,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -24902,7 +25032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 448,
+        "line": 452,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -24933,7 +25063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 448,
+        "line": 452,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -24964,7 +25094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 448,
+        "line": 452,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -24995,7 +25125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25026,7 +25156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25057,7 +25187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25088,7 +25218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25119,7 +25249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25150,7 +25280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25181,7 +25311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25212,7 +25342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25243,7 +25373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25274,7 +25404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25305,7 +25435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25336,7 +25466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25367,7 +25497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25398,7 +25528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25429,7 +25559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 453,
+        "line": 457,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25460,7 +25590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25491,7 +25621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25522,7 +25652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25553,7 +25683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25584,7 +25714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25615,7 +25745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25646,7 +25776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25677,7 +25807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 470,
+        "line": 474,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25708,7 +25838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 480,
+        "line": 484,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -25739,7 +25869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 480,
+        "line": 484,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -25770,7 +25900,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 484,
+        "line": 488,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -25801,7 +25931,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 484,
+        "line": 488,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -25832,7 +25962,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 485,
+        "line": 489,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -25863,7 +25993,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 486,
+        "line": 490,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -25894,7 +26024,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 486,
+        "line": 490,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -25925,7 +26055,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 486,
+        "line": 490,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -25956,7 +26086,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 491,
+        "line": 495,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -25987,7 +26117,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 491,
+        "line": 495,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26018,7 +26148,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26049,7 +26179,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26080,7 +26210,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26111,7 +26241,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26142,7 +26272,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26173,7 +26303,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26204,7 +26334,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26235,7 +26365,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26266,7 +26396,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26297,7 +26427,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26328,7 +26458,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26359,7 +26489,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26390,7 +26520,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26421,7 +26551,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26452,7 +26582,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26483,7 +26613,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26514,7 +26644,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26545,7 +26675,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26576,7 +26706,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 492,
+        "line": 496,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26595,7 +26725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26610,7 +26740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26629,7 +26759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26644,7 +26774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26663,7 +26793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26678,7 +26808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26697,7 +26827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26712,7 +26842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26731,7 +26861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26746,7 +26876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26765,7 +26895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26780,7 +26910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_clear_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26799,7 +26929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26814,7 +26944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26833,7 +26963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26848,7 +26978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26867,7 +26997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26882,7 +27012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26901,7 +27031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26916,7 +27046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26935,7 +27065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26950,7 +27080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26969,7 +27099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -26984,7 +27114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27003,7 +27133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27018,7 +27148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 530,
+        "line": 534,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -27037,7 +27167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27052,7 +27182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27071,7 +27201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27086,7 +27216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27105,7 +27235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27120,7 +27250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27139,7 +27269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27154,7 +27284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27173,7 +27303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27188,7 +27318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27207,7 +27337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27222,7 +27352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27241,7 +27371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27256,7 +27386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27275,7 +27405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27290,7 +27420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27309,7 +27439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27324,7 +27454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27343,7 +27473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27358,7 +27488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27377,7 +27507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27392,7 +27522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27411,7 +27541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27426,7 +27556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27445,7 +27575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27460,7 +27590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27479,7 +27609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27494,7 +27624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27513,7 +27643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27528,7 +27658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27547,7 +27677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27562,7 +27692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27581,7 +27711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27596,7 +27726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27615,7 +27745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27630,7 +27760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27649,7 +27779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27664,7 +27794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27683,7 +27813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27698,7 +27828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27717,7 +27847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27732,7 +27862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27751,7 +27881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27766,7 +27896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27785,7 +27915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27800,7 +27930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27819,7 +27949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27834,7 +27964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27853,7 +27983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27868,7 +27998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27887,7 +28017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27902,7 +28032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27921,7 +28051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27936,7 +28066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27955,7 +28085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -27970,7 +28100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27989,7 +28119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28004,7 +28134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28023,7 +28153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28038,7 +28168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28057,7 +28187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28072,7 +28202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28091,7 +28221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28106,7 +28236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28125,7 +28255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28140,7 +28270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28159,7 +28289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28174,7 +28304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28193,7 +28323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28208,7 +28338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28227,7 +28357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28242,7 +28372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28261,7 +28391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28276,7 +28406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28295,7 +28425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28310,7 +28440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28329,7 +28459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28344,7 +28474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28363,7 +28493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28378,7 +28508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28397,7 +28527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28412,7 +28542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28431,7 +28561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28446,7 +28576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28465,7 +28595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28480,7 +28610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28499,7 +28629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28514,7 +28644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28533,7 +28663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28548,7 +28678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28567,7 +28697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28582,7 +28712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28601,7 +28731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28616,7 +28746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28635,7 +28765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28650,7 +28780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28669,7 +28799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28684,7 +28814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28703,7 +28833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28718,7 +28848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28737,7 +28867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28752,7 +28882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28771,7 +28901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28786,7 +28916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28805,7 +28935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28820,7 +28950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28839,7 +28969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28854,7 +28984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28873,7 +29003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28888,7 +29018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28907,7 +29037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28922,7 +29052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28941,7 +29071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28956,7 +29086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28975,7 +29105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -28990,7 +29120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 602,
+        "line": 606,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29009,7 +29139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29024,7 +29154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 602,
+        "line": 606,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29043,7 +29173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29058,7 +29188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 602,
+        "line": 606,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29077,7 +29207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29092,7 +29222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29111,7 +29241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29126,7 +29256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29145,7 +29275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29160,7 +29290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29179,7 +29309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29194,7 +29324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29213,7 +29343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29228,7 +29358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29247,7 +29377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29262,7 +29392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29281,7 +29411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29296,7 +29426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29315,7 +29445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29330,7 +29460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29349,7 +29479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29364,7 +29494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29383,7 +29513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29398,7 +29528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29417,7 +29547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29432,7 +29562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29451,7 +29581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29466,7 +29596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29485,7 +29615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29500,7 +29630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29519,7 +29649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29534,7 +29664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29553,7 +29683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29568,7 +29698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29587,7 +29717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29602,7 +29732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29621,7 +29751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29636,7 +29766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29655,7 +29785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29670,7 +29800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29689,7 +29819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29704,7 +29834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29723,7 +29853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29738,7 +29868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29757,7 +29887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29772,7 +29902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29791,7 +29921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29806,7 +29936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29825,7 +29955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29840,7 +29970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29859,7 +29989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29874,7 +30004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29893,7 +30023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29908,7 +30038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29927,7 +30057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29942,7 +30072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29961,7 +30091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -29976,7 +30106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29995,7 +30125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30010,7 +30140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30029,7 +30159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30044,7 +30174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30063,7 +30193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30078,7 +30208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30097,7 +30227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30112,7 +30242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30131,7 +30261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30146,7 +30276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30165,7 +30295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30180,7 +30310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30199,7 +30329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30214,7 +30344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30233,7 +30363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30248,7 +30378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30267,7 +30397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30282,7 +30412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30301,7 +30431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30316,7 +30446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30335,7 +30465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30350,7 +30480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30369,7 +30499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30384,7 +30514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "ADVANCED_FIELD_LABELS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30403,7 +30533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30418,7 +30548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "ADVANCED_FIELD_PANES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30437,7 +30567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30452,7 +30582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "ADVANCED_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30471,7 +30601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30486,7 +30616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "EXTEND_PROMPT_SLOT_SPECS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30505,7 +30635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30520,7 +30650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30539,7 +30669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30554,7 +30684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30573,7 +30703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30588,7 +30718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30607,7 +30737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30622,7 +30752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30641,7 +30771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30656,7 +30786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30675,7 +30805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30690,7 +30820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30709,7 +30839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30724,7 +30854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30743,7 +30873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30758,7 +30888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30777,7 +30907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30792,7 +30922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30811,7 +30941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30826,7 +30956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30845,7 +30975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30860,7 +30990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30879,7 +31009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30894,7 +31024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_fields_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30913,7 +31043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30928,7 +31058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30947,7 +31077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30962,7 +31092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_pane_parts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30981,7 +31111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -30996,7 +31126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_prompt_data_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31015,7 +31145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31030,7 +31160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31049,7 +31179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31064,7 +31194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31083,7 +31213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31098,7 +31228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31117,7 +31247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31132,7 +31262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31151,7 +31281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31166,7 +31296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31185,7 +31315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31200,7 +31330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31219,7 +31349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31234,7 +31364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31253,7 +31383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31268,7 +31398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31287,7 +31417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31302,7 +31432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31321,7 +31451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31336,7 +31466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31355,7 +31485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31370,7 +31500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31389,7 +31519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31404,7 +31534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31423,7 +31553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31438,7 +31568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31457,7 +31587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31472,7 +31602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31491,7 +31621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31506,7 +31636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "REGIONAL_CONFIG_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31525,7 +31655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31540,7 +31670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31559,7 +31689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31574,7 +31704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31593,7 +31723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31608,7 +31738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "REGIONAL_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31627,7 +31757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31642,7 +31772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31661,7 +31791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31676,7 +31806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "REGIONAL_PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31695,7 +31825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31710,7 +31840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "REGIONAL_PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31729,7 +31859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31744,7 +31874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31763,7 +31893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31778,7 +31908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31797,7 +31927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31812,7 +31942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31831,7 +31961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31846,7 +31976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31865,7 +31995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31880,7 +32010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31899,7 +32029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31914,7 +32044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_normalize_mask_geometry",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31933,7 +32063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31948,7 +32078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31967,7 +32097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -31982,7 +32112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32001,7 +32131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32016,7 +32146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32035,7 +32165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32050,7 +32180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_normalize_regional_mask",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32069,7 +32199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32084,7 +32214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32103,7 +32233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32118,7 +32248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32137,7 +32267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32152,7 +32282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_default_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32171,7 +32301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32186,7 +32316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32205,7 +32335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32220,7 +32350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32239,7 +32369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32254,7 +32384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32273,7 +32403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32288,7 +32418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32307,7 +32437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32322,7 +32452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32341,7 +32471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32356,7 +32486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32375,7 +32505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32390,7 +32520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32409,7 +32539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32424,7 +32554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32443,7 +32573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32458,7 +32588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32477,7 +32607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32492,7 +32622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32511,7 +32641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32526,7 +32656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32545,7 +32675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32560,7 +32690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32579,7 +32709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32594,7 +32724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32613,7 +32743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32628,7 +32758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32647,7 +32777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32662,7 +32792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32681,7 +32811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32696,7 +32826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32715,7 +32845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32730,7 +32860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32749,7 +32879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32764,7 +32894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32783,7 +32913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32798,7 +32928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32817,7 +32947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32832,7 +32962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32851,7 +32981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32866,7 +32996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32885,7 +33015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32900,7 +33030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32919,7 +33049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32934,7 +33064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32953,7 +33083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -32968,7 +33098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32987,7 +33117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33002,7 +33132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33021,7 +33151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33036,7 +33166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33055,7 +33185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33070,7 +33200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33089,7 +33219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33104,7 +33234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33123,7 +33253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33138,7 +33268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33157,7 +33287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33172,7 +33302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33191,7 +33321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33206,7 +33336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33225,7 +33355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33240,7 +33370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33259,7 +33389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33274,7 +33404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33293,7 +33423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33308,7 +33438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33327,7 +33457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33342,7 +33472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33361,7 +33491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33376,7 +33506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33395,7 +33525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33410,7 +33540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33429,7 +33559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33444,7 +33574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33463,7 +33593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33478,7 +33608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33497,7 +33627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33512,7 +33642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33531,7 +33661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33546,7 +33676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33565,7 +33695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33580,7 +33710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33599,7 +33729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33614,7 +33744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33633,7 +33763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33648,7 +33778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33667,7 +33797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33682,7 +33812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33701,7 +33831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33716,7 +33846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33735,7 +33865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33750,7 +33880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33769,7 +33899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33784,7 +33914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33803,7 +33933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33818,7 +33948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33837,7 +33967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33852,7 +33982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33871,7 +34001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33886,7 +34016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33905,7 +34035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33920,7 +34050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33939,7 +34069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33954,7 +34084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33973,7 +34103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -33988,7 +34118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_group_token",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34007,7 +34137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34022,7 +34152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34041,7 +34171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34056,7 +34186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34075,7 +34205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34090,7 +34220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34109,7 +34239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34124,7 +34254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34143,7 +34273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34158,7 +34288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34177,7 +34307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34192,7 +34322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34211,7 +34341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34226,7 +34356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34245,7 +34375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34260,7 +34390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34279,7 +34409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34294,7 +34424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34313,7 +34443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34328,7 +34458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34347,7 +34477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34362,7 +34492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34381,7 +34511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34396,7 +34526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34415,7 +34545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34430,7 +34560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34449,7 +34579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34464,7 +34594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34483,7 +34613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34498,7 +34628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34517,7 +34647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34532,7 +34662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34551,7 +34681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34566,7 +34696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34585,7 +34715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34600,7 +34730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34619,7 +34749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34634,7 +34764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34653,7 +34783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34668,7 +34798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34687,7 +34817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34702,7 +34832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34721,7 +34851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34736,7 +34866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34755,7 +34885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34770,7 +34900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34789,7 +34919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34804,7 +34934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34823,7 +34953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34838,7 +34968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34857,7 +34987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34872,7 +35002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34891,7 +35021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34906,7 +35036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34925,7 +35055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34940,7 +35070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34959,7 +35089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -34974,7 +35104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34993,7 +35123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35008,7 +35138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35027,7 +35157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35042,7 +35172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35061,7 +35191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35076,7 +35206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35095,7 +35225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35110,7 +35240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35129,7 +35259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35144,7 +35274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35163,7 +35293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35178,7 +35308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35197,7 +35327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35212,7 +35342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35231,7 +35361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35246,7 +35376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35265,7 +35395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35280,7 +35410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35299,7 +35429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35314,7 +35444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35333,7 +35463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35348,7 +35478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35367,7 +35497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35382,7 +35512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35401,7 +35531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35416,7 +35546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35435,7 +35565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35450,7 +35580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35469,7 +35599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35484,7 +35614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35503,7 +35633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35518,7 +35648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35537,7 +35667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35552,7 +35682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35571,7 +35701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35586,7 +35716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35605,7 +35735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35620,7 +35750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35639,7 +35769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35654,7 +35784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35673,7 +35803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35688,7 +35818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35707,7 +35837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35722,7 +35852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "name": "EasyUseAnimaPromptStudioExtend",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35741,7 +35871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35756,7 +35886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35764,6 +35894,74 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/prompt_advanced_nodes.py"
+      },
+      {
+        "alias": "EasyUseAnimaInput",
+        "bound_name": "EasyUseAnimaInput",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 517,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "EasyUseAnimaInput",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
+        "kind": "static_from",
+        "line": 828,
+        "name": "EasyUseAnimaInput",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "alias": "_bind_aio_node_runtime",
+        "bound_name": "_bind_aio_node_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 517,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_node_runtime",
+          "target": "easyuse_anima/nodes/aio_nodes.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
+        "kind": "static_from",
+        "line": 828,
+        "name": "_bind_aio_node_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.nodes.aio_nodes",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
       },
       {
         "alias": "_align_down",
@@ -35775,7 +35973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35790,7 +35988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -35809,7 +36007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35824,7 +36022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -35843,7 +36041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35858,7 +36056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -35877,7 +36075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35892,7 +36090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -35911,7 +36109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35926,7 +36124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -35945,7 +36143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35960,7 +36158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 831,
+        "line": 839,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -35979,7 +36177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -35994,7 +36192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36013,7 +36211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36028,7 +36226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36047,7 +36245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36062,7 +36260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36081,7 +36279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36096,7 +36294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36115,7 +36313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36130,7 +36328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36149,7 +36347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36164,7 +36362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36183,7 +36381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36198,7 +36396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36217,7 +36415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36232,7 +36430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36251,7 +36449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36266,7 +36464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36285,7 +36483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36300,7 +36498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36319,7 +36517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36334,7 +36532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36353,7 +36551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36368,7 +36566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36387,7 +36585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36402,7 +36600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36421,7 +36619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36436,7 +36634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36455,7 +36653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36470,7 +36668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36489,7 +36687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36504,7 +36702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36523,7 +36721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36538,7 +36736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36557,7 +36755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36572,7 +36770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36591,7 +36789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36606,7 +36804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36625,7 +36823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36640,7 +36838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36659,7 +36857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36674,7 +36872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36693,7 +36891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36708,7 +36906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36727,7 +36925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36742,7 +36940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_impact_core_module",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36761,7 +36959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36776,7 +36974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36795,7 +36993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36810,7 +37008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36829,7 +37027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36844,7 +37042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36863,7 +37061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36878,7 +37076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -36897,7 +37095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36912,7 +37110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -36931,7 +37129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36946,7 +37144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -36965,7 +37163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -36980,7 +37178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -36999,7 +37197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37014,7 +37212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37033,7 +37231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37048,7 +37246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37067,7 +37265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37082,7 +37280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37101,7 +37299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37116,7 +37314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37135,7 +37333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37150,7 +37348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37169,7 +37367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37184,7 +37382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37203,7 +37401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37218,7 +37416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37237,7 +37435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37252,7 +37450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37271,7 +37469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37286,7 +37484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 884,
+        "line": 892,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -37305,7 +37503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37320,7 +37518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 884,
+        "line": 892,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -37339,7 +37537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37354,7 +37552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37373,7 +37571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37388,7 +37586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37407,7 +37605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37422,7 +37620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37441,7 +37639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37456,7 +37654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37475,7 +37673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37490,7 +37688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37509,7 +37707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37524,7 +37722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37543,7 +37741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37558,7 +37756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37577,7 +37775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37592,7 +37790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37611,7 +37809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37626,7 +37824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 900,
+        "line": 908,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37645,7 +37843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37660,7 +37858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 900,
+        "line": 908,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37679,7 +37877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37694,7 +37892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 908,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37713,7 +37911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37728,7 +37926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37747,7 +37945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37762,7 +37960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37781,7 +37979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37796,7 +37994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37815,7 +38013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37830,7 +38028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37849,7 +38047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37864,7 +38062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37883,7 +38081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37898,7 +38096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37917,7 +38115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37932,7 +38130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37951,7 +38149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -37966,7 +38164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37985,7 +38183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38000,7 +38198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38019,7 +38217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38034,7 +38232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38053,7 +38251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38068,7 +38266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38087,7 +38285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38102,7 +38300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38121,7 +38319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38136,7 +38334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38155,7 +38353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38170,7 +38368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38189,7 +38387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38204,7 +38402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38223,7 +38421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38238,7 +38436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38257,7 +38455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38272,7 +38470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38291,7 +38489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38306,7 +38504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38325,7 +38523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38340,7 +38538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38359,7 +38557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38374,7 +38572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38393,7 +38591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38408,7 +38606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38427,7 +38625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38442,7 +38640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38461,7 +38659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38476,7 +38674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38495,7 +38693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38510,7 +38708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38529,7 +38727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38544,7 +38742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38563,7 +38761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38578,7 +38776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38597,7 +38795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38612,7 +38810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38631,7 +38829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38646,7 +38844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38665,7 +38863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38680,7 +38878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38699,7 +38897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38714,7 +38912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38733,7 +38931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38748,7 +38946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38767,7 +38965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38782,7 +38980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38801,7 +38999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38816,7 +39014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38835,7 +39033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38850,7 +39048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38869,7 +39067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38884,7 +39082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38903,7 +39101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38918,7 +39116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38937,7 +39135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38952,7 +39150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38971,7 +39169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -38986,7 +39184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 946,
+        "line": 954,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39005,7 +39203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39020,7 +39218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 946,
+        "line": 954,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39039,7 +39237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39054,7 +39252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 950,
+        "line": 958,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39073,7 +39271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39088,7 +39286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 950,
+        "line": 958,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39107,7 +39305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39122,7 +39320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 950,
+        "line": 958,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39141,7 +39339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39156,7 +39354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39175,7 +39373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39190,7 +39388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39209,7 +39407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39224,7 +39422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39243,7 +39441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39258,7 +39456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39277,7 +39475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39292,7 +39490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39311,7 +39509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39326,7 +39524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39345,7 +39543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39360,7 +39558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39379,7 +39577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39394,7 +39592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39413,7 +39611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39428,7 +39626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39447,7 +39645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39462,7 +39660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39481,7 +39679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39496,7 +39694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39515,7 +39713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39530,7 +39728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39549,7 +39747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39564,7 +39762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39583,7 +39781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39598,7 +39796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39617,7 +39815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39632,7 +39830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39651,7 +39849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39666,7 +39864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39685,7 +39883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39700,7 +39898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39719,7 +39917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39734,7 +39932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39753,7 +39951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39768,7 +39966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39787,7 +39985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39802,7 +40000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39821,7 +40019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39836,7 +40034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39855,7 +40053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39870,7 +40068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39889,7 +40087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39904,7 +40102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39923,7 +40121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39938,7 +40136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 982,
+        "line": 990,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -39957,7 +40155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -39972,7 +40170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 982,
+        "line": 990,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -39991,7 +40189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40006,7 +40204,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 986,
+        "line": 994,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -40025,7 +40223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40040,7 +40238,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 986,
+        "line": 994,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -40059,7 +40257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40074,7 +40272,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 987,
+        "line": 995,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -40093,7 +40291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40108,7 +40306,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -40127,7 +40325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40142,7 +40340,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -40161,7 +40359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40176,7 +40374,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -40195,7 +40393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40210,7 +40408,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 993,
+        "line": 1001,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40229,7 +40427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40244,7 +40442,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 993,
+        "line": 1001,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40263,7 +40461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40278,7 +40476,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40297,7 +40495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40312,7 +40510,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40331,7 +40529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40346,7 +40544,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40365,7 +40563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40380,7 +40578,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40399,7 +40597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40414,7 +40612,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40433,7 +40631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40448,7 +40646,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40467,7 +40665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40482,7 +40680,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40501,7 +40699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40516,7 +40714,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40535,7 +40733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40550,7 +40748,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40569,7 +40767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40584,7 +40782,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40603,7 +40801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40618,7 +40816,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40637,7 +40835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40652,7 +40850,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40671,7 +40869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40686,7 +40884,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40705,7 +40903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40720,7 +40918,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40739,7 +40937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40754,7 +40952,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40773,7 +40971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40788,7 +40986,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40807,7 +41005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40822,7 +41020,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40841,7 +41039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40856,7 +41054,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40875,7 +41073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -40890,7 +41088,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40908,7 +41106,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1747
+            "line": 1755
           }
         ],
         "classification": "external",
@@ -40916,37 +41114,12 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1748,
+        "line": 1756,
         "name": null,
         "optional": true,
         "requested": "nodes",
         "role": "optional_dependency",
         "scope": "_comfy_max_resolution",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1784
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1785,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_find_comfy_node_class",
         "source": "nodes.py"
       },
       {
@@ -40967,6 +41140,31 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1793,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
+        "scope": "_find_comfy_node_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1800
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1801,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -42961,6 +43159,10 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/nodes/image_nodes.py"
       },
       {
@@ -43370,6 +43572,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/nodes/aio_nodes.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/nodes/image_nodes.py"
         ]
       },
@@ -43526,7 +43734,7 @@
     ]
   },
   "inventory": {
-    "module_count": 75,
+    "module_count": 76,
     "modules": [
       {
         "is_package": true,
@@ -44118,6 +44326,18 @@
       },
       {
         "is_package": false,
+        "loc": 156,
+        "module": "easyuse_anima.nodes.aio_nodes",
+        "normalized_git_blob_sha1": "8c77faeae9ca6fb124ed184e3a64b32ff570daa9",
+        "path": "easyuse_anima/nodes/aio_nodes.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 2,
+          "global_count": 3
+        }
+      },
+      {
+        "is_package": false,
         "loc": 131,
         "module": "easyuse_anima.nodes.image_nodes",
         "normalized_git_blob_sha1": "5dd0df22eb511b2454fbba95c636b0c72b5c907b",
@@ -44370,12 +44590,12 @@
       },
       {
         "is_package": false,
-        "loc": 3222,
+        "loc": 3122,
         "module": "nodes",
-        "normalized_git_blob_sha1": "3ee9fd57230b848b54b0c561d8c8e6cd8460a6da",
+        "normalized_git_blob_sha1": "08731747c5ced72546f4b3cd60fd7e2a7562a5a7",
         "path": "nodes.py",
         "top_level": {
-          "class_count": 4,
+          "class_count": 3,
           "function_count": 43,
           "global_count": 33
         }
@@ -45726,7 +45946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45735,7 +45955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45749,7 +45969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45758,7 +45978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45772,7 +45992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45781,7 +46001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45795,7 +46015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45804,7 +46024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45818,7 +46038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45827,7 +46047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45841,7 +46061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45850,7 +46070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45864,7 +46084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45873,7 +46093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45887,7 +46107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45896,7 +46116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45910,7 +46130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45919,7 +46139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 514,
+        "line": 518,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45933,7 +46153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45942,7 +46162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45956,7 +46176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45965,7 +46185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45979,7 +46199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -45988,7 +46208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 529,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46002,7 +46222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46011,7 +46231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 530,
+        "line": 534,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46025,7 +46245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46034,7 +46254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46048,7 +46268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46057,7 +46277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46071,7 +46291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46080,7 +46300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46094,7 +46314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46103,7 +46323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 533,
+        "line": 537,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46117,7 +46337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46126,7 +46346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46140,7 +46360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46149,7 +46369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46163,7 +46383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46172,7 +46392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46186,7 +46406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46195,7 +46415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46209,7 +46429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46218,7 +46438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46232,7 +46452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46241,7 +46461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46255,7 +46475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46264,7 +46484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46278,7 +46498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46287,7 +46507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46301,7 +46521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46310,7 +46530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46324,7 +46544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46333,7 +46553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46347,7 +46567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46356,7 +46576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46370,7 +46590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46379,7 +46599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 539,
+        "line": 543,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46393,7 +46613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46402,7 +46622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46416,7 +46636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46425,7 +46645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46439,7 +46659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46448,7 +46668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46462,7 +46682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46471,7 +46691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46485,7 +46705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46494,7 +46714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46508,7 +46728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46517,7 +46737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46531,7 +46751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46540,7 +46760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46554,7 +46774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46563,7 +46783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46577,7 +46797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46586,7 +46806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46600,7 +46820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46609,7 +46829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 553,
+        "line": 557,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46623,7 +46843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46632,7 +46852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46646,7 +46866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46655,7 +46875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46669,7 +46889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46678,7 +46898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46692,7 +46912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46701,7 +46921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46715,7 +46935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46724,7 +46944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46738,7 +46958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46747,7 +46967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46761,7 +46981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46770,7 +46990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46784,7 +47004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46793,7 +47013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46807,7 +47027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46816,7 +47036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46830,7 +47050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46839,7 +47059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 565,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46853,7 +47073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46862,7 +47082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46876,7 +47096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46885,7 +47105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46899,7 +47119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46908,7 +47128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46922,7 +47142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46931,7 +47151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46945,7 +47165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46954,7 +47174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46968,7 +47188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -46977,7 +47197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46991,7 +47211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47000,7 +47220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47014,7 +47234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47023,7 +47243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47037,7 +47257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47046,7 +47266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47060,7 +47280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47069,7 +47289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 577,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47083,7 +47303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47092,7 +47312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47106,7 +47326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47115,7 +47335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47129,7 +47349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47138,7 +47358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47152,7 +47372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47161,7 +47381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47175,7 +47395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47184,7 +47404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47198,7 +47418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47207,7 +47427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47221,7 +47441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47230,7 +47450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47244,7 +47464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47253,7 +47473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47267,7 +47487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47276,7 +47496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47290,7 +47510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47299,7 +47519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47313,7 +47533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47322,7 +47542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 589,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47336,7 +47556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47345,7 +47565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 602,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47359,7 +47579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47368,7 +47588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 602,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47382,7 +47602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47391,7 +47611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 602,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47405,7 +47625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47414,7 +47634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47428,7 +47648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47437,7 +47657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47451,7 +47671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47460,7 +47680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47474,7 +47694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47483,7 +47703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47497,7 +47717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47506,7 +47726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 607,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47520,7 +47740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47529,7 +47749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47543,7 +47763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47552,7 +47772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47566,7 +47786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47575,7 +47795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47589,7 +47809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47598,7 +47818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 614,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47612,7 +47832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47621,7 +47841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47635,7 +47855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47644,7 +47864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47658,7 +47878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47667,7 +47887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47681,7 +47901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47690,7 +47910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47704,7 +47924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47713,7 +47933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47727,7 +47947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47736,7 +47956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47750,7 +47970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47759,7 +47979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47773,7 +47993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47782,7 +48002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47796,7 +48016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47805,7 +48025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47819,7 +48039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47828,7 +48048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47842,7 +48062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47851,7 +48071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47865,7 +48085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47874,7 +48094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 620,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47888,7 +48108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47897,7 +48117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47911,7 +48131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47920,7 +48140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47934,7 +48154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47943,7 +48163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47957,7 +48177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47966,7 +48186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47980,7 +48200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -47989,7 +48209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48003,7 +48223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48012,7 +48232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48026,7 +48246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48035,7 +48255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48049,7 +48269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48058,7 +48278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48072,7 +48292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48081,7 +48301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48095,7 +48315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48104,7 +48324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48118,7 +48338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48127,7 +48347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48141,7 +48361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48150,7 +48370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48164,7 +48384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48173,7 +48393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48187,7 +48407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48196,7 +48416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48210,7 +48430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48219,7 +48439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48233,7 +48453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48242,7 +48462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 634,
+        "line": 638,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48256,7 +48476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48265,7 +48485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48279,7 +48499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48288,7 +48508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48302,7 +48522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48311,7 +48531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48325,7 +48545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48334,7 +48554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48348,7 +48568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48357,7 +48577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48371,7 +48591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48380,7 +48600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48394,7 +48614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48403,7 +48623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48417,7 +48637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48426,7 +48646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48440,7 +48660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48449,7 +48669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48463,7 +48683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48472,7 +48692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48486,7 +48706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48495,7 +48715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48509,7 +48729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48518,7 +48738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48532,7 +48752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48541,7 +48761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48555,7 +48775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48564,7 +48784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48578,7 +48798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48587,7 +48807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48601,7 +48821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48610,7 +48830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48624,7 +48844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48633,7 +48853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48647,7 +48867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48656,7 +48876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48670,7 +48890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48679,7 +48899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48693,7 +48913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48702,7 +48922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48716,7 +48936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48725,7 +48945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48739,7 +48959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48748,7 +48968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48762,7 +48982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48771,7 +48991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48785,7 +49005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48794,7 +49014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48808,7 +49028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48817,7 +49037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48831,7 +49051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48840,7 +49060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48854,7 +49074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48863,7 +49083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48877,7 +49097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48886,7 +49106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48900,7 +49120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48909,7 +49129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48923,7 +49143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48932,7 +49152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48946,7 +49166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48955,7 +49175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48969,7 +49189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -48978,7 +49198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48992,7 +49212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49001,7 +49221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49015,7 +49235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49024,7 +49244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 652,
+        "line": 656,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49038,7 +49258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49047,7 +49267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49061,7 +49281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49070,7 +49290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49084,7 +49304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49093,7 +49313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49107,7 +49327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49116,7 +49336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49130,7 +49350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49139,7 +49359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49153,7 +49373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49162,7 +49382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49176,7 +49396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49185,7 +49405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49199,7 +49419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49208,7 +49428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49222,7 +49442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49231,7 +49451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49245,7 +49465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49254,7 +49474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49268,7 +49488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49277,7 +49497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49291,7 +49511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49300,7 +49520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49314,7 +49534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49323,7 +49543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49337,7 +49557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49346,7 +49566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49360,7 +49580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49369,7 +49589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49383,7 +49603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49392,7 +49612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49406,7 +49626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49415,7 +49635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49429,7 +49649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49438,7 +49658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49452,7 +49672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49461,7 +49681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49475,7 +49695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49484,7 +49704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49498,7 +49718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49507,7 +49727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49521,7 +49741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49530,7 +49750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49544,7 +49764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49553,7 +49773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49567,7 +49787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49576,7 +49796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49590,7 +49810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49599,7 +49819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49613,7 +49833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49622,7 +49842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 688,
+        "line": 692,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49636,7 +49856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49645,7 +49865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49659,7 +49879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49668,7 +49888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49682,7 +49902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49691,7 +49911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49705,7 +49925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49714,7 +49934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49728,7 +49948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49737,7 +49957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49751,7 +49971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49760,7 +49980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49774,7 +49994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49783,7 +50003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49797,7 +50017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49806,7 +50026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49820,7 +50040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49829,7 +50049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49843,7 +50063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49852,7 +50072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49866,7 +50086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49875,7 +50095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49889,7 +50109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49898,7 +50118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49912,7 +50132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49921,7 +50141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49935,7 +50155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49944,7 +50164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 716,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49958,7 +50178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49967,7 +50187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49981,7 +50201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -49990,7 +50210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50004,7 +50224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50013,7 +50233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50027,7 +50247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50036,7 +50256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50050,7 +50270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50059,7 +50279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50073,7 +50293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50082,7 +50302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50096,7 +50316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50105,7 +50325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50119,7 +50339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50128,7 +50348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50142,7 +50362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50151,7 +50371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50165,7 +50385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50174,7 +50394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50188,7 +50408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50197,7 +50417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50211,7 +50431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50220,7 +50440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50234,7 +50454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50243,7 +50463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50257,7 +50477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50266,7 +50486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50280,7 +50500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50289,7 +50509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50303,7 +50523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50312,7 +50532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50326,7 +50546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50335,7 +50555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50349,7 +50569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50358,7 +50578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50372,7 +50592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50381,7 +50601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50395,7 +50615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50404,7 +50624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50418,7 +50638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50427,7 +50647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50441,7 +50661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50450,7 +50670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50464,7 +50684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50473,7 +50693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50487,7 +50707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50496,7 +50716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50510,7 +50730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50519,7 +50739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50533,7 +50753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50542,7 +50762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50556,7 +50776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50565,7 +50785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50579,7 +50799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50588,7 +50808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50602,7 +50822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50611,7 +50831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50625,7 +50845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50634,7 +50854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50648,7 +50868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50657,7 +50877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50671,7 +50891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50680,7 +50900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50694,7 +50914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50703,7 +50923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50717,7 +50937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50726,7 +50946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50740,7 +50960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50749,7 +50969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50763,7 +50983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50772,7 +50992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50786,7 +51006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50795,7 +51015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50809,7 +51029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50818,7 +51038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50832,7 +51052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50841,7 +51061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50855,7 +51075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50864,7 +51084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50878,7 +51098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50887,7 +51107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50901,7 +51121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50910,7 +51130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50924,7 +51144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50933,7 +51153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50947,7 +51167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50956,7 +51176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50970,7 +51190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -50979,7 +51199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50993,7 +51213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51002,7 +51222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51016,7 +51236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51025,7 +51245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51039,7 +51259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51048,7 +51268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51062,7 +51282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51071,7 +51291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51085,7 +51305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51094,7 +51314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51108,7 +51328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51117,7 +51337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51131,7 +51351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51140,7 +51360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51154,7 +51374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51163,7 +51383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51177,7 +51397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51186,7 +51406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51200,7 +51420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51209,7 +51429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51223,7 +51443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51232,7 +51452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51246,7 +51466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51255,7 +51475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51269,7 +51489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51278,7 +51498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51292,7 +51512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51301,7 +51521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51315,7 +51535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51324,7 +51544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51338,7 +51558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51347,7 +51567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51361,7 +51581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51370,7 +51590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51384,7 +51604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51393,7 +51613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51407,7 +51627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51416,7 +51636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51430,7 +51650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51439,7 +51659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51453,7 +51673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51462,7 +51682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51476,7 +51696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51485,7 +51705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51499,7 +51719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51508,7 +51728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51522,7 +51742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51531,7 +51751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51545,7 +51765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51554,7 +51774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51568,7 +51788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51577,7 +51797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51591,7 +51811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51600,7 +51820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51614,7 +51834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51623,7 +51843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51637,7 +51857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51646,7 +51866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51660,7 +51880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51669,7 +51889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51683,7 +51903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51692,7 +51912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51706,7 +51926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51715,7 +51935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51729,7 +51949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51738,7 +51958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 732,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51752,7 +51972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51761,7 +51981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51775,7 +51995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51784,7 +52004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51798,7 +52018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51807,7 +52027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51821,7 +52041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51830,7 +52050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 812,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51844,7 +52064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51853,7 +52073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51867,7 +52087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51876,7 +52096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51890,7 +52110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51899,7 +52119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51913,7 +52133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51922,7 +52142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 822,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51936,7 +52156,53 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
+        "kind": "static_from",
+        "line": 828,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 517,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
+        "kind": "static_from",
+        "line": 828,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51945,7 +52211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51959,7 +52225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51968,7 +52234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51982,7 +52248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -51991,7 +52257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52005,7 +52271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52014,7 +52280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52028,7 +52294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52037,7 +52303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 824,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52051,7 +52317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52060,7 +52326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 831,
+        "line": 839,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52074,7 +52340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52083,7 +52349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52097,7 +52363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52106,7 +52372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52120,7 +52386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52129,7 +52395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52143,7 +52409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52152,7 +52418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52166,7 +52432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52175,7 +52441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52189,7 +52455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52198,7 +52464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52212,7 +52478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52221,7 +52487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52235,7 +52501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52244,7 +52510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52258,7 +52524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52267,7 +52533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52281,7 +52547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52290,7 +52556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52304,7 +52570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52313,7 +52579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 834,
+        "line": 842,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52327,7 +52593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52336,7 +52602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52350,7 +52616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52359,7 +52625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52373,7 +52639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52382,7 +52648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52396,7 +52662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52405,7 +52671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52419,7 +52685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52428,7 +52694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52442,7 +52708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52451,7 +52717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 847,
+        "line": 855,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52465,7 +52731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52474,7 +52740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52488,7 +52754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52497,7 +52763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52511,7 +52777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52520,7 +52786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52534,7 +52800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52543,7 +52809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52557,7 +52823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52566,7 +52832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52580,7 +52846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52589,7 +52855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52603,7 +52869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52612,7 +52878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52626,7 +52892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52635,7 +52901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52649,7 +52915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52658,7 +52924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52672,7 +52938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52681,7 +52947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52695,7 +52961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52704,7 +52970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52718,7 +52984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52727,7 +52993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52741,7 +53007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52750,7 +53016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 866,
+        "line": 874,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52764,7 +53030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52773,7 +53039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52787,7 +53053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52796,7 +53062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52810,7 +53076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52819,7 +53085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52833,7 +53099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52842,7 +53108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52856,7 +53122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52865,7 +53131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52879,7 +53145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52888,7 +53154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 872,
+        "line": 880,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52902,7 +53168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52911,7 +53177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52925,7 +53191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52934,7 +53200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52948,7 +53214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52957,7 +53223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 884,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52971,7 +53237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -52980,7 +53246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 884,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52994,7 +53260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53003,7 +53269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53017,7 +53283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53026,7 +53292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53040,7 +53306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53049,7 +53315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53063,7 +53329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53072,7 +53338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53086,7 +53352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53095,7 +53361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53109,7 +53375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53118,7 +53384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53132,7 +53398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53141,7 +53407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53155,7 +53421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53164,7 +53430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 893,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53178,7 +53444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53187,7 +53453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 900,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53201,7 +53467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53210,7 +53476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 900,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53224,7 +53490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53233,7 +53499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53247,7 +53513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53256,7 +53522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53270,7 +53536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53279,7 +53545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53293,7 +53559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53302,7 +53568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53316,7 +53582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53325,7 +53591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53339,7 +53605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53348,7 +53614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53362,7 +53628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53371,7 +53637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53385,7 +53651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53394,7 +53660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53408,7 +53674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53417,7 +53683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53431,7 +53697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53440,7 +53706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53454,7 +53720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53463,7 +53729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53477,7 +53743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53486,7 +53752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53500,7 +53766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53509,7 +53775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53523,7 +53789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53532,7 +53798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53546,7 +53812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53555,7 +53821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53569,7 +53835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53578,7 +53844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53592,7 +53858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53601,7 +53867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 905,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53615,7 +53881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53624,7 +53890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53638,7 +53904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53647,7 +53913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53661,7 +53927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53670,7 +53936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53684,7 +53950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53693,7 +53959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53707,7 +53973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53716,7 +53982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53730,7 +53996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53739,7 +54005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53753,7 +54019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53762,7 +54028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53776,7 +54042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53785,7 +54051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53799,7 +54065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53808,7 +54074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53822,7 +54088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53831,7 +54097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53845,7 +54111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53854,7 +54120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53868,7 +54134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53877,7 +54143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53891,7 +54157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53900,7 +54166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53914,7 +54180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53923,7 +54189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53937,7 +54203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53946,7 +54212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53960,7 +54226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53969,7 +54235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53983,7 +54249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -53992,7 +54258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54006,7 +54272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54015,7 +54281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54029,7 +54295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54038,7 +54304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54052,7 +54318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54061,7 +54327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54075,7 +54341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54084,7 +54350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 923,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54098,7 +54364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54107,7 +54373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 946,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54121,7 +54387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54130,7 +54396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 946,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54144,7 +54410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54153,7 +54419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 950,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54167,7 +54433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54176,7 +54442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 950,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54190,7 +54456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54199,7 +54465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 950,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54213,7 +54479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54222,7 +54488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54236,7 +54502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54245,7 +54511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54259,7 +54525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54268,7 +54534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54282,7 +54548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54291,7 +54557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54305,7 +54571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54314,7 +54580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54328,7 +54594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54337,7 +54603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54351,7 +54617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54360,7 +54626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54374,7 +54640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54383,7 +54649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54397,7 +54663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54406,7 +54672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54420,7 +54686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54429,7 +54695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54443,7 +54709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54452,7 +54718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54466,7 +54732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54475,7 +54741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54489,7 +54755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54498,7 +54764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54512,7 +54778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54521,7 +54787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54535,7 +54801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54544,7 +54810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 955,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54558,7 +54824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54567,7 +54833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54581,7 +54847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54590,7 +54856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54604,7 +54870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54613,7 +54879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54627,7 +54893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54636,7 +54902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54650,7 +54916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54659,7 +54925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54673,7 +54939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54682,7 +54948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54696,7 +54962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54705,7 +54971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54719,7 +54985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54728,7 +54994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 972,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54742,7 +55008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54751,7 +55017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 982,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54765,7 +55031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54774,7 +55040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 982,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54788,7 +55054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54797,7 +55063,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 986,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54811,7 +55077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54820,7 +55086,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 986,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54834,7 +55100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54843,7 +55109,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 987,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54857,7 +55123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54866,7 +55132,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54880,7 +55146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54889,7 +55155,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54903,7 +55169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54912,7 +55178,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 988,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54926,7 +55192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54935,7 +55201,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 993,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54949,7 +55215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54958,7 +55224,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 993,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54972,7 +55238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -54981,7 +55247,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54995,7 +55261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55004,7 +55270,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55018,7 +55284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55027,7 +55293,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55041,7 +55307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55050,7 +55316,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55064,7 +55330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55073,7 +55339,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55087,7 +55353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55096,7 +55362,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55110,7 +55376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55119,7 +55385,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55133,7 +55399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55142,7 +55408,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55156,7 +55422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55165,7 +55431,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55179,7 +55445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55188,7 +55454,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55202,7 +55468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55211,7 +55477,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55225,7 +55491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55234,7 +55500,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55248,7 +55514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55257,7 +55523,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55271,7 +55537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55280,7 +55546,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55294,7 +55560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55303,7 +55569,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55317,7 +55583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55326,7 +55592,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55340,7 +55606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55349,7 +55615,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55363,7 +55629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55372,7 +55638,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55386,7 +55652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 513,
+            "handler_line": 517,
             "kind": "try",
             "line": 11
           }
@@ -55395,7 +55661,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -58156,6 +58422,50 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/nodes/aio_nodes.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/nodes/image_nodes.py"
       },
       {
@@ -59002,33 +59312,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1747
+            "line": 1755
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1748,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1784
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1785,
+        "line": 1756,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -59048,6 +59339,25 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1793,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1800
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1801,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -60422,33 +60732,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1747
+            "line": 1755
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1748,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1784
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1785,
+        "line": 1756,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -60468,6 +60759,25 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1793,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1800
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1801,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -60619,6 +60929,7 @@
       "easyuse_anima/naia/client.py",
       "easyuse_anima/naia/resolution.py",
       "easyuse_anima/nodes/__init__.py",
+      "easyuse_anima/nodes/aio_nodes.py",
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/impact_detailer_nodes.py",
       "easyuse_anima/nodes/lora_nodes.py",
@@ -60696,6 +61007,7 @@
       "easyuse_anima/naia/client.py",
       "easyuse_anima/naia/resolution.py",
       "easyuse_anima/nodes/__init__.py",
+      "easyuse_anima/nodes/aio_nodes.py",
       "easyuse_anima/nodes/image_nodes.py",
       "easyuse_anima/nodes/impact_detailer_nodes.py",
       "easyuse_anima/nodes/lora_nodes.py",
@@ -62065,7 +62377,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1016,
+        "line": 1024,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62074,7 +62386,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1532,
+        "line": 1540,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62083,7 +62395,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1698,
+        "line": 1706,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62092,7 +62404,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2592,
+        "line": 2600,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62101,7 +62413,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2595,
+        "line": 2603,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62110,7 +62422,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2598,
+        "line": 2606,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62119,7 +62431,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2601,
+        "line": 2609,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62128,7 +62440,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2604,
+        "line": 2612,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62137,7 +62449,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2607,
+        "line": 2615,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62146,7 +62458,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2610,
+        "line": 2618,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62155,7 +62467,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2613,
+        "line": 2621,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62164,7 +62476,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2616,
+        "line": 2624,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62173,7 +62485,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2619,
+        "line": 2627,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62182,7 +62494,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2622,
+        "line": 2630,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62191,7 +62503,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2625,
+        "line": 2633,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62200,7 +62512,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2628,
+        "line": 2636,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62209,7 +62521,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2632,
+        "line": 2640,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62218,7 +62530,16 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2635,
+        "line": 2643,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_aio_node_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 2647,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62227,7 +62548,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2639,
+        "line": 2650,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62236,7 +62557,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2643,
+        "line": 2654,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62245,7 +62566,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2646,
+        "line": 2657,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62254,7 +62575,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2649,
+        "line": 2660,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62263,7 +62584,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2652,
+        "line": 2663,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62272,7 +62593,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2655,
+        "line": 2666,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62281,7 +62602,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2658,
+        "line": 2669,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62290,7 +62611,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2665,
+        "line": 2676,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62299,7 +62620,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2671,
+        "line": 2682,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62308,7 +62629,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2676,
+        "line": 2687,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62317,7 +62638,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2680,
+        "line": 2691,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62807,25 +63128,25 @@
       },
       {
         "kind": "dict",
-        "line": 1086,
+        "line": 1094,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1075,
+        "line": 1083,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1070,
+        "line": 1078,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1697,
+        "line": 1705,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -1,13 +1,242 @@
 from __future__ import annotations
 
 import json
+import sys
 import unittest
 from unittest.mock import patch
 
 import nodes
+from easyuse_anima.nodes import aio_nodes
+from tests.test_node_contracts import _loaded_package_entrypoint
 
 
 class AIONodeContractTests(unittest.TestCase):
+    def test_input_node_is_the_canonical_public_adapter_in_both_import_modes(self):
+        self.assertEqual(aio_nodes.__all__, ("EasyUseAnimaInput",))
+        self.assertIs(nodes.EasyUseAnimaInput, aio_nodes.EasyUseAnimaInput)
+
+        with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
+            canonical_module = sys.modules[
+                f"{package_entrypoint.__name__}.easyuse_anima.nodes.aio_nodes"
+            ]
+            mapped_class = package_entrypoint.NODE_CLASS_MAPPINGS["EasyUseAnimaInput"]
+
+            self.assertIs(mapped_class, canonical_module.EasyUseAnimaInput)
+            self.assertIs(package_nodes.EasyUseAnimaInput, canonical_module.EasyUseAnimaInput)
+
+    def test_input_types_resolve_root_runtime_values_at_call_time(self):
+        calls = []
+        unet_names = ["unet-b", "unet-a"]
+        vae_names = ["vae-b", "vae-a"]
+        clip_names = ["clip-b", "clip-a"]
+        clip_types = ["stable_cascade", "qwen_image"]
+
+        def names(label, values):
+            def resolve():
+                calls.append(label)
+                return values
+
+            return resolve
+
+        def preferred_name(values, candidates):
+            calls.append(("preferred_name", values, candidates))
+            return candidates[0]
+
+        def preferred_clip_type(values):
+            calls.append(("preferred_clip_type", values))
+            return "qwen_image"
+
+        def input_settings_json():
+            calls.append("input_settings_json")
+            return '{"schema":"input-test"}'
+
+        with patch.multiple(
+            nodes,
+            PROMPT_DATA_TYPE="PROMPT_DATA_TEST",
+            ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES=("unet-a",),
+            ANIMA_DEFAULT_VAE_CANDIDATES=("vae-a",),
+            ANIMA_DEFAULT_CLIP_CANDIDATES=("clip-a",),
+            _comfy_diffusion_model_names=names("unet_names", unet_names),
+            _comfy_vae_names=names("vae_names", vae_names),
+            _comfy_text_encoder_names=names("clip_names", clip_names),
+            _comfy_clip_loader_types=names("clip_types", clip_types),
+            _preferred_name_default=preferred_name,
+            _preferred_clip_type_default=preferred_clip_type,
+            _aio_input_settings_json=input_settings_json,
+        ):
+            input_types = nodes.EasyUseAnimaInput.INPUT_TYPES()
+
+        self.assertEqual(
+            calls,
+            [
+                "unet_names",
+                "vae_names",
+                "clip_names",
+                "clip_types",
+                ("preferred_name", unet_names, ("unet-a",)),
+                ("preferred_name", vae_names, ("vae-a",)),
+                ("preferred_name", clip_names, ("clip-a",)),
+                ("preferred_clip_type", clip_types),
+                "input_settings_json",
+            ],
+        )
+        self.assertEqual(
+            input_types,
+            {
+                "required": {
+                    "PROMPT_DATA_TEST": ("PROMPT_DATA_TEST", {
+                        "forceInput": True,
+                        "tooltip": "Structured prompt data from Anima Prompt Studio Advanced v2.",
+                    }),
+                    "unet_name": (unet_names, {
+                        "default": "unet-a",
+                        "tooltip": "ANIMA diffusion model loaded with ComfyUI UNETLoader.",
+                    }),
+                    "vae_name": (vae_names, {
+                        "default": "vae-a",
+                        "tooltip": "VAE loaded with ComfyUI VAELoader.",
+                    }),
+                    "clip_name": (clip_names, {
+                        "default": "clip-a",
+                        "tooltip": "Text encoder loaded with ComfyUI CLIPLoader.",
+                    }),
+                    "clip_type": (clip_types, {
+                        "default": "qwen_image",
+                        "tooltip": "ComfyUI CLIPLoader type. Core ANIMA uses qwen_image.",
+                    }),
+                    "input_settings": ("STRING", {
+                        "multiline": True,
+                        "default": '{"schema":"input-test"}',
+                        "hidden": True,
+                        "tooltip": "Hidden versioned JSON storage for future resource settings. Kept serialized for workflow compatibility.",
+                    }),
+                },
+            },
+        )
+
+    def test_input_change_key_preserves_payload_and_runtime_call_order(self):
+        calls = []
+
+        def normalize_prompt(value):
+            calls.append(("normalize_prompt", value))
+            return {"normalized": value}
+
+        def json_safe(value):
+            calls.append(("json_safe", value))
+            return {"safe": value}
+
+        def normalize_settings(value):
+            calls.append(("normalize_settings", value))
+            return {"settings": value}
+
+        def stable_key(value):
+            calls.append(("stable_key", value))
+            return "change-key"
+
+        with patch.multiple(
+            nodes,
+            _normalize_prompt_data=normalize_prompt,
+            _prompt_data_json_safe=json_safe,
+            _normalize_aio_input_settings=normalize_settings,
+            _stable_change_key=stable_key,
+        ):
+            result = nodes.EasyUseAnimaInput.IS_CHANGED(
+                {"prompt": "raw"},
+                unet_name=None,
+                vae_name=3,
+                clip_name="clip",
+                clip_type=False,
+                input_settings="settings-json",
+                ignored="compatibility",
+            )
+
+        expected_payload = {
+            "mode": "easy_use_anima_input",
+            "prompt_data": {"safe": {"normalized": {"prompt": "raw"}}},
+            "unet_name": "",
+            "vae_name": "3",
+            "clip_name": "clip",
+            "clip_type": "",
+            "input_settings": {"settings": "settings-json"},
+        }
+        self.assertEqual(result, "change-key")
+        self.assertEqual(
+            calls,
+            [
+                ("normalize_prompt", {"prompt": "raw"}),
+                ("json_safe", {"normalized": {"prompt": "raw"}}),
+                ("normalize_settings", "settings-json"),
+                ("stable_key", expected_payload),
+            ],
+        )
+
+    def test_input_build_preserves_exact_context_and_copy_boundaries(self):
+        source_prompt = {"positive_prompt": "p", "nested": {"value": 1}}
+        settings = {
+            "schema": "settings-schema",
+            "resources": {
+                "unet_weight_dtype": "fp8_e4m3fn",
+                "clip_device": "cpu",
+            },
+        }
+
+        with (
+            patch.object(
+                nodes,
+                "_normalize_aio_input_settings",
+                return_value=settings,
+            ) as normalize_settings,
+            patch.object(
+                nodes,
+                "_copy_prompt_data_for_update",
+                wraps=nodes._copy_prompt_data_for_update,
+            ) as copy_prompt,
+        ):
+            context = nodes.EasyUseAnimaInput().build(
+                source_prompt,
+                7,
+                "vae.safetensors",
+                "clip.safetensors",
+                "",
+                "settings-json",
+            )[0]
+
+        resource_info = {
+            "loader_mode": "split",
+            "unet_name": "7",
+            "vae_name": "vae.safetensors",
+            "clip_name": "clip.safetensors",
+            "clip_type": "qwen_image",
+            "unet_weight_dtype": "fp8_e4m3fn",
+            "clip_device": "cpu",
+        }
+        self.assertEqual(
+            context,
+            {
+                "schema": nodes.EASY_USE_ANIMA_INPUT_SCHEMA,
+                "version": nodes.EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
+                "prompt_data": {
+                    "positive_prompt": "p",
+                    "nested": {"value": 1},
+                    "easy_use_anima_input": {
+                        "schema": nodes.EASY_USE_ANIMA_INPUT_SCHEMA,
+                        "version": nodes.EASY_USE_ANIMA_INPUT_SETTINGS_VERSION,
+                        "resource_info": resource_info,
+                    },
+                },
+                "resource_info": resource_info,
+                "input_settings": settings,
+            },
+        )
+        normalize_settings.assert_called_once_with("settings-json")
+        copy_prompt.assert_called_once_with(source_prompt)
+        self.assertNotIn("easy_use_anima_input", source_prompt)
+        self.assertIsNot(context["prompt_data"], source_prompt)
+        self.assertIsNot(
+            context["prompt_data"]["easy_use_anima_input"]["resource_info"],
+            context["resource_info"],
+        )
+
     def test_input_node_contract_uses_dedicated_context_socket(self):
         required = nodes.EasyUseAnimaInput.INPUT_TYPES()["required"]
 

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,14 +73,15 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "3ee9fd57230b848b54b0c561d8c8e6cd8460a6da")
-        # Issue #184 B-08e preserves the root AiO facade while moving current
-        # first-pass cache state and helpers behind direct aliases.
+        self.assertEqual(report["git_blob_sha1"], "08731747c5ced72546f4b3cd60fd7e2a7562a5a7")
+        # Issue #184 B-09a preserves the public AiO input adapter as a direct
+        # root alias while moving its implementation to canonical ownership.
         self.assertEqual(report["top_level"]["function_count"], 43)
-        self.assertEqual(report["top_level"]["class_count"], 4)
-        self.assertEqual(report["line_count"], 3_222)
+        self.assertEqual(report["top_level"]["class_count"], 3)
+        self.assertEqual(report["line_count"], 3_122)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
+        self.assertNotIn("EasyUseAnimaInput", class_names)
         self.assertNotIn("EasyUseAnimaPromptStudioAdvanced", class_names)
         self.assertNotIn("EasyUseAnimaPromptStudioAdvancedV2", class_names)
         self.assertNotIn("EasyUseAnimaPromptStudioExtend", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 75)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 75)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 75)
+        self.assertEqual(report["inventory"]["module_count"], 76)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 76)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 76)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -727,6 +727,7 @@ ignored/
                 "easyuse_anima/naia/client.py",
                 "easyuse_anima/naia/resolution.py",
                 "easyuse_anima/nodes/__init__.py",
+                "easyuse_anima/nodes/aio_nodes.py",
                 "easyuse_anima/nodes/image_nodes.py",
                 "easyuse_anima/nodes/impact_detailer_nodes.py",
                 "easyuse_anima/nodes/lora_nodes.py",
@@ -776,6 +777,7 @@ ignored/
                 "easyuse_anima/naia/__init__.py",
                 "easyuse_anima/naia/client.py",
                 "easyuse_anima/naia/resolution.py",
+                "easyuse_anima/nodes/aio_nodes.py",
                 "easyuse_anima/nodes/image_nodes.py",
                 "easyuse_anima/nodes/impact_detailer_nodes.py",
                 "easyuse_anima/nodes/lora_nodes.py",

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -40,6 +40,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.lora",
     "easyuse_anima.naia",
     "easyuse_anima.nodes",
+    "easyuse_anima.nodes.aio_nodes",
     "easyuse_anima.nodes.impact_detailer_nodes",
     "easyuse_anima.nodes.prompt_advanced_nodes",
     "easyuse_anima.nodes.prompt_data_nodes",
@@ -132,7 +133,11 @@ print(json.dumps({{
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["modules"], list(PACKAGE_MODULES))
-        self.assertEqual(payload["declared_all"], [[] for _ in PACKAGE_MODULES])
+        expected_all = [[] for _ in PACKAGE_MODULES]
+        expected_all[PACKAGE_MODULES.index("easyuse_anima.nodes.aio_nodes")] = [
+            "EasyUseAnimaInput"
+        ]
+        self.assertEqual(payload["declared_all"], expected_all)
         self.assertEqual(payload["new_forbidden"], [])
 
 

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -52,6 +52,7 @@ EXPECTED_PYTHON_PACKAGE_FILES = {
     "easyuse_anima/naia/client.py",
     "easyuse_anima/naia/resolution.py",
     "easyuse_anima/nodes/__init__.py",
+    "easyuse_anima/nodes/aio_nodes.py",
     "easyuse_anima/nodes/image_nodes.py",
     "easyuse_anima/nodes/impact_detailer_nodes.py",
     "easyuse_anima/nodes/lora_nodes.py",


### PR DESCRIPTION
## 작업 단위

- Task: B-09a — `EasyUseAnimaInput` adapter Move
- Owner: #184
- 분류: **Move**
- Base: `dev` / `d2594118607b3d1c2decaa37b96b57c51fe2c1f4`
- 상태: Ready

## 작업 전 symbol / caller / alias / global-state inventory

### public class

- `EasyUseAnimaInput` (`nodes.py:2711-2819`)
  - `INPUT_TYPES`, `RETURN_TYPES`, `RETURN_NAMES`, `FUNCTION`, `CATEGORY`
  - `IS_CHANGED`
  - `build`

신규 `easyuse_anima/nodes/aio_nodes.py`가 이 public ComfyUI adapter class 하나만 소유합니다. 뒤의 `EasyUseAnimaAIOGenerator`는 B-09b이므로 이 PR에서 이동하거나 수정하지 않습니다.

### canonical owner / compatibility seam

- root `nodes.py`는 양쪽 import 모드에서 canonical class를 direct identity alias로 가져옵니다.
- canonical module은 root `nodes.py`를 import하지 않고 `_bind_aio_node_runtime(resolve_helper=...)` 하나로 호출 시점 의존성을 해석합니다.
- `__init__.py`는 계속 root `nodes.py`에서 class를 import하므로 수정 없이 `NODE_CLASS_MAPPINGS["EasyUseAnimaInput"]`가 같은 canonical object identity를 유지합니다.
- import-time `RETURN_TYPES`에는 기존 socket literal `EASY_USE_ANIMA_INPUT`을 사용하고, schema/version은 build 시 root 값을 다시 조회합니다.

### INPUT_TYPES runtime inventory

- `_comfy_diffusion_model_names`
- `_comfy_vae_names`
- `_comfy_text_encoder_names`
- `_comfy_clip_loader_types`
- `_preferred_name_default`
- `_preferred_clip_type_default`
- `_aio_input_settings_json`
- `PROMPT_DATA_TYPE`
- `ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES`
- `ANIMA_DEFAULT_VAE_CANDIDATES`
- `ANIMA_DEFAULT_CLIP_CANDIDATES`

model/VAE/CLIP/type 목록 조회 순서, required input 순서, defaults, hidden/multiline/tooltip metadata를 보존합니다.

### IS_CHANGED / build inventory

- `IS_CHANGED`: `_stable_change_key`, `_prompt_data_json_safe`, `_normalize_prompt_data`, `_normalize_aio_input_settings`
- `build`: `_normalize_aio_input_settings`, `_copy_prompt_data_for_update`, `EASY_USE_ANIMA_INPUT_SCHEMA`, `EASY_USE_ANIMA_INPUT_SETTINGS_VERSION`

change-key payload key/order와 prompt/input normalization 순서, prompt-data copy 후 metadata 주입, resource_info key/order/default와 serializable result tuple을 보존합니다.

### callers / mapping evidence

- root `__init__.py`의 import와 `NODE_CLASS_MAPPINGS`/display mapping은 그대로 둡니다.
- `tests/test_aio_nodes.py`가 public input contract와 serializable build result를 직접 사용합니다.
- `tests/test_node_contracts.py`가 0.5.2 node/workflow contract와 package mapping identity를 검증합니다.
- generator는 shared socket type와 input validation/signature helpers를 사용하며 이 class 자체에는 의존하지 않으므로 B-09a와 분리됩니다.

### mutable/global state

- 신규 module에는 runtime resolver slot 하나만 둡니다.
- schema/default dictionaries, capability cache, model object, workflow state를 소유하거나 복제하지 않습니다.

## 동작·호환 계약

- class object identity, node id/mapping, input/output order·types·names, hidden field와 defaults를 보존합니다.
- `INPUT_TYPES`의 capability 조회와 preferred default 계산을 호출 시점에 유지합니다.
- `IS_CHANGED` payload/order/normalization과 `build` output shape/key order/copy isolation을 보존합니다.
- 기존 `_normalize_aio_input_settings`에 계속 위임하고 typed input contract를 새로 만들지 않습니다.
- public workflow serialization, locale/frontend, generator execution에는 변경이 없습니다.

## allowed-file boundary

### production

- `nodes.py`
- 신규 `easyuse_anima/nodes/aio_nodes.py`

### tests / analyzer / docs (필요한 항목만)

- `tests/test_aio_nodes.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_backend_analyzer.py`
- `tests/test_python_package_skeleton.py`
- `tests/test_registry_scanner_safety.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 범위

- `EasyUseAnimaAIOGenerator` 또는 legacy generation orchestration 이동
- `__init__.py`, mappings, locales, frontend, workflow/node contract fixture 수정
- input schema/default/normalizer 이동·재설계 또는 typed Contract 신규 도입
- GenerationRequest/stage protocol, seed reservation, cache policy 또는 실행 behavior 변경
- eager optional dependency 조회나 capability/default 순서 변경

## 검증 계획

- root/canonical/package mapping direct identity
- exact `INPUT_TYPES` key/order/metadata/default와 call-time root replacement seam
- exact `IS_CHANGED` payload/order와 `build` normalization/copy/resource/output parity
- 기존 AiO input·node contract와 analyzer/package/scanner focused checkpoint 1회
- 신규 canonical module compile/Pyright/Ruff, G-03a, `git diff --check`
- 독립 diff review 후 exact final head official full 1회
- Legacy canvas/Node 2.0 실제 브라우저 serialization을 실행하지 않으면 fixture/package identity와 미실행 표면을 구분해 기록

## 롤백 경계

- 신규 aio node module, root import/binder/direct class alias와 원본 class 이동, 대응 tests/fixtures/docs만 되돌리면 기존 root class로 복귀합니다.

## 구현 결과

- `EasyUseAnimaInput` 구현을 `easyuse_anima.nodes.aio_nodes`로 이동했습니다.
- root package/direct-import 양쪽이 canonical class를 direct alias하고, package mapping도 같은 class identity를 유지합니다.
- root globals를 호출 시점에 해석해 기존 monkeypatch seam과 capability/default 계산 순서를 보존했습니다.
- root `nodes.py`: 3,122 lines / 43 functions / 3 classes
- backend analyzer: 76 modules / 76 shipped modules / 76 runtime-closure modules, missing/unreachable 0
- 독립 diff review: P0-P2 발견 없음

## 검증 결과

- exact head: `6bb1142b32b1b6d22b3d950e88a9fa2a5049711a`
- focused `unittest`: 148 tests passed
- analyzer 기준선 영향 확인: 18 tests passed
- Python compile: passed
- targeted Ruff: passed
- Pyright 1.1.411 (신규 module): 0 errors
- G-03a: 6 completed package groups, 0 violations
- `git diff --check`: passed
- official full: 852 Python tests passed; 114 JavaScript files passed; Pyright baseline ratchet passed; G-03a passed
- official full의 Ruff 105건은 G-01 report-only 기존 기준선이며 blocking failure가 아닙니다.
- ComfyUI Codex test instance: contract/module checks
- Legacy canvas / Node 2.0 실제 브라우저 serialization 및 live ComfyUI smoke: 실행하지 않음

Closes no issue; #184 B-09a 완료 기록만 추가합니다.
