### PR TITLE
refactor(aio): move legacy generation orchestration (B-09b1)

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-22
 - Snapshot branch: `dev`
-- Snapshot commit: `d2594118607b3d1c2decaa37b96b57c51fe2c1f4`
+- Integrated `dev` snapshot commit: `fb85e9eaedb9dabfbcf77740b27bee98c99e679a`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -28,10 +28,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 
 ### Phase summary
 
-| Phase | State at the snapshot | Remaining exit work |
+| Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | In progress through B-09a | Continue B-09b AiO extraction, compatibility audit, registration/bootstrap, final root shim |
+| B - `nodes.py` extraction | Integrated through B-09a; B-09b1 implemented in PR #269 | Integrate B-09b1, then continue B-09b2 AiO adapter extraction, compatibility audit, registration/bootstrap, final root shim |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,12 +42,16 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- At the B-09a snapshot, root `nodes.py` is 3,122 lines.
-- The mechanical extraction has therefore removed 9,541 lines, approximately
-  75.3% of the baseline, while preserving the root compatibility surface.
+- Against the integrated `dev` snapshot above, the B-09b1 PR-head
+  implementation measures root `nodes.py` at 2,822 lines. This is a PR-head
+  measurement, not a claim that B-09b1 is already integrated into that commit.
+- At that implementation head the mechanical extraction has removed 9,841
+  lines, approximately 77.7% of the Phase A baseline, while preserving the root
+  compatibility surface.
 - B-01 through B-08e are integrated. The latest completed implementation slice
   is the AiO input-adapter Move in PR #268.
-- Root `nodes.py` still owns substantial AiO implementation.
+- Root `nodes.py` still owns the public AiO generator adapter and remaining
+  support seams, while its current-order `generate` body is canonical.
 - Root `__init__.py` still imports `api.py` for route-registration side effects,
   initializes the wildcard directory during package import, and owns mapping
   composition. B-11 is therefore not complete.
@@ -288,15 +292,16 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 7 | C168-06 normalizer ownership move | COMPLETE on `dev` | Move | #168/#184 | PR #257 / `3ca5500` |
 | 8 | B-08a through B-08e AiO support-helper extraction | COMPLETE on `dev` | Move | #184 | B-08a PR #259; B-08b1 PR #260; B-08b2 PR #261; B-08c PR #262; B-08d1 PR #263; B-08d2 PR #264; B-08e PR #265 |
 | 9 | B-09a AiO input adapter move | COMPLETE in PR #268 | Move | #184 | AiO helpers canonical through B-08e |
-| 10 | B-09b AiO generator and legacy orchestration move | READY | Move | #184 | B-09a implementation complete |
-| 11 | B-10 compatibility/private-alias audit | BLOCKED by B-09b | Contract/cleanup, split PRs | #184/#188 | All node implementations canonical |
-| 12 | B-11 registration/bootstrap/root shim | BLOCKED by B-10 | Move | #184 | Alias surface frozen |
-| 13 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
-| 14 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
-| 15 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
-| 16 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
-| 17 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
-| 18 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
+| 10 | B-09b1 AiO legacy orchestration body move | IMPLEMENTED in PR #269 | Move | #184 | B-09a implementation complete |
+| 11 | B-09b2 AiO generator adapter move | READY after B-09b1 | Move | #184 | B-09b1 integrated |
+| 12 | B-10 compatibility/private-alias audit | BLOCKED by B-09b | Contract/cleanup, split PRs | #184/#188 | All node implementations canonical |
+| 13 | B-11 registration/bootstrap/root shim | BLOCKED by B-10 | Move | #184 | Alias surface frozen |
+| 14 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
+| 15 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
+| 16 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
+| 17 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
+| 18 | E-series RuntimeServices/lifecycle | BLOCKED by canonical owners | Move/Contract, split PRs | #187 | Relevant D moves |
+| 19 | G-04 through G-06 and H | INCREMENTAL/LATER | Gate/Contract | #188 | Appropriate package and release evidence |
 
 Issue #199, authenticated diagnostics/settings access, is an independent security
 track. It may proceed when its threat model and owner are ready, but it does not
@@ -556,6 +561,21 @@ easyuse_anima/aio/legacy_generation.py  # temporary current-order orchestration 
 it exceeds the G-05 guidance, record #169 as its decomposition owner. Do not
 solve that debt by leaving the full orchestration in the node adapter or by
 inventing an unreviewed framework.
+
+B-09b is split at the existing compatibility boundary:
+
+- B-09b1 moves only the current 329-line `generate` orchestration body to
+  `easyuse_anima.aio.legacy_generation`. The root public class, `INPUT_TYPES`,
+  `IS_CHANGED`, mappings, input validator, and exact `generate` signature stay
+  in `nodes.py`; the method delegates through a direct private alias and a
+  resolver-only call-time seam. The deterministic v1 trace freezes base
+  txt2img and patched upscale-plus-intermediate-preview order, cleanup-before-
+  save, metadata, UI projection, and `id(generator)` cache scope without
+  introducing stage contracts.
+- B-09b2 moves the public `EasyUseAnimaAIOGenerator` adapter to canonical node
+  ownership after B-09b1 is integrated. It owns class/mapping identity and the
+  remaining workflow/browser serialization checkpoint. B-09 is not complete
+  until that adapter slice and the stated integration evidence are complete.
 
 Before merge, capture a deterministic execution trace fixture for the current
 major phases and prove no order/result/cleanup drift. Run at least:

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -170,6 +170,15 @@ EasyUseAnimaWildcard
   `__all__`; its narrow call-time runtime seam preserves root monkeypatches for
   resource candidates, normalization, stable change keys, schema/version
   values, and prompt-data copying. The adapter does not import `nodes.py`.
+- B-09b1 internal AiO orchestration transition: the current-order
+  `EasyUseAnimaAIOGenerator.generate` body moves to
+  `easyuse_anima.aio.legacy_generation` while the public class and exact method
+  signature remain root-owned for the B-09b2 adapter slice. Root retains direct
+  private identity aliases for the binder and orchestration function; the
+  canonical module imports no root module and resolves every legacy helper,
+  constant, and module at its original call site through one resolver slot.
+  These aliases are transitional internal seams for B-10 and are not public
+  package `__all__` entries.
 - Removal gate: 0.5.2 node/workflow fixture, mapping identity, direct import,
   Registry archive closure, consumer evidence, separate breaking-change issue,
   and release note. With no external-consumer evidence, retain these exports.

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+_RuntimeResolver = Callable[[str], Any]
+
+_RUNTIME_RESOLVER: _RuntimeResolver | None = None
+
+
+def _bind_aio_legacy_generation_runtime(*, resolve_helper: _RuntimeResolver) -> None:
+    global _RUNTIME_RESOLVER
+
+    _RUNTIME_RESOLVER = resolve_helper
+
+
+def _runtime_helper(name: str) -> Any:
+    resolver = _RUNTIME_RESOLVER
+    if resolver is None:
+        raise RuntimeError("AiO legacy generation runtime is not bound.")
+    return resolver(name)
+
+
+def _run_aio_legacy_generation(
+    generator,
+    easy_use_anima_input,
+    generation_settings: str | dict | None = None,
+    lora_stack=None,
+    workflow_prompt=None,
+    extra_pnginfo=None,
+    unique_id=None,
+):
+    context = _runtime_helper("_require_easy_use_anima_input")(easy_use_anima_input)
+    settings = _runtime_helper("_normalize_aio_generation_settings")(generation_settings)
+    settings["sampler"]["seed"] = _runtime_helper("_resolve_aio_runtime_seed")(
+        settings["sampler"].get("seed")
+    )
+    if settings["mode"] != "txt2img":
+        raise RuntimeError("[EasyUseAnima] AiO Generator draft currently supports txt2img only.")
+
+    base_model, base_clip, vae = _runtime_helper(
+        "_load_aio_resources_from_input_context"
+    )(context)
+    model_with_lora, clip, applied_loras = _runtime_helper("_apply_aio_lora_stack")(
+        base_model,
+        base_clip,
+        lora_stack,
+    )
+    model = _runtime_helper("_apply_aio_model_patches")(model_with_lora, settings)
+    prompt_data = _runtime_helper("_normalize_prompt_data")(context["prompt_data"])
+    (
+        positive_prompt,
+        negative_prompt,
+        quality_tags,
+        quality_neg,
+        use_anima_mod_guidance,
+        use_negative_anima_mod_guidance,
+        metadata_prompt,
+        metadata_negative_prompt,
+        width,
+        height,
+    ) = _runtime_helper("_advanced_outputs_from_prompt_data")(prompt_data)
+    image_saver_positive_prompt = metadata_prompt or positive_prompt
+    image_saver_negative_prompt = metadata_negative_prompt or negative_prompt
+
+    artist_mix = settings["artist_mix"]
+    positive = _runtime_helper("_encode_prompt_data_positive_conditioning")(
+        clip,
+        prompt_data,
+        positive_prompt,
+        artist_mix_mode=artist_mix["mode"],
+        artist_mix_start_percent=artist_mix["start_percent"],
+        artist_mix_strength_scale=artist_mix["strength_scale"],
+        artist_mix_style_gain=artist_mix["style_gain"],
+        artist_mix_rms_scale_cap=artist_mix["rms_scale_cap"],
+        artist_mix_exact_top_k=artist_mix["exact_top_k"],
+        artist_mix_cluster_count=artist_mix["cluster_count"],
+        artist_mix_dominant_isolation=artist_mix["dominant_isolation"],
+        artist_mix_dominant_threshold=artist_mix["dominant_threshold"],
+    )
+    negative = _runtime_helper("_encode_with_comfy_clip")(clip, negative_prompt)
+
+    sampler = settings["sampler"]
+    mod_guidance = settings["mod_guidance"]
+    will_run_highres = _runtime_helper("_as_bool")(
+        settings["highres"].get("enabled"), False
+    )
+    will_run_detailer = _runtime_helper("_aio_detailer_has_enabled_targets")(
+        settings["detailer"]
+    )
+    will_run_upscale = _runtime_helper("_as_bool")(
+        settings["upscale"].get("enabled"), False
+    )
+    will_run_postprocess = _runtime_helper("_as_bool")(
+        settings["postprocess"].get("enabled"), False
+    )
+    profile = _runtime_helper("_normalize_anima_mod_guidance_profile")(
+        mod_guidance["profile"]
+    )
+    use_mod_guidance = _runtime_helper("_resolve_anima_mod_guidance_enabled")(
+        use_anima_mod_guidance,
+        mod_guidance["mode"],
+    )
+    sampler_backend = str(sampler.get("backend") or "comfy_ksampler")
+    highres_backend = _runtime_helper("_aio_highres_effective_backend")(
+        sampler, settings["highres"]
+    )
+    mod_guidance_model = model
+    can_apply_standalone_mod_guidance = (
+        use_mod_guidance
+        and profile != _runtime_helper("ANIMA_MOD_GUIDANCE_PROFILE_OFF")
+    )
+
+    def ensure_standalone_mod_guidance_model():
+        nonlocal mod_guidance_model
+        if not can_apply_standalone_mod_guidance or mod_guidance_model is not model:
+            return mod_guidance_model
+        mod_guidance_model = _runtime_helper("_apply_spectrum_anima_mod_guidance")(
+            model,
+            clip,
+            positive,
+            negative,
+            quality_tags,
+            quality_neg if use_negative_anima_mod_guidance else "",
+            profile,
+        )
+        return mod_guidance_model
+
+    def model_and_mod_guidance_flag_for_backend(backend: str):
+        if backend == "spectrum_mod_guidance_advanced":
+            if mod_guidance_model is not model:
+                return mod_guidance_model, False
+            return model, use_mod_guidance
+        return ensure_standalone_mod_guidance_model(), False
+
+    base_sample_model, base_use_mod_guidance = model_and_mod_guidance_flag_for_backend(
+        sampler_backend
+    )
+    if sampler_backend == "comfy_ksampler":
+        base_sample_model = _runtime_helper(
+            "_apply_aio_spectrum_model_patches_for_comfy_sampler"
+        )(
+            base_sample_model,
+            clip,
+            positive,
+            sampler,
+        )
+
+    stage_metadata: dict[str, Any] = {}
+    preview_settings = settings["preview"]
+    preview_images: list[dict[str, Any]] = []
+    preview_node_id = _runtime_helper("_single_value")(unique_id)
+    preview_run_id = (
+        f"{preview_node_id or 'aio'}:"
+        f"{_runtime_helper('random').getrandbits(64):016x}"
+    )
+    first_pass_cache_key = _runtime_helper("_aio_first_pass_cache_key")(
+        cache_scope=str(unique_id or id(generator)),
+        context=context,
+        prompt_data=prompt_data,
+        lora_stack=lora_stack,
+        settings=settings,
+        positive_prompt=positive_prompt,
+        negative_prompt=negative_prompt,
+        quality_tags=quality_tags,
+        quality_neg=quality_neg,
+        use_anima_mod_guidance=use_anima_mod_guidance,
+        use_negative_anima_mod_guidance=use_negative_anima_mod_guidance,
+        width=width,
+        height=height,
+    )
+    first_pass_cache_hit = False
+
+    def add_preview(stage: str, stage_image):
+        images = _runtime_helper("_save_aio_temp_preview_image")(
+            stage_image,
+            stage,
+            workflow_prompt=workflow_prompt,
+            extra_pnginfo=extra_pnginfo,
+        )
+        if images:
+            preview_images.extend(images)
+            _runtime_helper("_send_aio_preview_event")(
+                preview_node_id, preview_run_id, stage, images
+            )
+
+    try:
+        cached_first_pass = _runtime_helper("_get_aio_first_pass_cache")(
+            first_pass_cache_key
+        )
+        if cached_first_pass is not None:
+            latent, image = cached_first_pass
+            first_pass_cache_hit = True
+        else:
+            latent_image = _runtime_helper("_generate_empty_latent_with_comfy")(
+                width, height
+            )
+            latent = _runtime_helper("_sample_latent_with_aio_backend")(
+                base_sample_model,
+                clip,
+                positive,
+                negative,
+                latent_image,
+                sampler,
+                mod_guidance,
+                base_use_mod_guidance,
+                quality_tags,
+                quality_neg if use_negative_anima_mod_guidance else "",
+            )
+            image = _runtime_helper("_decode_latent_with_comfy")(vae, latent)
+        image, first_pass_resized = _runtime_helper(
+            "_resize_image_to_size_if_needed"
+        )(
+            image,
+            width,
+            height,
+            "bicubic",
+        )
+        if first_pass_resized:
+            latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, image)
+        if not first_pass_cache_hit or first_pass_resized:
+            try:
+                _runtime_helper("_put_aio_first_pass_cache")(
+                    first_pass_cache_key, latent, image
+                )
+            except Exception as exc:
+                _runtime_helper("logger").debug(
+                    "[EasyUseAnima] failed to store AiO first-pass cache: %s", exc
+                )
+        stage_metadata["first_pass"] = {"cache_hit": first_pass_cache_hit}
+        if preview_settings["intermediate_images"]:
+            add_preview("first_pass", image)
+        highres_model, highres_use_mod_guidance = (
+            model_and_mod_guidance_flag_for_backend(highres_backend)
+            if will_run_highres
+            else (model, False)
+        )
+        latent, image, width, height, highres_metadata = _runtime_helper(
+            "_run_aio_highres_stage"
+        )(
+            highres_model,
+            clip,
+            vae,
+            positive,
+            negative,
+            image,
+            latent,
+            width,
+            height,
+            sampler,
+            settings["highres"],
+            mod_guidance,
+            highres_use_mod_guidance,
+            quality_tags,
+            quality_neg if use_negative_anima_mod_guidance else "",
+        )
+        stage_metadata["highres"] = highres_metadata
+        if highres_metadata.get("enabled") and isinstance(
+            highres_metadata.get("sampler"), dict
+        ):
+            if preview_settings["intermediate_images"] and will_run_detailer:
+                add_preview("highres", image)
+        image, detailer_metadata = _runtime_helper("_run_aio_detailer_stage")(
+            ensure_standalone_mod_guidance_model()
+            if will_run_detailer
+            else mod_guidance_model,
+            clip,
+            vae,
+            positive,
+            negative,
+            image,
+            sampler,
+            settings["detailer"],
+            add_preview if preview_settings["intermediate_images"] else None,
+        )
+        stage_metadata["detailer"] = detailer_metadata
+        if detailer_metadata.get("enabled"):
+            width, height = _runtime_helper("_image_tensor_size")(image, width, height)
+        image, upscale_metadata = _runtime_helper("_run_aio_upscale_stage")(
+            ensure_standalone_mod_guidance_model()
+            if will_run_upscale
+            else mod_guidance_model,
+            clip,
+            vae,
+            positive,
+            negative,
+            image,
+            sampler,
+            settings["upscale"],
+            quality_tags,
+            quality_neg,
+            prompt_data,
+            exclude_positive_quality=can_apply_standalone_mod_guidance,
+            exclude_negative_quality=(
+                can_apply_standalone_mod_guidance and use_negative_anima_mod_guidance
+            ),
+        )
+        stage_metadata["upscale"] = upscale_metadata
+        if upscale_metadata.get("enabled"):
+            width, height = _runtime_helper("_image_tensor_size")(image, width, height)
+            latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, image)
+            if preview_settings["intermediate_images"]:
+                add_preview("upscale", image)
+        image, postprocess_metadata = _runtime_helper("_run_aio_postprocess_stage")(
+            image,
+            settings["postprocess"],
+        )
+        stage_metadata["postprocess"] = postprocess_metadata
+        if postprocess_metadata.get("enabled"):
+            width, height = _runtime_helper("_image_tensor_size")(image, width, height)
+            postprocess_changed = _runtime_helper("_as_bool")(
+                (postprocess_metadata.get("fit") or {}).get("applied"),
+                False,
+            )
+            if postprocess_changed:
+                latent = _runtime_helper("_encode_image_with_comfy_vae")(vae, image)
+            if (
+                preview_settings["intermediate_images"]
+                and postprocess_changed
+                and will_run_postprocess
+            ):
+                add_preview("postprocess", image)
+    finally:
+        seen_model_ids: set[int] = set()
+        for ephemeral_model in (
+            base_sample_model,
+            mod_guidance_model,
+            model,
+            model_with_lora,
+        ):
+            if ephemeral_model is None:
+                continue
+            key = id(ephemeral_model)
+            if key in seen_model_ids:
+                continue
+            seen_model_ids.add(key)
+            _runtime_helper("_cleanup_aio_ephemeral_model")(
+                ephemeral_model, base_model
+            )
+
+    save_settings = settings["save"]
+    save_ui = {}
+    if save_settings.get("enabled"):
+        if save_settings.get("backend") == "image_saver":
+            save_result = _runtime_helper("_save_image_with_image_saver")(
+                image,
+                save_settings,
+                positive_prompt=image_saver_positive_prompt,
+                negative_prompt=image_saver_negative_prompt,
+                width=width,
+                height=height,
+                sampler_settings=sampler,
+                applied_loras=applied_loras,
+                resource_info=context.get("resource_info", {}),
+                workflow_prompt=workflow_prompt,
+                extra_pnginfo=extra_pnginfo,
+            )
+        else:
+            save_result = _runtime_helper("_save_image_with_comfy")(
+                image,
+                _runtime_helper("_aio_save_filename_prefix")(save_settings),
+                workflow_prompt=workflow_prompt,
+                extra_pnginfo=extra_pnginfo,
+            )
+        if isinstance(save_result, dict) and isinstance(save_result.get("ui"), dict):
+            save_ui = save_result["ui"]
+    final_preview = _runtime_helper("_tag_aio_preview_images")(
+        save_ui.get("images", []), "final", width=width, height=height
+    )
+    if not final_preview:
+        final_preview = _runtime_helper("_save_aio_temp_preview_image")(
+            image,
+            "final",
+            workflow_prompt=workflow_prompt,
+            extra_pnginfo=extra_pnginfo,
+        )
+    if (
+        final_preview
+        and preview_images
+        and str(preview_images[-1].get("stage") or "").startswith("detailer_")
+    ):
+        preview_images[-1] = final_preview[0]
+        final_preview = final_preview[1:]
+
+    metadata = {
+        "schema": "easyuse_anima_aio_generation_result",
+        "version": 1,
+        "width": int(width),
+        "height": int(height),
+        "resource_info": _runtime_helper("_prompt_data_json_safe")(
+            context.get("resource_info", {})
+        ),
+        "input_settings": _runtime_helper("_prompt_data_json_safe")(
+            context.get("input_settings", {})
+        ),
+        "lora_stack": _runtime_helper("_prompt_data_json_safe")(applied_loras),
+        "generation_settings": _runtime_helper("_prompt_data_json_safe")(settings),
+        "stages": _runtime_helper("_prompt_data_json_safe")(stage_metadata),
+        "prompt_data": _runtime_helper("_prompt_data_json_safe")(prompt_data),
+    }
+    metadata_json = _runtime_helper("json").dumps(
+        metadata, ensure_ascii=False, sort_keys=True
+    )
+    ui = {
+        "status": ["generated"],
+        "width": [int(width)],
+        "height": [int(height)],
+        "unet_name": [str(context.get("resource_info", {}).get("unet_name", ""))],
+        "sampler_backend": [str(sampler.get("backend") or "comfy_ksampler")],
+        "easyuse_anima_run_id": [preview_run_id],
+    }
+    preview_payload = preview_images + final_preview
+    if final_preview:
+        ui["images"] = final_preview
+    if preview_payload:
+        ui["easyuse_anima_preview"] = preview_payload
+    return {
+        "ui": ui,
+        "result": (image, latent, metadata_json),
+    }
+
+
+__all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -20,6 +20,10 @@ try:
         _get_aio_first_pass_cache as _get_aio_first_pass_cache,
         _put_aio_first_pass_cache as _put_aio_first_pass_cache,
     )
+    from .easyuse_anima.aio.legacy_generation import (
+        _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
+        _run_aio_legacy_generation as _run_aio_legacy_generation,
+    )
     from .easyuse_anima.aio.generation_normalization import (
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
         _merge_versioned_settings as _merge_versioned_settings,
@@ -525,6 +529,10 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _clone_aio_cache_value as _clone_aio_cache_value,
         _get_aio_first_pass_cache as _get_aio_first_pass_cache,
         _put_aio_first_pass_cache as _put_aio_first_pass_cache,
+    )
+    from easyuse_anima.aio.legacy_generation import (
+        _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
+        _run_aio_legacy_generation as _run_aio_legacy_generation,
     )
     from easyuse_anima.aio.generation_normalization import (
         _bind_aio_generation_normalization_runtime as _bind_aio_generation_normalization_runtime,
@@ -2600,6 +2608,9 @@ def _consume_reserved_wildcard_next_seed(
 _bind_aio_first_pass_cache_runtime(
     resolve_helper=lambda name: globals()[name],
 )
+_bind_aio_legacy_generation_runtime(
+    resolve_helper=lambda name: globals()[name],
+)
 _bind_aio_generation_normalization_runtime(
     resolve_helper=lambda name: globals()[name],
 )
@@ -2800,323 +2811,12 @@ class EasyUseAnimaAIOGenerator:
         extra_pnginfo=None,
         unique_id=None,
     ):
-        context = _require_easy_use_anima_input(easy_use_anima_input)
-        settings = _normalize_aio_generation_settings(generation_settings)
-        settings["sampler"]["seed"] = _resolve_aio_runtime_seed(settings["sampler"].get("seed"))
-        if settings["mode"] != "txt2img":
-            raise RuntimeError("[EasyUseAnima] AiO Generator draft currently supports txt2img only.")
-
-        base_model, base_clip, vae = _load_aio_resources_from_input_context(context)
-        model_with_lora, clip, applied_loras = _apply_aio_lora_stack(
-            base_model,
-            base_clip,
+        return _run_aio_legacy_generation(
+            self,
+            easy_use_anima_input,
+            generation_settings,
             lora_stack,
+            workflow_prompt,
+            extra_pnginfo,
+            unique_id,
         )
-        model = _apply_aio_model_patches(model_with_lora, settings)
-        prompt_data = _normalize_prompt_data(context["prompt_data"])
-        (
-            positive_prompt,
-            negative_prompt,
-            quality_tags,
-            quality_neg,
-            use_anima_mod_guidance,
-            use_negative_anima_mod_guidance,
-            metadata_prompt,
-            metadata_negative_prompt,
-            width,
-            height,
-        ) = _advanced_outputs_from_prompt_data(prompt_data)
-        image_saver_positive_prompt = metadata_prompt or positive_prompt
-        image_saver_negative_prompt = metadata_negative_prompt or negative_prompt
-
-        artist_mix = settings["artist_mix"]
-        positive = _encode_prompt_data_positive_conditioning(
-            clip,
-            prompt_data,
-            positive_prompt,
-            artist_mix_mode=artist_mix["mode"],
-            artist_mix_start_percent=artist_mix["start_percent"],
-            artist_mix_strength_scale=artist_mix["strength_scale"],
-            artist_mix_style_gain=artist_mix["style_gain"],
-            artist_mix_rms_scale_cap=artist_mix["rms_scale_cap"],
-            artist_mix_exact_top_k=artist_mix["exact_top_k"],
-            artist_mix_cluster_count=artist_mix["cluster_count"],
-            artist_mix_dominant_isolation=artist_mix["dominant_isolation"],
-            artist_mix_dominant_threshold=artist_mix["dominant_threshold"],
-        )
-        negative = _encode_with_comfy_clip(clip, negative_prompt)
-
-        sampler = settings["sampler"]
-        mod_guidance = settings["mod_guidance"]
-        will_run_highres = _as_bool(settings["highres"].get("enabled"), False)
-        will_run_detailer = _aio_detailer_has_enabled_targets(settings["detailer"])
-        will_run_upscale = _as_bool(settings["upscale"].get("enabled"), False)
-        will_run_postprocess = _as_bool(settings["postprocess"].get("enabled"), False)
-        profile = _normalize_anima_mod_guidance_profile(mod_guidance["profile"])
-        use_mod_guidance = _resolve_anima_mod_guidance_enabled(
-            use_anima_mod_guidance,
-            mod_guidance["mode"],
-        )
-        sampler_backend = str(sampler.get("backend") or "comfy_ksampler")
-        highres_backend = _aio_highres_effective_backend(sampler, settings["highres"])
-        mod_guidance_model = model
-        can_apply_standalone_mod_guidance = (
-            use_mod_guidance
-            and profile != ANIMA_MOD_GUIDANCE_PROFILE_OFF
-        )
-
-        def ensure_standalone_mod_guidance_model():
-            nonlocal mod_guidance_model
-            if not can_apply_standalone_mod_guidance or mod_guidance_model is not model:
-                return mod_guidance_model
-            mod_guidance_model = _apply_spectrum_anima_mod_guidance(
-                model,
-                clip,
-                positive,
-                negative,
-                quality_tags,
-                quality_neg if use_negative_anima_mod_guidance else "",
-                profile,
-            )
-            return mod_guidance_model
-
-        def model_and_mod_guidance_flag_for_backend(backend: str):
-            if backend == "spectrum_mod_guidance_advanced":
-                if mod_guidance_model is not model:
-                    return mod_guidance_model, False
-                return model, use_mod_guidance
-            return ensure_standalone_mod_guidance_model(), False
-
-        base_sample_model, base_use_mod_guidance = model_and_mod_guidance_flag_for_backend(sampler_backend)
-        if sampler_backend == "comfy_ksampler":
-            base_sample_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
-                base_sample_model,
-                clip,
-                positive,
-                sampler,
-            )
-
-        stage_metadata: dict[str, Any] = {}
-        preview_settings = settings["preview"]
-        preview_images: list[dict[str, Any]] = []
-        preview_node_id = _single_value(unique_id)
-        preview_run_id = f"{preview_node_id or 'aio'}:{random.getrandbits(64):016x}"
-        first_pass_cache_key = _aio_first_pass_cache_key(
-            cache_scope=str(unique_id or id(self)),
-            context=context,
-            prompt_data=prompt_data,
-            lora_stack=lora_stack,
-            settings=settings,
-            positive_prompt=positive_prompt,
-            negative_prompt=negative_prompt,
-            quality_tags=quality_tags,
-            quality_neg=quality_neg,
-            use_anima_mod_guidance=use_anima_mod_guidance,
-            use_negative_anima_mod_guidance=use_negative_anima_mod_guidance,
-            width=width,
-            height=height,
-        )
-        first_pass_cache_hit = False
-
-        def add_preview(stage: str, stage_image):
-            images = _save_aio_temp_preview_image(
-                stage_image,
-                stage,
-                workflow_prompt=workflow_prompt,
-                extra_pnginfo=extra_pnginfo,
-            )
-            if images:
-                preview_images.extend(images)
-                _send_aio_preview_event(preview_node_id, preview_run_id, stage, images)
-
-        try:
-            cached_first_pass = _get_aio_first_pass_cache(first_pass_cache_key)
-            if cached_first_pass is not None:
-                latent, image = cached_first_pass
-                first_pass_cache_hit = True
-            else:
-                latent_image = _generate_empty_latent_with_comfy(width, height)
-                latent = _sample_latent_with_aio_backend(
-                    base_sample_model,
-                    clip,
-                    positive,
-                    negative,
-                    latent_image,
-                    sampler,
-                    mod_guidance,
-                    base_use_mod_guidance,
-                    quality_tags,
-                    quality_neg if use_negative_anima_mod_guidance else "",
-                )
-                image = _decode_latent_with_comfy(vae, latent)
-            image, first_pass_resized = _resize_image_to_size_if_needed(
-                image,
-                width,
-                height,
-                "bicubic",
-            )
-            if first_pass_resized:
-                latent = _encode_image_with_comfy_vae(vae, image)
-            if not first_pass_cache_hit or first_pass_resized:
-                try:
-                    _put_aio_first_pass_cache(first_pass_cache_key, latent, image)
-                except Exception as exc:
-                    logger.debug("[EasyUseAnima] failed to store AiO first-pass cache: %s", exc)
-            stage_metadata["first_pass"] = {"cache_hit": first_pass_cache_hit}
-            if preview_settings["intermediate_images"]:
-                add_preview("first_pass", image)
-            highres_model, highres_use_mod_guidance = (
-                model_and_mod_guidance_flag_for_backend(highres_backend)
-                if will_run_highres
-                else (model, False)
-            )
-            latent, image, width, height, highres_metadata = _run_aio_highres_stage(
-                highres_model,
-                clip,
-                vae,
-                positive,
-                negative,
-                image,
-                latent,
-                width,
-                height,
-                sampler,
-                settings["highres"],
-                mod_guidance,
-                highres_use_mod_guidance,
-                quality_tags,
-                quality_neg if use_negative_anima_mod_guidance else "",
-            )
-            stage_metadata["highres"] = highres_metadata
-            if highres_metadata.get("enabled") and isinstance(highres_metadata.get("sampler"), dict):
-                if preview_settings["intermediate_images"] and will_run_detailer:
-                    add_preview("highres", image)
-            image, detailer_metadata = _run_aio_detailer_stage(
-                ensure_standalone_mod_guidance_model() if will_run_detailer else mod_guidance_model,
-                clip,
-                vae,
-                positive,
-                negative,
-                image,
-                sampler,
-                settings["detailer"],
-                add_preview if preview_settings["intermediate_images"] else None,
-            )
-            stage_metadata["detailer"] = detailer_metadata
-            if detailer_metadata.get("enabled"):
-                width, height = _image_tensor_size(image, width, height)
-            image, upscale_metadata = _run_aio_upscale_stage(
-                ensure_standalone_mod_guidance_model() if will_run_upscale else mod_guidance_model,
-                clip,
-                vae,
-                positive,
-                negative,
-                image,
-                sampler,
-                settings["upscale"],
-                quality_tags,
-                quality_neg,
-                prompt_data,
-                exclude_positive_quality=can_apply_standalone_mod_guidance,
-                exclude_negative_quality=can_apply_standalone_mod_guidance and use_negative_anima_mod_guidance,
-            )
-            stage_metadata["upscale"] = upscale_metadata
-            if upscale_metadata.get("enabled"):
-                width, height = _image_tensor_size(image, width, height)
-                latent = _encode_image_with_comfy_vae(vae, image)
-                if preview_settings["intermediate_images"]:
-                    add_preview("upscale", image)
-            image, postprocess_metadata = _run_aio_postprocess_stage(
-                image,
-                settings["postprocess"],
-            )
-            stage_metadata["postprocess"] = postprocess_metadata
-            if postprocess_metadata.get("enabled"):
-                width, height = _image_tensor_size(image, width, height)
-                postprocess_changed = _as_bool(
-                    (postprocess_metadata.get("fit") or {}).get("applied"),
-                    False,
-                )
-                if postprocess_changed:
-                    latent = _encode_image_with_comfy_vae(vae, image)
-                if preview_settings["intermediate_images"] and postprocess_changed and will_run_postprocess:
-                    add_preview("postprocess", image)
-        finally:
-            seen_model_ids: set[int] = set()
-            for ephemeral_model in (base_sample_model, mod_guidance_model, model, model_with_lora):
-                if ephemeral_model is None:
-                    continue
-                key = id(ephemeral_model)
-                if key in seen_model_ids:
-                    continue
-                seen_model_ids.add(key)
-                _cleanup_aio_ephemeral_model(ephemeral_model, base_model)
-
-        save_settings = settings["save"]
-        save_ui = {}
-        if save_settings.get("enabled"):
-            if save_settings.get("backend") == "image_saver":
-                save_result = _save_image_with_image_saver(
-                    image,
-                    save_settings,
-                    positive_prompt=image_saver_positive_prompt,
-                    negative_prompt=image_saver_negative_prompt,
-                    width=width,
-                    height=height,
-                    sampler_settings=sampler,
-                    applied_loras=applied_loras,
-                    resource_info=context.get("resource_info", {}),
-                    workflow_prompt=workflow_prompt,
-                    extra_pnginfo=extra_pnginfo,
-                )
-            else:
-                save_result = _save_image_with_comfy(
-                    image,
-                    _aio_save_filename_prefix(save_settings),
-                    workflow_prompt=workflow_prompt,
-                    extra_pnginfo=extra_pnginfo,
-                )
-            if isinstance(save_result, dict) and isinstance(save_result.get("ui"), dict):
-                save_ui = save_result["ui"]
-        final_preview = _tag_aio_preview_images(save_ui.get("images", []), "final", width=width, height=height)
-        if not final_preview:
-            final_preview = _save_aio_temp_preview_image(
-                image,
-                "final",
-                workflow_prompt=workflow_prompt,
-                extra_pnginfo=extra_pnginfo,
-            )
-        if final_preview and preview_images and str(preview_images[-1].get("stage") or "").startswith("detailer_"):
-            preview_images[-1] = final_preview[0]
-            final_preview = final_preview[1:]
-
-        metadata = {
-            "schema": "easyuse_anima_aio_generation_result",
-            "version": 1,
-            "width": int(width),
-            "height": int(height),
-            "resource_info": _prompt_data_json_safe(context.get("resource_info", {})),
-            "input_settings": _prompt_data_json_safe(context.get("input_settings", {})),
-            "lora_stack": _prompt_data_json_safe(applied_loras),
-            "generation_settings": _prompt_data_json_safe(settings),
-            "stages": _prompt_data_json_safe(stage_metadata),
-            "prompt_data": _prompt_data_json_safe(prompt_data),
-        }
-        metadata_json = json.dumps(metadata, ensure_ascii=False, sort_keys=True)
-        ui = {
-            "status": ["generated"],
-            "width": [int(width)],
-            "height": [int(height)],
-            "unet_name": [str(context.get("resource_info", {}).get("unet_name", ""))],
-            "sampler_backend": [str(sampler.get("backend") or "comfy_ksampler")],
-            "easyuse_anima_run_id": [preview_run_id],
-        }
-        preview_payload = preview_images + final_preview
-        if final_preview:
-            ui["images"] = final_preview
-        if preview_payload:
-            ui["easyuse_anima_preview"] = preview_payload
-        return {
-            "ui": ui,
-            "result": (image, latent, metadata_json),
-        }

--- a/tests/fixtures/aio_legacy_execution_trace.v1.json
+++ b/tests/fixtures/aio_legacy_execution_trace.v1.json
@@ -1,0 +1,339 @@
+{
+  "schema": "easyuse_anima_aio_legacy_execution_trace",
+  "version": 1,
+  "cases": {
+    "base_txt2img": {
+      "trace": [
+        "require_input",
+        "normalize_settings",
+        "resolve_seed",
+        "load_resources",
+        "apply_lora",
+        "apply_model_patches",
+        "normalize_prompt",
+        "advanced_outputs",
+        "encode_positive",
+        "encode_negative",
+        "detailer_enabled",
+        "normalize_profile",
+        "resolve_guidance",
+        "resolve_highres_backend",
+        "apply_spectrum_model_patches",
+        "random_run_id",
+        "cache_key:generator-id",
+        "get_cache",
+        "empty_latent",
+        "sample",
+        "decode",
+        "resize_first_pass",
+        "put_cache",
+        "run_highres",
+        "run_detailer",
+        "run_upscale",
+        "run_postprocess",
+        "cleanup:sample",
+        "cleanup:model",
+        "cleanup:lora",
+        "save_prefix",
+        "save_comfy",
+        "tag:final"
+      ],
+      "result": {
+        "image": "decoded-image",
+        "latent": "sampled-latent",
+        "metadata": {
+          "generation_settings": {
+            "artist_mix": {
+              "cluster_count": 1,
+              "dominant_isolation": false,
+              "dominant_threshold": 0.0,
+              "exact_top_k": 0,
+              "mode": "sequential",
+              "rms_scale_cap": 1.0,
+              "start_percent": 0.0,
+              "strength_scale": 1.0,
+              "style_gain": 1.0
+            },
+            "detailer": {},
+            "highres": {
+              "enabled": false
+            },
+            "mod_guidance": {
+              "mode": "auto",
+              "profile": "off"
+            },
+            "mode": "txt2img",
+            "postprocess": {
+              "enabled": false
+            },
+            "preview": {
+              "intermediate_images": false
+            },
+            "sampler": {
+              "backend": "comfy_ksampler",
+              "seed": 17
+            },
+            "save": {
+              "backend": "comfy",
+              "enabled": true,
+              "filename_prefix": "Anima"
+            },
+            "upscale": {
+              "enabled": false
+            }
+          },
+          "height": 96,
+          "input_settings": {
+            "schema": "input-settings"
+          },
+          "lora_stack": [
+            {
+              "name": "style.safetensors"
+            }
+          ],
+          "prompt_data": {
+            "positive_prompt": "prompt"
+          },
+          "resource_info": {
+            "unet_name": "model.safetensors"
+          },
+          "schema": "easyuse_anima_aio_generation_result",
+          "stages": {
+            "first_pass": {
+              "cache_hit": false
+            },
+            "highres": {
+              "enabled": false
+            },
+            "detailer": {
+              "enabled": false
+            },
+            "upscale": {
+              "enabled": false
+            },
+            "postprocess": {
+              "enabled": false
+            }
+          },
+          "version": 1,
+          "width": 64
+        },
+        "ui": {
+          "status": [
+            "generated"
+          ],
+          "width": [
+            64
+          ],
+          "height": [
+            96
+          ],
+          "unet_name": [
+            "model.safetensors"
+          ],
+          "sampler_backend": [
+            "comfy_ksampler"
+          ],
+          "easyuse_anima_run_id": [
+            "aio:0000000000001234"
+          ],
+          "images": [
+            {
+              "filename": "final.png",
+              "subfolder": "",
+              "type": "output",
+              "stage": "final",
+              "width": 64,
+              "height": 96
+            }
+          ],
+          "easyuse_anima_preview": [
+            {
+              "filename": "final.png",
+              "subfolder": "",
+              "type": "output",
+              "stage": "final",
+              "width": 64,
+              "height": 96
+            }
+          ]
+        }
+      }
+    },
+    "upscale_with_intermediate_preview": {
+      "trace": [
+        "require_input",
+        "normalize_settings",
+        "resolve_seed",
+        "load_resources",
+        "apply_lora",
+        "apply_model_patches",
+        "normalize_prompt",
+        "advanced_outputs",
+        "encode_positive",
+        "encode_negative",
+        "detailer_enabled",
+        "normalize_profile",
+        "resolve_guidance",
+        "resolve_highres_backend",
+        "apply_spectrum_model_patches",
+        "random_run_id",
+        "cache_key:node-7",
+        "get_cache",
+        "empty_latent",
+        "sample",
+        "decode",
+        "resize_first_pass",
+        "put_cache",
+        "temp_preview:first_pass",
+        "send_preview:first_pass",
+        "run_highres",
+        "run_detailer",
+        "run_upscale",
+        "image_size",
+        "encode_upscaled_image",
+        "temp_preview:upscale",
+        "send_preview:upscale",
+        "run_postprocess",
+        "cleanup:sample",
+        "cleanup:model",
+        "cleanup:lora",
+        "save_prefix",
+        "save_comfy",
+        "tag:final"
+      ],
+      "result": {
+        "image": "upscaled-image",
+        "latent": "upscaled-latent",
+        "metadata": {
+          "generation_settings": {
+            "artist_mix": {
+              "cluster_count": 1,
+              "dominant_isolation": false,
+              "dominant_threshold": 0.0,
+              "exact_top_k": 0,
+              "mode": "sequential",
+              "rms_scale_cap": 1.0,
+              "start_percent": 0.0,
+              "strength_scale": 1.0,
+              "style_gain": 1.0
+            },
+            "detailer": {},
+            "highres": {
+              "enabled": false
+            },
+            "mod_guidance": {
+              "mode": "auto",
+              "profile": "off"
+            },
+            "mode": "txt2img",
+            "postprocess": {
+              "enabled": false
+            },
+            "preview": {
+              "intermediate_images": true
+            },
+            "sampler": {
+              "backend": "comfy_ksampler",
+              "seed": 17
+            },
+            "save": {
+              "backend": "comfy",
+              "enabled": true,
+              "filename_prefix": "Anima"
+            },
+            "upscale": {
+              "enabled": true
+            }
+          },
+          "height": 192,
+          "input_settings": {
+            "schema": "input-settings"
+          },
+          "lora_stack": [
+            {
+              "name": "style.safetensors"
+            }
+          ],
+          "prompt_data": {
+            "positive_prompt": "prompt"
+          },
+          "resource_info": {
+            "unet_name": "model.safetensors"
+          },
+          "schema": "easyuse_anima_aio_generation_result",
+          "stages": {
+            "first_pass": {
+              "cache_hit": false
+            },
+            "highres": {
+              "enabled": false
+            },
+            "detailer": {
+              "enabled": false
+            },
+            "upscale": {
+              "enabled": true,
+              "backend": "stub"
+            },
+            "postprocess": {
+              "enabled": false
+            }
+          },
+          "version": 1,
+          "width": 128
+        },
+        "ui": {
+          "status": [
+            "generated"
+          ],
+          "width": [
+            128
+          ],
+          "height": [
+            192
+          ],
+          "unet_name": [
+            "model.safetensors"
+          ],
+          "sampler_backend": [
+            "comfy_ksampler"
+          ],
+          "easyuse_anima_run_id": [
+            "node-7:0000000000001234"
+          ],
+          "images": [
+            {
+              "filename": "final.png",
+              "subfolder": "",
+              "type": "output",
+              "stage": "final",
+              "width": 128,
+              "height": 192
+            }
+          ],
+          "easyuse_anima_preview": [
+            {
+              "filename": "first_pass.png",
+              "stage": "first_pass",
+              "type": "temp"
+            },
+            {
+              "filename": "upscale.png",
+              "stage": "upscale",
+              "type": "temp"
+            },
+            {
+              "filename": "final.png",
+              "subfolder": "",
+              "type": "output",
+              "stage": "final",
+              "width": 128,
+              "height": 192
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -6080,6 +6080,57 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 1,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 3,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 4,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 3,
         "name": "annotations",
         "optional": false,
@@ -13882,6 +13933,68 @@
         "target": "easyuse_anima/aio/first_pass_cache.py"
       },
       {
+        "alias": "_bind_aio_legacy_generation_runtime",
+        "bound_name": "_bind_aio_legacy_generation_runtime",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_legacy_generation_runtime",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_bind_aio_legacy_generation_runtime",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_legacy_generation",
+        "bound_name": "_run_aio_legacy_generation",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_legacy_generation",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
+        "kind": "static_from",
+        "line": 23,
+        "name": "_run_aio_legacy_generation",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
         "alias": "_bind_aio_generation_normalization_runtime",
         "bound_name": "_bind_aio_generation_normalization_runtime",
         "branch_context": [
@@ -13903,7 +14016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 23,
+        "line": 27,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -13934,7 +14047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 23,
+        "line": 27,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -13965,7 +14078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 23,
+        "line": 27,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -13996,7 +14109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 28,
+        "line": 32,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -14027,7 +14140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 31,
+        "line": 35,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14058,7 +14171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 31,
+        "line": 35,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14089,7 +14202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 31,
+        "line": 35,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14120,7 +14233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 31,
+        "line": 35,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -14151,7 +14264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14182,7 +14295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14213,7 +14326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14244,7 +14357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14275,7 +14388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14306,7 +14419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14337,7 +14450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14368,7 +14481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14399,7 +14512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14430,7 +14543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14461,7 +14574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14492,7 +14605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 37,
+        "line": 41,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -14523,7 +14636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14554,7 +14667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14585,7 +14698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14616,7 +14729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14647,7 +14760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14678,7 +14791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14709,7 +14822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14740,7 +14853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14771,7 +14884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14802,7 +14915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 51,
+        "line": 55,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -14833,7 +14946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -14864,7 +14977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -14895,7 +15008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -14926,7 +15039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -14957,7 +15070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -14988,7 +15101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15019,7 +15132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15050,7 +15163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15081,7 +15194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15112,7 +15225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 63,
+        "line": 67,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -15143,7 +15256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15174,7 +15287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15205,7 +15318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15236,7 +15349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15267,7 +15380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15298,7 +15411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15329,7 +15442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15360,7 +15473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15391,7 +15504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15422,7 +15535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 75,
+        "line": 79,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -15453,7 +15566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15484,7 +15597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15515,7 +15628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15546,7 +15659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15577,7 +15690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15608,7 +15721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15639,7 +15752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15670,7 +15783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15701,7 +15814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15732,7 +15845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15763,7 +15876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 87,
+        "line": 91,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -15794,7 +15907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -15825,7 +15938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -15856,7 +15969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 100,
+        "line": 104,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -15887,7 +16000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 105,
+        "line": 109,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -15918,7 +16031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 105,
+        "line": 109,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -15949,7 +16062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 105,
+        "line": 109,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -15980,7 +16093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 105,
+        "line": 109,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16011,7 +16124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 105,
+        "line": 109,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -16042,7 +16155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 112,
+        "line": 116,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16073,7 +16186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 112,
+        "line": 116,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16104,7 +16217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 112,
+        "line": 116,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16135,7 +16248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 112,
+        "line": 116,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -16166,7 +16279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16197,7 +16310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16228,7 +16341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16259,7 +16372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16290,7 +16403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16321,7 +16434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16352,7 +16465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16383,7 +16496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16414,7 +16527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16445,7 +16558,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16476,7 +16589,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16507,7 +16620,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 118,
+        "line": 122,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -16538,7 +16651,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16569,7 +16682,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16600,7 +16713,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16631,7 +16744,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16662,7 +16775,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16693,7 +16806,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16724,7 +16837,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16755,7 +16868,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16786,7 +16899,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16817,7 +16930,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16848,7 +16961,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16879,7 +16992,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16910,7 +17023,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16941,7 +17054,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -16972,7 +17085,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17003,7 +17116,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 132,
+        "line": 136,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -17034,7 +17147,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17065,7 +17178,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "ADVANCED_FIELD_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17096,7 +17209,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "ADVANCED_FIELD_PANES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17127,7 +17240,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "ADVANCED_FIELD_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17158,7 +17271,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "EXTEND_PROMPT_SLOT_SPECS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17189,7 +17302,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17220,7 +17333,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17251,7 +17364,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17282,7 +17395,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17313,7 +17426,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17344,7 +17457,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17375,7 +17488,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17406,7 +17519,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17437,7 +17550,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17468,7 +17581,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17499,7 +17612,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17530,7 +17643,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_fields_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17561,7 +17674,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17592,7 +17705,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_pane_parts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17623,7 +17736,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_prompt_data_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17654,7 +17767,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17685,7 +17798,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17716,7 +17829,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17747,7 +17860,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17778,7 +17891,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17809,7 +17922,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17840,7 +17953,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17871,7 +17984,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17902,7 +18015,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17933,7 +18046,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17964,7 +18077,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -17995,7 +18108,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18026,7 +18139,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18057,7 +18170,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 150,
+        "line": 154,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18088,7 +18201,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "REGIONAL_CONFIG_VERSION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18119,7 +18232,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18150,7 +18263,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18181,7 +18294,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "REGIONAL_FIELD_TYPES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18212,7 +18325,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18243,7 +18356,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "REGIONAL_PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18274,7 +18387,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "REGIONAL_PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18305,7 +18418,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18336,7 +18449,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18367,7 +18480,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18398,7 +18511,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18429,7 +18542,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18460,7 +18573,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_normalize_mask_geometry",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18491,7 +18604,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18522,7 +18635,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18553,7 +18666,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18584,7 +18697,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_normalize_regional_mask",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18615,7 +18728,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18646,7 +18759,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18677,7 +18790,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_default_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18708,7 +18821,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18739,7 +18852,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18770,7 +18883,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18801,7 +18914,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18832,7 +18945,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18863,7 +18976,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 186,
+        "line": 190,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -18894,7 +19007,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18925,7 +19038,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18956,7 +19069,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -18987,7 +19100,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19018,7 +19131,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19049,7 +19162,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19080,7 +19193,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19111,7 +19224,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19142,7 +19255,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19173,7 +19286,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19204,7 +19317,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19235,7 +19348,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19266,7 +19379,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19297,7 +19410,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 214,
+        "line": 218,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19328,7 +19441,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19359,7 +19472,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19390,7 +19503,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19421,7 +19534,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19452,7 +19565,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19483,7 +19596,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19514,7 +19627,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19545,7 +19658,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19576,7 +19689,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19607,7 +19720,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19638,7 +19751,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19669,7 +19782,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19700,7 +19813,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19731,7 +19844,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19762,7 +19875,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19793,7 +19906,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19824,7 +19937,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19855,7 +19968,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19886,7 +19999,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19917,7 +20030,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19948,7 +20061,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19979,7 +20092,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20010,7 +20123,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20041,7 +20154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20072,7 +20185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20103,7 +20216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20134,7 +20247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20165,7 +20278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20196,7 +20309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20227,7 +20340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20258,7 +20371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20289,7 +20402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20320,7 +20433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20351,7 +20464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_group_token",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20382,7 +20495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20413,7 +20526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20444,7 +20557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20475,7 +20588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20506,7 +20619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20537,7 +20650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20568,7 +20681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20599,7 +20712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20630,7 +20743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20661,7 +20774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20692,7 +20805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20723,7 +20836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20754,7 +20867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20785,7 +20898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20816,7 +20929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20847,7 +20960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20878,7 +20991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20909,7 +21022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20940,7 +21053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20971,7 +21084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21002,7 +21115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21033,7 +21146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21064,7 +21177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21095,7 +21208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21126,7 +21239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21157,7 +21270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21188,7 +21301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21219,7 +21332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21250,7 +21363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21281,7 +21394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21312,7 +21425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21343,7 +21456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21374,7 +21487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21405,7 +21518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21436,7 +21549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21467,7 +21580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21498,7 +21611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21529,7 +21642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21560,7 +21673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21591,7 +21704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21622,7 +21735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21653,7 +21766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21684,7 +21797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21715,7 +21828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 230,
+        "line": 234,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21746,7 +21859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 310,
+        "line": 314,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21777,7 +21890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 310,
+        "line": 314,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21808,7 +21921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 310,
+        "line": 314,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21839,7 +21952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 310,
+        "line": 314,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21870,7 +21983,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 316,
+        "line": 320,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21901,7 +22014,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 316,
+        "line": 320,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21932,7 +22045,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 316,
+        "line": 320,
         "name": "EasyUseAnimaPromptStudioExtend",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21963,7 +22076,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 316,
+        "line": 320,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21994,7 +22107,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 322,
+        "line": 326,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22025,7 +22138,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 322,
+        "line": 326,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22056,7 +22169,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 326,
+        "line": 330,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22087,7 +22200,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 326,
+        "line": 330,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22118,7 +22231,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 326,
+        "line": 330,
         "name": "_align_up",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22149,7 +22262,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 326,
+        "line": 330,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22180,7 +22293,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 326,
+        "line": 330,
         "name": "_alignment_value",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22211,7 +22324,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 333,
+        "line": 337,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": ".easyuse_anima.image.detailer",
@@ -22242,7 +22355,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22273,7 +22386,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22304,7 +22417,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22335,7 +22448,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22366,7 +22479,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22397,7 +22510,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22428,7 +22541,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22459,7 +22572,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22490,7 +22603,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22521,7 +22634,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22552,7 +22665,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 336,
+        "line": 340,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22583,7 +22696,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 349,
+        "line": 353,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22614,7 +22727,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 349,
+        "line": 353,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22645,7 +22758,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 349,
+        "line": 353,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22676,7 +22789,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 349,
+        "line": 353,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22707,7 +22820,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 349,
+        "line": 353,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22738,7 +22851,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 349,
+        "line": 353,
         "name": "_scale_by_value",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22769,7 +22882,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22800,7 +22913,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22831,7 +22944,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22862,7 +22975,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22893,7 +23006,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22924,7 +23037,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_impact_core_module",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22955,7 +23068,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22986,7 +23099,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23017,7 +23130,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 357,
+        "line": 361,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -23048,7 +23161,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 368,
+        "line": 372,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23079,7 +23192,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 368,
+        "line": 372,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23110,7 +23223,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 368,
+        "line": 372,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23141,7 +23254,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 368,
+        "line": 372,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -23172,7 +23285,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 378,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23203,7 +23316,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 374,
+        "line": 378,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23234,7 +23347,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 378,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23265,7 +23378,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 378,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23296,7 +23409,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 378,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23327,7 +23440,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 374,
+        "line": 378,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23358,7 +23471,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 382,
+        "line": 386,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23389,7 +23502,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 382,
+        "line": 386,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23420,7 +23533,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 386,
+        "line": 390,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -23451,7 +23564,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 386,
+        "line": 390,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -23482,7 +23595,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 390,
+        "line": 394,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23513,7 +23626,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 390,
+        "line": 394,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23544,7 +23657,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 390,
+        "line": 394,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23575,7 +23688,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 395,
+        "line": 399,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23606,7 +23719,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 395,
+        "line": 399,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23637,7 +23750,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 395,
+        "line": 399,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23668,7 +23781,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 395,
+        "line": 399,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23699,7 +23812,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 395,
+        "line": 399,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23730,7 +23843,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 402,
+        "line": 406,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23761,7 +23874,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 402,
+        "line": 406,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23792,7 +23905,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 402,
+        "line": 406,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23823,7 +23936,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23854,7 +23967,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23885,7 +23998,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23916,7 +24029,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23947,7 +24060,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23978,7 +24091,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24009,7 +24122,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24040,7 +24153,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "NAI_1MP",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24071,7 +24184,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24102,7 +24215,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24133,7 +24246,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24164,7 +24277,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "_clean_prompt",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24195,7 +24308,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24226,7 +24339,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24257,7 +24370,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24288,7 +24401,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 407,
+        "line": 411,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -24319,7 +24432,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24350,7 +24463,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24381,7 +24494,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24412,7 +24525,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24443,7 +24556,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24474,7 +24587,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24505,7 +24618,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24536,7 +24649,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24567,7 +24680,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24598,7 +24711,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24629,7 +24742,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24660,7 +24773,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24691,7 +24804,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24722,7 +24835,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24753,7 +24866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24784,7 +24897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24815,7 +24928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24846,7 +24959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24877,7 +24990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24908,7 +25021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24939,7 +25052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 425,
+        "line": 429,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -24970,7 +25083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 448,
+        "line": 452,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25001,7 +25114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 448,
+        "line": 452,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -25032,7 +25145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 452,
+        "line": 456,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25063,7 +25176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 452,
+        "line": 456,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25094,7 +25207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 452,
+        "line": 456,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -25125,7 +25238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25156,7 +25269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25187,7 +25300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25218,7 +25331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25249,7 +25362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25280,7 +25393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25311,7 +25424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25342,7 +25455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25373,7 +25486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25404,7 +25517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25435,7 +25548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25466,7 +25579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25497,7 +25610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25528,7 +25641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25559,7 +25672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 457,
+        "line": 461,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -25590,7 +25703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25621,7 +25734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25652,7 +25765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25683,7 +25796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25714,7 +25827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25745,7 +25858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25776,7 +25889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25807,7 +25920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 474,
+        "line": 478,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -25838,7 +25951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 484,
+        "line": 488,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -25869,7 +25982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 484,
+        "line": 488,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -25900,7 +26013,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 488,
+        "line": 492,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -25931,7 +26044,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 488,
+        "line": 492,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -25962,7 +26075,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 489,
+        "line": 493,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -25993,7 +26106,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 490,
+        "line": 494,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -26024,7 +26137,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 490,
+        "line": 494,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -26055,7 +26168,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 490,
+        "line": 494,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -26086,7 +26199,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 495,
+        "line": 499,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26117,7 +26230,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 495,
+        "line": 499,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -26148,7 +26261,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26179,7 +26292,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26210,7 +26323,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26241,7 +26354,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26272,7 +26385,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26303,7 +26416,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26334,7 +26447,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26365,7 +26478,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26396,7 +26509,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26427,7 +26540,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26458,7 +26571,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26489,7 +26602,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26520,7 +26633,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26551,7 +26664,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26582,7 +26695,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26613,7 +26726,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26644,7 +26757,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26675,7 +26788,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26706,7 +26819,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 496,
+        "line": 500,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -26725,7 +26838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26740,7 +26853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26759,7 +26872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26774,7 +26887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26793,7 +26906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26808,7 +26921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26827,7 +26940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26842,7 +26955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26861,7 +26974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26876,7 +26989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26895,7 +27008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26910,7 +27023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_clear_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26929,7 +27042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26944,7 +27057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26963,7 +27076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -26978,7 +27091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -26997,7 +27110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27012,7 +27125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -27020,6 +27133,74 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/aio/first_pass_cache.py"
+      },
+      {
+        "alias": "_bind_aio_legacy_generation_runtime",
+        "bound_name": "_bind_aio_legacy_generation_runtime",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 521,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_bind_aio_legacy_generation_runtime",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
+        "kind": "static_from",
+        "line": 533,
+        "name": "_bind_aio_legacy_generation_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_legacy_generation",
+        "bound_name": "_run_aio_legacy_generation",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 521,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_legacy_generation",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 11
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
+        "kind": "static_from",
+        "line": 533,
+        "name": "_run_aio_legacy_generation",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
         "alias": "_bind_aio_generation_normalization_runtime",
@@ -27031,7 +27212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27046,7 +27227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 529,
+        "line": 537,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27065,7 +27246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27080,7 +27261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 529,
+        "line": 537,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27099,7 +27280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27114,7 +27295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 529,
+        "line": 537,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -27133,7 +27314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27148,7 +27329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 534,
+        "line": 542,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -27167,7 +27348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27182,7 +27363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27201,7 +27382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27216,7 +27397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27235,7 +27416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27250,7 +27431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27269,7 +27450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27284,7 +27465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -27303,7 +27484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27318,7 +27499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27337,7 +27518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27352,7 +27533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27371,7 +27552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27386,7 +27567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27405,7 +27586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27420,7 +27601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27439,7 +27620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27454,7 +27635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27473,7 +27654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27488,7 +27669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27507,7 +27688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27522,7 +27703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27541,7 +27722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27556,7 +27737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27575,7 +27756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27590,7 +27771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27609,7 +27790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27624,7 +27805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27643,7 +27824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27658,7 +27839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27677,7 +27858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27692,7 +27873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27711,7 +27892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27726,7 +27907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27745,7 +27926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27760,7 +27941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27779,7 +27960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27794,7 +27975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27813,7 +27994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27828,7 +28009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27847,7 +28028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27862,7 +28043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27881,7 +28062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27896,7 +28077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27915,7 +28096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27930,7 +28111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27949,7 +28130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27964,7 +28145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27983,7 +28164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -27998,7 +28179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28017,7 +28198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28032,7 +28213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -28051,7 +28232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28066,7 +28247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28085,7 +28266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28100,7 +28281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28119,7 +28300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28134,7 +28315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28153,7 +28334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28168,7 +28349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28187,7 +28368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28202,7 +28383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28221,7 +28402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28236,7 +28417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28255,7 +28436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28270,7 +28451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28289,7 +28470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28304,7 +28485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28323,7 +28504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28338,7 +28519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28357,7 +28538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28372,7 +28553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28391,7 +28572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28406,7 +28587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28425,7 +28606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28440,7 +28621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28459,7 +28640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28474,7 +28655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28493,7 +28674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28508,7 +28689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28527,7 +28708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28542,7 +28723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28561,7 +28742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28576,7 +28757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28595,7 +28776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28610,7 +28791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28629,7 +28810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28644,7 +28825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28663,7 +28844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28678,7 +28859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28697,7 +28878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28712,7 +28893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28731,7 +28912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28746,7 +28927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28765,7 +28946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28780,7 +28961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28799,7 +28980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28814,7 +28995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28833,7 +29014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28848,7 +29029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28867,7 +29048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28882,7 +29063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28901,7 +29082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28916,7 +29097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28935,7 +29116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28950,7 +29131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28969,7 +29150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -28984,7 +29165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29003,7 +29184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29018,7 +29199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29037,7 +29218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29052,7 +29233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29071,7 +29252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29086,7 +29267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -29105,7 +29286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29120,7 +29301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 606,
+        "line": 614,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29139,7 +29320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29154,7 +29335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 606,
+        "line": 614,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29173,7 +29354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29188,7 +29369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 606,
+        "line": 614,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29207,7 +29388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29222,7 +29403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29241,7 +29422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29256,7 +29437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29275,7 +29456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29290,7 +29471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29309,7 +29490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29324,7 +29505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29343,7 +29524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29358,7 +29539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29377,7 +29558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29392,7 +29573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29411,7 +29592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29426,7 +29607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29445,7 +29626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29460,7 +29641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29479,7 +29660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29494,7 +29675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29513,7 +29694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29528,7 +29709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29547,7 +29728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29562,7 +29743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29581,7 +29762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29596,7 +29777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29615,7 +29796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29630,7 +29811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29649,7 +29830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29664,7 +29845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29683,7 +29864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29698,7 +29879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29717,7 +29898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29732,7 +29913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29751,7 +29932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29766,7 +29947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29785,7 +29966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29800,7 +29981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29819,7 +30000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29834,7 +30015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29853,7 +30034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29868,7 +30049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29887,7 +30068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29902,7 +30083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29921,7 +30102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29936,7 +30117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29955,7 +30136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -29970,7 +30151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29989,7 +30170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30004,7 +30185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30023,7 +30204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30038,7 +30219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30057,7 +30238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30072,7 +30253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30091,7 +30272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30106,7 +30287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30125,7 +30306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30140,7 +30321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30159,7 +30340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30174,7 +30355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30193,7 +30374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30208,7 +30389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30227,7 +30408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30242,7 +30423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30261,7 +30442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30276,7 +30457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_prompt_data_input_default",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30295,7 +30476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30310,7 +30491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30329,7 +30510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30344,7 +30525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30363,7 +30544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30378,7 +30559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30397,7 +30578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30412,7 +30593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30431,7 +30612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30446,7 +30627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "name": "_set_prompt_data_output",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -30465,7 +30646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30480,7 +30661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30499,7 +30680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30514,7 +30695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "ADVANCED_FIELD_LABELS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30533,7 +30714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30548,7 +30729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "ADVANCED_FIELD_PANES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30567,7 +30748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30582,7 +30763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "ADVANCED_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30601,7 +30782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30616,7 +30797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "EXTEND_PROMPT_SLOT_SPECS",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30635,7 +30816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30650,7 +30831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30669,7 +30850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30684,7 +30865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30703,7 +30884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30718,7 +30899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30737,7 +30918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30752,7 +30933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30771,7 +30952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30786,7 +30967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30805,7 +30986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30820,7 +31001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30839,7 +31020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30854,7 +31035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30873,7 +31054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30888,7 +31069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30907,7 +31088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30922,7 +31103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30941,7 +31122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30956,7 +31137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30975,7 +31156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -30990,7 +31171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31009,7 +31190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31024,7 +31205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_fields_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31043,7 +31224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31058,7 +31239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31077,7 +31258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31092,7 +31273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_pane_parts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31111,7 +31292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31126,7 +31307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_prompt_data_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31145,7 +31326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31160,7 +31341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31179,7 +31360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31194,7 +31375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31213,7 +31394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31228,7 +31409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31247,7 +31428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31262,7 +31443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31281,7 +31462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31296,7 +31477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31315,7 +31496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31330,7 +31511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31349,7 +31530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31364,7 +31545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31383,7 +31564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31398,7 +31579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31417,7 +31598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31432,7 +31613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31451,7 +31632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31466,7 +31647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31485,7 +31666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31500,7 +31681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31519,7 +31700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31534,7 +31715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31553,7 +31734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31568,7 +31749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31587,7 +31768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31602,7 +31783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -31621,7 +31802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31636,7 +31817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "REGIONAL_CONFIG_VERSION",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31655,7 +31836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31670,7 +31851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31689,7 +31870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31704,7 +31885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31723,7 +31904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31738,7 +31919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "REGIONAL_FIELD_TYPES",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31757,7 +31938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31772,7 +31953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31791,7 +31972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31806,7 +31987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "REGIONAL_PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31825,7 +32006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31840,7 +32021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "REGIONAL_PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31859,7 +32040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31874,7 +32055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31893,7 +32074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31908,7 +32089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31927,7 +32108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31942,7 +32123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31961,7 +32142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -31976,7 +32157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31995,7 +32176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32010,7 +32191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32029,7 +32210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32044,7 +32225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_normalize_mask_geometry",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32063,7 +32244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32078,7 +32259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32097,7 +32278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32112,7 +32293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32131,7 +32312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32146,7 +32327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32165,7 +32346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32180,7 +32361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_normalize_regional_mask",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32199,7 +32380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32214,7 +32395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32233,7 +32414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32248,7 +32429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32267,7 +32448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32282,7 +32463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_default_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32301,7 +32482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32316,7 +32497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32335,7 +32516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32350,7 +32531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32369,7 +32550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32384,7 +32565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32403,7 +32584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32418,7 +32599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32437,7 +32618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32452,7 +32633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32471,7 +32652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32486,7 +32667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -32505,7 +32686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32520,7 +32701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32539,7 +32720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32554,7 +32735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32573,7 +32754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32588,7 +32769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32607,7 +32788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32622,7 +32803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32641,7 +32822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32656,7 +32837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32675,7 +32856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32690,7 +32871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32709,7 +32890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32724,7 +32905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32743,7 +32924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32758,7 +32939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32777,7 +32958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32792,7 +32973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32811,7 +32992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32826,7 +33007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32845,7 +33026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32860,7 +33041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32879,7 +33060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32894,7 +33075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32913,7 +33094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32928,7 +33109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32947,7 +33128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32962,7 +33143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "name": "_warn_old_spectrum_anima_mod_guidance_once",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -32981,7 +33162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -32996,7 +33177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_CONTROL_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33015,7 +33196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33030,7 +33211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33049,7 +33230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33064,7 +33245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33083,7 +33264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33098,7 +33279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33117,7 +33298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33132,7 +33313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33151,7 +33332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33166,7 +33347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33185,7 +33366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33200,7 +33381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33219,7 +33400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33234,7 +33415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33253,7 +33434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33268,7 +33449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33287,7 +33468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33302,7 +33483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_EXACT_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33321,7 +33502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33336,7 +33517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33355,7 +33536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33370,7 +33551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33389,7 +33570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33404,7 +33585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33423,7 +33604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33438,7 +33619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33457,7 +33638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33472,7 +33653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_CLUSTERED",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33491,7 +33672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33506,7 +33687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33525,7 +33706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33540,7 +33721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_DELTA_RMS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33559,7 +33740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33574,7 +33755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33593,7 +33774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33608,7 +33789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33627,7 +33808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33642,7 +33823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33661,7 +33842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33676,7 +33857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_HYBRID",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33695,7 +33876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33710,7 +33891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_LATE_EXACT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33729,7 +33910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33744,7 +33925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33763,7 +33944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33778,7 +33959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33797,7 +33978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33812,7 +33993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33831,7 +34012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33846,7 +34027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_SCHEDULE_KEY",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33865,7 +34046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33880,7 +34061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_MIX_STUDIO_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33899,7 +34080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33914,7 +34095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_TAG_POSITION_BACK",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33933,7 +34114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33948,7 +34129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -33967,7 +34148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -33982,7 +34163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_TAG_POSITION_FRONT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34001,7 +34182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34016,7 +34197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34035,7 +34216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34050,7 +34231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_conditioning_feature",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34069,7 +34250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34084,7 +34265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_delta_rms_from_encoded",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34103,7 +34284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34118,7 +34299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_group_token",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34137,7 +34318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34152,7 +34333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34171,7 +34352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34186,7 +34367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34205,7 +34386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34220,7 +34401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_mix_prompt_tags",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34239,7 +34420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34254,7 +34435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34273,7 +34454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34288,7 +34469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34307,7 +34488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34322,7 +34503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_artist_variant_prompt_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34341,7 +34522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34356,7 +34537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34375,7 +34556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34390,7 +34571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34409,7 +34590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34424,7 +34605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34443,7 +34624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34458,7 +34639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34477,7 +34658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34492,7 +34673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_coalesce_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34511,7 +34692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34526,7 +34707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_conditionings_with_range",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34545,7 +34726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34560,7 +34741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_conditionings_with_strength",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34579,7 +34760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34594,7 +34775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_conditionings_with_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34613,7 +34794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34628,7 +34809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_copy_conditioning_metadata",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34647,7 +34828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34662,7 +34843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34681,7 +34862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34696,7 +34877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_average_late_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34715,7 +34896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34730,7 +34911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34749,7 +34930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34764,7 +34945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_composite_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34783,7 +34964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34798,7 +34979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34817,7 +34998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34832,7 +35013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34851,7 +35032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34866,7 +35047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_hybrid",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34885,7 +35066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34900,7 +35081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_artist_scheduled_average",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34919,7 +35100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34934,7 +35115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34953,7 +35134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -34968,7 +35149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_encoded_artist_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -34987,7 +35168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35002,7 +35183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_equal_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35021,7 +35202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35036,7 +35217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_fallback_artist_average_or_exact",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35055,7 +35236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35070,7 +35251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_greedy_cluster_encoded_artists",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35089,7 +35270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35104,7 +35285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_interpolate_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35123,7 +35304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35138,7 +35319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35157,7 +35338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35172,7 +35353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_mark_artist_mix_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35191,7 +35372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35206,7 +35387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35225,7 +35406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35240,7 +35421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35259,7 +35440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35274,7 +35455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_normalize_weight_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35293,7 +35474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35308,7 +35489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_normalized_artist_weights",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35327,7 +35508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35342,7 +35523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_pad_conditioning_tensor",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35361,7 +35542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35376,7 +35557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_parse_artist_mix_entries",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35395,7 +35576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35410,7 +35591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_parse_artist_mix_group",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35429,7 +35610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35444,7 +35625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35463,7 +35644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35478,7 +35659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_prompt_data_artist_base_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35497,7 +35678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35512,7 +35693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_prompt_data_artist_mix_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35531,7 +35712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35546,7 +35727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_prompt_data_positive_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35565,7 +35746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35580,7 +35761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_split_artist_mix_blocks",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35599,7 +35780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35614,7 +35795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "name": "_split_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -35633,7 +35814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35648,7 +35829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35667,7 +35848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35682,7 +35863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35701,7 +35882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35716,7 +35897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35735,7 +35916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35750,7 +35931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -35769,7 +35950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35784,7 +35965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35803,7 +35984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35818,7 +35999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35837,7 +36018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35852,7 +36033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "EasyUseAnimaPromptStudioExtend",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35871,7 +36052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35886,7 +36067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -35905,7 +36086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35920,7 +36101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 828,
+        "line": 836,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -35939,7 +36120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35954,7 +36135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 828,
+        "line": 836,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -35973,7 +36154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -35988,7 +36169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36007,7 +36188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36022,7 +36203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36041,7 +36222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36056,7 +36237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "name": "_align_up",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36075,7 +36256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36090,7 +36271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "name": "_aligned_size_near_scale",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36109,7 +36290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36124,7 +36305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "name": "_alignment_value",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -36143,7 +36324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36158,7 +36339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 839,
+        "line": 847,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "easyuse_anima.image.detailer",
@@ -36177,7 +36358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36192,7 +36373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36211,7 +36392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36226,7 +36407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36245,7 +36426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36260,7 +36441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36279,7 +36460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36294,7 +36475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36313,7 +36494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36328,7 +36509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36347,7 +36528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36362,7 +36543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36381,7 +36562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36396,7 +36577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36415,7 +36596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36430,7 +36611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36449,7 +36630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36464,7 +36645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36483,7 +36664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36498,7 +36679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36517,7 +36698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36532,7 +36713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -36551,7 +36732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36566,7 +36747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36585,7 +36766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36600,7 +36781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36619,7 +36800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36634,7 +36815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_image_scale_by_multiple_size",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36653,7 +36834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36668,7 +36849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_max_long_edge_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36687,7 +36868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36702,7 +36883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_normalize_image_scale_options",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36721,7 +36902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36736,7 +36917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "name": "_scale_by_value",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -36755,7 +36936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36770,7 +36951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36789,7 +36970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36804,7 +36985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36823,7 +37004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36838,7 +37019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36857,7 +37038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36872,7 +37053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36891,7 +37072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36906,7 +37087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36925,7 +37106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36940,7 +37121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_impact_core_module",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36959,7 +37140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -36974,7 +37155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -36993,7 +37174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37008,7 +37189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37027,7 +37208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37042,7 +37223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -37061,7 +37242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37076,7 +37257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37095,7 +37276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37110,7 +37291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37129,7 +37310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37144,7 +37325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37163,7 +37344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37178,7 +37359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -37197,7 +37378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37212,7 +37393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37231,7 +37412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37246,7 +37427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37265,7 +37446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37280,7 +37461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37299,7 +37480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37314,7 +37495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37333,7 +37514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37348,7 +37529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37367,7 +37548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37382,7 +37563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -37401,7 +37582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37416,7 +37597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37435,7 +37616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37450,7 +37631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -37469,7 +37650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37484,7 +37665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -37503,7 +37684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37518,7 +37699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -37537,7 +37718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37552,7 +37733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 896,
+        "line": 904,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37571,7 +37752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37586,7 +37767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 896,
+        "line": 904,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37605,7 +37786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37620,7 +37801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 896,
+        "line": 904,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -37639,7 +37820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37654,7 +37835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37673,7 +37854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37688,7 +37869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37707,7 +37888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37722,7 +37903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37741,7 +37922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37756,7 +37937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37775,7 +37956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37790,7 +37971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -37809,7 +37990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37824,7 +38005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 908,
+        "line": 916,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37843,7 +38024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37858,7 +38039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 908,
+        "line": 916,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37877,7 +38058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37892,7 +38073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 908,
+        "line": 916,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -37911,7 +38092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37926,7 +38107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "DEFAULT_HOST",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37945,7 +38126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37960,7 +38141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "DEFAULT_PORT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -37979,7 +38160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -37994,7 +38175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "HTTP_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38013,7 +38194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38028,7 +38209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38047,7 +38228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38062,7 +38243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "NAIA_LOCAL_HOSTS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38081,7 +38262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38096,7 +38277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "NAIA_MAX_RESOLUTION",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38115,7 +38296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38130,7 +38311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "NAIA_REQUEST_TIMEOUT",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38149,7 +38330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38164,7 +38345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "NAI_1MP",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38183,7 +38364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38198,7 +38379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "PP_STATE_CHOICES",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38217,7 +38398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38232,7 +38413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "PREPROCESSING_KEYS",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38251,7 +38432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38266,7 +38447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "_build_naia_random_url",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38285,7 +38466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38300,7 +38481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "_clean_prompt",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38319,7 +38500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38334,7 +38515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "_fit_to_1mp",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38353,7 +38534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38368,7 +38549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "_is_local_naia_host",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38387,7 +38568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38402,7 +38583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38421,7 +38602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38436,7 +38617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -38455,7 +38636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38470,7 +38651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "ADVANCED_RESOLUTION_BUCKETS",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38489,7 +38670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38504,7 +38685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38523,7 +38704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38538,7 +38719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38557,7 +38738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38572,7 +38753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38591,7 +38772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38606,7 +38787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "NAIA_ADVANCED_RESOLUTION_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38625,7 +38806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38640,7 +38821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "NAIA_RESOLUTION_MODE_BUCKET",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38659,7 +38840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38674,7 +38855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "NAIA_RESOLUTION_MODE_SCALE",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38693,7 +38874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38708,7 +38889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38727,7 +38908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38742,7 +38923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_fit_naia_resolution_to_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38761,7 +38942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38776,7 +38957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38795,7 +38976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38810,7 +38991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38829,7 +39010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38844,7 +39025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38863,7 +39044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38878,7 +39059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38897,7 +39078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38912,7 +39093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_resolve_naia_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38931,7 +39112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38946,7 +39127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_resolve_naia_resolution_max_long_edge",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38965,7 +39146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -38980,7 +39161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_resolve_naia_resolution_mode",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -38999,7 +39180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39014,7 +39195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_resolve_naia_resolution_scale",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39033,7 +39214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39048,7 +39229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_scale_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39067,7 +39248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39082,7 +39263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_snap_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39101,7 +39282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39116,7 +39297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_snap_scaled_resolution_32",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39135,7 +39316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39150,7 +39331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "name": "_sorted_resolution_options",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -39169,7 +39350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39184,7 +39365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 954,
+        "line": 962,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39203,7 +39384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39218,7 +39399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 954,
+        "line": 962,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -39237,7 +39418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39252,7 +39433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 958,
+        "line": 966,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39271,7 +39452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39286,7 +39467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 958,
+        "line": 966,
         "name": "WILDCARD_SEED_RANGE_NOTE",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39305,7 +39486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39320,7 +39501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 958,
+        "line": 966,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -39339,7 +39520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39354,7 +39535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39373,7 +39554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39388,7 +39569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39407,7 +39588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39422,7 +39603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39441,7 +39622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39456,7 +39637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39475,7 +39656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39490,7 +39671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39509,7 +39690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39524,7 +39705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39543,7 +39724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39558,7 +39739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39577,7 +39758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39592,7 +39773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39611,7 +39792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39626,7 +39807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39645,7 +39826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39660,7 +39841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39679,7 +39860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39694,7 +39875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39713,7 +39894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39728,7 +39909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39747,7 +39928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39762,7 +39943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39781,7 +39962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39796,7 +39977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39815,7 +39996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39830,7 +40011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -39849,7 +40030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39864,7 +40045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39883,7 +40064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39898,7 +40079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39917,7 +40098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39932,7 +40113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39951,7 +40132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -39966,7 +40147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -39985,7 +40166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40000,7 +40181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40019,7 +40200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40034,7 +40215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40053,7 +40234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40068,7 +40249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40087,7 +40268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40102,7 +40283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -40121,7 +40302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40136,7 +40317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 990,
+        "line": 998,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -40155,7 +40336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40170,7 +40351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 990,
+        "line": 998,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -40189,7 +40370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40204,7 +40385,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -40223,7 +40404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40238,7 +40419,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -40257,7 +40438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40272,7 +40453,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 995,
+        "line": 1003,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -40291,7 +40472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40306,7 +40487,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 996,
+        "line": 1004,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -40325,7 +40506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40340,7 +40521,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 996,
+        "line": 1004,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -40359,7 +40540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40374,7 +40555,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 996,
+        "line": 1004,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -40393,7 +40574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40408,7 +40589,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1009,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40427,7 +40608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40442,7 +40623,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1009,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -40461,7 +40642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40476,7 +40657,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40495,7 +40676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40510,7 +40691,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40529,7 +40710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40544,7 +40725,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40563,7 +40744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40578,7 +40759,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40597,7 +40778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40612,7 +40793,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40631,7 +40812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40646,7 +40827,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40665,7 +40846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40680,7 +40861,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40699,7 +40880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40714,7 +40895,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40733,7 +40914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40748,7 +40929,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40767,7 +40948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40782,7 +40963,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40801,7 +40982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40816,7 +40997,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40835,7 +41016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40850,7 +41031,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40869,7 +41050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40884,7 +41065,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40903,7 +41084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40918,7 +41099,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40937,7 +41118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40952,7 +41133,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -40971,7 +41152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -40986,7 +41167,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41005,7 +41186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -41020,7 +41201,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41039,7 +41220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -41054,7 +41235,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41073,7 +41254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -41088,7 +41269,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -41106,7 +41287,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1755
+            "line": 1763
           }
         ],
         "classification": "external",
@@ -41114,37 +41295,12 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1756,
+        "line": 1764,
         "name": null,
         "optional": true,
         "requested": "nodes",
         "role": "optional_dependency",
         "scope": "_comfy_max_resolution",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1792
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1793,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_find_comfy_node_class",
         "source": "nodes.py"
       },
       {
@@ -41165,6 +41321,31 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1801,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
+        "scope": "_find_comfy_node_class",
+        "source": "nodes.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1808
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1809,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -43087,6 +43268,10 @@
       },
       {
         "from": "nodes.py",
+        "to": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "from": "nodes.py",
         "to": "easyuse_anima/aio/model_preparation.py"
       },
       {
@@ -43422,6 +43607,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/aio/legacy_generation.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/aio/model_preparation.py"
         ]
       },
@@ -43734,7 +43925,7 @@
     ]
   },
   "inventory": {
-    "module_count": 76,
+    "module_count": 77,
     "modules": [
       {
         "is_package": true,
@@ -44022,6 +44213,18 @@
           "class_count": 3,
           "function_count": 12,
           "global_count": 4
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 423,
+        "module": "easyuse_anima.aio.legacy_generation",
+        "normalized_git_blob_sha1": "1776c827207c07e9b6ab3239b287abc4e96fcbe0",
+        "path": "easyuse_anima/aio/legacy_generation.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 3,
+          "global_count": 3
         }
       },
       {
@@ -44590,9 +44793,9 @@
       },
       {
         "is_package": false,
-        "loc": 3122,
+        "loc": 2822,
         "module": "nodes",
-        "normalized_git_blob_sha1": "08731747c5ced72546f4b3cd60fd7e2a7562a5a7",
+        "normalized_git_blob_sha1": "688ee31af1383b25856e258d918d3489f5aa4cdc",
         "path": "nodes.py",
         "top_level": {
           "class_count": 3,
@@ -45946,7 +46149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -45955,7 +46158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45969,7 +46172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -45978,7 +46181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45992,7 +46195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46001,7 +46204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46015,7 +46218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46024,7 +46227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46038,7 +46241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46047,7 +46250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46061,7 +46264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46070,7 +46273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clear_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46084,7 +46287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46093,7 +46296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46107,7 +46310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46116,7 +46319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46130,7 +46333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46139,7 +46342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 518,
+        "line": 522,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46153,7 +46356,53 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
+        "kind": "static_from",
+        "line": 533,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 521,
+            "kind": "try",
+            "line": 11
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
+        "kind": "static_from",
+        "line": 533,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46162,7 +46411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 529,
+        "line": 537,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46176,7 +46425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46185,7 +46434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 529,
+        "line": 537,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46199,7 +46448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46208,7 +46457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 529,
+        "line": 537,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46222,7 +46471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46231,7 +46480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 534,
+        "line": 542,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46245,7 +46494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46254,7 +46503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46268,7 +46517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46277,7 +46526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46291,7 +46540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46300,7 +46549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46314,7 +46563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46323,7 +46572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 537,
+        "line": 545,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46337,7 +46586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46346,7 +46595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46360,7 +46609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46369,7 +46618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46383,7 +46632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46392,7 +46641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46406,7 +46655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46415,7 +46664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46429,7 +46678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46438,7 +46687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46452,7 +46701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46461,7 +46710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46475,7 +46724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46484,7 +46733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46498,7 +46747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46507,7 +46756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46521,7 +46770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46530,7 +46779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46544,7 +46793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46553,7 +46802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46567,7 +46816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46576,7 +46825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46590,7 +46839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46599,7 +46848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 543,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46613,7 +46862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46622,7 +46871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46636,7 +46885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46645,7 +46894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46659,7 +46908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46668,7 +46917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46682,7 +46931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46691,7 +46940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46705,7 +46954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46714,7 +46963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46728,7 +46977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46737,7 +46986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46751,7 +47000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46760,7 +47009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46774,7 +47023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46783,7 +47032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46797,7 +47046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46806,7 +47055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46820,7 +47069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46829,7 +47078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 557,
+        "line": 565,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46843,7 +47092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46852,7 +47101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46866,7 +47115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46875,7 +47124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46889,7 +47138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46898,7 +47147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46912,7 +47161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46921,7 +47170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46935,7 +47184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46944,7 +47193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46958,7 +47207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46967,7 +47216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46981,7 +47230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -46990,7 +47239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47004,7 +47253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47013,7 +47262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47027,7 +47276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47036,7 +47285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47050,7 +47299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47059,7 +47308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 569,
+        "line": 577,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47073,7 +47322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47082,7 +47331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47096,7 +47345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47105,7 +47354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47119,7 +47368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47128,7 +47377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47142,7 +47391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47151,7 +47400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47165,7 +47414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47174,7 +47423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47188,7 +47437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47197,7 +47446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47211,7 +47460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47220,7 +47469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47234,7 +47483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47243,7 +47492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47257,7 +47506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47266,7 +47515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47280,7 +47529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47289,7 +47538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 581,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47303,7 +47552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47312,7 +47561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47326,7 +47575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47335,7 +47584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47349,7 +47598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47358,7 +47607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47372,7 +47621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47381,7 +47630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47395,7 +47644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47404,7 +47653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47418,7 +47667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47427,7 +47676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47441,7 +47690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47450,7 +47699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47464,7 +47713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47473,7 +47722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47487,7 +47736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47496,7 +47745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47510,7 +47759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47519,7 +47768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47533,7 +47782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47542,7 +47791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 593,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47556,7 +47805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47565,7 +47814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 606,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47579,7 +47828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47588,7 +47837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 606,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47602,7 +47851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47611,7 +47860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 606,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47625,7 +47874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47634,7 +47883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47648,7 +47897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47657,7 +47906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47671,7 +47920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47680,7 +47929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47694,7 +47943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47703,7 +47952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47717,7 +47966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47726,7 +47975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 611,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47740,7 +47989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47749,7 +47998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47763,7 +48012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47772,7 +48021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47786,7 +48035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47795,7 +48044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47809,7 +48058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47818,7 +48067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 618,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47832,7 +48081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47841,7 +48090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47855,7 +48104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47864,7 +48113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47878,7 +48127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47887,7 +48136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47901,7 +48150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47910,7 +48159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47924,7 +48173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47933,7 +48182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47947,7 +48196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47956,7 +48205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47970,7 +48219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -47979,7 +48228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47993,7 +48242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48002,7 +48251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48016,7 +48265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48025,7 +48274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48039,7 +48288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48048,7 +48297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48062,7 +48311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48071,7 +48320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48085,7 +48334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48094,7 +48343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 624,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48108,7 +48357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48117,7 +48366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48131,7 +48380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48140,7 +48389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48154,7 +48403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48163,7 +48412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48177,7 +48426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48186,7 +48435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48200,7 +48449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48209,7 +48458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48223,7 +48472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48232,7 +48481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48246,7 +48495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48255,7 +48504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48269,7 +48518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48278,7 +48527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48292,7 +48541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48301,7 +48550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48315,7 +48564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48324,7 +48573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48338,7 +48587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48347,7 +48596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_input_default",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48361,7 +48610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48370,7 +48619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48384,7 +48633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48393,7 +48642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48407,7 +48656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48416,7 +48665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_output",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48430,7 +48679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48439,7 +48688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48453,7 +48702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48462,7 +48711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_set_prompt_data_output",
         "kind": "static_from",
-        "line": 638,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48476,7 +48725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48485,7 +48734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48499,7 +48748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48508,7 +48757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_LABELS",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48522,7 +48771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48531,7 +48780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_PANES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48545,7 +48794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48554,7 +48803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:ADVANCED_FIELD_TYPES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48568,7 +48817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48577,7 +48826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:EXTEND_PROMPT_SLOT_SPECS",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48591,7 +48840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48600,7 +48849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_NAMES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48614,7 +48863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48623,7 +48872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_ADVANCED_RETURN_TYPES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48637,7 +48886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48646,7 +48895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48660,7 +48909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48669,7 +48918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48683,7 +48932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48692,7 +48941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48706,7 +48955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48715,7 +48964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48729,7 +48978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48738,7 +48987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48752,7 +49001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48761,7 +49010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48775,7 +49024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48784,7 +49033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48798,7 +49047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48807,7 +49056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48821,7 +49070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48830,7 +49079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48844,7 +49093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48853,7 +49102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_with_artist_override",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48867,7 +49116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48876,7 +49125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48890,7 +49139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48899,7 +49148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_pane_parts",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48913,7 +49162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48922,7 +49171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_data_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48936,7 +49185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48945,7 +49194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48959,7 +49208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48968,7 +49217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48982,7 +49231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -48991,7 +49240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49005,7 +49254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49014,7 +49263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49028,7 +49277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49037,7 +49286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49051,7 +49300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49060,7 +49309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49074,7 +49323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49083,7 +49332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49097,7 +49346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49106,7 +49355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49120,7 +49369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49129,7 +49378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49143,7 +49392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49152,7 +49401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49166,7 +49415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49175,7 +49424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49189,7 +49438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49198,7 +49447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49212,7 +49461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49221,7 +49470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49235,7 +49484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49244,7 +49493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 656,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49258,7 +49507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49267,7 +49516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_VERSION",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49281,7 +49530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49290,7 +49539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_CONFIG_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49304,7 +49553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49313,7 +49562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELDS_WORKFLOW_PROPERTY",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49327,7 +49576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49336,7 +49585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_FIELD_TYPES",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49350,7 +49599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49359,7 +49608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_BUNDLE_SCHEMA",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49373,7 +49622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49382,7 +49631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49396,7 +49645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49405,7 +49654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:REGIONAL_PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49419,7 +49668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49428,7 +49677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49442,7 +49691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49451,7 +49700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49465,7 +49714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49474,7 +49723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49488,7 +49737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49497,7 +49746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49511,7 +49760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49520,7 +49769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49534,7 +49783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49543,7 +49792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_geometry",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49557,7 +49806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49566,7 +49815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49580,7 +49829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49589,7 +49838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49603,7 +49852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49612,7 +49861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49626,7 +49875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49635,7 +49884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_mask",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49649,7 +49898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49658,7 +49907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49672,7 +49921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49681,7 +49930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49695,7 +49944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49704,7 +49953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_config",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49718,7 +49967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49727,7 +49976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_default_fields",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49741,7 +49990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49750,7 +49999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_field_prompt",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49764,7 +50013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49773,7 +50022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49787,7 +50036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49796,7 +50045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49810,7 +50059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49819,7 +50068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49833,7 +50082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49842,7 +50091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 692,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49856,7 +50105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49865,7 +50114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49879,7 +50128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49888,7 +50137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49902,7 +50151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49911,7 +50160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_DISABLED",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49925,7 +50174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49934,7 +50183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_ENABLED",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49948,7 +50197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49957,7 +50206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49971,7 +50220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -49980,7 +50229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -49994,7 +50243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50003,7 +50252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50017,7 +50266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50026,7 +50275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50040,7 +50289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50049,7 +50298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50063,7 +50312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50072,7 +50321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50086,7 +50335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50095,7 +50344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50109,7 +50358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50118,7 +50367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50132,7 +50381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50141,7 +50390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50155,7 +50404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50164,7 +50413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_warn_old_spectrum_anima_mod_guidance_once",
         "kind": "static_from",
-        "line": 720,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50178,7 +50427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50187,7 +50436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_CONTROL_KEY",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50201,7 +50450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50210,7 +50459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50224,7 +50473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50233,7 +50482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50247,7 +50496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50256,7 +50505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50270,7 +50519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50279,7 +50528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50293,7 +50542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50302,7 +50551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50316,7 +50565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50325,7 +50574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50339,7 +50588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50348,7 +50597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50362,7 +50611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50371,7 +50620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50385,7 +50634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50394,7 +50643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_EXACT_KEY",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50408,7 +50657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50417,7 +50666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50431,7 +50680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50440,7 +50689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50454,7 +50703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50463,7 +50712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50477,7 +50726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50486,7 +50735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_AVERAGE_LATE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50500,7 +50749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50509,7 +50758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_CLUSTERED",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50523,7 +50772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50532,7 +50781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_COMPOSITE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50546,7 +50795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50555,7 +50804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DELTA_RMS",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50569,7 +50818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50578,7 +50827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_DESCRIPTIONS",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50592,7 +50841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50601,7 +50850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50615,7 +50864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50624,7 +50873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50638,7 +50887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50647,7 +50896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_HYBRID",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50661,7 +50910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50670,7 +50919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_LATE_EXACT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50684,7 +50933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50693,7 +50942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50707,7 +50956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50716,7 +50965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50730,7 +50979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50739,7 +50988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_SCHEDULED_AVERAGE",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50753,7 +51002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50762,7 +51011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_SCHEDULE_KEY",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50776,7 +51025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50785,7 +51034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_STUDIO_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50799,7 +51048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50808,7 +51057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_BACK",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50822,7 +51071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50831,7 +51080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50845,7 +51094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50854,7 +51103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_FRONT",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50868,7 +51117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50877,7 +51126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50891,7 +51140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50900,7 +51149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_conditioning_feature",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50914,7 +51163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50923,7 +51172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_delta_rms_from_encoded",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50937,7 +51186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50946,7 +51195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_group_token",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50960,7 +51209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50969,7 +51218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50983,7 +51232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -50992,7 +51241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51006,7 +51255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51015,7 +51264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_prompt_tags",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51029,7 +51278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51038,7 +51287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51052,7 +51301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51061,7 +51310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51075,7 +51324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51084,7 +51333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_variant_prompt_from_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51098,7 +51347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51107,7 +51356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51121,7 +51370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51130,7 +51379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51144,7 +51393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51153,7 +51402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51167,7 +51416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51176,7 +51425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51190,7 +51439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51199,7 +51448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_coalesce_artist_mix_items",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51213,7 +51462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51222,7 +51471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_range",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51236,7 +51485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51245,7 +51494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_strength",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51259,7 +51508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51268,7 +51517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_conditionings_with_values",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51282,7 +51531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51291,7 +51540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_copy_conditioning_metadata",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51305,7 +51554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51314,7 +51563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51328,7 +51577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51337,7 +51586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_average_late_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51351,7 +51600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51360,7 +51609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51374,7 +51623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51383,7 +51632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_composite_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51397,7 +51646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51406,7 +51655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51420,7 +51669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51429,7 +51678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51443,7 +51692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51452,7 +51701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_hybrid",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51466,7 +51715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51475,7 +51724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_scheduled_average",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51489,7 +51738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51498,7 +51747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51512,7 +51761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51521,7 +51770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encoded_artist_conditionings",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51535,7 +51784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51544,7 +51793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_equal_artist_weights",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51558,7 +51807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51567,7 +51816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_fallback_artist_average_or_exact",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51581,7 +51830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51590,7 +51839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_greedy_cluster_encoded_artists",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51604,7 +51853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51613,7 +51862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_interpolate_artist_weights",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51627,7 +51876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51636,7 +51885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51650,7 +51899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51659,7 +51908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_mark_artist_mix_conditioning",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51673,7 +51922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51682,7 +51931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51696,7 +51945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51705,7 +51954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51719,7 +51968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51728,7 +51977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_weight_values",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51742,7 +51991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51751,7 +52000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalized_artist_weights",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51765,7 +52014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51774,7 +52023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_pad_conditioning_tensor",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51788,7 +52037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51797,7 +52046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_entries",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51811,7 +52060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51820,7 +52069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_group",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51834,7 +52083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51843,7 +52092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51857,7 +52106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51866,7 +52115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_base_prompt",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51880,7 +52129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51889,7 +52138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_artist_mix_config",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51903,7 +52152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51912,7 +52161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_prompt_data_positive_fields",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51926,7 +52175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51935,7 +52184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_blocks",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51949,7 +52198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51958,7 +52207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_split_artist_mix_items",
         "kind": "static_from",
-        "line": 736,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51972,7 +52221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -51981,7 +52230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51995,7 +52244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52004,7 +52253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52018,7 +52267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52027,7 +52276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52041,7 +52290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52050,7 +52299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52064,7 +52313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52073,7 +52322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52087,7 +52336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52096,7 +52345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52110,7 +52359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52119,7 +52368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioExtend",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52133,7 +52382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52142,7 +52391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 822,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52156,7 +52405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52165,7 +52414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 828,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52179,7 +52428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52188,7 +52437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 828,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52202,7 +52451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52211,7 +52460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52225,7 +52474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52234,7 +52483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52248,7 +52497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52257,7 +52506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_up",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52271,7 +52520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52280,7 +52529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_aligned_size_near_scale",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52294,7 +52543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52303,7 +52552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 832,
+        "line": 840,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52317,7 +52566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52326,7 +52575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 839,
+        "line": 847,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52340,7 +52589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52349,7 +52598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52363,7 +52612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52372,7 +52621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52386,7 +52635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52395,7 +52644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52409,7 +52658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52418,7 +52667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52432,7 +52681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52441,7 +52690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52455,7 +52704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52464,7 +52713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52478,7 +52727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52487,7 +52736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52501,7 +52750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52510,7 +52759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52524,7 +52773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52533,7 +52782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52547,7 +52796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52556,7 +52805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52570,7 +52819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52579,7 +52828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 842,
+        "line": 850,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52593,7 +52842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52602,7 +52851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52616,7 +52865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52625,7 +52874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52639,7 +52888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52648,7 +52897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_image_scale_by_multiple_size",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52662,7 +52911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52671,7 +52920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_max_long_edge_value",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52685,7 +52934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52694,7 +52943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_normalize_image_scale_options",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52708,7 +52957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52717,7 +52966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:_scale_by_value",
         "kind": "static_from",
-        "line": 855,
+        "line": 863,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52731,7 +52980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52740,7 +52989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52754,7 +53003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52763,7 +53012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52777,7 +53026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52786,7 +53035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52800,7 +53049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52809,7 +53058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52823,7 +53072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52832,7 +53081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52846,7 +53095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52855,7 +53104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_core_module",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52869,7 +53118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52878,7 +53127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52892,7 +53141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52901,7 +53150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52915,7 +53164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52924,7 +53173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 863,
+        "line": 871,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52938,7 +53187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52947,7 +53196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52961,7 +53210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52970,7 +53219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52984,7 +53233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -52993,7 +53242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53007,7 +53256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53016,7 +53265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 874,
+        "line": 882,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53030,7 +53279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53039,7 +53288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53053,7 +53302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53062,7 +53311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53076,7 +53325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53085,7 +53334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53099,7 +53348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53108,7 +53357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53122,7 +53371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53131,7 +53380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53145,7 +53394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53154,7 +53403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 880,
+        "line": 888,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53168,7 +53417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53177,7 +53426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53191,7 +53440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53200,7 +53449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 888,
+        "line": 896,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53214,7 +53463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53223,7 +53472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53237,7 +53486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53246,7 +53495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 892,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53260,7 +53509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53269,7 +53518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 896,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53283,7 +53532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53292,7 +53541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 896,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53306,7 +53555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53315,7 +53564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 896,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53329,7 +53578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53338,7 +53587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53352,7 +53601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53361,7 +53610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53375,7 +53624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53384,7 +53633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53398,7 +53647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53407,7 +53656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53421,7 +53670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53430,7 +53679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 901,
+        "line": 909,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53444,7 +53693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53453,7 +53702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 908,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53467,7 +53716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53476,7 +53725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 908,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53490,7 +53739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53499,7 +53748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 908,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53513,7 +53762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53522,7 +53771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_HOST",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53536,7 +53785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53545,7 +53794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:DEFAULT_PORT",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53559,7 +53808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53568,7 +53817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:HTTP_TIMEOUT",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53582,7 +53831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53591,7 +53840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53605,7 +53854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53614,7 +53863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_LOCAL_HOSTS",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53628,7 +53877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53637,7 +53886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_MAX_RESOLUTION",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53651,7 +53900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53660,7 +53909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAIA_REQUEST_TIMEOUT",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53674,7 +53923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53683,7 +53932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:NAI_1MP",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53697,7 +53946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53706,7 +53955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PP_STATE_CHOICES",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53720,7 +53969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53729,7 +53978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:PREPROCESSING_KEYS",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53743,7 +53992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53752,7 +54001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_build_naia_random_url",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53766,7 +54015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53775,7 +54024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_clean_prompt",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53789,7 +54038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53798,7 +54047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_fit_to_1mp",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53812,7 +54061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53821,7 +54070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_is_local_naia_host",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53835,7 +54084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53844,7 +54093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53858,7 +54107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53867,7 +54116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 913,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53881,7 +54130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53890,7 +54139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:ADVANCED_RESOLUTION_BUCKETS",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53904,7 +54153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53913,7 +54162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:CUSTOM_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53927,7 +54176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53936,7 +54185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53950,7 +54199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53959,7 +54208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:DEFAULT_ADVANCED_RESOLUTION_SIZE",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53973,7 +54222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -53982,7 +54231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_ADVANCED_RESOLUTION_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -53996,7 +54245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54005,7 +54254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_BUCKET",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54019,7 +54268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54028,7 +54277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:NAIA_RESOLUTION_MODE_SCALE",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54042,7 +54291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54051,7 +54300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54065,7 +54314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54074,7 +54323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_fit_naia_resolution_to_bucket",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54088,7 +54337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54097,7 +54346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54111,7 +54360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54120,7 +54369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54134,7 +54383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54143,7 +54392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54157,7 +54406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54166,7 +54415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54180,7 +54429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54189,7 +54438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_bucket",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54203,7 +54452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54212,7 +54461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_max_long_edge",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54226,7 +54475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54235,7 +54484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_mode",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54249,7 +54498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54258,7 +54507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution_scale",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54272,7 +54521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54281,7 +54530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_scale_naia_resolution",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54295,7 +54544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54304,7 +54553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_resolution_32",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54318,7 +54567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54327,7 +54576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_snap_scaled_resolution_32",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54341,7 +54590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54350,7 +54599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_sorted_resolution_options",
         "kind": "static_from",
-        "line": 931,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54364,7 +54613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54373,7 +54622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 954,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54387,7 +54636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54396,7 +54645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 954,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54410,7 +54659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54419,7 +54668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 958,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54433,7 +54682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54442,7 +54691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:WILDCARD_SEED_RANGE_NOTE",
         "kind": "static_from",
-        "line": 958,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54456,7 +54705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54465,7 +54714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 958,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54479,7 +54728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54488,7 +54737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54502,7 +54751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54511,7 +54760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54525,7 +54774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54534,7 +54783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54548,7 +54797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54557,7 +54806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54571,7 +54820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54580,7 +54829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54594,7 +54843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54603,7 +54852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54617,7 +54866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54626,7 +54875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54640,7 +54889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54649,7 +54898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54663,7 +54912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54672,7 +54921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54686,7 +54935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54695,7 +54944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54709,7 +54958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54718,7 +54967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54732,7 +54981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54741,7 +54990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54755,7 +55004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54764,7 +55013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54778,7 +55027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54787,7 +55036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54801,7 +55050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54810,7 +55059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 963,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54824,7 +55073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54833,7 +55082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54847,7 +55096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54856,7 +55105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54870,7 +55119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54879,7 +55128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54893,7 +55142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54902,7 +55151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54916,7 +55165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54925,7 +55174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54939,7 +55188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54948,7 +55197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54962,7 +55211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54971,7 +55220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54985,7 +55234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -54994,7 +55243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 980,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55008,7 +55257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55017,7 +55266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 990,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55031,7 +55280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55040,7 +55289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 990,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55054,7 +55303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55063,7 +55312,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55077,7 +55326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55086,7 +55335,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 994,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55100,7 +55349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55109,7 +55358,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 995,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55123,7 +55372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55132,7 +55381,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 996,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55146,7 +55395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55155,7 +55404,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 996,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55169,7 +55418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55178,7 +55427,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 996,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55192,7 +55441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55201,7 +55450,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55215,7 +55464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55224,7 +55473,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55238,7 +55487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55247,7 +55496,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55261,7 +55510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55270,7 +55519,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55284,7 +55533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55293,7 +55542,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55307,7 +55556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55316,7 +55565,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55330,7 +55579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55339,7 +55588,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55353,7 +55602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55362,7 +55611,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55376,7 +55625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55385,7 +55634,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55399,7 +55648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55408,7 +55657,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55422,7 +55671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55431,7 +55680,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55445,7 +55694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55454,7 +55703,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55468,7 +55717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55477,7 +55726,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55491,7 +55740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55500,7 +55749,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55514,7 +55763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55523,7 +55772,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55537,7 +55786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55546,7 +55795,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55560,7 +55809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55569,7 +55818,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55583,7 +55832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55592,7 +55841,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55606,7 +55855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55615,7 +55864,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55629,7 +55878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55638,7 +55887,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -55652,7 +55901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 517,
+            "handler_line": 521,
             "kind": "try",
             "line": 11
           }
@@ -55661,7 +55910,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -57069,6 +57318,39 @@
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/aio/generation_values.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 1,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/aio/legacy_generation.py"
       },
       {
         "branch_context": [],
@@ -59312,33 +59594,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1755
+            "line": 1763
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1756,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1792
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1793,
+        "line": 1764,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -59358,6 +59621,25 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1801,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1808
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1809,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -60732,33 +61014,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1755
+            "line": 1763
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1756,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1792
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1793,
+        "line": 1764,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -60778,6 +61041,25 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1801,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "nodes.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 1808
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 1809,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -60904,6 +61186,7 @@
       "easyuse_anima/aio/generation_sampling.py",
       "easyuse_anima/aio/generation_settings.py",
       "easyuse_anima/aio/generation_values.py",
+      "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/preview.py",
@@ -60982,6 +61265,7 @@
       "easyuse_anima/aio/generation_sampling.py",
       "easyuse_anima/aio/generation_settings.py",
       "easyuse_anima/aio/generation_values.py",
+      "easyuse_anima/aio/legacy_generation.py",
       "easyuse_anima/aio/model_preparation.py",
       "easyuse_anima/aio/output.py",
       "easyuse_anima/aio/preview.py",
@@ -62377,7 +62661,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1024,
+        "line": 1032,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62386,7 +62670,7 @@
         "column": 12,
         "context": "assign:_ANY_TYPE",
         "kind": "import_time_call",
-        "line": 1540,
+        "line": 1548,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62395,7 +62679,7 @@
         "column": 26,
         "context": "assign:_AIO_DETAILER_CUSTOM_RE",
         "kind": "import_time_call",
-        "line": 1706,
+        "line": 1714,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62404,7 +62688,16 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2600,
+        "line": 2608,
+        "module": "nodes.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "_bind_aio_legacy_generation_runtime",
+        "column": 0,
+        "context": "expression",
+        "kind": "import_time_call",
+        "line": 2611,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62413,7 +62706,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2603,
+        "line": 2614,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62422,7 +62715,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2606,
+        "line": 2617,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62431,7 +62724,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2609,
+        "line": 2620,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62440,7 +62733,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2612,
+        "line": 2623,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62449,7 +62742,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2615,
+        "line": 2626,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62458,7 +62751,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2618,
+        "line": 2629,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62467,7 +62760,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2621,
+        "line": 2632,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62476,7 +62769,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2624,
+        "line": 2635,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62485,7 +62778,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2627,
+        "line": 2638,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62494,7 +62787,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2630,
+        "line": 2641,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62503,7 +62796,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2633,
+        "line": 2644,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62512,7 +62805,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2636,
+        "line": 2647,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62521,7 +62814,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2640,
+        "line": 2651,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62530,7 +62823,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2643,
+        "line": 2654,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62539,7 +62832,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2647,
+        "line": 2658,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62548,7 +62841,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2650,
+        "line": 2661,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62557,7 +62850,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2654,
+        "line": 2665,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62566,7 +62859,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2657,
+        "line": 2668,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62575,7 +62868,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2660,
+        "line": 2671,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62584,7 +62877,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2663,
+        "line": 2674,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62593,7 +62886,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2666,
+        "line": 2677,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62602,7 +62895,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2669,
+        "line": 2680,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62611,7 +62904,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2676,
+        "line": 2687,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62620,7 +62913,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2682,
+        "line": 2693,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62629,7 +62922,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2687,
+        "line": 2698,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -62638,7 +62931,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2691,
+        "line": 2702,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -63128,25 +63421,25 @@
       },
       {
         "kind": "dict",
-        "line": 1094,
+        "line": 1102,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1083,
+        "line": 1091,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },
       {
         "kind": "set",
-        "line": 1078,
+        "line": 1086,
         "module": "nodes.py",
         "name": "AIO_SPECIAL_SEEDS"
       },
       {
         "kind": "set",
-        "line": 1705,
+        "line": 1713,
         "module": "nodes.py",
         "name": "_AIO_DETAILER_RESERVED_KEYS"
       },

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import copy
+import inspect
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import nodes
+from easyuse_anima.aio import legacy_generation
+from tests.test_node_contracts import _loaded_package_entrypoint
+
+ROOT = Path(__file__).resolve().parents[1]
+TRACE_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "aio_legacy_execution_trace.v1.json"
+
+
+class _Token:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class AIOGeneratorLegacyMoveTests(unittest.TestCase):
+    def test_private_implementation_aliases_are_canonical_in_both_import_modes(self):
+        self.assertEqual(legacy_generation.__all__, ())
+        self.assertIs(
+            nodes._bind_aio_legacy_generation_runtime,
+            legacy_generation._bind_aio_legacy_generation_runtime,
+        )
+        self.assertIs(
+            nodes._run_aio_legacy_generation,
+            legacy_generation._run_aio_legacy_generation,
+        )
+
+        with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
+            canonical_module = sys.modules[
+                f"{package_entrypoint.__name__}.easyuse_anima.aio.legacy_generation"
+            ]
+            self.assertIs(
+                package_nodes._bind_aio_legacy_generation_runtime,
+                canonical_module._bind_aio_legacy_generation_runtime,
+            )
+            self.assertIs(
+                package_nodes._run_aio_legacy_generation,
+                canonical_module._run_aio_legacy_generation,
+            )
+
+    def test_root_generate_keeps_signature_and_forwards_without_adaptation(self):
+        signature = inspect.signature(nodes.EasyUseAnimaAIOGenerator.generate)
+        self.assertEqual(
+            list(signature.parameters),
+            [
+                "self",
+                "easy_use_anima_input",
+                "generation_settings",
+                "lora_stack",
+                "workflow_prompt",
+                "extra_pnginfo",
+                "unique_id",
+            ],
+        )
+        self.assertIsNone(signature.parameters["generation_settings"].default)
+        for name in (
+            "lora_stack",
+            "workflow_prompt",
+            "extra_pnginfo",
+            "unique_id",
+        ):
+            self.assertIsNone(signature.parameters[name].default)
+
+        generator = nodes.EasyUseAnimaAIOGenerator()
+        forwarded = object()
+        with patch.object(
+            nodes,
+            "_run_aio_legacy_generation",
+            return_value=forwarded,
+        ) as run:
+            result = generator.generate(
+                "input",
+                {"settings": True},
+                "lora",
+                "workflow",
+                "pnginfo",
+                "node-id",
+            )
+
+        self.assertIs(result, forwarded)
+        run.assert_called_once_with(
+            generator,
+            "input",
+            {"settings": True},
+            "lora",
+            "workflow",
+            "pnginfo",
+            "node-id",
+        )
+
+    def test_execution_trace_matches_move_boundary_fixture(self):
+        fixture = json.loads(TRACE_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            fixture,
+            {
+                "schema": "easyuse_anima_aio_legacy_execution_trace",
+                "version": 1,
+                "cases": fixture["cases"],
+            },
+        )
+        actual = {
+            "base_txt2img": self._execute_case(
+                upscale_enabled=False,
+                intermediate_preview=False,
+                unique_id=None,
+            ),
+            "upscale_with_intermediate_preview": self._execute_case(
+                upscale_enabled=True,
+                intermediate_preview=True,
+                unique_id="node-7",
+            ),
+        }
+        self.assertEqual(actual, fixture["cases"])
+
+    def _execute_case(
+        self,
+        *,
+        upscale_enabled: bool,
+        intermediate_preview: bool,
+        unique_id,
+    ) -> dict:
+        trace: list[str] = []
+        generator = nodes.EasyUseAnimaAIOGenerator()
+        context = {
+            "prompt_data": {"positive_prompt": "prompt"},
+            "resource_info": {"unet_name": "model.safetensors"},
+            "input_settings": {"schema": "input-settings"},
+        }
+        settings = {
+            "mode": "txt2img",
+            "sampler": {"seed": "random", "backend": "comfy_ksampler"},
+            "artist_mix": {
+                "mode": "sequential",
+                "start_percent": 0.0,
+                "strength_scale": 1.0,
+                "style_gain": 1.0,
+                "rms_scale_cap": 1.0,
+                "exact_top_k": 0,
+                "cluster_count": 1,
+                "dominant_isolation": False,
+                "dominant_threshold": 0.0,
+            },
+            "mod_guidance": {"profile": "off", "mode": "auto"},
+            "highres": {"enabled": False},
+            "detailer": {},
+            "upscale": {"enabled": upscale_enabled},
+            "postprocess": {"enabled": False},
+            "preview": {"intermediate_images": intermediate_preview},
+            "save": {
+                "enabled": True,
+                "backend": "comfy",
+                "filename_prefix": "Anima",
+            },
+        }
+
+        base_model = _Token("base")
+        lora_model = _Token("lora")
+        patched_model = _Token("model")
+        sample_model = _Token("sample")
+        base_clip = _Token("base_clip")
+        clip = _Token("clip")
+        vae = _Token("vae")
+        model_names = {
+            id(lora_model): "lora",
+            id(patched_model): "model",
+            id(sample_model): "sample",
+        }
+
+        def phase(name, result):
+            def run(*args, **kwargs):
+                trace.append(name)
+                return result
+
+            return run
+
+        def require(value):
+            trace.append("require_input")
+            self.assertIs(value, context)
+            return value
+
+        def normalize_settings(value):
+            trace.append("normalize_settings")
+            self.assertEqual(value, "settings-json")
+            return copy.deepcopy(settings)
+
+        def resolve_seed(value):
+            trace.append("resolve_seed")
+            self.assertEqual(value, "random")
+            return 17
+
+        def load_resources(value):
+            trace.append("load_resources")
+            self.assertIs(value, context)
+            return base_model, base_clip, vae
+
+        def apply_lora(model, source_clip, stack):
+            trace.append("apply_lora")
+            self.assertIs(model, base_model)
+            self.assertIs(source_clip, base_clip)
+            self.assertEqual(stack, "lora-stack")
+            return lora_model, clip, [{"name": "style.safetensors"}]
+
+        def apply_model_patches(model, normalized_settings):
+            trace.append("apply_model_patches")
+            self.assertIs(model, lora_model)
+            self.assertEqual(normalized_settings["sampler"]["seed"], 17)
+            return patched_model
+
+        def advanced_outputs(prompt_data):
+            trace.append("advanced_outputs")
+            return (
+                "positive",
+                "negative",
+                "quality",
+                "quality-neg",
+                False,
+                False,
+                "metadata-positive",
+                "metadata-negative",
+                64,
+                96,
+            )
+
+        def apply_spectrum_model(model, source_clip, positive, sampler):
+            trace.append("apply_spectrum_model_patches")
+            self.assertIs(model, patched_model)
+            return sample_model
+
+        class _Random:
+            @staticmethod
+            def getrandbits(bits):
+                trace.append("random_run_id")
+                self.assertEqual(bits, 64)
+                return 0x1234
+
+        def cache_key(**kwargs):
+            scope = kwargs["cache_scope"]
+            if unique_id is None:
+                self.assertEqual(scope, str(id(generator)))
+                scope = "generator-id"
+            trace.append(f"cache_key:{scope}")
+            return "cache-key"
+
+        def run_highres(
+            model,
+            source_clip,
+            source_vae,
+            positive,
+            negative,
+            image,
+            latent,
+            width,
+            height,
+            *args,
+        ):
+            trace.append("run_highres")
+            return latent, image, width, height, {"enabled": False}
+
+        def run_detailer(*args):
+            trace.append("run_detailer")
+            return args[5], {"enabled": False}
+
+        def run_upscale(*args, **kwargs):
+            trace.append("run_upscale")
+            if upscale_enabled:
+                return "upscaled-image", {"enabled": True, "backend": "stub"}
+            return args[5], {"enabled": False}
+
+        def run_postprocess(image, postprocess):
+            trace.append("run_postprocess")
+            return image, {"enabled": False}
+
+        def image_size(image, fallback_width, fallback_height):
+            trace.append("image_size")
+            self.assertEqual(image, "upscaled-image")
+            return 128, 192
+
+        def encode_image(source_vae, image):
+            trace.append("encode_upscaled_image")
+            self.assertIs(source_vae, vae)
+            return "upscaled-latent"
+
+        def cleanup(model, original_model):
+            trace.append(f"cleanup:{model_names[id(model)]}")
+            self.assertIs(original_model, base_model)
+
+        def save_temp(image, stage, **kwargs):
+            trace.append(f"temp_preview:{stage}")
+            return [{"filename": f"{stage}.png", "stage": stage, "type": "temp"}]
+
+        def send_preview(node_id, run_id, stage, images):
+            trace.append(f"send_preview:{stage}")
+
+        def save_prefix(save_settings):
+            trace.append("save_prefix")
+            return save_settings["filename_prefix"]
+
+        def save_comfy(image, prefix, **kwargs):
+            trace.append("save_comfy")
+            self.assertTrue(all(item.startswith("cleanup:") for item in trace[-5:-2]))
+            return {
+                "ui": {
+                    "images": [
+                        {"filename": "final.png", "subfolder": "", "type": "output"}
+                    ]
+                }
+            }
+
+        def tag_images(images, stage, *, width, height):
+            trace.append(f"tag:{stage}")
+            return [
+                {**item, "stage": stage, "width": width, "height": height}
+                for item in images
+            ]
+
+        def unexpected(*args, **kwargs):
+            self.fail("standalone Mod Guidance must remain lazy for the fixture cases")
+
+        with patch.multiple(
+            nodes,
+            _require_easy_use_anima_input=require,
+            _normalize_aio_generation_settings=normalize_settings,
+            _resolve_aio_runtime_seed=resolve_seed,
+            _load_aio_resources_from_input_context=load_resources,
+            _apply_aio_lora_stack=apply_lora,
+            _apply_aio_model_patches=apply_model_patches,
+            _normalize_prompt_data=phase("normalize_prompt", context["prompt_data"]),
+            _advanced_outputs_from_prompt_data=advanced_outputs,
+            _encode_prompt_data_positive_conditioning=phase(
+                "encode_positive", "positive-conditioning"
+            ),
+            _encode_with_comfy_clip=phase("encode_negative", "negative-conditioning"),
+            _as_bool=lambda value, default: bool(value),
+            _aio_detailer_has_enabled_targets=phase("detailer_enabled", False),
+            _normalize_anima_mod_guidance_profile=phase("normalize_profile", "off"),
+            _resolve_anima_mod_guidance_enabled=phase("resolve_guidance", False),
+            _aio_highres_effective_backend=phase(
+                "resolve_highres_backend", "comfy_ksampler"
+            ),
+            _apply_spectrum_anima_mod_guidance=unexpected,
+            _apply_aio_spectrum_model_patches_for_comfy_sampler=apply_spectrum_model,
+            _single_value=lambda value: value,
+            random=_Random,
+            _aio_first_pass_cache_key=cache_key,
+            _get_aio_first_pass_cache=phase("get_cache", None),
+            _generate_empty_latent_with_comfy=phase("empty_latent", "empty-latent"),
+            _sample_latent_with_aio_backend=phase("sample", "sampled-latent"),
+            _decode_latent_with_comfy=phase("decode", "decoded-image"),
+            _resize_image_to_size_if_needed=phase(
+                "resize_first_pass", ("decoded-image", False)
+            ),
+            _put_aio_first_pass_cache=phase("put_cache", None),
+            _run_aio_highres_stage=run_highres,
+            _run_aio_detailer_stage=run_detailer,
+            _run_aio_upscale_stage=run_upscale,
+            _image_tensor_size=image_size,
+            _encode_image_with_comfy_vae=encode_image,
+            _run_aio_postprocess_stage=run_postprocess,
+            _cleanup_aio_ephemeral_model=cleanup,
+            _save_aio_temp_preview_image=save_temp,
+            _send_aio_preview_event=send_preview,
+            _aio_save_filename_prefix=save_prefix,
+            _save_image_with_comfy=save_comfy,
+            _tag_aio_preview_images=tag_images,
+            _prompt_data_json_safe=copy.deepcopy,
+        ):
+            output = generator.generate(
+                context,
+                "settings-json",
+                "lora-stack",
+                {"workflow": True},
+                {"pnginfo": True},
+                unique_id,
+            )
+
+        image, latent, metadata_json = output["result"]
+        metadata = json.loads(metadata_json)
+        return {
+            "trace": trace,
+            "result": {
+                "image": image,
+                "latent": latent,
+                "metadata": metadata,
+                "ui": output["ui"],
+            },
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "08731747c5ced72546f4b3cd60fd7e2a7562a5a7")
-        # Issue #184 B-09a preserves the public AiO input adapter as a direct
-        # root alias while moving its implementation to canonical ownership.
+        self.assertEqual(report["git_blob_sha1"], "688ee31af1383b25856e258d918d3489f5aa4cdc")
+        # Issue #184 B-09b1 preserves the AiO generator adapter in root while
+        # moving its current-order execution body behind a direct private alias.
         self.assertEqual(report["top_level"]["function_count"], 43)
         self.assertEqual(report["top_level"]["class_count"], 3)
-        self.assertEqual(report["line_count"], 3_122)
+        self.assertEqual(report["line_count"], 2_822)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 76)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 76)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 76)
+        self.assertEqual(report["inventory"]["module_count"], 77)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 77)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 77)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -694,6 +694,7 @@ ignored/
                 "easyuse_anima/aio/__init__.py",
                 "easyuse_anima/aio/conditioning.py",
                 "easyuse_anima/aio/first_pass_cache.py",
+                "easyuse_anima/aio/legacy_generation.py",
                 "easyuse_anima/aio/generation_values.py",
                 "easyuse_anima/aio/generation_sampling.py",
                 "easyuse_anima/aio/generation_features.py",
@@ -757,6 +758,7 @@ ignored/
             {
                 "easyuse_anima/aio/conditioning.py",
                 "easyuse_anima/aio/first_pass_cache.py",
+                "easyuse_anima/aio/legacy_generation.py",
                 "easyuse_anima/aio/model_preparation.py",
                 "easyuse_anima/aio/output.py",
                 "easyuse_anima/aio/preview.py",

--- a/tests/test_python_package_skeleton.py
+++ b/tests/test_python_package_skeleton.py
@@ -13,6 +13,7 @@ PACKAGE_MODULES = (
     "easyuse_anima.aio",
     "easyuse_anima.aio.conditioning",
     "easyuse_anima.aio.first_pass_cache",
+    "easyuse_anima.aio.legacy_generation",
     "easyuse_anima.aio.generation_normalization",
     "easyuse_anima.aio.generation_values",
     "easyuse_anima.aio.model_preparation",

--- a/tests/test_registry_scanner_safety.py
+++ b/tests/test_registry_scanner_safety.py
@@ -166,6 +166,7 @@ class RegistryScannerSafetyTests(unittest.TestCase):
             "api_contract.py",
             "easyuse_anima/aio/conditioning.py",
             "easyuse_anima/aio/first_pass_cache.py",
+            "easyuse_anima/aio/legacy_generation.py",
             "easyuse_anima/aio/generation_values.py",
             "easyuse_anima/aio/generation_sampling.py",
             "easyuse_anima/aio/generation_features.py",


### PR DESCRIPTION
## 작업 단위

- Task: B-09b1 — current-order AiO legacy orchestration Move
- Owner: #184
- 분류: **Move**
- Base: `dev` / `fb85e9eaedb9dabfbcf77740b27bee98c99e679a`
- 상태: Ready

## 분할 근거

`EasyUseAnimaAIOGenerator.generate`는 중첩된 Mod Guidance model 선택, first-pass cache, preview, 네 optional stage, `finally` model cleanup, save, metadata/UI 조립을 하나의 약 329-line 원자적 순서로 소유합니다. public adapter identity 이동까지 같은 PR에서 수행하면 orchestration parity와 node contract 검토 경계가 겹칩니다.

B-09b1은 현재 순서 orchestration만 `easyuse_anima/aio/legacy_generation.py`로 이동합니다. public class, input-context validator, `INPUT_TYPES`, `IS_CHANGED`, mapping identity 이동은 후속 B-09b2로 남깁니다. stage 객체, `GenerationRequest`, hook dispatcher, cache/seed/save 정책은 도입하지 않습니다.

## 작업 전 symbol / caller / alias / global-state inventory

### moving symbols

- `EasyUseAnimaAIOGenerator.generate` body (`nodes.py:2794-3122` at base)

canonical module은 `_run_aio_legacy_generation`을 소유합니다. root public class에는 기존과 동일한 `generate` signature의 thin delegate만 남겨 ComfyUI의 `FUNCTION = "generate"`, bound-method introspection, `id(self)` cache-scope fallback을 유지합니다. root `_run_aio_legacy_generation`은 delegate가 소비하는 canonical function의 direct private alias이며, input-context helper와 public class 이동은 B-09b2로 남깁니다.

### callers / public surface

- ComfyUI executor: `NODE_CLASS_MAPPINGS["EasyUseAnimaAIOGenerator"]` → `FUNCTION = "generate"`
- direct root import와 package entrypoint의 public class는 B-09b1에서 그대로 root-owned
- `tests/test_aio_nodes.py`의 base sampling, backend/Mod Guidance, stage order, cache, preview, save/metadata/cleanup 호출
- 0.5.2 AiO workflow fixture의 node id, hidden `generation_settings`, optional `lora_stack`, hidden workflow metadata

### call-time runtime dependencies

- input/config/seed: `_require_easy_use_anima_input`, `_normalize_aio_generation_settings`, `_resolve_aio_runtime_seed`
- resources/model/prompt: `_load_aio_resources_from_input_context`, `_apply_aio_lora_stack`, `_apply_aio_model_patches`, `_normalize_prompt_data`, `_advanced_outputs_from_prompt_data`, `_encode_prompt_data_positive_conditioning`, `_encode_with_comfy_clip`
- stage decisions/model variants: `_as_bool`, `_aio_detailer_has_enabled_targets`, `_normalize_anima_mod_guidance_profile`, `_resolve_anima_mod_guidance_enabled`, `ANIMA_MOD_GUIDANCE_PROFILE_OFF`, `_aio_highres_effective_backend`, `_apply_spectrum_anima_mod_guidance`, `_apply_aio_spectrum_model_patches_for_comfy_sampler`
- preview/cache/base sampling: `_single_value`, `_aio_first_pass_cache_key`, `_save_aio_temp_preview_image`, `_send_aio_preview_event`, `_get_aio_first_pass_cache`, `_generate_empty_latent_with_comfy`, `_sample_latent_with_aio_backend`, `_decode_latent_with_comfy`, `_resize_image_to_size_if_needed`, `_encode_image_with_comfy_vae`, `_put_aio_first_pass_cache`
- optional stages: `_run_aio_highres_stage`, `_run_aio_detailer_stage`, `_run_aio_upscale_stage`, `_run_aio_postprocess_stage`, `_image_tensor_size`
- cleanup/output: `_cleanup_aio_ephemeral_model`, `_save_image_with_image_saver`, `_save_image_with_comfy`, `_aio_save_filename_prefix`, `_tag_aio_preview_images`, `_prompt_data_json_safe`
- standard/root state: `random.getrandbits`, `json.dumps`, `logger.debug`

canonical module은 root `nodes.py`를 import하지 않고 하나의 narrow runtime resolver로 위 이름을 **사용 지점마다** 조회합니다. root delegate가 original generator instance를 그대로 전달하므로 기존 `patch.object(nodes, ...)` seam, optional dependency의 지연 실패 시점, helper 평가 순서를 보존합니다.

### mutable/global state

- 신규 module 소유 상태: runtime resolver slot만 허용
- first-pass cache state/order/limit은 계속 `easyuse_anima.aio.first_pass_cache`가 소유
- model/CLIP/VAE/tensor, stage metadata, preview list/run id는 현재와 같은 per-call local state
- cleanup 대상 deduplication과 `finally` 순서, cache put의 debug-only 예외 처리, save/preview side effect 순서를 그대로 유지

### optional dependency and error boundary

- Spectrum/Impact/USDU/upscale/Image Saver/PromptServer 의존성은 기존 helper를 통해서만 접근
- dependency lookup, unsupported txt2img mode error, invalid input error, cache put warning, stage/save exception 전파 정책을 변경하지 않음

## deterministic trace gate

새 fixture/test는 새 stage abstraction 없이 기존 helper 호출을 기록합니다.

1. optional stage가 모두 disabled인 base txt2img
2. upscale 경로 하나와 intermediate preview가 enabled인 대표 optional-stage case

각 case에서 resource → conditioning → sampler/cache → highres/detailer/upscale/postprocess → cleanup → save/preview → metadata/result 순서, final dimensions, stage metadata, UI/preview payload와 cleanup deduplication을 고정합니다. 실제 optional provider가 없어도 production의 같은 분기/호출 순서를 결정적으로 검증하며, 실제 provider/live queue는 별도 실행 여부를 명시합니다.

## allowed-file boundary

### production

- `nodes.py`
- 신규 `easyuse_anima/aio/legacy_generation.py`

### focused evidence / analyzer / docs

- 신규 `tests/test_aio_legacy_generation.py`
- 신규 `tests/fixtures/aio_legacy_execution_trace.v1.json`
- 필요한 경우 `tests/test_aio_nodes.py`
- `tests/test_node_contracts.py` (검증만; 계약 변화 금지)
- `tests/test_nodes_module_analyzer.py`
- `tests/test_python_backend_analyzer.py`
- `tests/test_python_package_skeleton.py`
- `tests/test_registry_scanner_safety.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/python-backend-execution-roadmap.md`
- `docs/architecture/python-compatibility-shims.md`

## 금지 범위

- `EasyUseAnimaAIOGenerator` class/`INPUT_TYPES`/`IS_CHANGED`/mapping 이동 또는 public contract 변경
- `easyuse_anima/nodes/aio_nodes.py`, root `__init__.py`, locales/frontend/workflow fixture 수정
- stage/request/state DTO, hook seam/dispatcher, pipeline 재설계
- cache entry/copy/limit/eviction, seed reservation, save/preview/metadata/error/cleanup behavior 변경
- helper 재정렬, eager dependency lookup, public `generate` delegate 외 새로운 root wrapper/private API

## 검증 계획

- root `generate` delegate의 exact public signature와 canonical orchestration 호출 parity
- deterministic two-case execution trace와 기존 generator focused parity
- 0.5.2 node/workflow contract, package/direct import, analyzer/package/scanner closure
- 신규 module compile/Ruff/Pyright와 G-03a
- 독립 diff review 후 exact final head official full 1회
- 가능한 live queue/Legacy canvas/Node 2.0 evidence는 실제 실행과 fixture evidence를 구분해 기록

## 구현 결과

- root `generate`는 기존 exact signature와 public class identity를 유지한 thin delegate가 됐습니다.
- orchestration 본문은 call-time runtime resolver를 통해 canonical module에서 실행되며 root monkeypatch seam, helper 평가 시점, `id(self)` cache scope를 보존합니다.
- AST-normalized 기존/신규 orchestration 52 statements가 일치합니다.
- deterministic trace 두 case가 전체 decoded metadata, helper 순서, cleanup-before-save, preview/result projection을 고정합니다.
- root `nodes.py`는 2,822 lines, analyzer closure는 77 modules / missing 0 / unreachable 0입니다.

## 검증 결과

- exact head: `3bda5d71244543c58a314af5c3c8ba6034dacc6d`
- focused trace: `tests.test_aio_legacy_generation` 3 tests passed
- staged analyzer: `tests.test_python_backend_analyzer` 18 tests passed
- affected focused subset 18 tests passed
- targeted Pyright 1.1.411: 0 diagnostics
- targeted Ruff 0.15.22: new files clean
- G-03a: 6 package groups, 0 violations
- targeted compile 및 `git diff --check`: passed
- 독립 diff review: 남은 P0-P2 없음
- official `tools/check_project.ps1 -Profile full`: Python 855 tests passed, frontend 114 JavaScript files passed, Pyright baseline ratchet passed, G-03a passed, diff check passed
- Ruff 105 findings는 기존 G-01 report-only baseline이며 blocking failure가 아닙니다.

## ComfyUI 런타임 검증

- ComfyUI 0.27.0 Codex test instance: module import 및 `object_info/EasyUseAnimaAIOGenerator` passed
- v0.5.2 workflow Legacy canvas: load -> save -> reload passed; 6 nodes / 5 links와 AiO Input·Generator type, hidden settings schema/version/seed/backend가 보존됐습니다.
- Node 2.0: 같은 저장본 load -> save -> reload passed; public node types, widget counts, input widgets, schema/version/seed/backend와 optional-stage settings가 보존됐습니다.
- actual queue base path: 512x512, 2 steps, optional stages disabled, Spectrum backend, success in 20.57s
- actual queue representative optional path: Highres enabled at 1.25x / 2 steps, first-pass cache reused, 640x640 result, success in 8.25s
- Detailer/USDU/Postprocess provider branches는 이번 Move 검증에서 실제 실행하지 않았고 deterministic trace 및 기존 focused tests로만 확인했습니다.
- 테스트 후 Node 2.0 설정을 원래 값으로 복원하고 test server를 종료했습니다.

## 롤백 경계

신규 legacy module, root import/binder/method alias, trace/analyzer/docs 갱신만 되돌리면 원래 root method body로 복귀합니다.

Move-only 경계, focused/full/runtime gate, 독립 리뷰를 모두 통과했으며 알려진 차단점은 없습니다.

Closes no issue; #184 B-09b1 완료 기록만 추가합니다.
